### PR TITLE
Docs/update

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -192,12 +192,12 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: build
         shell: pwsh
-        run: ctest -C "${env:BUILD_TYPE}" --output-on-failure
+        run: ctest -C "${env:BUILD_TYPE}" --output-on-failure -LE docs_snippets
 
       - name: Test (Linux/macOS)
         if: runner.os != 'Windows'
         working-directory: build
-        run: ctest --output-on-failure --parallel 2
+        run: ctest --output-on-failure --parallel 2 -LE docs_snippets
 
       - name: Verify Python Import (Windows)
         if: matrix.build_python == 'ON' && runner.os == 'Windows'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: |
           cd build-coverage
-          ctest --output-on-failure --parallel $(nproc)
+          ctest --output-on-failure --parallel $(nproc) -LE docs_snippets
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Test
         shell: bash
-        run: ctest --test-dir build --output-on-failure -C Release
+        run: ctest --test-dir build --output-on-failure -C Release -LE docs_snippets
 
       - name: Package
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,58 @@ jobs:
         retention-days: 7
         overwrite: true
 
+  docs-snippets:
+    name: Docs Snippets (ubuntu-22.04, gcc)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: []
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Cache ccache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ runner.os }}-docs-snippets-${{ hashFiles('**/CMakeLists.txt', 'docs/**/*.md', 'docs/scripts/*.py') }}
+        restore-keys: |
+          ccache-${{ runner.os }}-docs-snippets-
+
+    - name: Install dependencies
+      uses: ./.github/actions/apt-install
+      with:
+        packages: "build-essential cmake ccache gcc-11 g++-11 python3 libboost1.74-dev libboost-system1.74-dev"
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build-docs-snippets \
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+          -DCMAKE_CXX_STANDARD=${{ env.CXX_STANDARD }} \
+          -DUNILINK_ENABLE_CONFIG=ON \
+          -DUNILINK_BUILD_EXAMPLES=OFF \
+          -DUNILINK_BUILD_DOCS=OFF \
+          -DUNILINK_BUILD_TESTS=ON \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build doc snippet smoke target
+      run: cmake --build build-docs-snippets --target doc_snippets_smoke -j $(nproc)
+
+    - name: Run doc snippet tests
+      run: |
+        cd build-docs-snippets
+        ctest --output-on-failure -L docs_snippets
+
+    - name: Upload docs snippet test results
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: docs-snippet-test-results
+        path: build-docs-snippets/Testing/
+        retention-days: 7
+        overwrite: true
+
   # Integration Tests
   integration-tests:
     name: Integration Tests (ubuntu-22.04, gcc)
@@ -337,7 +389,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-22.04
-    needs: [unit-tests, integration-tests, performance-tests, memory-safety-tests, e2e-tests]
+    needs: [unit-tests, docs-snippets, integration-tests, performance-tests, memory-safety-tests, e2e-tests]
     if: always()
 
     steps:
@@ -347,6 +399,7 @@ jobs:
         echo "| Test Suite | Status |" >> $GITHUB_STEP_SUMMARY
         echo "|------------|--------|" >> $GITHUB_STEP_SUMMARY
         echo "| Unit Tests | ${{ needs.unit-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Docs Snippets | ${{ needs.docs-snippets.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Integration Tests | ${{ needs.integration-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Performance Tests | ${{ needs.performance-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Memory Safety Tests | ${{ needs.memory-safety-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     libboost-dev \
     libboost-system-dev \
+    python3 \
     doxygen \
     graphviz \
     git \

--- a/README.md
+++ b/README.md
@@ -12,22 +12,23 @@
 
 ## Description
 
-Simple, cross-platform async C++ communication library for Serial, TCP, and UDP
+Simple async C++ communication library for Serial, TCP, UDP, and Unix Domain Sockets
 
-`unilink` provides a unified interface for asynchronous communication across different transports, allowing applications to switch between Serial, TCP, and UDP with minimal code changes.
+`unilink` provides a unified interface for asynchronous communication across different transports, allowing applications to switch between Serial, TCP, UDP, and UDS with minimal code changes. The public C++ API exposes builders and wrappers for all four transport families; Python bindings currently cover TCP client/server, Serial, and UDP.
 
 The project prioritizes **API clarity, predictable runtime behavior, and stability** over rapid feature expansion.
 
 ## Feature Highlights
 
-*   **Zero-copy memory safety via SafeSpan**: Efficient data handling without unnecessary copies.
-*   **Fluent API with CRTP Builders**: Type-safe configuration with improved method chaining.
-*   **Unified Async Interface**: Consistent API across TCP, UDP, and Serial transports.
+* **Unified transport surface**: Consistent builders and wrappers for TCP client/server, UDP, Serial, and UDS.
+* **Zero-copy memory safety via SafeSpan**: Efficient data handling without unnecessary copies.
+* **Fluent API with CRTP Builders**: Type-safe configuration with improved method chaining.
+* **Tested runtime behavior**: Unit, integration, and end-to-end test suites are part of the repository and documented in `test/`.
 
 ## Requirements
 
-*   **C++17 compliant compiler** (required)
-*   CMake 3.10 or later
+* **C++17 compliant compiler** (required)
+* CMake 3.10 or later
 
 ## 📦 Installation
 
@@ -41,16 +42,18 @@ For CMake usage, source builds, and other installation options, see the [Install
 
 ## 🐍 Python Bindings
 
-Unilink provides Python bindings for core functionality (`TcpClient`, `TcpServer`, `Serial`, `Udp`).
+Unilink provides Python bindings for core functionality (`TcpClient`, `TcpServer`, `Serial`, `Udp`). UDS wrappers are available in the C++ API but are not currently exposed in `unilink_py`.
 
 For a complete guide, see the **[Python Bindings Guide](docs/guides/core/python_bindings.md)**.
 
 ### Prerequisites
+
 * Python 3.8+ (dev headers)
 * pybind11 (`sudo apt-get install pybind11-dev python3-pybind11` on Ubuntu)
 * Boost (`boost-system`, `boost-asio`, `boost-thread`)
 
 ### Build
+
 Pass `-DBUILD_PYTHON_BINDINGS=ON` to CMake:
 
 ```bash
@@ -76,12 +79,13 @@ You do **not** need to read everything to get started.
 * [Installation Guide](docs/guides/setup/installation.md) – Package, source, and build options
 * [Build Guide](docs/guides/setup/build_guide.md) – Build configurations and flags
 * [Requirements](docs/guides/setup/requirements.md) – Supported platforms and dependencies
+* [Implementation Status](docs/implementation_status.md) – Current codebase snapshot, verified scope, and known gaps
 
 ### 🏗️ Architecture & Design
 
 * [Runtime Behavior](docs/architecture/runtime_behavior.md) – Threading model, reconnection, backpressure
 * [Memory Safety](docs/architecture/memory_safety.md) – Ownership rules and safety guarantees
-* [System Overview](docs/architecture/system_overview.md) – High-level structure
+* [Architecture Overview](docs/architecture/README.md) – High-level structure and layer responsibilities
 
 ### 🔧 Guides & Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ python3 -m http.server 8000
 - Keep public wrapper/builder APIs and transport-internal behavior in separate documents.
 - When documenting callbacks or methods, verify signatures against headers under `unilink/wrapper/` and `unilink/builder/`.
 - Treat runnable examples under `examples/` as the preferred source for tutorial snippets when possible.
+- For compile-checked tutorial snippets, keep the `<!-- doc-compile: ... -->` marker attached to the canonical fenced C++ block.
 - When build flags or defaults change, update `README.md`, `docs/index.md`, and `docs/guides/setup/build_guide.md` together.
 - When adding public APIs, update `docs/reference/api_guide.md` and `docs/implementation_status.md`.
 - When changing config behavior, update both `docs/reference/api_guide.md` and architecture notes that mention configuration flow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,191 +1,90 @@
 # unilink Documentation
 
-This directory contains all documentation-related files for the unilink library.
+This directory contains the hand-written documentation for `unilink` plus the configuration and helper scripts used to generate Doxygen output.
 
 ## Directory Structure
 
-```
+```text
 docs/
-├── README.md              # This file
-├── INDEX.md               # Documentation entry point
-├── guides/                # Quickstart, best practices, troubleshooting
-├── reference/             # API reference (API_GUIDE.md)
-├── architecture/          # System overview and design notes
-├── tutorials/             # Step-by-step tutorials
-├── development/           # Contributor guides and notes
-├── scripts/               # Documentation generation scripts
-├── config/                # Doxygen configuration
-└── html/                  # Generated HTML documentation (after generation)
+├── README.md                 # Documentation maintenance guide
+├── index.md                  # Main handwritten documentation index
+├── implementation_status.md  # Current codebase snapshot
+├── architecture/             # Design and runtime notes
+├── config/                   # Doxygen configuration
+├── guides/                   # Setup, usage, testing, troubleshooting
+├── img/                      # Images referenced by docs
+├── reference/                # API guide and reference material
+├── scripts/                  # Helper scripts for docs generation/serving
+└── tutorials/                # Step-by-step walkthroughs
 ```
+
+Generated HTML is written to `docs/html/` when Doxygen runs. That output is a generated artefact, not the source of truth.
+
+## Where To Start
+
+- Reader entry point: `docs/index.md`
+- Current implementation snapshot: `docs/implementation_status.md`
+- Doxygen configuration: `docs/config/Doxyfile`
+- Helper scripts: `docs/scripts/generate_docs.sh`, `serve_docs.sh`, `clean_docs.sh`
 
 ## Generating Documentation
 
 ### Prerequisites
 
-Install Doxygen and Graphviz:
-
 ```bash
-# Ubuntu/Debian
 sudo apt install doxygen graphviz
-
-# CentOS/RHEL/Fedora
-sudo yum install doxygen graphviz
-
-# Windows
-# Download from https://www.doxygen.nl/download.html
 ```
 
-### Generation Methods
+### Supported Methods
 
-#### Method 1: Using the Script
+Using the helper script:
+
 ```bash
 ./docs/scripts/generate_docs.sh
 ```
 
-#### Method 2: Using CMake
-```bash
-mkdir build && cd build
-cmake .. -DBUILD_DOCUMENTATION=ON
-make docs
-```
+Using the top-level Makefile:
 
-#### Method 3: Using Makefile (from project root)
 ```bash
 make docs
 ```
 
-#### Method 4: Using Documentation Makefile (from docs directory)
+Using the docs Makefile:
+
 ```bash
 cd docs
 make generate
 ```
 
-#### Method 5: Direct Doxygen
+Running Doxygen directly:
+
 ```bash
 doxygen docs/config/Doxyfile
 ```
 
-> The scripts and make targets pass the top-level `project(VERSION ...)` from `CMakeLists.txt` into Doxygen automatically. If you invoke Doxygen manually, export `PROJECT_NUMBER` yourself to keep the displayed version in sync.
+If you invoke Doxygen directly, set `PROJECT_NUMBER` yourself if you want the generated version banner to match `project(VERSION ...)` from `CMakeLists.txt`.
 
-### Viewing Documentation
+## Viewing Generated HTML
 
-After generation, you can view the documentation in several ways:
-
-#### Method 1: Direct File Access
 ```bash
-# Open in browser
-xdg-open docs/html/index.html  # Linux
-start docs/html/index.html     # Windows
-```
-
-#### Method 2: Local Server (Recommended)
-```bash
-# Using the provided script
-make serve-docs
-# or
-./docs/scripts/serve_docs.sh
-
-# Manual server
-cd docs/html && python3 -m http.server 8000
-# Then open http://localhost:8000
-```
-
-### Additional Scripts
-
-#### Clean Documentation
-```bash
-make clean-docs
-# or
-./docs/scripts/clean_docs.sh
-```
-
-#### Serve Documentation
-```bash
-make serve-docs
-# or
 ./docs/scripts/serve_docs.sh
 ```
 
-## Documentation Structure
+Or:
 
-The generated documentation includes:
-
-- **Main Page**: Overview of the library and quick start guide
-- **Classes**: Detailed API documentation for all classes
-- **Files**: Source file documentation
-- **Namespaces**: Namespace organization
-- **Examples**: Code examples and usage patterns
-- **Modules**: Logical grouping of related functionality
-
-## Features
-
-- **Cross-references**: Links between related classes and functions
-- **Call graphs**: Visual representation of function call relationships
-- **Inheritance diagrams**: Class hierarchy visualization
-- **Collaboration diagrams**: Class interaction visualization
-- **Search functionality**: Full-text search across all documentation
-- **Code examples**: Inline code examples with syntax highlighting
-
-## Customization
-
-The documentation can be customized by modifying the `Doxyfile` configuration:
-
-- **HTML output**: Custom CSS styling, navigation, and layout
-- **Input sources**: Additional source files and directories
-- **Output format**: HTML, LaTeX, RTF, XML, etc.
-- **Diagrams**: Graphviz integration for class and call graphs
-- **Search**: Full-text search configuration
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Doxygen not found**: Install Doxygen using the package manager
-2. **Graphviz not found**: Install Graphviz for diagram generation
-3. **Permission denied**: Ensure write permissions for the docs directory
-4. **Missing diagrams**: Check Graphviz installation and PATH
-
-### Debug Information
-
-Enable verbose output:
 ```bash
-doxygen -d Doxyfile
+cd docs/html
+python3 -m http.server 8000
 ```
 
-Check Doxygen version:
-```bash
-doxygen --version
-```
+## Maintenance Notes
 
-## Continuous Integration
-
-The documentation can be automatically generated in CI/CD pipelines:
-
-```yaml
-# GitHub Actions example
-- name: Generate Documentation
-  run: |
-    sudo apt install doxygen graphviz
-    make docs
-    # Upload docs to GitHub Pages or artifact storage
-```
-
-## Contributing
-
-When adding new classes or functions, please include proper Doxygen comments:
-
-```cpp
-/**
- * @brief Brief description of the function
- * @param param1 Description of parameter 1
- * @param param2 Description of parameter 2
- * @return Description of return value
- * @throws ExceptionType When this exception is thrown
- * @note Additional notes
- * @warning Important warnings
- * @example
- * @code
- * // Example usage
- * @endcode
- */
-```
+- Keep links aligned with real file names and directory layout.
+- Prefer documenting verified behavior over aspirational behavior.
+- When build flags or defaults change, update `README.md`, `docs/index.md`, and `docs/guides/setup/build_guide.md` together.
+- When adding public APIs, update `docs/reference/api_guide.md` and `docs/implementation_status.md`.
+- Keep document roles separated to avoid copy drift:
+  - `quickstart`: shortest successful path
+  - `tutorials`: step-by-step workflows
+  - `reference/api_guide.md`: protocol and API surface details
+  - `examples/*/README.md`: runnable example commands and CLI usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,8 +81,12 @@ python3 -m http.server 8000
 
 - Keep links aligned with real file names and directory layout.
 - Prefer documenting verified behavior over aspirational behavior.
+- Keep public wrapper/builder APIs and transport-internal behavior in separate documents.
+- When documenting callbacks or methods, verify signatures against headers under `unilink/wrapper/` and `unilink/builder/`.
+- Treat runnable examples under `examples/` as the preferred source for tutorial snippets when possible.
 - When build flags or defaults change, update `README.md`, `docs/index.md`, and `docs/guides/setup/build_guide.md` together.
 - When adding public APIs, update `docs/reference/api_guide.md` and `docs/implementation_status.md`.
+- When changing config behavior, update both `docs/reference/api_guide.md` and architecture notes that mention configuration flow.
 - Keep document roles separated to avoid copy drift:
   - `quickstart`: shortest successful path
   - `tutorials`: step-by-step workflows

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -347,8 +347,8 @@ client->stop();         // Thread 3
 Callbacks are executed in the I/O thread context:
 
 ```cpp
-.on_data([](const std::string& data) {
-    // This runs in I/O thread
+.on_data([](const unilink::MessageContext& ctx) {
+    // This runs in the I/O thread.
     // Don't block here!
 });
 ```

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -734,6 +734,6 @@ Unilink's architecture emphasizes:
 
 **See Also:**
 
-- [Design Patterns](design_patterns.md)
-- [Threading Model](threading_model.md)
-- [Performance Guide](../guides/performance_tuning.md)
+- [Runtime Behavior](runtime_behavior.md)
+- [Memory Safety](memory_safety.md)
+- [Performance Guide](../guides/advanced/performance.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,6 +2,10 @@
 
 Comprehensive overview of unilink's architecture and design principles.
 
+> Scope note
+>
+> This section mixes public high-level concepts with internal implementation details. For exact application-facing APIs, prefer `docs/reference/api_guide.md`. For transport-internal contracts, prefer `docs/architecture/channel_contract.md`.
+
 ---
 
 ## Table of Contents
@@ -119,17 +123,28 @@ namespace unilink::builder {
 
 ```cpp
 namespace unilink::wrapper {
-    // Base interface
     class ChannelInterface {
-        virtual void send(const std::string& data) = 0;
-        virtual void start() = 0;
+        virtual std::future<bool> start() = 0;
         virtual void stop() = 0;
+        virtual bool is_connected() const = 0;
+        virtual void send(std::string_view data) = 0;
+        virtual void send_line(std::string_view line) = 0;
     };
 
-    // Implementations
+    class ServerInterface {
+        virtual std::future<bool> start() = 0;
+        virtual void stop() = 0;
+        virtual bool is_listening() const = 0;
+        virtual bool broadcast(std::string_view data) = 0;
+        virtual bool send_to(size_t client_id, std::string_view data) = 0;
+    };
+
     class TcpClient : public ChannelInterface;
-    class TcpServer : public ChannelInterface;
     class Serial : public ChannelInterface;
+    class Udp : public ChannelInterface;
+    class UdsClient : public ChannelInterface;
+    class TcpServer : public ServerInterface;
+    class UdsServer : public ServerInterface;
 }
 ```
 
@@ -165,25 +180,23 @@ namespace unilink::transport {
 ### 4. Common Utilities
 
 ```cpp
-namespace unilink::common {
-    // Thread safety
-    template<typename T>
-    class ThreadSafeState;
+namespace unilink {
+namespace concurrency {
+    template<typename T> class ThreadSafeState;
+    template<typename T> class AtomicState;
+}
 
-    template<typename T>
-    class AtomicState;
-
-    // Memory management
+namespace memory {
     class MemoryPool;
     class MemoryTracker;
     class SafeDataBuffer;
+}
 
-    // Logging
+namespace diagnostics {
     class Logger;
     class LogRotation;
-
-    // Error handling
     class ErrorHandler;
+}
 }
 ```
 
@@ -560,15 +573,19 @@ class MemoryTracker { ... };
 ### Runtime Configuration
 
 ```cpp
-struct TcpClientConfig {
-    std::string host;
-    uint16_t port;
-    unsigned retry_interval_ms{3000};  // Default is 3 seconds
-};
+#include "unilink/config/config_factory.hpp"
 
-// Load from file
-auto config = ConfigManager::load_from_file("config.json");
-auto client_config = config->get_tcp_client_config("my_client");
+auto config = unilink::config::ConfigFactory::create_with_defaults();
+config->load_from_file("unilink.conf");
+
+auto host = std::any_cast<std::string>(config->get("tcp.client.host"));
+auto port = static_cast<uint16_t>(std::any_cast<int>(config->get("tcp.client.port")));
+
+auto client = unilink::tcp_client(host, port)
+    .retry_interval(static_cast<unsigned>(
+        std::any_cast<int>(config->get("tcp.client.retry_interval_ms"))
+    ))
+    .build();
 ```
 
 ---
@@ -606,8 +623,8 @@ class ConnectionPool {
 
 ```cpp
 // Avoid repeated allocations
-MemoryPool buffer_pool_(1024, 100);
-auto buffer = buffer_pool_.allocate();  // Fast!
+unilink::memory::MemoryPool buffer_pool_;
+auto buffer = buffer_pool_.acquire(1024);  // Fast!
 ```
 
 ---

--- a/docs/architecture/channel_contract.md
+++ b/docs/architecture/channel_contract.md
@@ -1,7 +1,11 @@
-# Channel Contract: Ensuring Predictable and Robust Communication
+# Transport Channel Contract
+
+> Internal architecture note
+>
+> This document describes the transport-layer `unilink::interface::Channel` contract and related implementation guarantees. It is not the public wrapper/builder API reference. Public application-facing behavior is documented in `docs/reference/api_guide.md`.
 
 ## 1. Introduction
-The Unilink library provides flexible communication channels (TCP, UDP, Serial) that abstract away low-level networking and hardware details. To ensure consistent, predictable, and robust behavior across these diverse transports, a formal "Channel Contract" is established. This document outlines the fundamental rules and guarantees that all Unilink channels must adhere to. Adherence to this contract is critical for building reliable applications and simplifying the interaction with various communication mechanisms.
+The unilink library provides flexible communication channels (TCP, UDP, Serial, UDS) that abstract away low-level networking and hardware details. To keep behavior consistent across these transports, the transport layer follows a formal "Channel Contract". This document outlines the guarantees expected from internal channel implementations and the runtime assumptions built on top of them.
 
 ## 2. Core Principles
 The Channel Contract is built upon the following core principles:
@@ -13,7 +17,7 @@ The Channel Contract is built upon the following core principles:
 One of the most critical aspects of the Channel Contract is the "Stop Semantics."
 
 **Contract Rule:**
-> **Once `Channel::stop()` is called and returns, no further asynchronous callbacks (e.g., `on_state`, `on_bytes`, `on_backpressure`) related to that specific channel instance shall be invoked.**
+> **Once `Channel::stop()` is called and returns, no further transport-layer asynchronous callbacks (for example `on_state`, `on_bytes`, `on_backpressure`) related to that specific channel instance shall be invoked.**
 
 This rule ensures that once an application explicitly requests a channel to stop, it can safely clean up resources and assume that no more events will arrive from that channel, preventing potential use-after-free bugs or unexpected state changes.
 
@@ -40,9 +44,9 @@ This rule ensures that once an application explicitly requests a channel to stop
 To prevent memory exhaustion and manage flow control, channels implement a backpressure mechanism based on the size of the internal write queue.
 
 **Contract Rules:**
-1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the channel MUST invoke the `on_backpressure` callback with the current queue size. This signals the application to pause or slow down data generation.
+1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the transport MUST invoke its internal `on_backpressure` callback with the current queue size. Wrapper APIs may choose not to expose this directly.
     
-2.  **Relieving (Low Watermark):** Once backpressure is active, when the queue size drops to or below a "Low Watermark" (typically defined as `threshold / 2` or `0` depending on implementation, but must be strictly less than the high watermark), the channel MUST invoke the `on_backpressure` callback with the new (lower) queue size. This signals the application that it can resume normal data generation.
+2.  **Relieving (Low Watermark):** Once backpressure is active, when the queue size drops to or below a "Low Watermark" (typically defined as `threshold / 2` or `0` depending on implementation, but must be strictly less than the high watermark), the transport MUST invoke its internal `on_backpressure` callback with the new lower queue size.
 
 3.  **No Relief on Stop:** As per the **Stop Semantics**, clearing the queue during a `stop()` or shutdown sequence MUST NOT trigger a backpressure relief callback. The application is shutting down the channel and does not need to know that the queue is empty.
 
@@ -50,7 +54,7 @@ To prevent memory exhaustion and manage flow control, channels implement a backp
 *   **TcpClient:** Implements a high watermark at `backpressure_threshold` and a low watermark at `threshold / 2` (or 1 if threshold is small). Checks are performed after every write operation (enqueue/dequeue).
 *   **Serial:** Should follow the same logic as TcpClient.
 *   **TcpServer:** Implements backpressure per-session (`TcpServerSession`).
-    *   **Note:** If `on_backpressure` callback is registered on `TcpServer` after client connections have been established, existing sessions will not receive this updated callback. It is recommended to register all callbacks before calling `start()` on the `TcpServer`.
+    *   **Note:** This is a transport concern. The current wrapper/builder API does not expose a public `on_backpressure()` hook.
 
 ## 5. Error Handling Consistency
 (To be defined in future iterations)

--- a/docs/architecture/memory_safety.md
+++ b/docs/architecture/memory_safety.md
@@ -54,11 +54,9 @@ Immutable, type-safe buffer wrapper around existing data:
 #include "unilink/memory/safe_span.hpp"
 #include "unilink/memory/safe_data_buffer.hpp"
 
-using namespace unilink::common;
-
 // Create from existing data
-SafeDataBuffer from_vec(std::vector<uint8_t>{1, 2, 3});
-SafeDataBuffer from_str(std::string("hello"));
+unilink::memory::SafeDataBuffer from_vec(std::vector<uint8_t>{1, 2, 3});
+unilink::memory::SafeDataBuffer from_str(std::string("hello"));
 
 // Read access
 auto span = from_vec.as_span();      // Non-owning view
@@ -132,9 +130,7 @@ Lightweight, non-owning view of contiguous data:
 ```cpp
 #include "unilink/memory/safe_span.hpp"
 
-using namespace unilink::common;
-
-void process_data(safe_span<const uint8_t> data) {
+void process_data(unilink::memory::ConstByteSpan data) {
     // Iteration (operator[] is unchecked)
     for (size_t i = 0; i < data.size(); i++) {
         uint8_t byte = data[i];
@@ -147,7 +143,7 @@ void process_data(safe_span<const uint8_t> data) {
 
 // Usage
 std::vector<uint8_t> buffer = {1, 2, 3, 4, 5};
-process_data(safe_span<const uint8_t>(buffer));
+process_data(unilink::memory::ConstByteSpan(buffer));
 ```
 
 **Features:**
@@ -168,8 +164,6 @@ Read-write lock based state management:
 ```cpp
 #include "unilink/concurrency/thread_safe_state.hpp"
 
-using namespace unilink::common;
-
 enum class ConnectionState {
     Closed,
     Connecting,
@@ -177,7 +171,7 @@ enum class ConnectionState {
     Error
 };
 
-ThreadSafeState<ConnectionState> state(ConnectionState::Closed);
+unilink::concurrency::ThreadSafeState<ConnectionState> state(ConnectionState::Closed);
 
 // Thread 1: Write
 state.set_state(ConnectionState::Connecting);
@@ -295,17 +289,16 @@ Monitor all memory allocations and deallocations:
 ```cpp
 #include "unilink/memory/memory_tracker.hpp"
 
-using namespace unilink::common;
-
 // Tracking happens automatically
 auto* data = new uint8_t[1024];  // Tracked
 delete[] data;  // Tracked
 
 // Query statistics
-MemoryTracker::Stats stats = MemoryTracker::instance().get_stats();
+unilink::memory::MemoryTracker::MemoryStats stats =
+    unilink::memory::MemoryTracker::instance().get_stats();
 std::cout << "Total allocations: " << stats.total_allocations << std::endl;
 std::cout << "Total deallocations: " << stats.total_deallocations << std::endl;
-std::cout << "Current usage: " << stats.current_usage << " bytes" << std::endl;
+std::cout << "Current usage: " << stats.current_bytes_allocated << " bytes" << std::endl;
 ```
 
 ---
@@ -316,7 +309,7 @@ Identify potential memory leaks:
 
 ```cpp
 // At program exit, check for leaks
-MemoryTracker::Stats stats = MemoryTracker::instance().get_stats();
+auto stats = unilink::memory::MemoryTracker::instance().get_stats();
 
 if (stats.total_allocations != stats.total_deallocations) {
     size_t leaked = stats.total_allocations - stats.total_deallocations;

--- a/docs/architecture/memory_safety.md
+++ b/docs/architecture/memory_safety.md
@@ -634,7 +634,7 @@ All memory safety features are tested in CI/CD:
 - ✅ ThreadSanitizer enabled (selected tests)
 - ✅ Valgrind memcheck
 
-See [Testing Guide](../guides/testing.md) for details.
+See [Testing Guide](../guides/core/testing.md) for details.
 
 ---
 
@@ -642,5 +642,5 @@ See [Testing Guide](../guides/testing.md) for details.
 
 - [Runtime Behavior](runtime_behavior.md) - Threading and execution model
 - [System Overview](README.md) - High-level architecture
-- [Testing Guide](../guides/testing.md) - Memory safety testing
-- [Best Practices](../guides/best_practices.md) - Safe coding patterns
+- [Testing Guide](../guides/core/testing.md) - Memory safety testing
+- [Best Practices](../guides/core/best_practices.md) - Safe coding patterns

--- a/docs/architecture/runtime_behavior.md
+++ b/docs/architecture/runtime_behavior.md
@@ -577,5 +577,5 @@ Backpressure handling ensures:
 
 - [Memory Safety](memory_safety.md) - Memory safety features
 - [System Overview](README.md) - High-level architecture
-- [Performance Guide](../guides/performance.md) - Optimization techniques
-- [Best Practices](../guides/best_practices.md) - Recommended patterns
+- [Performance Guide](../guides/advanced/performance.md) - Optimization techniques
+- [Best Practices](../guides/core/best_practices.md) - Recommended patterns

--- a/docs/architecture/runtime_behavior.md
+++ b/docs/architecture/runtime_behavior.md
@@ -72,10 +72,10 @@ std::thread t3([&client]() { client->stop(); });
 
 ```cpp
 auto client = unilink::tcp_client("server.com", 8080)
-    .on_data([](const std::string& data) {
+    .on_data([](const unilink::MessageContext& ctx) {
         // ⚠️ This runs in the I/O thread!
         // Don't block here!
-        std::cout << "Received: " << data << std::endl;
+        std::cout << "Received: " << ctx.data() << std::endl;
     })
     .build();
 ```
@@ -86,7 +86,6 @@ auto client = unilink::tcp_client("server.com", 8080)
 - `on_disconnect()` - Connection lost
 - `on_data()` - Data received
 - `on_error()` - Error occurred
-- `on_backpressure()` - Queue size exceeded threshold
 
 ---
 
@@ -95,27 +94,28 @@ auto client = unilink::tcp_client("server.com", 8080)
 **Bad - Blocks I/O thread:**
 
 ```cpp
-.on_data([](const std::string& data) {
+.on_data([](const unilink::MessageContext& ctx) {
     // ❌ BAD: Blocks I/O thread
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    heavy_computation(data);
-    database_query(data);  // Blocking I/O
+    heavy_computation(ctx.data());
+    database_query(ctx.data());  // Blocking I/O
 })
 ```
 
 **Good - Offload to worker threads:**
 
 ```cpp
-.on_data([](const std::string& data) {
+.on_data([](const unilink::MessageContext& ctx) {
     // ✅ GOOD: Offload to worker thread
-    std::thread([data]() {
-        heavy_computation(data);
-        database_query(data);
+    std::string payload(ctx.data());
+    std::thread([payload]() {
+        heavy_computation(payload);
+        database_query(payload);
     }).detach();
 
     // Or use a thread pool
-    thread_pool.submit([data]() {
-        heavy_computation(data);
+    thread_pool.submit([payload]() {
+        heavy_computation(payload);
     });
 })
 ```
@@ -211,10 +211,10 @@ stateDiagram-v2
 ```cpp
 auto client = unilink::tcp_client("server.com", 8080)
     .retry_interval(5000)    // Retry every 5 seconds
-    .on_connect([]() {
+    .on_connect([](const unilink::ConnectionContext&) {
         std::cout << "Connected!" << std::endl;
     })
-    .on_disconnect([]() {
+    .on_disconnect([](const unilink::ConnectionContext&) {
         std::cout << "Disconnected - will auto-reconnect" << std::endl;
     })
     .build();
@@ -255,17 +255,17 @@ Monitor connection state changes:
 
 ```cpp
 auto client = unilink::tcp_client("server.com", 8080)
-    .on_connect([]() {
+    .on_connect([](const unilink::ConnectionContext&) {
         // Connection established
         std::cout << "✅ Connected" << std::endl;
     })
-    .on_disconnect([]() {
+    .on_disconnect([](const unilink::ConnectionContext&) {
         // Connection lost (will auto-reconnect)
         std::cout << "❌ Disconnected" << std::endl;
     })
-    .on_error([](const std::string& error) {
+    .on_error([](const unilink::ErrorContext& ctx) {
         // Error occurred
-        std::cout << "⚠️ Error: " << error << std::endl;
+        std::cout << "⚠️ Error: " << ctx.message() << std::endl;
     })
     .build();
 ```
@@ -340,7 +340,7 @@ client.reset();
 
 ## Backpressure Handling
 
-When the send queue grows too large (network slower than application), `unilink` notifies your application via backpressure callbacks. If a safety cap is exceeded, the transport closes the socket, clears the queue, and transitions to `Error`.
+When the send queue grows too large (network slower than application), `unilink` applies internal backpressure protection in the transport layer. The public wrapper/builder API does not currently expose an `on_backpressure()` callback, so applications should implement rate limiting and queue monitoring at the application level and react to send failures or error callbacks.
 
 ### Backpressure Flow
 
@@ -352,8 +352,8 @@ flowchart TD
     Check -->|No| Write[Continue Normal Write]
     Write --> Complete([Data Sent])
 
-    Check -->|Yes: queue_bytes > 1MB| Callback[Trigger on_backpressure callback]
-    Callback --> AppDecision{Application Decision}
+    Check -->|Yes: queue_bytes > 1MB| Protect[Internal backpressure protection]
+    Protect --> AppDecision{Application Decision}
 
     AppDecision -->|Pause Sending| Wait[Wait for queue to drain]
     AppDecision -->|Rate Limit| Throttle[Reduce send rate]
@@ -369,7 +369,7 @@ flowchart TD
     Force --> Write
     Resume --> Complete
 
-    style Callback fill:#f9f,stroke:#333,stroke-width:2px
+    style Protect fill:#f9f,stroke:#333,stroke-width:2px
     style AppDecision fill:#ff9,stroke:#333,stroke-width:2px
     style Force fill:#f66,stroke:#333,stroke-width:2px
 ```
@@ -378,17 +378,7 @@ flowchart TD
 
 ### Backpressure Configuration
 
-```cpp
-auto client = unilink::tcp_client("server.com", 8080)
-    .on_backpressure([](size_t queue_bytes) {
-        std::cout << "⚠️ Queue size: " << queue_bytes << " bytes" << std::endl;
-
-        // Option 1: Pause sending
-        // Option 2: Rate limit
-        // Option 3: Drop non-critical data
-    })
-    .build();
-```
+Use transport-layer configuration if you need direct queue-threshold control. At the wrapper level, keep your own send budget and stop producing data when downstream systems slow down.
 
 **Default threshold:** 1 MB (1,048,576 bytes)  
 **Configurable range:** 1 KB - 100 MB  
@@ -404,20 +394,11 @@ Stop sending until queue drains:
 
 ```cpp
 std::atomic<bool> can_send{true};
+std::atomic<size_t> queued_messages{0};
 
-auto client = unilink::tcp_client("server.com", 8080)
-    .on_backpressure([&can_send](size_t queue_bytes) {
-        if (queue_bytes > 5 * 1024 * 1024) {  // 5 MB
-            can_send = false;
-        } else if (queue_bytes < 1024 * 1024) {  // 1 MB
-            can_send = true;
-        }
-    })
-    .build();
-
-// Application code
-if (can_send) {
+if (queued_messages.load() < 1000 && can_send.load()) {
     client->send(data);
+    queued_messages.fetch_add(1);
 }
 ```
 
@@ -430,12 +411,10 @@ if (can_send) {
 Reduce send rate:
 
 ```cpp
-auto client = unilink::tcp_client("server.com", 8080)
-    .on_backpressure([](size_t queue_bytes) {
-        // Slow down sending
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    })
-    .build();
+for (const auto& packet : packets) {
+    client->send(packet);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
 ```
 
 **Best for:** Continuous data streams
@@ -447,16 +426,9 @@ auto client = unilink::tcp_client("server.com", 8080)
 Skip non-critical data:
 
 ```cpp
-std::atomic<bool> high_backpressure{false};
+std::atomic<bool> degraded_mode{false};
 
-auto client = unilink::tcp_client("server.com", 8080)
-    .on_backpressure([&high_backpressure](size_t queue_bytes) {
-        high_backpressure = (queue_bytes > 10 * 1024 * 1024);  // 10 MB
-    })
-    .build();
-
-// Send only critical data when backpressure is high
-if (!high_backpressure || is_critical) {
+if (!degraded_mode.load() || is_critical) {
     client->send(data);
 }
 ```
@@ -470,15 +442,17 @@ if (!high_backpressure || is_critical) {
 Track queue size continuously:
 
 ```cpp
-size_t max_queue_size = 0;
+size_t sent_messages = 0;
+size_t dropped_messages = 0;
 
-auto client = unilink::tcp_client("server.com", 8080)
-    .on_backpressure([&max_queue_size](size_t queue_bytes) {
-        max_queue_size = std::max(max_queue_size, queue_bytes);
-        std::cout << "Current queue: " << queue_bytes
-                  << " bytes, Max: " << max_queue_size << " bytes\n";
-    })
-    .build();
+for (const auto& packet : packets) {
+    if (should_send(packet)) {
+        client->send(packet);
+        ++sent_messages;
+    } else {
+        ++dropped_messages;
+    }
+}
 ```
 
 ---
@@ -488,9 +462,9 @@ auto client = unilink::tcp_client("server.com", 8080)
 Backpressure handling ensures:
 
 - ✅ Queue size is monitored continuously
-- ✅ Callback fires when `queue_bytes > threshold`
-- ✅ Application can take corrective action
-- ⚠️ **No automatic flow control** - application must handle backpressure
+- ✅ Queue growth is bounded internally in the transport layer
+- ✅ Applications can add their own send throttling policy
+- ⚠️ Wrapper-level backpressure callbacks are not part of the current public API
 - ✅ Memory pools reduce allocation overhead for small buffers (<64KB)
 
 ---

--- a/docs/guides/advanced/performance.md
+++ b/docs/guides/advanced/performance.md
@@ -98,11 +98,11 @@ Logging can be a major bottleneck. Enable async logging for high-performance app
 
 ```cpp
 // ✅ GOOD: Async logging (non-blocking)
-unilink::common::AsyncLogConfig config;
+unilink::diagnostics::AsyncLogConfig config;
 config.batch_size = 1000;
 config.flush_interval = std::chrono::milliseconds(1000);
 
-unilink::common::Logger::instance().set_async_logging(true, config);
+unilink::diagnostics::Logger::instance().set_async_logging(true, config);
 ```
 
 **Impact**: 10-100x faster logging throughput.

--- a/docs/guides/advanced/performance.md
+++ b/docs/guides/advanced/performance.md
@@ -113,15 +113,16 @@ Never perform heavy computation or blocking operations (like `sleep`) inside cal
 
 ```cpp
 // ❌ BAD: Blocking I/O thread
-.on_data([](const std::string& data) {
+.on_data([](const unilink::MessageContext& ctx) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    process_data(data);
+    process_data(ctx.data());
 })
 
 // ✅ GOOD: Offload to worker thread/pool
-.on_data([&thread_pool](const std::string& data) {
-    thread_pool.submit([data]() {
-        process_data(data);
+.on_data([&thread_pool](const unilink::MessageContext& ctx) {
+    std::string payload(ctx.data());
+    thread_pool.submit([payload = std::move(payload)]() {
+        process_data(payload);
     });
 })
 ```

--- a/docs/guides/core/best_practices.md
+++ b/docs/guides/core/best_practices.md
@@ -80,8 +80,8 @@ auto client = unilink::tcp_client("server.com", 8080)
 ```cpp
 // GOOD - Centralized error management
 void setup_error_handler() {
-    unilink::common::ErrorHandler::instance()
-        .register_callback([](const ErrorInfo& error) {
+    unilink::diagnostics::ErrorHandler::instance()
+        .register_callback([](const unilink::diagnostics::ErrorInfo& error) {
             // Log to file
             log_to_file(error);
             
@@ -287,8 +287,9 @@ client->send(large_data);  // Copy entire string
 
 ```cpp
 // GOOD - Async logging for performance
-unilink::common::Logger::instance().enable_async(true);
-unilink::common::Logger::instance().set_batch_size(100);
+unilink::diagnostics::AsyncLogConfig config;
+config.batch_size = 100;
+unilink::diagnostics::Logger::instance().set_async_logging(true, config);
 
 // Now logging is non-blocking
 logger.info("component", "operation", "message");  // Fast!
@@ -598,11 +599,11 @@ logger.error("client", "connect", "Connected to server");  // Not an error!
 ```cpp
 // GOOD - Debug mode for development
 #ifdef DEBUG
-    unilink::common::Logger::instance().set_level(LogLevel::DEBUG);
-    unilink::common::ErrorHandler::instance().set_min_error_level(ErrorLevel::INFO);
+    unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::DEBUG);
+    unilink::diagnostics::ErrorHandler::instance().set_min_error_level(unilink::diagnostics::ErrorLevel::INFO);
 #else
-    unilink::common::Logger::instance().set_level(LogLevel::WARNING);
-    unilink::common::ErrorHandler::instance().set_min_error_level(ErrorLevel::WARNING);
+    unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::WARNING);
+    unilink::diagnostics::ErrorHandler::instance().set_min_error_level(unilink::diagnostics::ErrorLevel::WARNING);
 #endif
 ```
 

--- a/docs/guides/core/best_practices.md
+++ b/docs/guides/core/best_practices.md
@@ -24,8 +24,8 @@ Learn the recommended patterns and practices for using unilink effectively.
 ```cpp
 // GOOD
 auto client = unilink::tcp_client("server.com", 8080)
-    .on_error([](const std::string& error) {
-        log_error("TCP Client", error);
+    .on_error([](const unilink::ErrorContext& ctx) {
+        log_error("TCP Client", std::string(ctx.message()));
         // Handle error appropriately
     })
     .build();
@@ -54,11 +54,11 @@ client->send("Hello");  // May fail silently
 ```cpp
 // GOOD - Graceful recovery
 auto client = unilink::tcp_client("server.com", 8080)
-    .on_error([this](const std::string& error) {
-        log_error(error);
+    .on_error([this](const unilink::ErrorContext& ctx) {
+        log_error(std::string(ctx.message()));
         
         // Categorize error
-        if (is_retryable(error)) {
+        if (is_retryable(ctx.code())) {
             schedule_retry();
         } else {
             notify_user("Connection failed permanently");
@@ -69,8 +69,8 @@ auto client = unilink::tcp_client("server.com", 8080)
 
 // BAD - No recovery strategy
 auto client = unilink::tcp_client("server.com", 8080)
-    .on_error([](const std::string& error) {
-        std::cerr << error << std::endl;  // Just print and hope
+    .on_error([](const unilink::ErrorContext& ctx) {
+        std::cerr << ctx.message() << std::endl;  // Just print and hope
     })
     .build();
 ```
@@ -89,7 +89,7 @@ void setup_error_handler() {
             send_to_monitoring(error);
             
             // Alert on critical
-            if (error.level == ErrorLevel::CRITICAL) {
+            if (error.level == unilink::diagnostics::ErrorLevel::CRITICAL) {
                 send_alert(error);
             }
         });
@@ -130,7 +130,7 @@ delete client;   // Must remember to delete
 ```cpp
 // GOOD - Graceful shutdown
 class Application {
-    std::shared_ptr<unilink::wrapper::TcpClient> client_;
+    std::unique_ptr<unilink::wrapper::TcpClient> client_;
     
     ~Application() {
         shutdown();
@@ -148,7 +148,7 @@ class Application {
 
 // BAD - Abrupt shutdown
 class Application {
-    std::shared_ptr<unilink::wrapper::TcpClient> client_;
+    std::unique_ptr<unilink::wrapper::TcpClient> client_;
     
     ~Application() {
         // client_ destroyed abruptly
@@ -165,7 +165,7 @@ class Application {
 ```cpp
 // GOOD - Reuse connection
 class DataSender {
-    std::shared_ptr<unilink::wrapper::TcpClient> client_;
+    std::unique_ptr<unilink::wrapper::TcpClient> client_;
     
     void send_multiple_messages() {
         for (const auto& msg : messages) {
@@ -225,14 +225,14 @@ class Server {
 #include "unilink/concurrency/thread_safe_state.hpp"
 
 class Connection {
-    unilink::common::ThreadSafeState<State> state_;
+    unilink::concurrency::ThreadSafeState<State> state_;
     
     void set_state(State new_state) {
-        state_.set(new_state);  // Thread-safe
+        state_.set_state(new_state);  // Thread-safe
     }
     
     State get_state() const {
-        return state_.get();  // Thread-safe
+        return state_.get_state();  // Thread-safe
     }
 };
 ```
@@ -242,18 +242,18 @@ class Connection {
 ```cpp
 // BAD - Blocking in callback
 auto client = tcp_client("server.com", 8080)
-    .on_data([](const std::string& data) {
+    .on_data([](const unilink::MessageContext& ctx) {
         // This blocks the I/O thread!
         std::this_thread::sleep_for(std::chrono::seconds(10));
-        process_data(data);
+        process_data(ctx.data());
     })
     .build();
 
 // GOOD - Process asynchronously
 auto client = tcp_client("server.com", 8080)
-    .on_data([this](const std::string& data) {
+    .on_data([this](const unilink::MessageContext& ctx) {
         // Queue for processing in another thread
-        message_queue_.push(data);
+        message_queue_.push(std::string(ctx.data()));
     })
     .build();
 
@@ -351,29 +351,29 @@ for (const auto& msg : small_messages) {
 // GOOD - Organized in a class
 class ChatClient {
 private:
-    std::shared_ptr<unilink::wrapper::TcpClient> client_;
+    std::unique_ptr<unilink::wrapper::TcpClient> client_;
     std::string nickname_;
     
 public:
     void connect(const std::string& server, uint16_t port) {
         client_ = unilink::tcp_client(server, port)
-            .on_connect([this]() { handle_connect(); })
-            .on_data([this](const std::string& data) { handle_data(data); })
-            .on_disconnect([this]() { handle_disconnect(); })
+            .on_connect([this](const unilink::ConnectionContext&) { handle_connect(); })
+            .on_data([this](const unilink::MessageContext& ctx) { handle_data(ctx.data()); })
+            .on_disconnect([this](const unilink::ConnectionContext&) { handle_disconnect(); })
             .build();
     }
     
 private:
     void handle_connect() { /* ... */ }
-    void handle_data(const std::string& data) { /* ... */ }
+    void handle_data(std::string_view data) { /* ... */ }
     void handle_disconnect() { /* ... */ }
 };
 
 // BAD - Everything in main()
 int main() {
     auto client = tcp_client("server.com", 8080)
-        .on_connect([]() { /* 100 lines of code */ })
-        .on_data([](const std::string& data) { /* 200 lines */ })
+        .on_connect([](const unilink::ConnectionContext&) { /* 100 lines of code */ })
+        .on_data([](const unilink::MessageContext& ctx) { /* 200 lines */ })
         .build();
     // Hard to maintain!
 }
@@ -397,8 +397,8 @@ class Application {
     MessageHandler handler_;
     
     void start() {
-        network_.on_data([this](const std::string& msg) {
-            handler_.process_message(msg);  // Delegate
+        network_.on_data([this](const unilink::MessageContext& ctx) {
+            handler_.process_message(std::string(ctx.data()));  // Delegate
         });
     }
 };
@@ -406,7 +406,7 @@ class Application {
 // BAD - Mixed concerns
 class Application {
     void start() {
-        client_->on_data([](const std::string& msg) {
+        client_->on_data([](const unilink::MessageContext& ctx) {
             // Network logic
             // Business logic
             // UI logic
@@ -457,7 +457,7 @@ TEST(ClientTest, HandlesConnectionError) {
     bool error_received = false;
     
     auto client = tcp_client("invalid.server", 9999)
-        .on_error([&](const std::string& error) {
+        .on_error([&](const unilink::ErrorContext& ctx) {
             error_received = true;
         })
         .build();
@@ -543,13 +543,13 @@ class RateLimiter {
 };
 
 // Use in server
-server_->on_data([this, limiter](size_t id, const std::string& data) {
-    if (!limiter->is_allowed(id)) {
-        log_warning("Rate limit exceeded for client " + std::to_string(id));
+server_->on_data([this, limiter](const unilink::MessageContext& ctx) {
+    if (!limiter->is_allowed(ctx.client_id())) {
+        log_warning("Rate limit exceeded for client " + std::to_string(ctx.client_id()));
         return;
     }
     
-    process_data(id, data);
+    process_data(ctx.client_id(), std::string(ctx.data()));
 });
 ```
 
@@ -561,10 +561,10 @@ class Server {
     const size_t max_clients_{100};
     std::atomic<size_t> current_clients_{0};
     
-    void on_connect(size_t id, const std::string& ip) {
+    void on_connect(const unilink::ConnectionContext& ctx) {
         if (current_clients_ >= max_clients_) {
-            log_warning("Max clients reached, rejecting " + ip);
-            server_->send_to_client(id, "Server full\n");
+            log_warning("Max clients reached, rejecting " + ctx.client_info());
+            server_->send_to(ctx.client_id(), "Server full\n");
             // Disconnect client
             return;
         }

--- a/docs/guides/core/quickstart.md
+++ b/docs/guides/core/quickstart.md
@@ -138,6 +138,7 @@ client->start();  // Will automatically reconnect on disconnect
 ### Pattern 2: Error Handling
 ```cpp
 auto server = unilink::tcp_server(8080)
+    .unlimited_clients()
     .on_error([](const unilink::ErrorContext& ctx) {
         std::cerr << "Error: " << ctx.message() << std::endl;
     })
@@ -196,6 +197,7 @@ unilink::diagnostics::Logger::instance().set_console_output(true);
 ### Port already in use?
 ```cpp
 auto server = unilink::tcp_server(8080)
+    .unlimited_clients()
     .enable_port_retry(true, 5, 1000)  // Try 5 times
     .build();
 ```

--- a/docs/guides/core/quickstart.md
+++ b/docs/guides/core/quickstart.md
@@ -177,7 +177,7 @@ auto server = unilink::tcp_server(8080)
 
 ## Next Steps
 
-1. **Read the API Guide**: `docs/reference/API_GUIDE.md`
+1. **Read the API Guide**: `docs/reference/api_guide.md`
 2. **Check Examples**: `examples/` directory
 3. **Run Tests**: `cd build && ctest`
 4. **View Full Docs**: `docs/html/index.html` (run `make docs` first)
@@ -189,8 +189,8 @@ auto server = unilink::tcp_server(8080)
 ### Can't connect to server?
 ```cpp
 // Enable logging to see what's happening
-unilink::common::Logger::instance().set_level(unilink::common::LogLevel::DEBUG);
-unilink::common::Logger::instance().set_console_output(true);
+unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::DEBUG);
+unilink::diagnostics::Logger::instance().set_console_output(true);
 ```
 
 ### Port already in use?

--- a/docs/guides/core/testing.md
+++ b/docs/guides/core/testing.md
@@ -719,7 +719,7 @@ xdg-open coverage_html/index.html
 
 ## Next Steps
 
-- [Performance Optimization](performance.md) - Optimize your tests
+- [Performance Optimization](../advanced/performance.md) - Optimize your tests
 - [Best Practices](best_practices.md) - Testing best practices
-- [Build Guide](build_guide.md) - Build options for testing
+- [Build Guide](../setup/build_guide.md) - Build options for testing
 - [Troubleshooting](troubleshooting.md) - Common test issues

--- a/docs/guides/core/testing.md
+++ b/docs/guides/core/testing.md
@@ -515,15 +515,15 @@ TEST(CustomTest, ClientServerCommunication) {
     // Create server
     auto server = unilink::tcp_server(8080)
         .unlimited_clients()
-        .on_accept([](const std::string& client_id) {
-            std::cout << "Client connected: " << client_id << std::endl;
+        .on_connect([](const unilink::ConnectionContext& ctx) {
+            std::cout << "Client connected: " << ctx.client_id() << std::endl;
         })
-        .on_data([&received_data](const std::string& data) {
-            received_data = data;
+        .on_data([&received_data](const unilink::MessageContext& ctx) {
+            received_data = std::string(ctx.data());
         })
         .build();
     
-    server->start();
+    ASSERT_TRUE(server->start().get());
     server_ready = true;
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     
@@ -531,7 +531,7 @@ TEST(CustomTest, ClientServerCommunication) {
     auto client = unilink::tcp_client("127.0.0.1", 8080)
         .build();
     
-    client->start();
+    ASSERT_TRUE(client->start().get());
     
     // Wait for connection
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/docs/guides/core/troubleshooting.md
+++ b/docs/guides/core/troubleshooting.md
@@ -631,16 +631,16 @@ unilink::common::ThreadSafeState<State> state_;
 // In main() or initialization
 void setup_debugging() {
     // Set debug log level
-    unilink::common::Logger::instance().set_level(unilink::common::LogLevel::DEBUG);
-    unilink::common::Logger::instance().set_console_output(true);
-    unilink::common::Logger::instance().set_file_output("debug.log");
+    unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::DEBUG);
+    unilink::diagnostics::Logger::instance().set_console_output(true);
+    unilink::diagnostics::Logger::instance().set_file_output("debug.log");
     
     // Enable error handler
-    unilink::common::ErrorHandler::instance().set_min_error_level(
-        unilink::common::ErrorLevel::INFO
+    unilink::diagnostics::ErrorHandler::instance().set_min_error_level(
+        unilink::diagnostics::ErrorLevel::INFO
     );
-    unilink::common::ErrorHandler::instance().register_callback(
-        [](const unilink::common::ErrorInfo& error) {
+    unilink::diagnostics::ErrorHandler::instance().register_callback(
+        [](const unilink::diagnostics::ErrorInfo& error) {
             std::cerr << "[ERROR] " << error.get_summary() << std::endl;
         }
     );
@@ -700,7 +700,7 @@ nc localhost 8080 < test_data.txt
 If you're still experiencing issues:
 
 1. **Check Examples**: Look at `examples/` directory
-2. **Read API Guide**: See `docs/reference/API_GUIDE.md`
+2. **Read API Guide**: See `docs/reference/api_guide.md`
 3. **Search Issues**: https://github.com/jwsung91/unilink/issues
 4. **Ask Community**: Create a new issue with:
    - Minimal reproducible example
@@ -712,5 +712,5 @@ If you're still experiencing issues:
 
 **See Also:**
 - [Best Practices](best_practices.md)
-- [Performance Tuning](performance_tuning.md)
-- [API Reference](../reference/API_GUIDE.md)
+- [Performance Guide](../advanced/performance.md)
+- [API Reference](../reference/api_guide.md)

--- a/docs/guides/core/troubleshooting.md
+++ b/docs/guides/core/troubleshooting.md
@@ -21,6 +21,7 @@ Common issues and solutions when using unilink.
 ### Problem: Connection Refused
 
 **Symptoms:**
+
 ```
 ✗ Error: Connection refused
 ```
@@ -28,6 +29,7 @@ Common issues and solutions when using unilink.
 **Possible Causes & Solutions:**
 
 #### 1. Server Not Running
+
 ```bash
 # Check if server is running
 netstat -an | grep 8080
@@ -38,6 +40,7 @@ lsof -i :8080
 **Solution:** Start the server before connecting client.
 
 #### 2. Wrong Host/Port
+
 ```cpp
 // Check your configuration
 auto client = tcp_client("127.0.0.1", 8080)  // Correct port?
@@ -47,6 +50,7 @@ auto client = tcp_client("127.0.0.1", 8080)  // Correct port?
 **Solution:** Verify server address and port number.
 
 #### 3. Firewall Blocking
+
 ```bash
 # Check firewall rules (Linux)
 sudo iptables -L | grep 8080
@@ -60,6 +64,7 @@ sudo ufw allow 8080
 ### Problem: Connection Timeout
 
 **Symptoms:**
+
 ```
 ✗ Error: Connection timeout
 ```
@@ -67,6 +72,7 @@ sudo ufw allow 8080
 **Possible Causes & Solutions:**
 
 #### 1. Network Unreachable
+
 ```bash
 # Test connectivity
 ping server.com
@@ -76,7 +82,9 @@ telnet server.com 8080
 **Solution:** Check network connectivity, DNS resolution.
 
 #### 2. Server Overloaded
+
 **Solution:** Increase retry interval:
+
 ```cpp
 auto client = tcp_client("server.com", 8080)
     .retry_interval(10000)  // Wait 10 seconds
@@ -84,7 +92,9 @@ auto client = tcp_client("server.com", 8080)
 ```
 
 #### 3. Slow Network
+
 **Solution:** Increase timeout (requires custom implementation):
+
 ```cpp
 // Set socket options for longer timeout
 boost::asio::socket_base::linger option(true, 30);
@@ -96,26 +106,29 @@ socket.set_option(option);
 ### Problem: Connection Drops Randomly
 
 **Symptoms:**
+
 - Client disconnects unexpectedly
 - `on_disconnect()` called without `stop()`
 
 **Possible Causes & Solutions:**
 
 #### 1. Network Instability
+
 ```cpp
 // Enable auto-reconnection
 auto client = tcp_client("server.com", 8080)
     .retry_interval(3000)  // Retry every 3 seconds
-    .on_disconnect([]() {
+    .on_disconnect([](const unilink::ConnectionContext&) {
         log_info("Disconnected, will auto-retry");
     })
     .build();
 ```
 
 #### 2. Server Closing Connection
+
 ```cpp
 // Log disconnect reason
-.on_disconnect([this]() {
+.on_disconnect([this](const unilink::ConnectionContext&) {
     // Check if stop() was called
     if (!intentional_disconnect_) {
         log_warning("Unexpected disconnect from server");
@@ -124,6 +137,7 @@ auto client = tcp_client("server.com", 8080)
 ```
 
 #### 3. Keep-Alive Not Set
+
 ```cpp
 // Implement heartbeat
 std::thread heartbeat_thread([this]() {
@@ -141,6 +155,7 @@ std::thread heartbeat_thread([this]() {
 ### Problem: Port Already in Use
 
 **Symptoms:**
+
 ```
 ✗ Error: Address already in use
 ```
@@ -148,6 +163,7 @@ std::thread heartbeat_thread([this]() {
 **Solutions:**
 
 #### 1. Kill Existing Process
+
 ```bash
 # Find process using port
 lsof -i :8080
@@ -159,19 +175,24 @@ kill -9 <PID>
 ```
 
 #### 2. Use Different Port
+
 ```cpp
 auto server = tcp_server(8081)  // Try different port
+    .unlimited_clients()
     .build();
 ```
 
 #### 3. Enable Port Retry
+
 ```cpp
 auto server = tcp_server(8080)
+    .unlimited_clients()
     .enable_port_retry(true, 5, 1000)  // Retry 5 times
     .build();
 ```
 
 #### 4. Set SO_REUSEADDR (Advanced)
+
 ```cpp
 // Allow immediate port reuse
 boost::asio::socket_base::reuse_address option(true);
@@ -185,6 +206,7 @@ acceptor.set_option(option);
 ### Problem: unilink/unilink.hpp Not Found
 
 **Symptoms:**
+
 ```
 fatal error: unilink/unilink.hpp: No such file or directory
 ```
@@ -192,13 +214,15 @@ fatal error: unilink/unilink.hpp: No such file or directory
 **Solutions:**
 
 #### 1. Install unilink
+
 ```bash
-cd interface-socket
+cd unilink
 cmake -S . -B build
 sudo cmake --install build
 ```
 
 #### 2. Add Include Path
+
 ```bash
 # CMake
 target_include_directories(your_app PRIVATE /path/to/unilink/include)
@@ -208,6 +232,7 @@ g++ -I/path/to/unilink/include ...
 ```
 
 #### 3. Use as Subdirectory
+
 ```cmake
 # CMakeLists.txt
 add_subdirectory(unilink)
@@ -219,6 +244,7 @@ target_link_libraries(your_app PRIVATE unilink)
 ### Problem: Undefined Reference to unilink Symbols
 
 **Symptoms:**
+
 ```
 undefined reference to `unilink::tcp_client(std::string const&, unsigned short)'
 ```
@@ -226,6 +252,7 @@ undefined reference to `unilink::tcp_client(std::string const&, unsigned short)'
 **Solutions:**
 
 #### 1. Link unilink Library
+
 ```bash
 # g++
 g++ main.cpp -o app -lunilink -lboost_system -pthread
@@ -235,6 +262,7 @@ target_link_libraries(your_app PRIVATE unilink Boost::system pthread)
 ```
 
 #### 2. Check Library Path
+
 ```bash
 # Add to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
@@ -249,6 +277,7 @@ sudo ldconfig
 ### Problem: Boost Not Found
 
 **Symptoms:**
+
 ```
 CMake Error: Could not find Boost
 ```
@@ -256,21 +285,25 @@ CMake Error: Could not find Boost
 **Solutions:**
 
 #### Ubuntu/Debian
+
 ```bash
 sudo apt install libboost-all-dev
 ```
 
 #### macOS
+
 ```bash
 brew install boost
 ```
 
 #### Windows (vcpkg)
+
 ```bash
 vcpkg install boost
 ```
 
 #### Manual Boost Path
+
 ```cmake
 set(BOOST_ROOT /path/to/boost)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -283,6 +316,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 ### Problem: Segmentation Fault
 
 **Symptoms:**
+
 ```
 Segmentation fault (core dumped)
 ```
@@ -290,6 +324,7 @@ Segmentation fault (core dumped)
 **Debugging Steps:**
 
 #### 1. Enable Core Dumps
+
 ```bash
 ulimit -c unlimited
 ./your_app
@@ -301,6 +336,7 @@ gdb ./your_app core
 ```
 
 #### 2. Use AddressSanitizer
+
 ```bash
 # Compile with sanitizer
 cmake -DUNILINK_ENABLE_SANITIZERS=ON ..
@@ -314,6 +350,7 @@ cmake --build .
 #### 3. Common Causes
 
 **Dangling Pointer:**
+
 ```cpp
 // BAD
 auto* client = client_ptr.get();
@@ -326,6 +363,7 @@ client->send("data");
 ```
 
 **Use After Stop:**
+
 ```cpp
 // BAD
 client->stop();
@@ -342,12 +380,14 @@ if (client->is_connected()) {
 ### Problem: Callbacks Not Being Called
 
 **Symptoms:**
+
 - `on_connect()` never called
 - `on_data()` not receiving data
 
 **Possible Causes & Solutions:**
 
 #### 1. Callback Not Registered
+
 ```cpp
 // BAD - Forgot to register callback
 auto client = tcp_client("server.com", 8080)
@@ -355,13 +395,14 @@ auto client = tcp_client("server.com", 8080)
 
 // GOOD
 auto client = tcp_client("server.com", 8080)
-    .on_data([](const std::string& data) {
-        std::cout << data << std::endl;
+    .on_data([](const unilink::MessageContext& ctx) {
+        std::cout << ctx.data() << std::endl;
     })
     .build();
 ```
 
 #### 2. Client Not Started
+
 ```cpp
 // BAD - Forgot to start
 auto client = tcp_client("server.com", 8080)
@@ -375,11 +416,12 @@ client->start();  // Start the connection
 ```
 
 #### 3. Application Exits Too Quickly
+
 ```cpp
 // BAD
 int main() {
     auto client = tcp_client("server.com", 8080)
-        .on_connect([]() { std::cout << "Connected!\n"; })
+        .on_connect([](const unilink::ConnectionContext&) { std::cout << "Connected!\n"; })
         .build();
     client->start();
     
@@ -389,7 +431,7 @@ int main() {
 // GOOD
 int main() {
     auto client = tcp_client("server.com", 8080)
-        .on_connect([]() { std::cout << "Connected!\n"; })
+        .on_connect([](const unilink::ConnectionContext&) { std::cout << "Connected!\n"; })
         .build();
     client->start();
     
@@ -405,27 +447,30 @@ int main() {
 ### Problem: High CPU Usage
 
 **Symptoms:**
+
 - Process using 100% CPU
 - System becomes slow
 
 **Possible Causes & Solutions:**
 
 #### 1. Busy Loop in Callback
+
 ```cpp
 // BAD - Blocks I/O thread
-.on_data([](const std::string& data) {
+.on_data([](const unilink::MessageContext& ctx) {
     while (processing) {  // Busy loop!
         process();
     }
 })
 
 // GOOD - Process asynchronously
-.on_data([this](const std::string& data) {
-    message_queue_.push(data);  // Queue for processing
+.on_data([this](const unilink::MessageContext& ctx) {
+    message_queue_.push(std::string(ctx.data()));  // Queue for processing
 })
 ```
 
 #### 2. Too Many Retries
+
 ```cpp
 // BAD - Retries too often
 .retry_interval(10)  // Retry every 10ms!
@@ -435,17 +480,18 @@ int main() {
 ```
 
 #### 3. Excessive Logging
+
 ```cpp
 // BAD - Log every byte
-.on_data([](const std::string& data) {
-    for (auto byte : data) {
+.on_data([](const unilink::MessageContext& ctx) {
+    for (auto byte : ctx.data()) {
         logger.debug("byte", "received", std::to_string(byte));
     }
 })
 
 // GOOD - Log summary
-.on_data([](const std::string& data) {
-    logger.debug("data", "received", "Received " + std::to_string(data.size()) + " bytes");
+.on_data([](const unilink::MessageContext& ctx) {
+    logger.debug("data", "received", "Received " + std::to_string(ctx.data().size()) + " bytes");
 })
 ```
 
@@ -454,12 +500,14 @@ int main() {
 ### Problem: High Memory Usage
 
 **Symptoms:**
+
 - Memory usage keeps growing
 - Out of memory errors
 
 **Solutions:**
 
 #### 1. Enable Memory Tracking (Debug)
+
 ```bash
 cmake -DUNILINK_ENABLE_MEMORY_TRACKING=ON ..
 cmake --build .
@@ -469,6 +517,7 @@ cmake --build .
 ```
 
 #### 2. Fix Memory Leaks
+
 ```cpp
 // BAD - Circular reference
 class Client {
@@ -485,6 +534,7 @@ class Handler {
 ```
 
 #### 3. Limit Buffer Sizes
+
 ```cpp
 // Limit message queue size
 std::deque<std::string> message_queue_;
@@ -503,12 +553,14 @@ void add_message(const std::string& msg) {
 ### Problem: Slow Data Transfer
 
 **Symptoms:**
+
 - Low throughput
 - Messages take long to arrive
 
 **Solutions:**
 
 #### 1. Batch Small Messages
+
 ```cpp
 // BAD - Send each character
 for (char c : message) {
@@ -520,6 +572,7 @@ client->send(message);
 ```
 
 #### 2. Use Binary Protocol
+
 ```cpp
 // Instead of text: "LENGTH:1024\nDATA:..."
 // Use binary: [4 bytes length][data]
@@ -534,9 +587,12 @@ std::vector<uint8_t> create_binary_message(const std::string& data) {
 ```
 
 #### 3. Enable Async Logging
+
 ```cpp
 // Don't let logging slow down I/O
-Logger::instance().enable_async(true);
+unilink::diagnostics::AsyncLogConfig config;
+config.batch_size = 100;
+unilink::diagnostics::Logger::instance().set_async_logging(true, config);
 ```
 
 ---
@@ -546,6 +602,7 @@ Logger::instance().enable_async(true);
 ### Problem: Memory Leak Detected
 
 **Symptoms:**
+
 ```
 Memory leak detected: 1024 bytes at 0x...
 ```
@@ -577,8 +634,9 @@ valgrind --leak-check=full ./your_app
 // 2. Circular shared_ptr
 // See "High Memory Usage" section above
 
-// 3. Not clearing callbacks
-server->clear_callbacks();  // Clear before destruction
+// 3. Keeping wrappers alive longer than intended
+server->stop();
+server.reset();
 ```
 
 ---
@@ -588,6 +646,7 @@ server->clear_callbacks();  // Clear before destruction
 ### Problem: Race Condition / Data Corruption
 
 **Symptoms:**
+
 - Occasional crashes
 - Corrupted data
 - Inconsistent state
@@ -595,6 +654,7 @@ server->clear_callbacks();  // Clear before destruction
 **Solutions:**
 
 #### 1. Protect Shared State
+
 ```cpp
 // BAD - No protection
 std::map<size_t, ClientInfo> clients_;
@@ -614,10 +674,11 @@ void add_client(size_t id) {
 ```
 
 #### 2. Use Thread-Safe Containers
+
 ```cpp
 #include <unilink/concurrency/thread_safe_state.hpp>
 
-unilink::common::ThreadSafeState<State> state_;
+unilink::concurrency::ThreadSafeState<State> state_;
 // All operations are thread-safe
 ```
 
@@ -701,7 +762,7 @@ If you're still experiencing issues:
 
 1. **Check Examples**: Look at `examples/` directory
 2. **Read API Guide**: See `docs/reference/api_guide.md`
-3. **Search Issues**: https://github.com/jwsung91/unilink/issues
+3. **Search Issues**: <https://github.com/jwsung91/unilink/issues>
 4. **Ask Community**: Create a new issue with:
    - Minimal reproducible example
    - Error messages / logs
@@ -711,6 +772,7 @@ If you're still experiencing issues:
 ---
 
 **See Also:**
+
 - [Best Practices](best_practices.md)
 - [Performance Guide](../advanced/performance.md)
 - [API Reference](../reference/api_guide.md)

--- a/docs/guides/setup/build_guide.md
+++ b/docs/guides/setup/build_guide.md
@@ -113,14 +113,15 @@ cmake --build build -j
 |--------|---------|-------------|
 | `CMAKE_BUILD_TYPE` | `Release` | Build type: `Release`, `Debug`, `RelWithDebInfo` |
 | `UNILINK_ENABLE_CONFIG` | `ON` | Enable configuration management API |
-| `BUILD_EXAMPLES` | `ON` | Build example applications |
-| `BUILD_TESTING` | `ON` | Build unit tests |
+| `UNILINK_BUILD_EXAMPLES` | `ON` | Build example applications |
+| `UNILINK_BUILD_TESTS` | `ON` | Build tests |
+| `UNILINK_BUILD_DOCS` | `ON` | Enable documentation targets |
 
 ### Development Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `UNILINK_ENABLE_MEMORY_TRACKING` | `ON` | Enable memory tracking for debugging |
+| `UNILINK_ENABLE_MEMORY_TRACKING` | `OFF` | Enable memory tracking for debugging |
 | `UNILINK_ENABLE_SANITIZERS` | `OFF` | Enable AddressSanitizer and other sanitizers |
 | `CMAKE_EXPORT_COMPILE_COMMANDS` | `OFF` | Generate `compile_commands.json` for IDEs |
 
@@ -129,7 +130,8 @@ cmake --build build -j
 | Option | Default | Description |
 |--------|---------|-------------|
 | `CMAKE_INSTALL_PREFIX` | `/usr/local` | Installation directory |
-| `UNILINK_INSTALL_DOCS` | `ON` | Install documentation files |
+| `UNILINK_ENABLE_INSTALL` | `ON` | Enable install and export targets |
+| `UNILINK_ENABLE_PKGCONFIG` | `ON` | Install `unilink.pc` |
 
 ---
 
@@ -190,8 +192,8 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake -S . -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DUNILINK_ENABLE_CONFIG=OFF \
-  -DBUILD_EXAMPLES=OFF \
-  -DBUILD_TESTING=OFF
+  -DUNILINK_BUILD_EXAMPLES=OFF \
+  -DUNILINK_BUILD_TESTS=OFF
 
 cmake --build build -j
 sudo cmake --install build
@@ -205,8 +207,8 @@ sudo cmake --install build
 cmake -S . -B build \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUNILINK_ENABLE_CONFIG=ON \
-  -DBUILD_EXAMPLES=ON \
-  -DBUILD_TESTING=ON \
+  -DUNILINK_BUILD_EXAMPLES=ON \
+  -DUNILINK_BUILD_TESTS=ON \
   -DUNILINK_ENABLE_MEMORY_TRACKING=ON
 
 cmake --build build -j
@@ -220,7 +222,7 @@ cmake --build build -j
 cmake -S . -B build \
   -DCMAKE_BUILD_TYPE=Debug \
   -DUNILINK_ENABLE_CONFIG=ON \
-  -DBUILD_TESTING=ON \
+  -DUNILINK_BUILD_TESTS=ON \
   -DUNILINK_ENABLE_SANITIZERS=ON
 
 cmake --build build -j
@@ -316,8 +318,8 @@ cmake -S . -B build \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_STANDARD=17 \
   -DUNILINK_ENABLE_CONFIG=ON \
-  -DBUILD_EXAMPLES=ON \
-  -DBUILD_TESTING=ON
+  -DUNILINK_BUILD_EXAMPLES=ON \
+  -DUNILINK_BUILD_TESTS=ON
 
 # 3. Build
 cmake --build build -j $(nproc)
@@ -584,7 +586,6 @@ pkg-config --cflags --libs unilink
 
 - [Installation Guide](installation.md) - Complete installation instructions
 - [Requirements](requirements.md) - System requirements and dependencies
-- [Performance Optimization](performance.md) - Optimize build configuration
-- [Testing Guide](testing.md) - Run tests and CI/CD integration
-- [Quick Start Guide](QUICKSTART.md) - Start using unilink
-
+- [Performance Optimization](../advanced/performance.md) - Optimize build configuration
+- [Testing Guide](../core/testing.md) - Run tests and CI/CD integration
+- [Quick Start Guide](../core/quickstart.md) - Start using unilink

--- a/docs/guides/setup/installation.md
+++ b/docs/guides/setup/installation.md
@@ -152,6 +152,7 @@ cmake -S . -B build \
 
 ## Next Steps
 
-- [Quick Start Guide](QUICKSTART.md)
-- [API Reference](../reference/API_GUIDE.md)
+- [Quick Start Guide](../core/quickstart.md)
+- [API Reference](../reference/api_guide.md)
+- [Implementation Status](../../implementation_status.md)
 - [Examples](../../examples/)

--- a/docs/guides/setup/requirements.md
+++ b/docs/guides/setup/requirements.md
@@ -223,6 +223,5 @@ sudo apt install cmake
 ## Next Steps
 
 - [Build Guide](build_guide.md) - Build instructions for different configurations
-- [Quick Start Guide](QUICKSTART.md) - Get started with unilink
-- [Troubleshooting](troubleshooting.md) - Common issues and solutions
-
+- [Quick Start Guide](../core/quickstart.md) - Get started with unilink
+- [Troubleshooting](../core/troubleshooting.md) - Common issues and solutions

--- a/docs/implementation_status.md
+++ b/docs/implementation_status.md
@@ -1,0 +1,68 @@
+# Implementation Status
+
+This page summarizes the implementation scope of the repository without duplicating release-specific values that already live elsewhere.
+
+## Scope
+
+The repository currently contains implemented source trees for:
+
+- C++ wrapper API
+- Builder API
+- Transport implementations
+- Diagnostics and logging
+- Configuration management
+- Memory and framing utilities
+- Examples and test suites
+- Optional Python bindings
+
+## C++ API Surface
+
+The public umbrella header `unilink/unilink.hpp` exposes wrappers and builders for:
+
+- TCP client
+- TCP server
+- UDP
+- Serial
+- UDS client
+- UDS server
+
+If you need the exact public entry points, treat `unilink/unilink.hpp` and the headers under `unilink/wrapper/` and `unilink/builder/` as the source of truth.
+
+## Python Binding Scope
+
+The Python module is implemented in `bindings/python/module.cpp`.
+
+At a high level, `unilink_py` currently covers:
+
+- TCP client
+- TCP server
+- UDP
+- Serial
+
+If binding coverage changes, update this section only when the exposed API surface changes, not when the package version changes.
+
+## Build And Test Status
+
+Dynamic build defaults and flags should be read from:
+
+- `CMakeLists.txt`
+- `cmake/UnilinkOptions.cmake`
+- [Build Guide](guides/setup/build_guide.md)
+
+Dynamic test registration and current pass/fail state should be read from:
+
+- `test/CMakeLists.txt`
+- [Test Structure](test_structure.md)
+- `ctest` output from the active build directory
+
+This document intentionally does not repeat exact version numbers, build-cache values, or test counts, because those change more often than the implementation scope itself.
+
+## Recommended Reading Order
+
+If you are trying to understand "what is implemented right now", read in this order:
+
+1. `unilink/unilink.hpp`
+2. [API Guide](reference/api_guide.md)
+3. [Examples Directory](../examples/README.md)
+4. [Test Structure](test_structure.md)
+5. [Architecture Overview](architecture/README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,327 +1,58 @@
 # Unilink Documentation Index
 
-Welcome to the comprehensive documentation for unilink - a modern C++ communication library.
-
----
-
-## 📚 Documentation Structure
-
-```
-docs/
-├── guides/
-│   ├── setup/       # Installation and build guides
-│   ├── core/        # Core concepts and usage guides
-│   └── advanced/    # Performance and advanced topics
-├── tutorials/       # Step-by-step tutorials
-├── reference/       # API reference documentation
-├── architecture/    # System design and architecture
-└── development/     # Development and contribution guides
-```
-
----
-
-## 🚀 Getting Started
-
-### New to Unilink?
-
-1. **[Quick Start Guide](guides/core/quickstart.md)** - Get up and running in 5 minutes
-2. **[Tutorial 1: Getting Started](tutorials/01_getting_started.md)** - Your first application
-3. **[API Guide](reference/api_guide.md)** - Complete API reference
-
-### Core Documentation
-
-| Document | Description | Difficulty |
-|----------|-------------|------------|
-| [Quick Start](guides/core/quickstart.md) | 5-minute quick start | ⭐ Beginner |
-| [API Guide](reference/api_guide.md) | Comprehensive API reference | ⭐⭐ All Levels |
-| [Python Bindings Guide](guides/core/python_bindings.md) | Python interface reference | ⭐⭐ All Levels |
-| [Best Practices](guides/core/best_practices.md) | Recommended patterns | ⭐⭐ Intermediate |
-| [System Overview](architecture/README.md) | Architecture deep-dive | ⭐⭐⭐ Advanced |
-
----
-
-## 📖 Tutorials
-
-Step-by-step guides for common tasks:
-
-### Beginner Tutorials
-- **[Tutorial 1: Getting Started](tutorials/01_getting_started.md)**
-  - Install dependencies
-  - Create your first client
-  - Connect and send data
-  - Duration: 15 minutes
-
-- **[Tutorial 2: Building a TCP Server](tutorials/02_tcp_server.md)**
-  - Create echo server
-  - Handle multiple clients
-  - Implement chat server
-  - Duration: 20 minutes
-
-- **[Tutorial 3: Local IPC with UDS](tutorials/03_uds_communication.md)**
-  - Use Unix Domain Sockets
-  - High-performance local IPC
-  - Server and Client setup
-  - Duration: 10 minutes
-
-### Coming Soon
-- Tutorial 4: Serial Communication
-- Tutorial 5: Error Handling & Recovery
-- Tutorial 6: Performance Optimization
-- Tutorial 7: Building Production Systems
-
----
-
-## 📋 Guides
-
-Practical guides for using unilink effectively:
-
-### Setup Guides
-| Guide | Topics Covered |
-|-------|----------------|
-| **[Installation](guides/setup/installation.md)** | Installing dependencies, CMake setup |
-| **[Build Guide](guides/setup/build_guide.md)** | Build options, configurations |
-| **[Requirements](guides/setup/requirements.md)** | System requirements |
-
-### Core Guides
-| Guide | Topics Covered |
-|-------|----------------|
-| **[Best Practices](guides/core/best_practices.md)** | Error handling, resource management, thread safety |
-| **[Troubleshooting](guides/core/troubleshooting.md)** | Common issues, debugging tips, solutions |
-| **[Testing](guides/core/testing.md)** | Testing strategies, unit tests |
-
-### Advanced Guides
-| Guide | Topics Covered |
-|-------|----------------|
-| **[Performance Guide](guides/advanced/performance.md)** | Optimization, tuning, benchmarks |
-
-### Quick Reference
-
-- **Error Handling**: [Best Practices §1](guides/core/best_practices.md#error-handling)
-- **Thread Safety**: [Best Practices §3](guides/core/best_practices.md#thread-safety)
-- **Performance**: [Performance Guide](guides/advanced/performance.md)
-- **Debugging**: [Troubleshooting](guides/core/troubleshooting.md#debugging-tips)
-
----
-
-## 📚 API Reference
-
-Complete API documentation:
-
-### Core APIs
-
-| API | Description |
-|-----|-------------|
-| **[TCP Client](reference/api_guide.md#tcp-client)** | Connect to TCP servers |
-| **[TCP Server](reference/api_guide.md#tcp-server)** | Accept client connections |
-| **[UDS Communication](reference/api_guide.md#uds-communication)** | High-performance local IPC |
-| **[Serial Communication](reference/api_guide.md#serial-communication)** | Interface with serial devices |
-| **[Error Handling](reference/api_guide.md#error-handling)** | Centralized error management |
-| **[Logging System](reference/api_guide.md#logging-system)** | Flexible logging |
-
-### Advanced Features
-
-- **[Configuration Management](reference/api_guide.md#configuration-management)** (Optional)
-- **[Memory Pool](reference/api_guide.md#memory-pool)**
-- **[Thread-Safe State](reference/api_guide.md#thread-safe-state)**
-- **[Safe Data Buffer](reference/api_guide.md#safe-data-buffer)**
-
----
-
-## 🏗️ Architecture
-
-Understanding unilink's design:
-
-### Architecture Documentation
-
-| Document | Description |
-|----------|-------------|
-| **[System Overview](architecture/README.md)** | Complete architecture documentation |
-| Design Patterns | Patterns used in unilink (Coming Soon) |
-| Threading Model | Concurrency and thread safety (Coming Soon) |
-
-### Key Concepts
-
-1. **[Layered Architecture](architecture/README.md#layered-architecture)**
-   - Builder API Layer
-   - Wrapper API Layer
-   - Transport Layer
-   - Common Utilities Layer
-
-2. **[Design Patterns](architecture/README.md#design-patterns)**
-   - Builder Pattern
-   - Observer Pattern
-   - Dependency Injection
-   - RAII
-
-3. **[Threading Model](architecture/README.md#threading-model)**
-   - IO Context Management
-   - Thread Safety
-   - Callback Execution
-
-4. **[Memory Management](architecture/README.md#memory-management)**
-   - Smart Pointers
-   - Memory Pools
-   - Safe Buffers
-
----
-
-## 🔧 Development
-
-For contributors and advanced users:
-
-### Development Documentation
-
-| Document | Description |
-|----------|-------------|
-| **[Improvement Recommendations](development/improvement_recommendations.md)** | Code quality assessment & roadmap |
-| Contributing Guide | How to contribute (Coming Soon) |
-| Code Style Guide | Coding standards (Coming Soon) |
-| Testing Guide | Writing and running tests (Coming Soon) |
-
-### Build Options
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `CMAKE_BUILD_TYPE` | `Release` | Build type (Release/Debug) |
-| `UNILINK_BUILD_EXAMPLES` | `ON` | Build example applications |
-| `UNILINK_BUILD_TESTS` | `ON` | Master test toggle |
-| `UNILINK_ENABLE_PERFORMANCE_TESTS` | `OFF` | Build performance/benchmark tests |
-| `UNILINK_ENABLE_CONFIG` | `ON` | Enable configuration API |
-| `UNILINK_ENABLE_MEMORY_TRACKING` | `ON` | Enable memory tracking |
-| `UNILINK_ENABLE_SANITIZERS` | `OFF` | Enable AddressSanitizer |
-
----
-
-## 💡 Examples
-
-Practical code examples:
-
-### Example Applications
-
-Located in `examples/` directory:
-
-| Example | Description | Lines of Code |
-|---------|-------------|---------------|
-| **TCP Echo Server** | Simple echo server | ~100 |
-| **TCP Echo Client** | Echo client with reconnection | ~80 |
-| **Serial Echo** | Serial port echo | ~90 |
-| **Chat Server** | Multi-client chat server | ~200 |
-| **Logging Example** | Logging system demo | ~60 |
-| **Error Handling Example** | Error handling demo | ~80 |
-
-### Code Snippets
-
-**Quick TCP Client:**
-```cpp
-auto client = unilink::tcp_client("127.0.0.1", 8080)
-    .on_data([](const std::string& data) {
-        std::cout << "Received: " << data << std::endl;
-    })
-    .build();
-
-client->start();
-```
-
-**Quick TCP Server:**
-```cpp
-auto server = unilink::tcp_server(8080)
-    .unlimited_clients()
-    .on_data([](size_t id, const std::string& data) {
-        std::cout << "Client " << id << ": " << data << std::endl;
-    })
-    .build();
-
-server->start();
-// ... do work ...
-server->stop();  // Clean shutdown
-```
-
----
-
-## 🔍 Search & Find
-
-### By Topic
-
-- **Connection Issues**: [Troubleshooting §1](guides/core/troubleshooting.md#connection-issues)
-- **Performance Problems**: [Troubleshooting §4](guides/core/troubleshooting.md#performance-issues)
-- **Memory Leaks**: [Troubleshooting §5](guides/core/troubleshooting.md#memory-issues)
-- **Thread Safety**: [Best Practices §3](guides/core/best_practices.md#thread-safety)
-- **Error Handling**: [Best Practices §1](guides/core/best_practices.md#error-handling)
-
-### By Use Case
-
-| Use Case | Relevant Documentation |
-|----------|------------------------|
-| IoT Device | [Serial API](reference/api_guide.md#serial-communication), [Performance](guides/advanced/performance.md) |
-| Web Service | [TCP Server](reference/api_guide.md#tcp-server), [Best Practices](guides/core/best_practices.md) |
-| Data Streaming | [Performance Guide](guides/advanced/performance.md), [Architecture](architecture/README.md) |
-| Testing | [Troubleshooting](guides/core/troubleshooting.md), [API Guide](reference/api_guide.md) |
-
----
-
-## 📊 Documentation Stats
-
-| Metric | Count |
-|--------|-------|
-| Total Pages | 10+ |
-| Tutorials | 2 (more coming) |
-| Guides | 7 |
-| Code Examples | 50+ |
-| API Methods Documented | 100+ |
-
----
-
-## 🆘 Need Help?
-
-### Quick Links
-
-- **Common Issues**: [Troubleshooting Guide](guides/core/troubleshooting.md)
-- **FAQ**: [Troubleshooting §Getting Help](guides/core/troubleshooting.md#getting-help)
-- **Examples**: [Examples Directory](../examples/)
-- **GitHub Issues**: [Report a Bug](https://github.com/jwsung91/unilink/issues)
-
-### Learning Path
-
-**Beginner Path:**
-1. Quick Start Guide
-2. Tutorial 1: Getting Started
-3. Tutorial 2: TCP Server
-4. API Guide (TCP sections)
-5. Best Practices (Error Handling)
-
-**Intermediate Path:**
-1. API Guide (complete)
-2. Best Practices (complete)
-3. Performance Guide
-4. Architecture Overview
-
-**Advanced Path:**
-1. System Architecture
-2. Threading Model
-3. Memory Management
-4. Contributing Guide
-
----
-
-## 📝 Document History
-
-| Date | Version | Changes |
-|------|---------|---------|
-| 2025-10-11 | 1.0 | Initial comprehensive documentation release |
-| 2025-12-27 | 1.1 | Restructured documentation (Categories, snake_case) |
-
----
-
-## 🤝 Contributing
-
-Found an issue or want to improve documentation?
-
-1. **Report Issues**: [GitHub Issues](https://github.com/jwsung91/unilink/issues)
-2. **Suggest Improvements**: Create a pull request
-3. **Ask Questions**: Create an issue with "question" label
-
----
-
-**Happy Coding with Unilink!** 🚀
+This index is the stable entry point for the handwritten documentation in `docs/`. It is intentionally kept lightweight so version bumps, option changes, and test-count changes do not require editing this page.
+
+## Start Here
+
+1. [Quick Start Guide](guides/core/quickstart.md)
+2. [Installation Guide](guides/setup/installation.md)
+3. [API Guide](reference/api_guide.md)
+4. [Implementation Status](implementation_status.md)
+5. [Build Guide](guides/setup/build_guide.md)
+
+## Core Guides
+
+| Document | What it covers |
+|----------|----------------|
+| [Build Guide](guides/setup/build_guide.md) | Actual CMake options and build profiles |
+| [Requirements](guides/setup/requirements.md) | Platform and dependency expectations |
+| [Best Practices](guides/core/best_practices.md) | Runtime usage patterns and guardrails |
+| [Troubleshooting](guides/core/troubleshooting.md) | Common failures and debugging steps |
+| [Testing](guides/core/testing.md) | Running tests and understanding coverage |
+| [Python Bindings](guides/core/python_bindings.md) | `unilink_py` usage and current scope |
+| [Performance](guides/advanced/performance.md) | Tuning and async logging considerations |
+
+## Tutorials
+
+| Tutorial | Focus |
+|----------|-------|
+| [Getting Started](tutorials/01_getting_started.md) | First TCP client |
+| [TCP Server](tutorials/02_tcp_server.md) | Server lifecycle and callbacks |
+| [UDS Communication](tutorials/03_uds_communication.md) | Local IPC with Unix domain sockets |
+| [Serial Communication](tutorials/04_serial_communication.md) | Device I/O and virtual-port testing |
+| [UDP Communication](tutorials/05_udp_communication.md) | Connectionless send/receive workflow |
+
+Tutorial companion material is split between `examples/tutorials/` and the protocol-specific example directories under `examples/serial/` and `examples/udp/`.
+
+## Architecture Notes
+
+| Document | Focus |
+|----------|-------|
+| [Architecture Overview](architecture/README.md) | Layers, responsibilities, design patterns |
+| [Runtime Behavior](architecture/runtime_behavior.md) | Lifecycle, retries, callback behavior |
+| [Memory Safety](architecture/memory_safety.md) | Ownership and buffer handling rules |
+| [Channel Contract](architecture/channel_contract.md) | Wrapper/transport expectations |
+
+## Examples and Tests
+
+- [Examples Directory](../examples/README.md)
+- [Test Overview](test_structure.md)
+- [Top-level Test Notes](../test/README.md)
+
+## Notes For Maintainers
+
+- Keep this page aligned with actual files under `docs/`.
+- Prefer linking to existing files over placeholder topics.
+- Do not duplicate release-specific values here. Version, build defaults, and test status belong in source-of-truth files or generated output.
 
 [Back to Main README](../README.md)

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -774,48 +774,43 @@ _(Available when built with `UNILINK_ENABLE_CONFIG=ON`)_
 ### Load Configuration from File
 
 ```cpp
-#include "unilink/config/config_manager.hpp"
+#include <any>
+#include "unilink/config/config_factory.hpp"
 
-using namespace unilink::config;
+auto config = unilink::config::ConfigFactory::create_with_defaults();
+config->load_from_file("unilink.conf");
 
-auto config = ConfigManager::load_from_file("config.json");
-
-// Access configuration
-auto host = config->get_tcp_client_config("main_client").host;
-auto port = config->get_tcp_client_config("main_client").port;
+auto host = std::any_cast<std::string>(config->get("tcp.client.host"));
+auto port = static_cast<uint16_t>(std::any_cast<int>(config->get("tcp.client.port")));
+auto retry_interval_ms = static_cast<unsigned>(
+    std::any_cast<int>(config->get("tcp.client.retry_interval_ms"))
+);
 
 // Create client from config
 auto client = unilink::tcp_client(host, port)
-    .retry_interval(config->get_tcp_client_config("main_client").retry_interval_ms)
+    .retry_interval(retry_interval_ms)
     .build();
 ```
 
-### Configuration File Format (JSON)
+### Configuration File Format
 
-```json
-{
-  "tcp_clients": {
-    "main_client": {
-      "host": "192.168.1.100",
-      "port": 8080,
-      "retry_interval_ms": 3000
-    }
-  },
-  "tcp_servers": {
-    "main_server": {
-      "port": 9000,
-      "single_client_mode": false
-    }
-  },
-  "serials": {
-    "arduino": {
-      "device": "/dev/ttyACM0",
-      "baud_rate": 115200,
-      "retry_interval_ms": 5000
-    }
-  }
-}
+The current configuration manager reads simple `key=value` files.
+
+```ini
+# unilink.conf
+tcp.client.host=192.168.1.100
+tcp.client.port=8080
+tcp.client.retry_interval_ms=3000
+
+tcp.server.port=9000
+tcp.server.max_connections=100
+
+serial.port=/dev/ttyACM0
+serial.baud_rate=115200
+serial.retry_interval_ms=5000
 ```
+
+Common preset keys are populated by `unilink::config::ConfigPresets` through `ConfigFactory::create_with_defaults()`.
 
 ---
 

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -909,8 +909,8 @@ auto remote_client = unilink::tcp_client("remote.com", 8080)
 ### 4. Enable Logging for Debugging
 
 ```cpp
-unilink::common::Logger::instance().set_level(unilink::common::LogLevel::DEBUG);
-unilink::common::Logger::instance().set_console_output(true);
+unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::DEBUG);
+unilink::diagnostics::Logger::instance().set_console_output(true);
 ```
 
 ### 5. Use Member Functions for OOP Design

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -10,10 +10,12 @@ Comprehensive API reference for the unilink library.
 2. [TCP Client](#tcp-client)
 3. [TCP Server](#tcp-server)
 4. [Serial Communication](#serial-communication)
-5. [Error Handling](#error-handling)
-6. [Logging System](#logging-system)
-7. [Configuration Management](#configuration-management)
-8. [Advanced Features](#advanced-features)
+5. [UDP Communication](#udp-communication)
+6. [UDS Communication](#uds-communication)
+7. [Error Handling](#error-handling)
+8. [Logging System](#logging-system)
+9. [Configuration Management](#configuration-management)
+10. [Advanced Features](#advanced-features)
 
 ---
 
@@ -36,14 +38,16 @@ auto channel = unilink::{type}(params)
 
 | Method                           | Description                                                       | Default |
 | -------------------------------- | ----------------------------------------------------------------- | ------- |
-| `.on_data(callback)`             | Handle incoming data (`const MessageContext&`)                    | None    |
-| `.on_bytes(callback)`            | Handle incoming raw data (`ConstByteSpan`)                        | None    |
-| `.on_connect(callback)`          | Handle connection events (`const ConnectionContext&`)             | None    |
-| `.on_disconnect(callback)`       | Handle disconnection (`const ConnectionContext&`)                 | None    |
-| `.on_error(callback)`            | Handle errors (`const ErrorContext&`)                             | None    |
-| `.auto_manage(bool)`             | Auto-start/stop the wrapper (starts immediately when `true`)      | `false` |
-| `.use_independent_context(bool)` | Create and run a dedicated `io_context` thread managed by unilink | `false` |
-| `.build()`                       | **Required**: Build the wrapper instance                          | -       |
+| `.on_data(callback)`             | Handle incoming data (`const MessageContext&`)                             | None    |
+| `.on_connect(callback)`          | Handle connection events (`const ConnectionContext&`)                      | None    |
+| `.on_disconnect(callback)`       | Handle disconnection (`const ConnectionContext&`)                          | None    |
+| `.on_error(callback)`            | Handle errors (`const ErrorContext&`)                                      | None    |
+| `.auto_manage(bool)`             | Auto-start/stop the wrapper (starts immediately when `true`)               | `false` |
+| `.use_independent_context(bool)` | Create and run a dedicated `io_context` thread managed by unilink          | `false` |
+| `.use_line_framer(...)`          | Split incoming bytes into delimiter-based messages                         | Disabled |
+| `.use_packet_framer(...)`        | Split incoming bytes into packet-based messages                            | Disabled |
+| `.on_message(callback)`          | Handle framed messages as `unilink::memory::ConstByteSpan`                 | None    |
+| `.build()`                       | **Required**: Build the wrapper instance                                   | -       |
 
 **Builder-Specific Options**
 
@@ -52,9 +56,9 @@ auto channel = unilink::{type}(params)
 - `TcpServerBuilder`: `.single_client()`, `.multi_client(max>=2)`, `.unlimited_clients()` **(must choose one before `build()`)**
 - TCP server callbacks use the same Context-based signatures. Use `ctx.client_id()` and `ctx.client_info()` to distinguish clients.
 
-### Efficient Data Handling with SafeSpan
+### Framed Message Handling with `ConstByteSpan`
 
-The `.on_bytes()` callback uses `unilink::memory::ConstByteSpan` (a C++17 compatible view) to provide zero-copy access to the receive buffer.
+Use `.on_message()` together with a framer when you want zero-copy access to framed payloads.
 
 **Benefits:**
 - **Performance**: Avoids `std::string` allocation overhead.
@@ -62,13 +66,13 @@ The `.on_bytes()` callback uses `unilink::memory::ConstByteSpan` (a C++17 compat
 
 **Example:**
 ```cpp
-.on_bytes([](unilink::memory::ConstByteSpan data) {
-    // Access metadata
-    size_t len = data.size();
-    const uint8_t* ptr = data.data();
+.use_line_framer("\n")
+.on_message([](unilink::memory::ConstByteSpan msg) {
+    size_t len = msg.size();
+    const uint8_t* ptr = msg.data();
 
-    // Convert to string using helper
-    std::string s = unilink::common::safe_convert::uint8_to_string(ptr, len);
+    std::string text(reinterpret_cast<const char*>(ptr), len);
+    std::cout << "Framed message: " << text << std::endl;
 })
 ```
 
@@ -77,9 +81,10 @@ The `.on_bytes()` callback uses `unilink::memory::ConstByteSpan` (a C++17 compat
 | ------------------------------------ | ---------------------------------------------------------------------- |
 | `->start()` | **Required**: Start the connection |
 | `->stop()` | Stop the connection |
-| `->send(data)` / `->send_line(text)` | Send data to peer(s) |
-| `->is_connected()` | Check connection status (`TcpServer` reports underlying channel state) |
-| `TcpServer::is_listening()` | Check if the server socket is bound and listening |
+| `TcpClient` / `Serial` / `Udp` / `UdsClient`: `->send(data)` / `->send_line(text)` | Send data to the configured peer |
+| `TcpClient` / `Serial` / `Udp` / `UdsClient`: `->is_connected()` | Check channel state |
+| `TcpServer` / `UdsServer`: `->broadcast(data)` / `->send_to(client_id, data)` | Send data to one or more connected clients |
+| `TcpServer` / `UdsServer`: `->is_listening()` | Check if the server socket is bound and listening |
 
 **Builder Flow**
 
@@ -160,7 +165,7 @@ unilink::tcp_client(const std::string& host, uint16_t port)
 | `send()`                   | `void` | Send data to server                                                   |
 | `send_line()`              | `void` | Send data with trailing newline                                       |
 | `is_connected()`           | `bool` | Check connection status                                               |
-| `start()`                  | `void` | Start connection attempt                                              |
+| `start()`                  | `std::future<bool>` | Start connection attempt                                  |
 | `stop()`                   | `void` | Stop and disconnect                                                   |
 | `set_retry_interval()`     | `void` | Adjust reconnection interval at runtime (`std::chrono::milliseconds`) |
 | `set_max_retries()`        | `void` | Set max reconnect attempts (`-1` for unlimited)                       |
@@ -172,7 +177,7 @@ unilink::tcp_client(const std::string& host, uint16_t port)
 
 ```cpp
 class MyClient {
-    std::shared_ptr<unilink::TcpClient> client_;
+    std::unique_ptr<unilink::TcpClient> client_;
 
 public:
     void on_data(const unilink::MessageContext& ctx) {
@@ -235,6 +240,7 @@ Accept multiple client connections with thread-safe operations.
 #include "unilink/unilink.hpp"
 
 auto server = unilink::tcp_server(8080)
+    .unlimited_clients()
     .on_connect([](const unilink::ConnectionContext& ctx) {
         std::cout << "Client " << ctx.client_id() << " connected from " << ctx.client_info() << std::endl;
     })
@@ -250,10 +256,10 @@ auto server = unilink::tcp_server(8080)
 server->start();
 
 // Send to specific client
-server->send_to_client(1, "Hello, Client 1!");
+server->send_to(1, "Hello, Client 1!");
 
 // Send to all clients
-server->send("Broadcast message");
+server->broadcast("Broadcast message");
 
 // Check if listening
 if (server->is_listening()) {
@@ -290,18 +296,19 @@ Multi-client callbacks use the standard `ConnectionContext` and `MessageContext`
 
 #### Instance Methods
 
-| Method                    | Return                | Description                     |
-| ------------------------- | --------------------- | ------------------------------- |
-| `send()`                  | `void`                | Send to all connected clients   |
-| `send_to_client()`        | `void`                | Send to specific client         |
-| `broadcast()`             | `void`                | Explicit broadcast helper       |
-| `send_line()`             | `void`                | Send data with trailing newline |
-| `get_client_count()`      | `size_t`              | Number of connected clients     |
-| `get_connected_clients()` | `std::vector<size_t>` | List of connected client IDs    |
-| `is_connected()`          | `bool`                | Channel connection state        |
-| `is_listening()`          | `bool`                | Check if server is listening    |
-| `start()`                 | `void`                | Start accepting connections     |
-| `stop()`                  | `void`                | Stop server and disconnect all  |
+| Method                    | Return                | Description                            |
+| ------------------------- | --------------------- | -------------------------------------- |
+| `broadcast()`             | `bool`                | Send to all connected clients          |
+| `send_to()`               | `bool`                | Send to a specific client              |
+| `get_client_count()`      | `size_t`              | Number of connected clients            |
+| `get_connected_clients()` | `std::vector<size_t>` | List of connected client IDs           |
+| `on_client_connect()`     | `ServerInterface&`    | Register runtime connect callback      |
+| `on_client_disconnect()`  | `ServerInterface&`    | Register runtime disconnect callback   |
+| `on_data()`               | `ServerInterface&`    | Register runtime message callback      |
+| `on_error()`              | `ServerInterface&`    | Register runtime error callback        |
+| `is_listening()`          | `bool`                | Check if server is listening           |
+| `start()`                 | `std::future<bool>`   | Start accepting connections            |
+| `stop()`                  | `void`                | Stop server and disconnect all clients |
 
 ### Advanced Examples
 
@@ -335,7 +342,7 @@ auto server = unilink::tcp_server(8080)
     .build();
 
 server->on_data([&server](const unilink::MessageContext& ctx) {
-    server->send_to_client(ctx.client_id(), "Echo: " + std::string(ctx.data()));
+    server->send_to(ctx.client_id(), "Echo: " + std::string(ctx.data()));
 });
 
 server->start();
@@ -367,9 +374,9 @@ serial->start();
 // Send AT command
 serial->send("AT\r\n");
 
-// Send binary data
-std::vector<uint8_t> binary = {0x01, 0x02, 0x03};
-serial->send(binary);
+// Send binary payload through string-compatible storage
+std::string binary_payload("\x01\x02\x03", 3);
+serial->send(binary_payload);
 ```
 
 ### API Reference
@@ -399,7 +406,7 @@ unilink::serial(const std::string& device, uint32_t baud_rate)
 | `send()`               | `void`         | Send data to device                                        |
 | `send_line()`          | `void`         | Send data with trailing newline                            |
 | `is_connected()`       | `bool`         | Check if port is open                                      |
-| `start()`              | `void`         | Open serial port                                           |
+| `start()`              | `std::future<bool>` | Open serial port                                      |
 | `stop()`               | `void`         | Close serial port                                          |
 | `set_baud_rate()`      | `void`         | Adjust baud rate at runtime                                |
 | `set_data_bits()`      | `void`         | Set data bits (5-8)                                        |
@@ -513,18 +520,17 @@ unilink::udp(uint16_t local_port)
 
 | Method                      | Parameters         | Description                                   |
 | --------------------------- | ------------------ | --------------------------------------------- |
-| `set_local_port(port)`      | `uint16_t`         | Bind to specific local port                   |
-| `set_local_address(ip)`     | `string`           | Bind to specific local IP (default "0.0.0.0") |
-| `set_remote(ip, port)`      | `string, uint16_t` | Set default destination for `send()`          |
-| `use_independent_context()` | `bool`             | Run on dedicated IO thread                    |
-| `auto_manage()`             | `bool`             | Auto-start/stop lifecycle                     |
+| `set_local_port(port)`      | `uint16_t`         | Bind to a specific local port          |
+| `set_remote(ip, port)`      | `string, uint16_t` | Set default destination for `send()`   |
+| `use_independent_context()` | `bool`             | Run on dedicated IO thread             |
+| `auto_manage()`             | `bool`             | Auto-start/stop lifecycle              |
 
 #### Instance Methods
 
 | Method           | Return | Description                            |
 | ---------------- | ------ | -------------------------------------- |
 | `send()`         | `void` | Send data to configured remote address |
-| `start()`        | `void` | Start listening/sending                |
+| `start()`        | `std::future<bool>` | Start listening/sending         |
 | `stop()`         | `void` | Close socket                           |
 | `is_connected()` | `bool` | Check if socket is open and ready      |
 
@@ -593,12 +599,12 @@ unilink::uds_client(const std::string& socket_path)
 
 #### Builder Methods (UDS Server)
 
-| Method                | Parameters     | Description                                     |
-| --------------------- | -------------- | ----------------------------------------------- |
-| `single_client()`     | None           | Only allow one client at a time                 |
-| `multi_client(max)`   | `size_t (>=2)` | Allow up to `max` concurrent clients            |
-| `unlimited_clients()` | None           | Allow unlimited clients                         |
-| `auto_manage()`       | `bool`         | Auto-start/stop lifecycle                       |
+| Method                      | Parameters | Description                               |
+| --------------------------- | ---------- | ----------------------------------------- |
+| `max_clients(max)`          | `size_t`   | Allow up to `max` concurrent clients      |
+| `unlimited_clients()`       | None       | Allow unlimited clients                   |
+| `use_independent_context()` | `bool`     | Run on dedicated IO thread                |
+| `auto_manage()`             | `bool`     | Auto-start/stop lifecycle                 |
 
 #### Builder Methods (UDS Client)
 
@@ -607,15 +613,27 @@ unilink::uds_client(const std::string& socket_path)
 | `retry_interval(ms)`  | `unsigned` | Set reconnection interval (default `3000`) |
 | `auto_manage()`       | `bool`     | Auto-start/stop lifecycle                  |
 
-#### Instance Methods (Common)
+#### Instance Methods (UDS Client)
 
-| Method            | Return | Description                       |
-| ----------------- | ------ | --------------------------------- |
-| `start()`         | `void` | Start communication               |
-| `stop()`          | `void` | Stop communication                |
-| `is_connected()`  | `bool` | Check if channel is active        |
-| `send(data)`      | `void` | Send data to peer(s)              |
-| `is_listening()`  | `bool` | (Server only) Check if listening  |
+| Method            | Return              | Description                              |
+| ----------------- | ------------------- | ---------------------------------------- |
+| `start()`         | `std::future<bool>` | Start communication                      |
+| `stop()`          | `void`              | Stop communication                       |
+| `is_connected()`  | `bool`              | Check if the client channel is active    |
+| `send(data)`      | `void`              | Send data to the server                  |
+| `send_line(text)` | `void`              | Send text with a trailing newline        |
+
+#### Instance Methods (UDS Server)
+
+| Method                    | Return                | Description                            |
+| ------------------------- | --------------------- | -------------------------------------- |
+| `start()`                 | `std::future<bool>`   | Start accepting connections            |
+| `stop()`                  | `void`                | Stop the server                        |
+| `is_listening()`          | `bool`                | Check if the socket is listening       |
+| `broadcast(data)`         | `bool`                | Send to all connected clients          |
+| `send_to(client_id, data)`| `bool`                | Send to a specific client              |
+| `get_client_count()`      | `size_t`              | Number of connected clients            |
+| `get_connected_clients()` | `std::vector<size_t>` | List of connected client IDs           |
 
 ### Notes on UDS
 
@@ -634,7 +652,7 @@ Centralized error handling system with callbacks and statistics.
 ```cpp
 #include "unilink/diagnostics/error_handler.hpp"
 
-using namespace unilink::common;
+using namespace unilink::diagnostics;
 
 // Register global error callback
 ErrorHandler::instance().register_callback([](const ErrorInfo& error) {
@@ -672,7 +690,7 @@ std::cout << "Errors: " << stats.error_count << std::endl;
 ### Error Categories
 
 ```cpp
-namespace error_reporting = unilink::common::error_reporting;
+namespace error_reporting = unilink::diagnostics::error_reporting;
 
 // Connection errors
 error_reporting::report_connection_error("tcp_client", "connect", ec, true);
@@ -699,13 +717,11 @@ Flexible logging with multiple outputs and async processing.
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 
-using namespace unilink::common;
+auto& logger = unilink::diagnostics::Logger::instance();
 
 // Get logger instance
-auto& logger = Logger::instance();
-
 // Configure logger
-logger.set_level(LogLevel::DEBUG);
+logger.set_level(unilink::diagnostics::LogLevel::DEBUG);
 logger.set_console_output(true);
 logger.set_file_output("app.log");
 
@@ -731,7 +747,7 @@ logger.critical("component", "operation", "Critical message");
 
 ```cpp
 // Enable async logging for better performance
-AsyncLogConfig config;
+unilink::diagnostics::AsyncLogConfig config;
 config.batch_size = 100;                    // Process 100 logs at once
 config.flush_interval = std::chrono::milliseconds(1000); // Flush every 1 second
 
@@ -813,14 +829,12 @@ Efficient memory allocation for high-performance scenarios.
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/memory/safe_data_buffer.hpp"
 
-using namespace unilink::common;
-
-MemoryPool pool(1024, 100);  // 1KB blocks, 100 blocks
+unilink::memory::MemoryPool pool;
 
 // Allocate from pool
-auto buffer = pool.allocate();
+auto buffer = pool.acquire(1024);
 // ... use buffer ...
-pool.deallocate(buffer);
+pool.release(std::move(buffer), 1024);
 ```
 
 ### Safe Data Buffer
@@ -830,16 +844,11 @@ Type-safe data buffer with bounds checking.
 ```cpp
 #include "unilink/memory/safe_data_buffer.hpp"
 
-using namespace unilink::common;
-
-SafeDataBuffer buffer(1024);
+unilink::memory::SafeDataBuffer buffer("Hello");
 
 // Safe operations
-buffer.append("Hello");
-buffer.append_bytes({0x01, 0x02, 0x03});
-
-auto data = buffer.to_string();
-auto bytes = buffer.to_vector();
+auto text = buffer.as_string();
+auto bytes = buffer.as_span();
 ```
 
 ### Thread-Safe State
@@ -849,20 +858,18 @@ Thread-safe state management with read-write locks.
 ```cpp
 #include "unilink/concurrency/thread_safe_state.hpp"
 
-using namespace unilink::common;
-
 enum class State { Idle, Running, Stopped };
 
-ThreadSafeState<State> state(State::Idle);
+unilink::concurrency::ThreadSafeState<State> state(State::Idle);
 
 // Read state
-auto current = state.get();
+auto current = state.get_state();
 
 // Write state
-state.set(State::Running);
+state.set_state(State::Running);
 
 // Atomic compare-and-swap
-state.compare_exchange(State::Idle, State::Running);
+state.compare_and_set(State::Idle, State::Running);
 ```
 
 ---
@@ -917,7 +924,7 @@ unilink::diagnostics::Logger::instance().set_console_output(true);
 
 ```cpp
 class MyApplication {
-    std::shared_ptr<unilink::TcpClient> client_;
+    std::unique_ptr<unilink::TcpClient> client_;
 
     void on_data(const unilink::MessageContext& ctx) { /* ... */ }
 
@@ -946,7 +953,9 @@ class MyApplication {
 ### 2. Enable Async Logging
 
 ```cpp
-Logger::instance().enable_async(true);
+unilink::diagnostics::AsyncLogConfig config;
+config.batch_size = 100;
+unilink::diagnostics::Logger::instance().set_async_logging(true, config);
 ```
 
 ### 3. Use Memory Pool for Frequent Allocations

--- a/docs/scripts/extract_doc_snippet.py
+++ b/docs/scripts/extract_doc_snippet.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Extract a compile-checked C++ snippet from a Markdown document.
+
+Markers use the form:
+    <!-- doc-compile: snippet_name -->
+
+The next fenced C++ code block after the marker is written to the output path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Markdown source file")
+    parser.add_argument("--snippet", required=True, help="Snippet marker name")
+    parser.add_argument("--output", required=True, help="Output .cc file path")
+    return parser.parse_args()
+
+
+def is_cpp_fence(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped.startswith("```"):
+        return False
+    info = stripped[3:].strip().lower()
+    return info in {"cpp", "c++", "cc"}
+
+
+def extract_snippet(markdown_path: pathlib.Path, snippet_name: str) -> str:
+    lines = markdown_path.read_text(encoding="utf-8").splitlines()
+    marker = f"<!-- doc-compile: {snippet_name} -->"
+
+    for index, line in enumerate(lines):
+        if line.strip() != marker:
+            continue
+
+        cursor = index + 1
+        while cursor < len(lines) and not lines[cursor].strip():
+            cursor += 1
+
+        if cursor >= len(lines) or not is_cpp_fence(lines[cursor]):
+            raise ValueError(
+                f"Marker '{snippet_name}' in {markdown_path} is not followed by a fenced C++ block"
+            )
+
+        cursor += 1
+        snippet_lines: list[str] = []
+        while cursor < len(lines) and lines[cursor].strip() != "```":
+            snippet_lines.append(lines[cursor])
+            cursor += 1
+
+        if cursor >= len(lines):
+            raise ValueError(f"Unterminated fenced block for marker '{snippet_name}' in {markdown_path}")
+
+        snippet_text = "\n".join(snippet_lines).strip() + "\n"
+        if "int main" not in snippet_text:
+            raise ValueError(
+                f"Snippet '{snippet_name}' in {markdown_path} does not look like a standalone program"
+            )
+        return snippet_text
+
+    raise ValueError(f"Marker '{snippet_name}' not found in {markdown_path}")
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = pathlib.Path(args.input)
+    output_path = pathlib.Path(args.output)
+
+    try:
+        snippet = extract_snippet(input_path, args.snippet)
+    except Exception as exc:  # pragma: no cover - simple CLI error path
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        f"// Generated from {input_path} [{args.snippet}]\n{snippet}",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -1,348 +1,88 @@
 # Test Structure
 
-This document describes the organized test structure of the `unilink` library.
+This document describes how the test tree is organized and how to work with it, without embedding release-specific counts or dated snapshots.
 
----
+## Layout
 
-## Overview
-
-Tests are organized into **4 main categories**:
-
-| Category | Purpose | Speed | Test Count | Labels |
-|----------|---------|-------|------------|--------|
-| **Unit** | Isolated component tests | Fast (~10s) | 97 | `unit`, `fast` |
-| **Integration** | Component interaction tests | Medium (~75s) | 118 | `integration`, `medium` |
-| **E2E** | End-to-end scenarios | Slow (~64s) | 22 | `e2e`, `slow` |
-| **Performance** | Benchmarks and profiling | Optional (~10s) | 58 | `performance`, `optional` |
-
-**Total**: 295 tests (~160 seconds full suite)
-
----
-
-## Directory Structure
-
-```
+```text
 test/
-├── unit/                       # Fast unit tests
-│   ├── common/                 # Common utilities tests
-│   │   ├── test_core.cc
-│   │   ├── test_memory.cc
-│   │   ├── test_boundary.cc
-│   │   └── test_error_handler.cc
-│   ├── builder/                # Builder pattern tests
-│   │   ├── test_builder.cc
-│   │   └── test_builder_coverage.cc
-│   ├── config/                 # Configuration tests
-│   │   └── test_config.cc
-│   └── CMakeLists.txt
-│
-├── integration/                # Integration tests
-│   ├── tcp/                    # TCP communication tests
-│   │   ├── test_integration.cc
-│   │   ├── test_simple_server.cc
-│   │   └── test_client_limit_integration.cc
-│   ├── serial/                 # Serial communication tests
-│   │   ├── test_serial.cc
-│   │   └── test_serial_builder_improvements.cc
-│   ├── mock/                   # Mock-based tests
-│   │   ├── test_mock_integration.cc
-│   │   └── test_mock_integrated.cc
-│   ├── test_builder_integration.cc
-│   ├── test_stable_integration.cc
-│   ├── test_core_integrated.cc
-│   ├── test_safety_integrated.cc
-│   └── CMakeLists.txt
-│
-├── e2e/                        # End-to-end tests
-│   ├── scenarios/              # Real-world scenarios
-│   │   ├── test_architecture.cc
-│   │   └── test_error_recovery.cc
-│   ├── stress/                 # Stress tests
-│   │   └── test_stress.cc
-│   └── CMakeLists.txt
-│
-├── performance/                # Performance tests
-│   ├── benchmark/              # Benchmarks
-│   │   ├── test_performance.cc
-│   │   ├── test_benchmark.cc
-│   │   ├── test_transport_performance.cc
-│   │   └── test_platform.cc
-│   └── CMakeLists.txt
-│
-├── fixtures/                   # Shared test resources
-│   ├── mocks/                  # Mock objects
-│   └── data/                   # Test data
-│
-├── utils/                      # Test utilities
-│   └── test_utils.hpp
-│
-└── CMakeLists.txt              # Main test configuration
+├── unit/          # Unit and transport-focused tests
+├── integration/   # Cross-component and real I/O integration tests
+├── e2e/           # End-to-end scenarios and stress tests
+├── performance/   # Optional benchmarks and profiling tests
+├── fixtures/      # Shared mocks and fixtures
+├── mocks/         # Additional mock types used by tests
+├── utils/         # Shared test helpers and constants
+└── CMakeLists.txt # Main test registration
 ```
 
----
+## What Each Area Covers
+
+- `unit/`: isolated component behavior, transport edge cases, wrapper behavior, framing, config, and utility coverage
+- `integration/`: interaction between components and real I/O paths
+- `e2e/`: scenario-level behavior, recovery cases, and stress-oriented coverage
+- `performance/`: optional benchmarks that are only registered when explicitly enabled
+
+## Build-Time Controls
+
+The test tree is controlled by CMake options rather than hardcoded assumptions in this document.
+
+- `UNILINK_BUILD_TESTS`: enables test targets
+- `UNILINK_ENABLE_PERFORMANCE_TESTS`: registers optional performance tests
+
+Treat `test/CMakeLists.txt` and the active build directory as the source of truth for what is currently registered.
 
 ## Running Tests
 
-### Run All Tests
+### Run All Registered Tests
 
 ```bash
 cd build
 ctest --output-on-failure
 ```
 
-### Run by Category
+### Run By Broad Category
 
 ```bash
-# Fast feedback (unit tests only)
 ctest -L unit
-
-# Medium tests (integration)
 ctest -L integration
-
-# Slow tests (E2E)
 ctest -L e2e
-
-# Performance tests
 ctest -L performance
 ```
 
-### Run by Component
+`performance` only returns results if the build was configured with `-DUNILINK_ENABLE_PERFORMANCE_TESTS=ON`.
+
+### Useful Focused Runs
 
 ```bash
-# All TCP-related tests
+# TCP-heavy tests
 ctest -L tcp
 
-# All builder-related tests
+# Builder-related tests
 ctest -L builder
 
-# All mock tests
-ctest -L mock
+# Security and contract checks
+ctest -L security
+ctest -L contract
 ```
 
-### Run Specific Test Executable
+### Inspect What Is Currently Registered
 
 ```bash
-# Run specific test file
-./test/unit/run_unit_test_builder --gtest_filter="BuilderTest.*"
-
-# List all tests
-./test/unit/run_unit_test_builder --gtest_list_tests
-
-# Run with verbose output
-./test/unit/run_unit_test_builder --gtest_verbose
+ctest -N
+ctest -N -L unit
+ctest -N -L integration
+ctest -N -L e2e
 ```
 
----
+Use these commands instead of storing counts in documentation. The exact number of tests changes as coverage grows.
+
+## Notes
+
+- Label sets are not necessarily exclusive.
+- Performance sources may exist in the tree even when no performance tests are currently registered.
+- When test organization changes, update the commands and directory descriptions here, not the output of a particular local run.
 
 ## CI/CD Integration
 
-### GitHub Actions Workflows
-
-The project uses a **staged testing approach** in CI:
-
-#### 1. **Pull Request** (Fast feedback)
-- ✅ Unit Tests (~10s)
-- ✅ Integration Tests (~75s)
-- ⏭️ E2E Tests (skipped for PRs)
-
-#### 2. **Main/Develop Branch** (Full validation)
-- ✅ Unit Tests
-- ✅ Integration Tests
-- ✅ E2E Tests (~64s)
-
-#### 3. **Nightly/On-Demand** (Performance)
-- ✅ Performance Tests (~10s)
-- 📊 Benchmark results archived
-
-### Workflow Files
-
-- `.github/workflows/test-organized.yml` - Organized test execution
-- `.github/workflows/ci.yml` - Full CI/CD pipeline
-- `.github/workflows/coverage.yml` - Code coverage analysis
-
----
-
-## Test Results Summary
-
-Latest test run results:
-
-```
-Unit Tests:         91% pass rate (88/97)   ~10s
-Integration Tests:  83% pass rate (98/118)  ~75s
-E2E Tests:          91% pass rate (20/22)   ~64s
-Performance Tests:  100% pass rate (58/58)  ~10s
-----------------------------------------
-Total:              89% pass rate (264/295) ~160s
-```
-
----
-
-## Benefits of Organized Structure
-
-### 1. **Faster Feedback** ⚡
-- PR feedback in <2 minutes (unit tests only)
-- Parallel test execution
-- Selective test running
-
-### 2. **Better Maintainability** 🔧
-- Clear test organization
-- Easy to find specific tests
-- Logical grouping by functionality
-
-### 3. **Improved Developer Experience** 👨‍💻
-```bash
-# Quick check during development
-ctest -L unit
-
-# Full validation before commit
-ctest -L "unit|integration"
-
-# Performance regression check
-ctest -L performance
-```
-
-### 4. **CI Optimization** 🚀
-- Unit tests on every PR
-- Integration tests on develop/main
-- E2E tests on main only
-- Performance tests nightly
-
----
-
-## Adding New Tests
-
-### 1. Choose the Right Category
-
-- **Unit Test**: Testing a single class/function in isolation
-- **Integration Test**: Testing interaction between components
-- **E2E Test**: Testing complete user scenarios
-- **Performance Test**: Benchmarking and profiling
-
-### 2. Add Test File
-
-```cpp
-// test/unit/common/test_my_feature.cc
-#include <gtest/gtest.h>
-#include "unilink/my_feature.hpp"
-
-TEST(MyFeatureTest, BasicFunctionality) {
-  // Your test here
-}
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-```
-
-### 3. Update CMakeLists.txt
-
-```cmake
-# test/unit/CMakeLists.txt
-add_executable(run_unit_test_my_feature common/test_my_feature.cc)
-target_link_libraries(run_unit_test_my_feature
-  PRIVATE
-    unilink
-    GTest::gtest
-    GTest::gtest_main
-    GTest::gmock
-)
-gtest_discover_tests(run_unit_test_my_feature
-  PROPERTIES
-    LABELS "unit;common;fast"
-    TIMEOUT 30
-)
-```
-
-### 4. Build and Run
-
-```bash
-cd build
-cmake --build . --target run_unit_test_my_feature
-./test/unit/run_unit_test_my_feature
-```
-
----
-
-## Test Best Practices
-
-### Unit Tests
-- ✅ Fast (< 1 second per test)
-- ✅ Isolated (no external dependencies)
-- ✅ Deterministic (same result every time)
-- ✅ Focus on single responsibility
-
-### Integration Tests
-- ✅ Test component interactions
-- ✅ Use mocks when appropriate
-- ✅ Keep under 60 seconds
-- ✅ Test realistic scenarios
-
-### E2E Tests
-- ✅ Test complete user workflows
-- ✅ Minimize test count (high value only)
-- ✅ Can be slower (up to 2 minutes)
-- ✅ Test critical paths
-
-### Performance Tests
-- ✅ Measure performance metrics
-- ✅ Detect regressions
-- ✅ Archive results for comparison
-- ✅ Run in Release mode
-
----
-
-## Troubleshooting
-
-### Test Failures
-
-```bash
-# Run specific test with verbose output
-ctest -R "test_name" --verbose --output-on-failure
-
-# Run test directly (more control)
-./test/unit/run_unit_test_builder --gtest_filter="BuilderTest.BasicFunctionality"
-
-# Run with debugging
-gdb ./test/unit/run_unit_test_builder
-```
-
-### Build Issues
-
-```bash
-# Clean rebuild
-rm -rf build
-cmake -S . -B build -DUNILINK_BUILD_TESTS=ON
-cmake --build build
-
-# Check test targets
-cmake --build build --target help | grep test
-```
-
-### Timeout Issues
-
-If tests timeout in CI:
-1. Check test timeout settings in CMakeLists.txt
-2. Reduce test complexity
-3. Use mocks instead of real I/O
-4. Consider moving to E2E category
-
----
-
-## Future Improvements
-
-- [ ] Add code coverage per test category
-- [ ] Implement test sharding for parallel execution
-- [ ] Add test result trending and analytics
-- [ ] Create test templates for common patterns
-- [ ] Add mutation testing for test quality
-- [ ] Implement visual test reports
-
----
-
-## References
-
-- [Google Test Documentation](https://google.github.io/googletest/)
-- [CTest Documentation](https://cmake.org/cmake/help/latest/manual/ctest.1.html)
-- [Test Coverage Guide](./COVERAGE_IMPROVEMENT_GUIDE.md)
-- [Test Refactoring Plan](./TEST_REFACTORING_PLAN.md)
+Repository workflows live under `.github/workflows/`. If labels or test grouping changes, keep CI filters in sync with the commands documented here.

--- a/docs/tutorials/01_getting_started.md
+++ b/docs/tutorials/01_getting_started.md
@@ -1,317 +1,163 @@
 # Getting Started with Unilink
 
-This tutorial will guide you through creating your first application with unilink.
+This tutorial shows the current builder-based C++ API for creating a simple TCP client with connection, data, disconnect, and error callbacks.
 
-**Duration**: 15 minutes  
-**Difficulty**: Beginner  
-**Prerequisites**: Basic C++ knowledge, CMake installed
+**Duration**: 10 minutes
+**Difficulty**: Beginner
+**Prerequisites**: Basic C++ and CMake familiarity
 
 ---
 
 ## What You'll Build
 
-A simple TCP client that:
-1. Connects to a server
-2. Sends a message
-3. Receives a response
-4. Handles disconnections gracefully
+A small TCP client that:
+
+1. connects to a server
+2. prints connection status
+3. receives messages through `MessageContext`
+4. sends user input until `/quit`
 
 ---
 
-## Step 1: Install Dependencies
+## Step 1: Create The Client
 
-### Ubuntu/Debian
-```bash
-sudo apt update
-sudo apt install -y build-essential cmake libboost-dev libboost-system-dev
-```
-
-### macOS
-```bash
-brew install cmake boost
-```
-
-### Windows (vcpkg)
-```bash
-vcpkg install boost
-```
-
----
-
-## Step 2: Install Unilink
-
-### Option A: From Source
-```bash
-git clone https://github.com/jwsung91/unilink.git
-cd unilink
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j
-sudo cmake --install build
-```
-
-### Option B: Use as Subdirectory
-```cmake
-# In your CMakeLists.txt
-add_subdirectory(unilink)
-target_link_libraries(your_app PRIVATE unilink)
-```
-
----
-
-## Step 3: Create Your First Client
-
-Create a file named `my_first_client.cpp`:
+Create `my_first_client.cpp`:
 
 ```cpp
 #include <iostream>
-#include <thread>
-#include <chrono>
+#include <string>
 #include "unilink/unilink.hpp"
 
-int main() {
-    std::cout << "=== My First Unilink Client ===" << std::endl;
-    
-    // Step 1: Create a TCP client
-    auto client = unilink::tcp_client("127.0.0.1", 8080)
-        
-        // Step 2: Handle connection event
-        .on_connect([]() {
-            std::cout << "✓ Connected to server!" << std::endl;
+int main(int argc, char** argv) {
+    std::string host = (argc > 1) ? argv[1] : "127.0.0.1";
+    uint16_t port = (argc > 2) ? static_cast<uint16_t>(std::stoi(argv[2])) : 8080;
+
+    auto client = unilink::tcp_client(host, port)
+        .retry_interval(2000)
+        .max_retries(3)
+        .on_connect([](const unilink::ConnectionContext&) {
+            std::cout << "Connected to server" << std::endl;
         })
-        
-        // Step 3: Handle incoming data (Zero-copy with ConstByteSpan)
-        .on_bytes([](unilink::memory::ConstByteSpan data) {
-            // Convert to string safely
-            std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-            std::cout << "✓ Received: " << str << std::endl;
+        .on_disconnect([](const unilink::ConnectionContext&) {
+            std::cout << "Disconnected from server" << std::endl;
         })
-        
-        // Step 4: Handle disconnection
-        .on_disconnect([]() {
-            std::cout << "✗ Disconnected from server" << std::endl;
+        .on_data([](const unilink::MessageContext& ctx) {
+            std::cout << "[Server] " << ctx.data() << std::endl;
         })
-        
-        // Step 5: Handle errors
-        .on_error([](const std::string& error) {
-            std::cerr << "✗ Error: " << error << std::endl;
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "[Error] " << ctx.message()
+                      << " (code=" << static_cast<int>(ctx.code()) << ")" << std::endl;
         })
-        
-        // Step 6: Configure auto-reconnection (default is 3000ms)
-        // .retry_interval(3000)  // This is the default, so we can omit it
-        
-        // Build the client
         .build();
-    
-    // Step 7: Start the connection explicitly
-    client->start();
-    
-    // Wait for connection (up to 5 seconds)
-    std::cout << "Waiting for connection..." << std::endl;
-    for (int i = 0; i < 50; ++i) {
-        if (client->is_connected()) {
-            break;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-    
-    // Send a message
-    if (client->is_connected()) {
-        std::cout << "Sending message..." << std::endl;
-        client->send("Hello from unilink!");
-    } else {
-        std::cerr << "Failed to connect. Is the server running?" << std::endl;
+
+    std::cout << "Connecting to " << host << ":" << port << "..." << std::endl;
+    if (!client->start().get()) {
+        std::cerr << "Initial connection attempt failed" << std::endl;
         return 1;
     }
-    
-    // Keep running for 10 seconds
-    std::cout << "Running for 10 seconds..." << std::endl;
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-    
-    std::cout << "Shutting down..." << std::endl;
+
+    std::cout << "Type messages. Use /quit to exit." << std::endl;
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "/quit") break;
+        client->send(line);
+    }
+
+    client->stop();
     return 0;
 }
 ```
 
 ---
 
-## Step 4: Create CMakeLists.txt
+## Step 2: Build With CMake
+
+Create `CMakeLists.txt`:
 
 ```cmake
-cmake_minimum_required(VERSION 3.10)
-project(MyFirstUnilinkApp)
+cmake_minimum_required(VERSION 3.12)
+project(my_first_unilink_app LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+find_package(unilink CONFIG REQUIRED)
 
-# Find unilink (adjust path if needed)
-find_package(unilink REQUIRED)
-
-# Create executable
 add_executable(my_first_client my_first_client.cpp)
+target_link_libraries(my_first_client PRIVATE unilink::unilink)
+target_compile_features(my_first_client PRIVATE cxx_std_17)
+```
 
-# Link libraries
-target_link_libraries(my_first_client
-    PRIVATE
-        unilink
-        Boost::system
-        pthread
-)
+Then build:
+
+```bash
+cmake -S . -B build
+cmake --build build
 ```
 
 ---
 
-## Step 5: Build Your Application
+## Step 3: Run Against A Test Server
 
-```bash
-mkdir build && cd build
-cmake ..
-cmake --build .
-```
+Start a simple server in another terminal:
 
-Or with direct compilation:
-```bash
-g++ -std=c++17 my_first_client.cpp \
-    -o my_first_client \
-    -lunilink \
-    -lboost_system \
-    -pthread
-```
-
----
-
-## Step 6: Test Your Application
-
-### Start a Test Server
-
-**Terminal 1** (using netcat):
 ```bash
 nc -l 8080
 ```
 
-Or use the provided example server:
+Run the client:
+
 ```bash
-cd interface-socket/build/examples/tcp/single-echo
-./echo_tcp_server 8080
+./build/my_first_client
 ```
 
-### Run Your Client
-
-**Terminal 2**:
-```bash
-./my_first_client
-```
-
-**Expected Output**:
-```
-=== My First Unilink Client ===
-Waiting for connection...
-✓ Connected to server!
-Sending message...
-✓ Received: Hello from unilink!
-Running for 10 seconds...
-Shutting down...
-```
+Type a message in the client, then type a reply in the `nc` terminal.
 
 ---
 
-## Step 7: Understanding the Code
+## What Changed In The Current API
 
-### 1. Builder Pattern
+The current tutorial code uses context-based callbacks consistently:
+
+- `on_connect(const ConnectionContext&)`
+- `on_disconnect(const ConnectionContext&)`
+- `on_data(const MessageContext&)`
+- `on_error(const ErrorContext&)`
+
+The initial `start()` call returns `std::future<bool>`, so the common pattern is:
+
 ```cpp
-auto client = unilink::tcp_client("127.0.0.1", 8080)
-    .on_connect(...)
-    .on_data(...)
-    .build();
+if (!client->start().get()) {
+    // handle startup failure
+}
 ```
-The builder pattern provides a fluent, chainable API for configuration.
 
-### 2. Callbacks
-```cpp
-.on_connect([]() { /* called when connected */ })
-.on_bytes([](unilink::memory::ConstByteSpan data) { /* zero-copy data access */ })
-```
-Callbacks are invoked automatically by the library. The `.on_bytes` callback provides high-performance access to data.
+After the client is running, use:
 
-### 3. Automatic Reconnection
-```cpp
-.retry_interval(3000)  // Retry every 3 seconds (default)
-```
-After calling `client->start()`, the client will automatically attempt to reconnect if disconnected.
-
-### 4. Thread Safety
-All callbacks are executed in a thread-safe manner. You can safely access shared data from callbacks using proper synchronization.
+- `client->send(...)`
+- `client->send_line(...)`
+- `client->is_connected()`
+- `client->stop()`
 
 ---
 
-## Common Issues
+## Use The Full Example If You Want More
 
-### Issue 1: Connection Refused
-```
-✗ Error: Connection refused
-```
+The repository already includes ready-to-build tutorial examples:
 
-**Solution**: Make sure the server is running on the correct port.
+- [examples/tutorials/getting_started/simple_client.cpp](../../examples/tutorials/getting_started/simple_client.cpp)
+- [examples/tutorials/getting_started/my_first_client.cpp](../../examples/tutorials/getting_started/my_first_client.cpp)
+- [examples/tutorials/README.md](../../examples/tutorials/README.md)
 
-### Issue 2: Port Already in Use
-```
-✗ Error: Address already in use
-```
-
-**Solution**: The port is being used by another application. Choose a different port or stop the other application.
-
-### Issue 3: Compilation Error - unilink not found
-```
-fatal error: unilink/unilink.hpp: No such file or directory
-```
-
-**Solution**: 
-```bash
-# Make sure unilink is installed
-sudo cmake --install build
-
-# Or add include path
-g++ -I/path/to/unilink/include ...
-```
+This tutorial stays smaller than the example sources on purpose.
 
 ---
 
 ## Next Steps
 
-Congratulations! You've created your first unilink application. 
-
-**Continue learning:**
 - [Building a TCP Server](02_tcp_server.md)
 - [UDS Communication](03_uds_communication.md)
 - [Serial Communication](04_serial_communication.md)
 - [UDP Communication](05_udp_communication.md)
-- [Best Practices](../guides/core/best_practices.md)
-
-**Explore more:**
-- [API Reference](../reference/api_guide.md)
-- [Best Practices](../guides/core/best_practices.md)
-- [Examples Directory](../../examples/)
-
----
-
-## Full Example Code
-
-✅ **Ready-to-compile examples are available!**
-
-**Location**: `examples/tutorials/getting_started/`
-
-| File | Description |
-|------|-------------|
-| `simple_client.cpp` | Minimal 30-second example |
-| `my_first_client.cpp` | Complete walkthrough from this tutorial |
-
-**Build and run**:
-```bash
-# From project root
-cmake --build build --target tutorial_my_first_client
-./build/examples/tutorials/tutorial_my_first_client
-```
-
-See [examples/tutorials/README.md](../../examples/tutorials/README.md) for detailed build instructions.
+- [API Reference](../reference/api_guide.md#tcp-client)
 
 ---
 

--- a/docs/tutorials/01_getting_started.md
+++ b/docs/tutorials/01_getting_started.md
@@ -1,4 +1,4 @@
-# Tutorial 1: Getting Started with Unilink
+# Getting Started with Unilink
 
 This tutorial will guide you through creating your first application with unilink.
 
@@ -280,13 +280,15 @@ g++ -I/path/to/unilink/include ...
 Congratulations! You've created your first unilink application. 
 
 **Continue learning:**
-- [Tutorial 2: Building a TCP Server](02_tcp_server.md)
-- [Tutorial 3: Serial Communication](03_serial_communication.md)
-- [Tutorial 4: Error Handling](04_error_handling.md)
+- [Building a TCP Server](02_tcp_server.md)
+- [UDS Communication](03_uds_communication.md)
+- [Serial Communication](04_serial_communication.md)
+- [UDP Communication](05_udp_communication.md)
+- [Best Practices](../guides/core/best_practices.md)
 
 **Explore more:**
-- [API Reference](../reference/API_GUIDE.md)
-- [Best Practices](../guides/best_practices.md)
+- [API Reference](../reference/api_guide.md)
+- [Best Practices](../guides/core/best_practices.md)
 - [Examples Directory](../../examples/)
 
 ---
@@ -313,5 +315,4 @@ See [examples/tutorials/README.md](../../examples/tutorials/README.md) for detai
 
 ---
 
-**Next Tutorial**: [Building a TCP Server →](02_tcp_server.md)
-
+**Next**: [Building a TCP Server →](02_tcp_server.md)

--- a/docs/tutorials/01_getting_started.md
+++ b/docs/tutorials/01_getting_started.md
@@ -23,6 +23,7 @@ A small TCP client that:
 
 Create `my_first_client.cpp`:
 
+<!-- doc-compile: tutorial_getting_started_client -->
 ```cpp
 #include <iostream>
 #include <string>

--- a/docs/tutorials/02_tcp_server.md
+++ b/docs/tutorials/02_tcp_server.md
@@ -69,7 +69,7 @@ public:
     }
 
 private:
-    std::shared_ptr<unilink::TcpServer> server_;
+    std::unique_ptr<unilink::TcpServer> server_;
 };
 
 int main() {

--- a/docs/tutorials/02_tcp_server.md
+++ b/docs/tutorials/02_tcp_server.md
@@ -1,596 +1,162 @@
 # Building a TCP Server
 
-Learn how to create a robust TCP server with unilink.
+This tutorial uses the current `TcpServerBuilder` and `TcpServer` wrapper API to build a simple echo server with context-based callbacks.
 
-**Duration**: 20 minutes  
-**Difficulty**: Beginner to Intermediate  
+**Duration**: 15 minutes
+**Difficulty**: Beginner to Intermediate
 **Prerequisites**: [Getting Started](01_getting_started.md)
 
 ---
 
 ## What You'll Build
 
-A TCP echo server that:
-1. Accepts multiple client connections
-2. Echoes back any received data
-3. Tracks connected clients
-4. Handles client disconnections gracefully
+A TCP server that:
+
+1. listens on a port
+2. accepts multiple clients
+3. logs connect and disconnect events
+4. echoes messages back to the sender
 
 ---
 
-## Step 1: Basic Server Setup
+## Step 1: Create The Server
 
 Create `echo_server.cpp`:
 
 ```cpp
 #include <iostream>
-#include <atomic>
-#include <thread>
+#include <string>
 #include "unilink/unilink.hpp"
 
-class EchoServer {
-private:
-    std::shared_ptr<unilink::wrapper::TcpServer> server_;
-    std::atomic<int> client_count_{0};
-    uint16_t port_;
-
-public:
-    EchoServer(uint16_t port) : port_(port) {}
-    
-    void start() {
-        std::cout << "Starting echo server on port " << port_ << std::endl;
-        
-        server_ = unilink::tcp_server(port_)
-            .on_connect([this](size_t client_id, const std::string& ip) {
-                handle_connect(client_id, ip);
-            })
-            .on_bytes([this](size_t client_id, unilink::memory::ConstByteSpan data) {
-                std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-                handle_data(client_id, str);
-            })
-            .on_disconnect([this](size_t client_id) {
-                handle_disconnect(client_id);
-            })
-            .on_error([this](const std::string& error) {
-                handle_error(error);
-            })
-            .build();
-        
-        server_->start();
-        std::cout << "Server started! Waiting for connections..." << std::endl;
-    }
-    
-    void handle_connect(size_t client_id, const std::string& ip) {
-        client_count_++;
-        std::cout << "[Client " << client_id << "] Connected from " << ip 
-                  << " (Total clients: " << client_count_ << ")" << std::endl;
-        
-        // Send welcome message
-        server_->send_to_client(client_id, "Welcome to Echo Server!\n");
-    }
-    
-    void handle_data(size_t client_id, const std::string& data) {
-        std::cout << "[Client " << client_id << "] Received: " << data << std::endl;
-        
-        // Echo back the data
-        server_->send_to_client(client_id, "Echo: " + data);
-    }
-    
-    void handle_disconnect(size_t client_id) {
-        client_count_--;
-        std::cout << "[Client " << client_id << "] Disconnected "
-                  << "(Remaining clients: " << client_count_ << ")" << std::endl;
-    }
-    
-    void handle_error(const std::string& error) {
-        std::cerr << "[Error] " << error << std::endl;
-    }
-    
-    void stop() {
-        if (server_) {
-            std::cout << "Stopping server..." << std::endl;
-            server_->send("Server shutting down. Goodbye!\n");
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            server_->stop();
-        }
-    }
-    
-    bool is_running() const {
-        return server_ && server_->is_listening();
-    }
-};
-
-int main(int argc, char** argv) {
-    uint16_t port = (argc > 1) ? std::stoi(argv[1]) : 8080;
-    
-    EchoServer server(port);
-    server.start();
-    
-    // Run until user presses Ctrl+C
-    std::cout << "Press Ctrl+C to stop the server" << std::endl;
-    while (server.is_running()) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-    
-    server.stop();
-    return 0;
-}
-```
-
----
-
-## Step 2: Build and Test
-
-### Compile
-```bash
-g++ -std=c++17 echo_server.cpp -o echo_server -lunilink -lboost_system -pthread
-```
-
-### Run Server
-```bash
-./echo_server 8080
-```
-
-### Test with Multiple Clients
-
-**Terminal 1** (Server):
-```bash
-./echo_server 8080
-```
-
-**Terminal 2** (Client 1):
-```bash
-telnet localhost 8080
-```
-
-**Terminal 3** (Client 2):
-```bash
-telnet localhost 8080
-```
-
-Type messages in each client terminal and see them echoed back!
-
----
-
-## Step 3: Add Client Management
-
-Enhanced version with client tracking:
-
-```cpp
-#include <map>
-#include <mutex>
-
-class AdvancedEchoServer {
-private:
-    struct ClientInfo {
-        std::string ip;
-        std::chrono::system_clock::time_point connected_at;
-        size_t messages_sent{0};
-    };
-    
-    std::shared_ptr<unilink::wrapper::TcpServer> server_;
-    std::map<size_t, ClientInfo> clients_;
-    std::mutex clients_mutex_;
-    uint16_t port_;
-
-public:
-    AdvancedEchoServer(uint16_t port) : port_(port) {}
-    
-    void start() {
-        server_ = unilink::tcp_server(port_)
-            .on_connect([this](size_t id, const std::string& ip) {
-                std::lock_guard<std::mutex> lock(clients_mutex_);
-                clients_[id] = {ip, std::chrono::system_clock::now(), 0};
-                
-                std::cout << "[Client " << id << "] Connected from " << ip << std::endl;
-                server_->send_to_client(id, "Welcome! You are client #" + 
-                                       std::to_string(id) + "\n");
-            })
-            .on_bytes([this](size_t id, unilink::memory::ConstByteSpan data) {
-                {
-                    std::lock_guard<std::mutex> lock(clients_mutex_);
-                    if (clients_.count(id)) {
-                        clients_[id].messages_sent++;
-                    }
-                }
-                
-                std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-
-                // Handle commands
-                if (str == "/stats\n") {
-                    send_statistics(id);
-                } else if (str == "/clients\n") {
-                    send_client_list(id);
-                } else {
-                    // Echo normally
-                    server_->send_to_client(id, "Echo: " + str);
-                }
-            })
-            .on_disconnect([this](size_t id) {
-                std::lock_guard<std::mutex> lock(clients_mutex_);
-                clients_.erase(id);
-                std::cout << "[Client " << id << "] Disconnected" << std::endl;
-            })
-            .build();
-        
-        server_->start();
-        std::cout << "Advanced Echo Server started on port " << port_ << std::endl;
-    }
-    
-    void send_statistics(size_t client_id) {
-        std::lock_guard<std::mutex> lock(clients_mutex_);
-        
-        if (clients_.count(client_id) == 0) return;
-        
-        auto& info = clients_[client_id];
-        auto duration = std::chrono::system_clock::now() - info.connected_at;
-        auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration).count();
-        
-        std::string stats = "=== Your Statistics ===\n";
-        stats += "IP: " + info.ip + "\n";
-        stats += "Connected for: " + std::to_string(seconds) + " seconds\n";
-        stats += "Messages sent: " + std::to_string(info.messages_sent) + "\n";
-        stats += "======================\n";
-        
-        server_->send_to_client(client_id, stats);
-    }
-    
-    void send_client_list(size_t client_id) {
-        std::lock_guard<std::mutex> lock(clients_mutex_);
-        
-        std::string list = "=== Connected Clients ===\n";
-        for (const auto& [id, info] : clients_) {
-            list += "Client " + std::to_string(id) + ": " + info.ip;
-            if (id == client_id) list += " (you)";
-            list += "\n";
-        }
-        list += "Total: " + std::to_string(clients_.size()) + " clients\n";
-        list += "========================\n";
-        
-        server_->send_to_client(client_id, list);
-    }
-    
-    void stop() {
-        if (server_) {
-            server_->send("Server shutting down...\n");
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            server_->stop();
-        }
-    }
-};
-```
-
----
-
-## Step 4: Single Client Mode
-
-For applications that only need one client at a time:
-
-```cpp
-auto server = unilink::tcp_server(8080)
-    .single_client()  // Only accept one client
-    .on_connect([](size_t id, const std::string& ip) {
-        std::cout << "Client connected: " << ip << std::endl;
-        // Previous client is automatically disconnected
-    })
-    .on_bytes([](size_t id, unilink::memory::ConstByteSpan data) {
-        std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-        std::cout << "Received: " << str << std::endl;
-    })
-    .build();
-
-server->start();
-// ... do work ...
-server->stop();  // Clean shutdown when done
-```
-
----
-
-## Step 5: Port Retry Logic
-
-Handle cases where the port might be in use:
-
-```cpp
-auto server = unilink::tcp_server(8080)
-    .enable_port_retry(
-        true,   // Enable retry
-        5,      // Try 5 times
-        1000    // Wait 1 second between attempts
-    )
-    .on_error([](const std::string& error) {
-        std::cerr << "Server error: " << error << std::endl;
-    })
-    .build();
-
-server->start();
-
-// Check if server started successfully
-std::this_thread::sleep_for(std::chrono::seconds(6)); // Wait for retries
-if (!server->is_listening()) {
-    std::cerr << "Failed to start server after retries" << std::endl;
-    return 1;
-}
-
-// ... do work ...
-server->stop();  // Clean shutdown
-```
-
----
-
-## Step 6: Broadcasting to All Clients
-
-Send messages to all connected clients:
-
-```cpp
-class BroadcastServer {
-private:
-    std::shared_ptr<unilink::wrapper::TcpServer> server_;
-
-public:
-    void start() {
-        server_ = unilink::tcp_server(8080)
-            .on_bytes([this](size_t sender_id, unilink::memory::ConstByteSpan data) {
-                std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-
-                // Broadcast to all clients
-                std::string msg = "[Client " + std::to_string(sender_id) + "]: " + str;
-                server_->send(msg);  // Send to ALL clients
-                
-                std::cout << "Broadcasted: " << msg << std::endl;
-            })
-            .build();
-        
-        server_->start();
-    }
-};
-```
-
----
-
-## Complete Example: Chat Server
-
-```cpp
-#include <iostream>
-#include <map>
-#include <mutex>
-#include "unilink/unilink.hpp"
-
-class ChatServer {
-private:
-    std::shared_ptr<unilink::wrapper::TcpServer> server_;
-    std::map<size_t, std::string> nicknames_;
-    std::mutex mutex_;
-
+class EchoServerApp {
 public:
     void start(uint16_t port) {
         server_ = unilink::tcp_server(port)
-            .on_connect([this](size_t id, const std::string& ip) {
-                std::lock_guard<std::mutex> lock(mutex_);
-                nicknames_[id] = "User" + std::to_string(id);
-                
-                std::string msg = nicknames_[id] + " joined the chat!\n";
-                server_->send(msg);
-                std::cout << msg;
-                
-                server_->send_to_client(id, "Welcome! Type /nick <name> to set your nickname\n");
+            .unlimited_clients()
+            .enable_port_retry(true)
+            .on_connect([this](const unilink::ConnectionContext& ctx) {
+                std::cout << "[Connect] client=" << ctx.client_id()
+                          << " info=" << ctx.client_info() << std::endl;
+                if (server_) {
+                    server_->send_to(ctx.client_id(), "Welcome to Echo Server!\n");
+                }
             })
-            .on_bytes([this](size_t id, unilink::memory::ConstByteSpan data) {
-                std::string str = unilink::common::safe_convert::uint8_to_string(data.data(), data.size());
-                handle_message(id, str);
+            .on_data([this](const unilink::MessageContext& ctx) {
+                std::cout << "[Data] client=" << ctx.client_id()
+                          << " data=" << ctx.data() << std::endl;
+                if (server_) {
+                    server_->send_to(ctx.client_id(), "Echo: " + std::string(ctx.data()));
+                }
             })
-            .on_disconnect([this](size_t id) {
-                std::lock_guard<std::mutex> lock(mutex_);
-                std::string msg = nicknames_[id] + " left the chat.\n";
-                nicknames_.erase(id);
-                
-                server_->send(msg);
-                std::cout << msg;
+            .on_disconnect([](const unilink::ConnectionContext& ctx) {
+                std::cout << "[Disconnect] client=" << ctx.client_id() << std::endl;
+            })
+            .on_error([](const unilink::ErrorContext& ctx) {
+                std::cerr << "[Error] " << ctx.message() << std::endl;
             })
             .build();
-        
-        server_->start();
-        std::cout << "Chat server started on port " << port << std::endl;
-    }
-    
-    void handle_message(size_t id, const std::string& data) {
-        if (data.substr(0, 5) == "/nick") {
-            // Change nickname
-            std::string new_nick = data.substr(6);
-            new_nick.erase(new_nick.find_last_not_of(" \n\r\t") + 1);
-            
-            std::lock_guard<std::mutex> lock(mutex_);
-            std::string old_nick = nicknames_[id];
-            nicknames_[id] = new_nick;
-            
-            std::string msg = old_nick + " is now known as " + new_nick + "\n";
-            server_->send(msg);
-        } else {
-            // Broadcast message
-            std::lock_guard<std::mutex> lock(mutex_);
-            std::string msg = nicknames_[id] + ": " + data;
-            server_->send(msg);
-            std::cout << msg;
+
+        if (!server_->start().get()) {
+            throw std::runtime_error("failed to start TCP server");
         }
     }
+
+    void stop() {
+        if (server_) {
+            server_->broadcast("Server shutting down\n");
+            server_->stop();
+        }
+    }
+
+private:
+    std::shared_ptr<unilink::TcpServer> server_;
 };
 
-int main(int argc, char** argv) {
-    uint16_t port = (argc > 1) ? std::stoi(argv[1]) : 8080;
-    
-    ChatServer server;
-    server.start(port);
-    
-    std::cout << "Chat server running. Press Ctrl+C to stop." << std::endl;
-    while (true) {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-    
+int main() {
+    EchoServerApp app;
+    app.start(8080);
+
+    std::cout << "Press Enter to stop..." << std::endl;
+    std::cin.get();
+
+    app.stop();
     return 0;
 }
 ```
 
 ---
 
-## Testing Your Chat Server
+## Step 2: Run It
 
-### Start Server
+Start the server:
+
 ```bash
-./chat_server 8080
+./echo_server
 ```
 
-### Connect Multiple Clients
+Open another terminal and connect:
+
 ```bash
-# Terminal 1
-telnet localhost 8080
-
-# Terminal 2
-telnet localhost 8080
-
-# Terminal 3
-telnet localhost 8080
+nc localhost 8080
 ```
 
-### Try Commands
-```
-/nick Alice
-Hello everyone!
-/nick Bob
-Hi Alice!
-```
+Anything you send should be echoed back.
 
 ---
 
-## Best Practices
+## Step 3: Understand The Current Server API
 
-### 1. Always Check Server Status
-```cpp
-if (!server->is_listening()) {
-    std::cerr << "Server failed to start" << std::endl;
-    return 1;
-}
-```
+The current server wrapper uses these key methods:
 
-### 2. Use Thread-Safe Data Structures
-```cpp
-std::mutex mutex_;
-std::map<size_t, ClientInfo> clients_;
+- `start().get()` to verify startup
+- `broadcast(...)` to send to all connected clients
+- `send_to(client_id, ...)` to reply to one client
+- `is_listening()` to check listener state
+- `get_client_count()` and `get_connected_clients()` for inspection
 
-// Always lock when accessing shared data
-{
-    std::lock_guard<std::mutex> lock(mutex_);
-    clients_[id] = info;
-}
-```
+The key callback contexts are:
 
-### 3. Handle Graceful Shutdown
-```cpp
-void shutdown() {
-    // Notify clients
-    server_->send("Server shutting down...\n");
-    
-    // Wait for messages to be sent
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    
-    // Stop server
-    server_->stop();
-}
-```
-
-### 4. Implement Error Recovery
-```cpp
-.on_error([this](const std::string& error) {
-    log_error(error);
-    
-    // Attempt recovery if needed
-    if (is_recoverable(error)) {
-        attempt_recovery();
-    }
-})
-```
+- `ConnectionContext`: client id and client info
+- `MessageContext`: client id, message data, and peer info
+- `ErrorContext`: error code and message
 
 ---
 
-## Common Patterns
+## Client Limits
 
-### Pattern 1: Command Parser
+Choose a client-limit mode before `build()`:
+
 ```cpp
-void handle_command(size_t client_id, const std::string& cmd) {
-    if (cmd == "/help") {
-        send_help(client_id);
-    } else if (cmd == "/quit") {
-        disconnect_client(client_id);
-    } else if (cmd.substr(0, 5) == "/msg ") {
-        send_private_message(client_id, cmd.substr(5));
-    } else {
-        server_->send_to_client(client_id, "Unknown command\n");
-    }
-}
+unilink::tcp_server(8080).single_client();
+unilink::tcp_server(8080).multi_client(8);
+unilink::tcp_server(8080).unlimited_clients();
 ```
 
-### Pattern 2: Rate Limiting
-```cpp
-struct RateLimiter {
-    size_t max_messages_per_second{10};
-    std::map<size_t, std::deque<std::chrono::steady_clock::time_point>> timestamps;
-    
-    bool is_allowed(size_t client_id) {
-        auto now = std::chrono::steady_clock::now();
-        auto& times = timestamps[client_id];
-        
-        // Remove old timestamps
-        while (!times.empty() && 
-               now - times.front() > std::chrono::seconds(1)) {
-            times.pop_front();
-        }
-        
-        // Check limit
-        if (times.size() >= max_messages_per_second) {
-            return false;
-        }
-        
-        times.push_back(now);
-        return true;
-    }
-};
-```
+For tutorial simplicity, the example above uses `unlimited_clients()`.
+
+---
+
+## Use The Full Example Programs For More
+
+The repository already includes maintained tutorial examples:
+
+- [examples/tutorials/tcp_server/echo_server.cpp](../../examples/tutorials/tcp_server/echo_server.cpp)
+- [examples/tutorials/tcp_server/chat_server.cpp](../../examples/tutorials/tcp_server/chat_server.cpp)
+- [examples/tutorials/README.md](../../examples/tutorials/README.md)
+
+Use the chat example when you want a larger stateful server example with nicknames and broadcast behavior.
 
 ---
 
 ## Next Steps
 
-- [UDS Communication →](03_uds_communication.md)
+- [UDS Communication](03_uds_communication.md)
 - [Serial Communication](04_serial_communication.md)
 - [UDP Communication](05_udp_communication.md)
+- [API Reference](../reference/api_guide.md#tcp-server)
 - [Best Practices Guide](../guides/core/best_practices.md)
-- [Performance Guide](../guides/advanced/performance.md)
 
 ---
 
-## Full Example Code
-
-✅ **Ready-to-compile examples are available!**
-
-**Location**: `examples/tutorials/tcp_server/`
-
-| File | Description |
-|------|-------------|
-| `echo_server.cpp` | Basic echo server from this tutorial |
-| `chat_server.cpp` | Complete chat server with commands |
-
-**Build and run**:
-```bash
-# Build echo server
-cmake --build build --target tutorial_echo_server
-./build/examples/tutorials/tutorial_echo_server 8080
-
-# Build chat server
-cmake --build build --target tutorial_chat_server
-./build/examples/tutorials/tutorial_chat_server 8080
-```
-
-See [examples/tutorials/README.md](../../examples/tutorials/README.md) for detailed build instructions.
-
----
-
-**Previous**: [← Getting Started](01_getting_started.md)  
+**Previous**: [← Getting Started](01_getting_started.md)
 **Next**: [UDS Communication →](03_uds_communication.md)

--- a/docs/tutorials/02_tcp_server.md
+++ b/docs/tutorials/02_tcp_server.md
@@ -1,10 +1,10 @@
-# Tutorial 2: Building a TCP Server
+# Building a TCP Server
 
 Learn how to create a robust TCP server with unilink.
 
 **Duration**: 20 minutes  
 **Difficulty**: Beginner to Intermediate  
-**Prerequisites**: [Tutorial 1: Getting Started](01_getting_started.md)
+**Prerequisites**: [Getting Started](01_getting_started.md)
 
 ---
 
@@ -558,9 +558,11 @@ struct RateLimiter {
 
 ## Next Steps
 
-- [Tutorial 3: Serial Communication →](03_serial_communication.md)
-- [Best Practices Guide](../guides/best_practices.md)
-- [Performance Tuning](../guides/performance_tuning.md)
+- [UDS Communication →](03_uds_communication.md)
+- [Serial Communication](04_serial_communication.md)
+- [UDP Communication](05_udp_communication.md)
+- [Best Practices Guide](../guides/core/best_practices.md)
+- [Performance Guide](../guides/advanced/performance.md)
 
 ---
 
@@ -591,5 +593,4 @@ See [examples/tutorials/README.md](../../examples/tutorials/README.md) for detai
 ---
 
 **Previous**: [← Getting Started](01_getting_started.md)  
-**Next**: [Serial Communication →](03_serial_communication.md)
-
+**Next**: [UDS Communication →](03_uds_communication.md)

--- a/docs/tutorials/02_tcp_server.md
+++ b/docs/tutorials/02_tcp_server.md
@@ -23,6 +23,7 @@ A TCP server that:
 
 Create `echo_server.cpp`:
 
+<!-- doc-compile: tutorial_tcp_server_echo -->
 ```cpp
 #include <iostream>
 #include <string>

--- a/docs/tutorials/03_uds_communication.md
+++ b/docs/tutorials/03_uds_communication.md
@@ -1,4 +1,4 @@
-# Tutorial 03: Local IPC with Unix Domain Sockets (UDS)
+# Local IPC with Unix Domain Sockets (UDS)
 
 In this tutorial, you'll learn how to implement high-performance local inter-process communication using Unix Domain Sockets (UDS) in Unilink.
 
@@ -119,3 +119,16 @@ Since the socket is a file, you can control which users can connect to your serv
 
 ## Summary
 You have successfully implemented a local IPC system using Unilink's UDS support. The Builder API makes it easy to switch between TCP and UDS by simply changing one line of code, while keeping your business logic intact.
+
+---
+
+## Next Steps
+
+- [Serial Communication](04_serial_communication.md)
+- [UDP Communication](05_udp_communication.md)
+- [API Reference](../reference/api_guide.md#uds-communication)
+
+---
+
+**Previous**: [← Building a TCP Server](02_tcp_server.md)
+**Next**: [Serial Communication →](04_serial_communication.md)

--- a/docs/tutorials/03_uds_communication.md
+++ b/docs/tutorials/03_uds_communication.md
@@ -20,6 +20,7 @@ A local echo service that:
 
 ## Step 1: Create A UDS Server
 
+<!-- doc-compile: tutorial_uds_server -->
 ```cpp
 #include <iostream>
 #include <string>
@@ -63,6 +64,7 @@ int main() {
 
 ## Step 2: Create A UDS Client
 
+<!-- doc-compile: tutorial_uds_client -->
 ```cpp
 #include <iostream>
 #include <string>

--- a/docs/tutorials/03_uds_communication.md
+++ b/docs/tutorials/03_uds_communication.md
@@ -1,62 +1,70 @@
-# Local IPC with Unix Domain Sockets (UDS)
+# UDS Communication
 
-In this tutorial, you'll learn how to implement high-performance local inter-process communication using Unix Domain Sockets (UDS) in Unilink.
+This tutorial shows the current UDS client/server API using `uds_server(...)` and `uds_client(...)` from `unilink/unilink.hpp`.
+
+**Duration**: 10 minutes
+**Difficulty**: Beginner to Intermediate
+**Prerequisites**: [Building a TCP Server](02_tcp_server.md)
 
 ---
 
-## What are Unix Domain Sockets?
+## What You'll Build
 
-Unix Domain Sockets (UDS) are a data communication endpoint for exchanging data between processes executing on the same host operating system. While TCP/IP is designed for network communication, UDS is optimized for local communication, offering:
+A local echo service that:
 
-- **Lower Latency**: No network stack overhead (routing, checksums, etc.).
-- **Higher Throughput**: Efficient memory-to-memory transfers.
-- **Security**: Access can be controlled using standard filesystem permissions.
+1. binds a Unix domain socket path
+2. accepts multiple local clients
+3. echoes each message back to the sender
 
-## Step 1: Creating a UDS Server
+---
 
-Creating a UDS server is almost identical to creating a TCP server, but instead of a port number, you provide a filesystem path.
+## Step 1: Create A UDS Server
 
 ```cpp
 #include <iostream>
+#include <memory>
+#include <string>
 #include "unilink/unilink.hpp"
 
 int main() {
-    // Define the socket path
-    std::string socket_path = "/tmp/unilink_echo.sock";
+    const std::string socket_path = "/tmp/unilink_echo.sock";
 
-    // Build the UDS server
-    auto server = unilink::uds_server(socket_path)
-        .unlimited_clients() // Support multiple concurrent connections
-        .on_connect([](const unilink::ConnectionContext& ctx) {
-            std::cout << "Client connected!" << std::endl;
-        })
-        .on_data([&](const unilink::MessageContext& ctx) {
-            std::string msg(ctx.data());
-            std::cout << "Received: " << msg << std::endl;
-            
-            // Echo back to client
-            ctx.reply("Echo: " + msg);
-        })
-        .on_disconnect([](const unilink::ConnectionContext& ctx) {
-            std::cout << "Client disconnected" << std::endl;
-        })
-        .build();
+    std::shared_ptr<unilink::UdsServer> server;
+    server = std::move(
+        unilink::uds_server(socket_path)
+            .unlimited_clients()
+            .on_connect([](const unilink::ConnectionContext& ctx) {
+                std::cout << "Client connected: " << ctx.client_id()
+                          << " info=" << ctx.client_info() << std::endl;
+            })
+            .on_data([&server](const unilink::MessageContext& ctx) {
+                std::cout << "Received: " << ctx.data() << std::endl;
+                server->send_to(ctx.client_id(), "Echo: " + std::string(ctx.data()));
+            })
+            .on_disconnect([](const unilink::ConnectionContext& ctx) {
+                std::cout << "Client disconnected: " << ctx.client_id() << std::endl;
+            })
+            .on_error([](const unilink::ErrorContext& ctx) {
+                std::cerr << "[Error] " << ctx.message() << std::endl;
+            })
+            .build()
+    );
 
-    // Start the server
-    std::cout << "Starting UDS server on " << socket_path << "..." << std::endl;
-    server->start();
+    if (!server->start().get()) {
+        std::cerr << "Failed to start UDS server" << std::endl;
+        return 1;
+    }
 
-    std::cout << "Press Enter to stop..." << std::endl;
+    std::cout << "Listening on " << socket_path << std::endl;
     std::cin.get();
-
     server->stop();
     return 0;
 }
 ```
 
-## Step 2: Creating a UDS Client
+---
 
-Similarly, the UDS client connects to the specified socket path.
+## Step 2: Create A UDS Client
 
 ```cpp
 #include <iostream>
@@ -64,36 +72,29 @@ Similarly, the UDS client connects to the specified socket path.
 #include "unilink/unilink.hpp"
 
 int main() {
-    std::string socket_path = "/tmp/unilink_echo.sock";
+    const std::string socket_path = "/tmp/unilink_echo.sock";
 
-    // Build the UDS client
     auto client = unilink::uds_client(socket_path)
-        .on_connect([](const unilink::ConnectionContext& ctx) {
-            std::cout << "Connected to server!" << std::endl;
+        .on_connect([](const unilink::ConnectionContext&) {
+            std::cout << "Connected to UDS server" << std::endl;
         })
         .on_data([](const unilink::MessageContext& ctx) {
-            std::cout << "Server said: " << ctx.data() << std::endl;
+            std::cout << "[Server] " << ctx.data() << std::endl;
         })
         .on_error([](const unilink::ErrorContext& ctx) {
-            std::cerr << "Client error: " << ctx.message() << std::endl;
+            std::cerr << "[Error] " << ctx.message() << std::endl;
         })
         .build();
 
-    // Start connecting
-    client->start();
+    if (!client->start().get()) {
+        std::cerr << "Failed to connect to UDS server" << std::endl;
+        return 1;
+    }
 
-    // Interaction loop
     std::string input;
-    while (true) {
-        std::cout << "> ";
-        std::getline(std::cin, input);
-        if (input == "exit") break;
-
-        if (client->is_connected()) {
-            client->send(input);
-        } else {
-            std::cout << "Connecting..." << std::endl;
-        }
+    while (std::getline(std::cin, input)) {
+        if (input == "/quit") break;
+        client->send(input);
     }
 
     client->stop();
@@ -101,24 +102,25 @@ int main() {
 }
 ```
 
-## Key Considerations for UDS
+---
 
-### Socket Cleanup
-Unilink handles the creation and removal of the socket file for you.
-- **On Start**: The library automatically removes any existing file at the specified path before binding to prevent "Address already in use" errors.
-- **On Stop/Destruction**: The library removes the socket file to leave the filesystem clean.
+## Why Use UDS Instead Of TCP
 
-### Platform Support
-- **Linux/macOS**: Native and robust support.
-- **Windows**: Supported on Windows 10 (build 17063) and later. For older Windows versions, consider using TCP or Named Pipes.
+UDS is useful when both processes are on the same machine and you want:
 
-### Permissions
-Since the socket is a file, you can control which users can connect to your server by setting permissions on the socket file or the directory containing it.
+- low local IPC overhead
+- filesystem-based access control
+- a socket path instead of a TCP port
+
+The callback model and wrapper lifecycle are intentionally very similar to the TCP API.
 
 ---
 
-## Summary
-You have successfully implemented a local IPC system using Unilink's UDS support. The Builder API makes it easy to switch between TCP and UDS by simply changing one line of code, while keeping your business logic intact.
+## Operational Notes
+
+- The socket path should usually live under `/tmp` or another writable runtime directory.
+- Old socket files can cause bind failures if a process crashes before cleanup.
+- On Linux and macOS, UDS is a natural choice for local service-to-service IPC.
 
 ---
 
@@ -127,6 +129,7 @@ You have successfully implemented a local IPC system using Unilink's UDS support
 - [Serial Communication](04_serial_communication.md)
 - [UDP Communication](05_udp_communication.md)
 - [API Reference](../reference/api_guide.md#uds-communication)
+- [Examples Directory](../../examples/uds/)
 
 ---
 

--- a/docs/tutorials/03_uds_communication.md
+++ b/docs/tutorials/03_uds_communication.md
@@ -22,33 +22,30 @@ A local echo service that:
 
 ```cpp
 #include <iostream>
-#include <memory>
 #include <string>
 #include "unilink/unilink.hpp"
 
 int main() {
     const std::string socket_path = "/tmp/unilink_echo.sock";
 
-    std::shared_ptr<unilink::UdsServer> server;
-    server = std::move(
-        unilink::uds_server(socket_path)
-            .unlimited_clients()
-            .on_connect([](const unilink::ConnectionContext& ctx) {
-                std::cout << "Client connected: " << ctx.client_id()
-                          << " info=" << ctx.client_info() << std::endl;
-            })
-            .on_data([&server](const unilink::MessageContext& ctx) {
-                std::cout << "Received: " << ctx.data() << std::endl;
-                server->send_to(ctx.client_id(), "Echo: " + std::string(ctx.data()));
-            })
-            .on_disconnect([](const unilink::ConnectionContext& ctx) {
-                std::cout << "Client disconnected: " << ctx.client_id() << std::endl;
-            })
-            .on_error([](const unilink::ErrorContext& ctx) {
-                std::cerr << "[Error] " << ctx.message() << std::endl;
-            })
-            .build()
-    );
+    std::unique_ptr<unilink::UdsServer> server;
+    server = unilink::uds_server(socket_path)
+        .unlimited_clients()
+        .on_connect([](const unilink::ConnectionContext& ctx) {
+            std::cout << "Client connected: " << ctx.client_id()
+                      << " info=" << ctx.client_info() << std::endl;
+        })
+        .on_data([&server](const unilink::MessageContext& ctx) {
+            std::cout << "Received: " << ctx.data() << std::endl;
+            server->send_to(ctx.client_id(), "Echo: " + std::string(ctx.data()));
+        })
+        .on_disconnect([](const unilink::ConnectionContext& ctx) {
+            std::cout << "Client disconnected: " << ctx.client_id() << std::endl;
+        })
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "[Error] " << ctx.message() << std::endl;
+        })
+        .build();
 
     if (!server->start().get()) {
         std::cerr << "Failed to start UDS server" << std::endl;

--- a/docs/tutorials/04_serial_communication.md
+++ b/docs/tutorials/04_serial_communication.md
@@ -39,6 +39,7 @@ This creates two connected ports, `/tmp/ttyA` and `/tmp/ttyB`.
 
 ## Step 2: Create A Minimal Serial Terminal
 
+<!-- doc-compile: tutorial_serial_terminal -->
 ```cpp
 #include <iostream>
 #include <string>

--- a/docs/tutorials/04_serial_communication.md
+++ b/docs/tutorials/04_serial_communication.md
@@ -1,0 +1,171 @@
+# Serial Communication
+
+This tutorial walks through a practical serial workflow with `unilink`: open a device, receive lines, send commands, and test locally with virtual ports before connecting real hardware.
+
+**Duration**: 15 minutes  
+**Difficulty**: Beginner to Intermediate  
+**Prerequisites**: [Getting Started](01_getting_started.md)
+
+---
+
+## What You'll Build
+
+A simple serial terminal that:
+
+1. opens a serial device
+2. logs connect and disconnect events
+3. prints incoming data
+4. sends user input back over the serial link
+
+---
+
+## Step 1: Choose A Device Path
+
+Typical serial device names:
+
+- Linux USB adapter: `/dev/ttyUSB0`
+- Linux CDC/Arduino style device: `/dev/ttyACM0`
+- Windows serial port: `COM3`
+
+If you are testing on Linux without hardware, use `socat` to create a virtual pair:
+
+```bash
+socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
+```
+
+This creates two connected ports, `/tmp/ttyA` and `/tmp/ttyB`.
+
+---
+
+## Step 2: Create A Minimal Serial Terminal
+
+```cpp
+#include <iostream>
+#include <string>
+#include "unilink/unilink.hpp"
+
+int main(int argc, char** argv) {
+    std::string device = (argc > 1) ? argv[1] : "/dev/ttyUSB0";
+    uint32_t baud = (argc > 2) ? static_cast<uint32_t>(std::stoul(argv[2])) : 115200;
+
+    auto serial = unilink::serial(device, baud)
+        .on_connect([](const unilink::ConnectionContext&) {
+            std::cout << "Serial port opened" << std::endl;
+        })
+        .on_disconnect([](const unilink::ConnectionContext&) {
+            std::cout << "Serial port closed" << std::endl;
+        })
+        .on_data([](const unilink::MessageContext& ctx) {
+            std::cout << "[RX] " << ctx.data() << std::endl;
+        })
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "[ERROR] " << ctx.message() << std::endl;
+        })
+        .build();
+
+    if (!serial->start().get()) {
+        std::cerr << "Failed to open serial device" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Type messages. Use /quit to exit." << std::endl;
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "/quit") break;
+        if (serial->is_connected()) {
+            serial->send(line);
+        }
+    }
+
+    serial->stop();
+    return 0;
+}
+```
+
+---
+
+## Step 3: Build And Run
+
+```bash
+g++ -std=c++17 serial_terminal.cpp -o serial_terminal -lunilink -lboost_system -pthread
+```
+
+Run against a real device:
+
+```bash
+./serial_terminal /dev/ttyUSB0 115200
+```
+
+Run against a virtual port:
+
+```bash
+./serial_terminal /tmp/ttyA 115200
+```
+
+---
+
+## Step 4: Test With A Second Terminal
+
+If you used the `socat` pair above:
+
+**Terminal 1**
+
+```bash
+./serial_terminal /tmp/ttyA 115200
+```
+
+**Terminal 2**
+
+```bash
+./serial_terminal /tmp/ttyB 115200
+```
+
+Messages typed in one terminal should appear in the other.
+
+---
+
+## Common Adjustments
+
+You can tune the serial wrapper before `build()`:
+
+```cpp
+auto serial = unilink::serial("/dev/ttyUSB0", 115200)
+    .retry_interval(1000)
+    .build();
+```
+
+At runtime, you can also adjust settings on the wrapper:
+
+```cpp
+serial->set_baud_rate(9600);
+serial->set_data_bits(8);
+serial->set_stop_bits(1);
+serial->set_parity("none");
+serial->set_flow_control("none");
+```
+
+---
+
+## When To Use The Example Programs Instead
+
+If you want a fuller interactive sample, use the existing example programs:
+
+- [examples/serial/README.md](../../examples/serial/README.md)
+- [examples/serial/echo/README.md](../../examples/serial/echo/README.md)
+- [examples/serial/chat/README.md](../../examples/serial/chat/README.md)
+
+Those examples are a better fit for device bring-up and manual testing than this short tutorial.
+
+---
+
+## Next Steps
+
+- [UDP Communication](05_udp_communication.md)
+- [API Reference](../reference/api_guide.md#serial-communication)
+- [Examples Directory](../../examples/serial/README.md)
+
+---
+
+**Previous**: [← UDS Communication](03_uds_communication.md)  
+**Next**: [UDP Communication →](05_udp_communication.md)

--- a/docs/tutorials/05_udp_communication.md
+++ b/docs/tutorials/05_udp_communication.md
@@ -20,6 +20,7 @@ A two-process UDP setup:
 
 ## Step 1: Create A Receiver
 
+<!-- doc-compile: tutorial_udp_receiver -->
 ```cpp
 #include <iostream>
 #include "unilink/unilink.hpp"
@@ -50,6 +51,7 @@ int main() {
 
 ## Step 2: Create A Sender
 
+<!-- doc-compile: tutorial_udp_sender -->
 ```cpp
 #include <iostream>
 #include <string>

--- a/docs/tutorials/05_udp_communication.md
+++ b/docs/tutorials/05_udp_communication.md
@@ -1,0 +1,145 @@
+# UDP Communication
+
+This tutorial covers the basic UDP workflow in `unilink`: bind a receiver, configure a sender, and observe how the wrapper behaves with connectionless traffic.
+
+**Duration**: 10 minutes  
+**Difficulty**: Beginner to Intermediate  
+**Prerequisites**: [Getting Started](01_getting_started.md)
+
+---
+
+## What You'll Build
+
+A two-process UDP setup:
+
+1. one receiver bound to a local port
+2. one sender with a configured remote endpoint
+3. simple message exchange between the two
+
+---
+
+## Step 1: Create A Receiver
+
+```cpp
+#include <iostream>
+#include "unilink/unilink.hpp"
+
+int main() {
+    auto receiver = unilink::udp(9000)
+        .on_data([](const unilink::MessageContext& ctx) {
+            std::cout << "[RX] " << ctx.data() << std::endl;
+        })
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "[ERROR] " << ctx.message() << std::endl;
+        })
+        .build();
+
+    if (!receiver->start().get()) {
+        std::cerr << "Failed to start receiver" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Listening on UDP port 9000. Press Enter to stop." << std::endl;
+    std::cin.get();
+    receiver->stop();
+    return 0;
+}
+```
+
+---
+
+## Step 2: Create A Sender
+
+```cpp
+#include <iostream>
+#include <string>
+#include "unilink/unilink.hpp"
+
+int main() {
+    auto sender = unilink::udp(0)
+        .set_remote("127.0.0.1", 9000)
+        .on_connect([](const unilink::ConnectionContext&) {
+            std::cout << "UDP sender ready" << std::endl;
+        })
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "[ERROR] " << ctx.message() << std::endl;
+        })
+        .build();
+
+    sender->start();
+
+    std::cout << "Type messages. Use /quit to exit." << std::endl;
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        if (line == "/quit") break;
+        sender->send(line);
+    }
+
+    sender->stop();
+    return 0;
+}
+```
+
+---
+
+## Step 3: Run Both Programs
+
+**Terminal 1**
+
+```bash
+./udp_receiver_app
+```
+
+**Terminal 2**
+
+```bash
+./udp_sender_app
+```
+
+Type messages in the sender terminal and verify that the receiver prints them.
+
+---
+
+## What Is Different About UDP
+
+Unlike TCP:
+
+- there is no session handshake
+- delivery is not guaranteed
+- message ordering is not guaranteed
+- the sender can write as soon as it has a destination
+
+For simple local tests, UDP is useful when you want low overhead and can tolerate datagram semantics.
+
+---
+
+## Practical Notes
+
+- `unilink::udp(0)` uses an ephemeral local port for the sender.
+- `set_remote(host, port)` configures the default destination for `send()`.
+- The receiver can run without a predefined remote peer.
+- If you need more operational examples, the protocol-specific examples are richer than this tutorial.
+
+---
+
+## Use The Full Examples For Repeated Testing
+
+For CLI flags, reply behavior, and sender timing options, use:
+
+- [examples/udp/README.md](../../examples/udp/README.md)
+- [examples/udp/udp_receiver.cpp](../../examples/udp/udp_receiver.cpp)
+- [examples/udp/udp_sender.cpp](../../examples/udp/udp_sender.cpp)
+
+This tutorial intentionally stays smaller than the example README to avoid duplicating all command-line details.
+
+---
+
+## Next Steps
+
+- [API Reference](../reference/api_guide.md#udp-communication)
+- [Performance Guide](../guides/advanced/performance.md)
+- [Examples Directory](../../examples/udp/README.md)
+
+---
+
+**Previous**: [← Serial Communication](04_serial_communication.md)

--- a/examples/tutorials/CMakeLists.txt
+++ b/examples/tutorials/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-# Tutorial 1: Getting Started Examples
+# Getting Started examples
 add_executable(tutorial_simple_client
     getting_started/simple_client.cpp
 )
@@ -36,7 +36,7 @@ target_link_libraries(tutorial_my_first_client
 )
 unilink_configure_executable(tutorial_my_first_client)
 
-# Tutorial 2: TCP Server Examples
+# TCP server examples
 add_executable(tutorial_echo_server
     tcp_server/echo_server.cpp
 )

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -6,19 +6,19 @@ Ready-to-compile examples from the unilink tutorials.
 
 ## 📚 Included Examples
 
-### Tutorial 1: Getting Started
+### Getting Started
 
 | Example | File | Description | Tutorial Link |
 |---------|------|-------------|---------------|
-| **Simple Client** | `simple_client.cpp` | Minimal 30-second example | [Tutorial 1](../../docs/tutorials/01_getting_started.md) |
-| **My First Client** | `my_first_client.cpp` | Complete first application | [Tutorial 1](../../docs/tutorials/01_getting_started.md) |
+| **Simple Client** | `simple_client.cpp` | Minimal 30-second example | [Getting Started](../../docs/tutorials/01_getting_started.md) |
+| **My First Client** | `my_first_client.cpp` | Complete first application | [Getting Started](../../docs/tutorials/01_getting_started.md) |
 
-### Tutorial 2: TCP Server
+### TCP Server
 
 | Example | File | Description | Tutorial Link |
 |---------|------|-------------|---------------|
-| **Echo Server** | `echo_server.cpp` | Basic echo server | [Tutorial 2](../../docs/tutorials/02_tcp_server.md) |
-| **Chat Server** | `chat_server.cpp` | Multi-client chat server | [Tutorial 2](../../docs/tutorials/02_tcp_server.md) |
+| **Echo Server** | `echo_server.cpp` | Basic echo server | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
+| **Chat Server** | `chat_server.cpp` | Multi-client chat server | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
 
 ---
 
@@ -119,7 +119,7 @@ Hello everyone!      # Send a message
 
 Each example corresponds to a tutorial in the documentation:
 
-### Tutorial 1: Getting Started
+### Getting Started
 - **Documentation**: [docs/tutorials/01_getting_started.md](../../docs/tutorials/01_getting_started.md)
 - **Examples**: 
   - `simple_client.cpp` - The 30-second example
@@ -133,7 +133,7 @@ Each example corresponds to a tutorial in the documentation:
 
 ---
 
-### Tutorial 2: Building a TCP Server
+### Building a TCP Server
 - **Documentation**: [docs/tutorials/02_tcp_server.md](../../docs/tutorials/02_tcp_server.md)
 - **Examples**:
   - `echo_server.cpp` - Basic echo server
@@ -144,6 +144,20 @@ Each example corresponds to a tutorial in the documentation:
 - Accepting multiple clients
 - Broadcasting messages
 - Implementing commands
+
+---
+
+## Additional Protocol Tutorials
+
+Not every tutorial has dedicated files under `examples/tutorials/`. The Serial and UDP tutorials intentionally reuse the protocol-specific example directories instead of duplicating near-identical sample programs.
+
+### Serial Communication
+- **Documentation**: [docs/tutorials/04_serial_communication.md](../../docs/tutorials/04_serial_communication.md)
+- **Examples**: [examples/serial/README.md](../../examples/serial/README.md)
+
+### UDP Communication
+- **Documentation**: [docs/tutorials/05_udp_communication.md](../../docs/tutorials/05_udp_communication.md)
+- **Examples**: [examples/udp/README.md](../../examples/udp/README.md)
 
 ---
 
@@ -290,19 +304,18 @@ lsof -i :8080
 After trying these examples:
 
 1. **Read the Tutorials**: [docs/tutorials/](../../docs/tutorials/)
-2. **Explore API Guide**: [docs/reference/API_GUIDE.md](../../docs/reference/API_GUIDE.md)
-3. **Learn Best Practices**: [docs/guides/best_practices.md](../../docs/guides/best_practices.md)
+2. **Explore API Guide**: [docs/reference/api_guide.md](../../docs/reference/api_guide.md)
+3. **Learn Best Practices**: [docs/guides/core/best_practices.md](../../docs/guides/core/best_practices.md)
 4. **Build Your Own**: Modify these examples or create new ones!
 
 ---
 
 ## 🆘 Need Help?
 
-- **Can't compile?** See [Troubleshooting Guide](../../docs/guides/troubleshooting.md#compilation-errors)
-- **Connection issues?** See [Troubleshooting Guide](../../docs/guides/troubleshooting.md#connection-issues)
-- **Questions?** Check the [Documentation Index](../../docs/INDEX.md)
+- **Can't compile?** See [Troubleshooting Guide](../../docs/guides/core/troubleshooting.md#compilation-errors)
+- **Connection issues?** See [Troubleshooting Guide](../../docs/guides/core/troubleshooting.md#connection-issues)
+- **Questions?** Check the [Documentation Index](../../docs/index.md)
 
 ---
 
 **Happy Coding!** 🚀
-

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -16,6 +16,7 @@
 # Each test file is built as a separate executable due to having its own main()
 
 get_property(_unilink_test_lib GLOBAL PROPERTY UNILINK_TEST_LIB)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Default: discover after build so test executables exist
 set(_UNILINK_GTEST_DISCOVERY_MODE POST_BUILD)
@@ -174,6 +175,63 @@ gtest_discover_tests(run_unit_wrapper_serial_config_mapping
   PROPERTIES
     LABELS "unit_wrapper_serial"
     TIMEOUT 30
+)
+
+# Documentation snippet compile smoke tests
+set(_unilink_doc_snippet_dir ${CMAKE_CURRENT_BINARY_DIR}/generated/doc_snippets)
+set(_unilink_doc_extract_script ${CMAKE_SOURCE_DIR}/docs/scripts/extract_doc_snippet.py)
+set(_unilink_doc_snippets
+  "tutorial_getting_started_client|docs/tutorials/01_getting_started.md"
+  "tutorial_tcp_server_echo|docs/tutorials/02_tcp_server.md"
+  "tutorial_uds_server|docs/tutorials/03_uds_communication.md"
+  "tutorial_uds_client|docs/tutorials/03_uds_communication.md"
+  "tutorial_serial_terminal|docs/tutorials/04_serial_communication.md"
+  "tutorial_udp_receiver|docs/tutorials/05_udp_communication.md"
+  "tutorial_udp_sender|docs/tutorials/05_udp_communication.md"
+)
+
+set(_unilink_doc_targets)
+foreach(doc_entry IN LISTS _unilink_doc_snippets)
+  string(REPLACE "|" ";" doc_entry_parts "${doc_entry}")
+  list(GET doc_entry_parts 0 doc_snippet_name)
+  list(GET doc_entry_parts 1 doc_source_relpath)
+
+  set(doc_source_path ${CMAKE_SOURCE_DIR}/${doc_source_relpath})
+  set(doc_generated_source ${_unilink_doc_snippet_dir}/${doc_snippet_name}.cc)
+  set(doc_target run_doc_snippet_${doc_snippet_name})
+
+  add_custom_command(
+    OUTPUT ${doc_generated_source}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_unilink_doc_snippet_dir}
+    COMMAND
+      ${Python3_EXECUTABLE}
+      ${_unilink_doc_extract_script}
+      --input ${doc_source_path}
+      --snippet ${doc_snippet_name}
+      --output ${doc_generated_source}
+    DEPENDS ${doc_source_path} ${_unilink_doc_extract_script}
+    VERBATIM
+  )
+
+  add_executable(${doc_target} ${doc_generated_source})
+  target_link_libraries(${doc_target} PRIVATE ${_unilink_test_lib})
+  target_include_directories(${doc_target} PRIVATE ${CMAKE_SOURCE_DIR})
+  target_compile_features(${doc_target} PRIVATE cxx_std_17)
+  unilink_set_test_warning_options(${doc_target})
+
+  list(APPEND _unilink_doc_targets ${doc_target})
+endforeach()
+
+add_custom_target(doc_snippets_smoke DEPENDS ${_unilink_doc_targets})
+add_test(
+  NAME DocSnippetsCompile
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target doc_snippets_smoke --config $<CONFIG>
+)
+set_tests_properties(
+  DocSnippetsCompile
+  PROPERTIES
+    LABELS "docs_snippets"
+    TIMEOUT 120
 )
 
 # Transport tests (fast, unit-level without real network dependencies)


### PR DESCRIPTION
## Summary

This PR refreshes the documentation to match the current public C++ API, fills in missing protocol tutorial coverage, reduces duplication across docs, and adds a dedicated CI/CTest smoke check to catch future documentation drift in compileable tutorial snippets.

## Changes

- Updated top-level docs, guides, and API reference to align with the current wrapper/builder API, including context-based callbacks, current server send methods, logger/error-handler namespaces, and actual configuration APIs.
- Added missing Serial and UDP tutorial coverage and cleaned up tutorial titles/indexing so the documentation structure is more stable and easier to maintain across releases.
- Clarified the boundary between public API docs and internal transport/architecture notes to avoid mixing wrapper-level behavior with transport-layer implementation details.
- Reworked configuration documentation to reflect the current `ConfigFactory` / `ConfigManagerInterface` flow and the actual `key=value` file format used by the config manager.
- Added documentation maintenance rules and a compile-smoke pipeline for tutorial snippets using `<!-- doc-compile: ... -->` markers plus an extraction script.
- Added a dedicated `docs_snippets` CTest label and a separate GitHub Actions job so documentation snippet failures are reported independently from unit tests.

## Related Issues

- N/A
- Related to documentation/API drift cleanup

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Additional Notes

- Verified locally with:
  - `cmake -S . -B build`
  - `cmake --build build --target doc_snippets_smoke -j4`
  - `cd build && ctest --output-on-failure -L docs_snippets`
  - `git diff --check`
- The new docs smoke check intentionally validates only canonical tutorial snippets, not every fenced code block in the docs, to keep noise low and avoid false failures from partial examples.
