### PR TITLE
refactor: serial test and improve

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,5 +18,3 @@ target_link_libraries(run_tests
 # Discover and add tests to CTest
 include(GoogleTest)
 gtest_discover_tests(run_tests)
-
-add_test(NAME ${PROJECT_NAME} COMMAND run_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,3 +18,14 @@ target_link_libraries(run_tests
 # Discover and add tests to CTest
 include(GoogleTest)
 gtest_discover_tests(run_tests)
+
+# Enable sanitizers for debugging memory errors and undefined behavior.
+# This is typically done for Debug or RelWithDebInfo builds.
+if(CMAKE_BUILD_TYPE MATCHES "Debug|RelWithDebInfo")
+    # AddressSanitizer (ASan) for memory errors like use-after-free, buffer overflows, etc.
+    target_compile_options(run_tests PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(run_tests PRIVATE -fsanitize=address)
+    # UndefinedBehaviorSanitizer (UBSan) for various forms of undefined behavior.
+    target_compile_options(run_tests PRIVATE -fsanitize=undefined)
+    target_link_options(run_tests PRIVATE -fsanitize=undefined)
+endif()

--- a/test/test_serial.cc
+++ b/test/test_serial.cc
@@ -491,16 +491,15 @@ TEST_F(SerialTest, FutureWaitSucceedsWithinTimeout) {
 
   // 2초 후에 데이터 수신을 시뮬레이션하는 별도 스레드
   std::thread sim_thread([&]() {
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_GE(read_buffer.size(), test_message.length());
     std::memcpy(read_buffer.data(), test_message.data(), test_message.length());
     net::post(test_ioc_, [&] {
       read_handler(boost::system::error_code(), test_message.length());
     });
   });
-
-  // 3초 타임아웃으로 future를 기다림
-  auto status = data_future.wait_for(std::chrono::seconds(3));
+  // 100ms 타임아웃으로 future를 기다림
+  auto status = data_future.wait_for(std::chrono::milliseconds(100));
 
   // --- Verification ---
   // 2초 후에 promise가 set_value() 되므로, 3초 타임아웃 내에 future는 ready
@@ -541,8 +540,8 @@ TEST_F(SerialTest, FutureWaitTimesOut) {
   serial_->start();
   ioc_thread_ = std::thread([this] { test_ioc_.run(); });
 
-  // 3초 타임아웃으로 future를 기다림
-  auto status = timeout_future.wait_for(std::chrono::seconds(3));
+  // 50ms 타임아웃으로 future를 기다림
+  auto status = timeout_future.wait_for(std::chrono::milliseconds(50));
 
   // --- Verification ---
   // 데이터 수신이 없으므로, 3초 후에 future는 timeout 상태가 되어야 함


### PR DESCRIPTION
## Key Changes:

### Consistent Use of MockPortBuilder and Test Fixtures:

- Refactored tests that previously set up mock objects manually (e.g., HandlesWriteError, QueuesMultipleWrites) to use MockPortBuilder and specialized fixtures like BasicConnectionTest and ErrorHandlingTest.
- This eliminates repetitive EXPECT_CALL blocks and makes the intent of each test clearer.

### Removal of Redundant Tests:

- The tests with the _WithBuilder suffix were good examples to showcase the builder pattern. 
- Now that all tests use the builder, I've merged them with the original tests to remove duplication.

### Improved Asynchronous Test Stability:

- Replaced std::this_thread::sleep_for with synchronization mechanisms using StateTracker and std::condition_variable. 
- This reduces the chance of flaky tests that can fail depending on the execution environment.

### Leveraged ErrorScenario Class:

- Actively used the ErrorScenario class to test various error conditions, allowing for more systematic and concise verification of the error handling logic.


## Expected Benefits:

- Improved Readability: The 'Given-When-Then' structure of each test becomes more apparent.
- Increased Maintainability: Mock object setup is centralized and simplified, making it easier to adapt to future changes in the Serial class.
- Enhanced Stability: Eliminating unnecessary sleeps speeds up test execution and improves the reliability of the results.