### PR TITLE
Test/serial advance

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -35,4 +35,8 @@ This approach allows for precise unit testing of:
 - **Data Reception**: Ensuring that when the mock port simulates receiving data, the `on_bytes` callback is correctly invoked with the right payload.
 - **Data Transmission**: Confirming that a call to `async_write_copy` results in the correct data being passed to the mock port's `async_write` method.
 
-By isolating the `Serial` class from its I/O dependencies, these tests provide a fast, stable, and platform-independent way to validate its core logic.
+By isolating the `Serial` class from its I/O dependencies, these tests provide a fast, stable, and platform-independent way to validate its core logic, including advanced scenarios:
+
+- **Error Handling and Retries**: Validating that the class correctly handles connection failures (e.g., `open()` fails) and attempts to reconnect according to the configured retry policy.
+- **Write Error Handling**: Checking that asynchronous write errors are properly managed, leading to the correct state transition (e.g., to an `Error` state when `reopen_on_error` is false).
+- **Write Queuing**: Verifying that multiple consecutive `async_write_copy` calls are queued and executed in the correct order, ensuring data integrity.


### PR DESCRIPTION
This feature significantly improves the robustness and reliability of the Serial transport class. 

It introduces a suite of new unit tests to cover critical edge cases and fixes several underlying bugs related to error handling and resource lifecycle management that were discovered during testing.

## Added Advanced Unit Tests for Serial Class

- Connection Retry (HandlesConnectionFailureAndRetries): A new test verifies that the class correctly handles an initial open() failure and successfully reconnects according to the configured retry policy. This ensures the link can self-heal from transient connection issues.
- Write Error Handling (HandlesWriteError): This test confirms that an asynchronous write error correctly transitions the link state to Error when reopen_on_error is disabled, preventing unexpected behavior.
- Write Queuing (QueuesMultipleWrites): We now verify that sequential async_write_copy requests are properly queued and executed in order, guaranteeing data transmission integrity under load.

## Critical Bug Fixes

- Lifecycle Management (Segfault Fix)Lifecycle Management (Segfault Fix)
- Consistent Error Handling
- State Transitions

## Test Infrastructure Improvements

- The test fixture (SerialTest) was refactored to instantiate the Serial object within each test case instead of in SetUp(). This improves test isolation and allows for per-test configuration.