### PR TITLE
Feat/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ You do **not** need to read everything to get started.
 * [TCP Examples](examples/tcp/)
 * [UDP Examples](examples/udp/)
 * [Serial Examples](examples/serial/)
+* [UDS Examples](examples/uds/)
+* [Common Examples](examples/common/)
 * [Tutorials](docs/tutorials/)
 * [Documentation Index](docs/index.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ This index is the stable entry point for the handwritten documentation in `docs/
 | [Serial Communication](tutorials/04_serial_communication.md) | Device I/O and virtual-port testing |
 | [UDP Communication](tutorials/05_udp_communication.md) | Connectionless send/receive workflow |
 
-Tutorial companion material is split between `examples/tutorials/` and the protocol-specific example directories under `examples/serial/` and `examples/udp/`.
+Tutorial companion material is split between `examples/tutorials/` and the protocol-specific example directories under `examples/serial/`, `examples/udp/`, and `examples/uds/`.
 
 ## Architecture Notes
 
@@ -46,6 +46,11 @@ Tutorial companion material is split between `examples/tutorials/` and the proto
 ## Examples and Tests
 
 - [Examples Directory](../examples/README.md)
+- [Tutorial Examples](../examples/tutorials/README.md)
+- [Protocol Examples](../examples/tcp/README.md)
+- [Serial Examples](../examples/serial/README.md)
+- [UDP Examples](../examples/udp/README.md)
+- [UDS Examples](../examples/uds/README.md)
 - [Test Overview](test_structure.md)
 - [Top-level Test Notes](../test/README.md)
 

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -131,10 +131,10 @@ auto client = unilink::tcp_client("192.168.1.100", 8080)
     .build();
 
 // Start connection
-client->start();
+bool connected = client->start().get();
 
 // Send data
-if (client->is_connected()) {
+if (connected && client->is_connected()) {
     client->send("Hello, Server!");
 }
 
@@ -155,6 +155,8 @@ unilink::tcp_client(const std::string& host, uint16_t port)
 | Method                      | Parameters | Description                                                |
 | --------------------------- | ---------- | ---------------------------------------------------------- |
 | `retry_interval(ms)`        | `unsigned` | Set reconnection interval in milliseconds (default `3000`) |
+| `max_retries(count)`        | `int`      | Set maximum reconnect attempts (`-1` for unlimited)        |
+| `connection_timeout(ms)`    | `unsigned` | Set connection timeout in milliseconds                     |
 | `use_independent_context()` | `bool`     | Use separate IO thread (for testing)                       |
 | `auto_manage()`             | `bool`     | Auto-start immediately and stop on destruction             |
 
@@ -206,7 +208,7 @@ auto client = unilink::tcp_client("127.0.0.1", 8080)
 
 #### Custom Reconnect Policy (Transport Layer)
 
-To use advanced reconnection policies (like Exponential Backoff), use the transport layer directly:
+If you need transport-level reconnect policy control such as `ExponentialBackoff(...)`, you can drop below the wrapper API and use the transport layer directly. This is an advanced path; the recommended public entry point remains `unilink::tcp_client(...)`.
 
 ```cpp
 #include "unilink/transport/tcp_client/tcp_client.hpp"
@@ -253,16 +255,20 @@ auto server = unilink::tcp_server(8080)
     .build();
 
 // Start server
-server->start();
+bool listening = server->start().get();
 
 // Send to specific client
-server->send_to(1, "Hello, Client 1!");
+if (listening) {
+    server->send_to(1, "Hello, Client 1!");
+}
 
 // Send to all clients
-server->broadcast("Broadcast message");
+if (listening) {
+    server->broadcast("Broadcast message");
+}
 
 // Check if listening
-if (server->is_listening()) {
+if (listening && server->is_listening()) {
     std::cout << "Server is listening" << std::endl;
 }
 
@@ -327,6 +333,7 @@ auto server = unilink::tcp_server(8080)
 
 ```cpp
 auto server = unilink::tcp_server(8080)
+    .single_client()
     .enable_port_retry(true, 5, 1000)  // 5 retries, 1 second each
     .on_error([](const unilink::ErrorContext& ctx) {
         std::cerr << "Server error: " << ctx.message() << std::endl;
@@ -369,14 +376,18 @@ auto serial = unilink::serial("/dev/ttyUSB0", 115200)
     .build();
 
 // Start serial communication
-serial->start();
+bool opened = serial->start().get();
 
 // Send AT command
-serial->send("AT\r\n");
+if (opened) {
+    serial->send("AT\r\n");
+}
 
 // Send binary payload through string-compatible storage
 std::string binary_payload("\x01\x02\x03", 3);
-serial->send(binary_payload);
+if (opened) {
+    serial->send(binary_payload);
+}
 ```
 
 ### API Reference
@@ -395,6 +406,10 @@ unilink::serial(const std::string& device, uint32_t baud_rate)
 
 | Method                      | Parameters | Description                                               |
 | --------------------------- | ---------- | --------------------------------------------------------- |
+| `data_bits(bits)`           | `int`      | Set serial data bits before `build()`                     |
+| `stop_bits(bits)`           | `int`      | Set serial stop bits before `build()`                     |
+| `parity(mode)`              | `string`   | Set serial parity before `build()`                        |
+| `flow_control(mode)`        | `string`   | Set flow control before `build()`                         |
 | `retry_interval(ms)`        | `unsigned` | Set reconnection interval (default `3000`)                |
 | `use_independent_context()` | `bool`     | Run on a dedicated `io_context` thread managed by unilink |
 | `auto_manage()`             | `bool`     | Auto-start immediately and stop on destruction            |
@@ -486,11 +501,13 @@ auto receiver = unilink::udp(8080)
     })
     .build();
 
-receiver->start();
+bool receiver_started = receiver->start().get();
 
 // Keep running...
-std::this_thread::sleep_for(std::chrono::seconds(60));
-receiver->stop();
+if (receiver_started) {
+    std::this_thread::sleep_for(std::chrono::seconds(60));
+    receiver->stop();
+}
 ```
 
 #### UDP Sender (Client)
@@ -503,8 +520,10 @@ auto sender = unilink::udp(0)  // 0 = ephemeral port
     .set_remote("127.0.0.1", 8080)
     .build();
 
-sender->start();
-sender->send("Hello UDP!");
+bool sender_started = sender->start().get();
+if (sender_started) {
+    sender->send("Hello UDP!");
+}
 ```
 
 ### API Reference
@@ -570,7 +589,10 @@ auto server = unilink::uds_server("/tmp/my_service.sock")
     })
     .build();
 
-server->start();
+bool listening = server->start().get();
+if (!listening) {
+    std::cerr << "Failed to start UDS server" << std::endl;
+}
 ```
 
 #### UDS Client
@@ -584,8 +606,10 @@ auto client = unilink::uds_client("/tmp/my_service.sock")
     })
     .build();
 
-client->start();
-client->send("Hello IPC!");
+bool connected = client->start().get();
+if (connected) {
+    client->send("Hello IPC!");
+}
 ```
 
 ### API Reference
@@ -611,6 +635,9 @@ unilink::uds_client(const std::string& socket_path)
 | Method                | Parameters | Description                                |
 | --------------------- | ---------- | ------------------------------------------ |
 | `retry_interval(ms)`  | `unsigned` | Set reconnection interval (default `3000`) |
+| `max_retries(count)`  | `int`      | Set maximum reconnect attempts             |
+| `connection_timeout(ms)` | `unsigned` | Set connection timeout in milliseconds   |
+| `use_independent_context()` | `bool` | Run on a dedicated `io_context` thread    |
 | `auto_manage()`       | `bool`     | Auto-start/stop lifecycle                  |
 
 #### Instance Methods (UDS Client)

--- a/docs/tutorials/03_uds_communication.md
+++ b/docs/tutorials/03_uds_communication.md
@@ -128,7 +128,7 @@ The callback model and wrapper lifecycle are intentionally very similar to the T
 - [Serial Communication](04_serial_communication.md)
 - [UDP Communication](05_udp_communication.md)
 - [API Reference](../reference/api_guide.md#uds-communication)
-- [Examples Directory](../../examples/uds/)
+- [Examples Directory](../../examples/uds/README.md)
 
 ---
 

--- a/docs/tutorials/05_udp_communication.md
+++ b/docs/tutorials/05_udp_communication.md
@@ -84,18 +84,29 @@ int main() {
 
 ---
 
-## Step 3: Run Both Programs
+## Step 3: Build The Two Programs
+
+If you saved the snippets as `udp_receiver.cpp` and `udp_sender.cpp`:
+
+```bash
+g++ -std=c++17 udp_receiver.cpp -o udp_receiver -lunilink -lboost_system -pthread
+g++ -std=c++17 udp_sender.cpp -o udp_sender -lunilink -lboost_system -pthread
+```
+
+---
+
+## Step 4: Run Both Programs
 
 **Terminal 1**
 
 ```bash
-./udp_receiver_app
+./udp_receiver
 ```
 
 **Terminal 2**
 
 ```bash
-./udp_sender_app
+./udp_sender
 ```
 
 Type messages in the sender terminal and verify that the receiver prints them.
@@ -126,13 +137,13 @@ For simple local tests, UDP is useful when you want low overhead and can tolerat
 
 ## Use The Full Examples For Repeated Testing
 
-For CLI flags, reply behavior, and sender timing options, use:
+For ready-to-run maintained examples, use:
 
 - [examples/udp/README.md](../../examples/udp/README.md)
 - [examples/udp/udp_receiver.cpp](../../examples/udp/udp_receiver.cpp)
 - [examples/udp/udp_sender.cpp](../../examples/udp/udp_sender.cpp)
 
-This tutorial intentionally stays smaller than the example README to avoid duplicating all command-line details.
+Those examples intentionally stay minimal too: one receiver bound to `9000` and one sender targeting `127.0.0.1:9000`.
 
 ---
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ project(unilink_examples)
 
 # Add subdirectories
 add_subdirectory(tutorials)
+add_subdirectory(common)
 add_subdirectory(serial)
 add_subdirectory(tcp)
 add_subdirectory(udp)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,15 +1,27 @@
 # Unilink Examples
 
-This directory contains various examples demonstrating how to use the unilink library for different communication protocols and common functionality.
+This directory contains runnable examples for the current public `unilink/unilink.hpp` API.
 
 ## Structure
 
+- **tutorials/**: Small tutorial companions that mirror the docs
+- **common/**: Logging and error handling examples
 - **serial/**: Serial communication examples
 - **tcp/**: TCP communication examples
 - **udp/**: UDP communication examples
-- **common/**: Common functionality examples
+- **uds/**: Unix domain socket examples
 
 ## Quick Start
+
+### Build Examples
+
+```bash
+# From project root
+mkdir -p build
+cd build
+cmake ..
+cmake --build .
+```
 
 ### Serial Communication
 
@@ -32,9 +44,10 @@ socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
 # Terminal 3: Connect to second port
 socat - /tmp/ttyB
 ```
+
 ### TCP Communication
 
-````bash
+```bash
 # TCP echo server
 cd tcp/single-echo
 ./echo_tcp_server 9000
@@ -50,31 +63,35 @@ cd tcp/single-chat
 # TCP chat client
 cd tcp/single-chat
 ./chat_tcp_client 127.0.0.1 9000
-````
+```
 
 ### UDS Communication
 
 ```bash
 # UDS echo server
 cd uds
+./echo_uds_server
+# or
 ./echo_uds_server /tmp/my_socket.sock
 
 # UDS echo client
 cd uds
+./echo_uds_client
+# or
 ./echo_uds_client /tmp/my_socket.sock
 ```
 
 ### UDP Communication
 
 ```bash
-# UDP receiver (reply enabled)
+# UDP receiver (listens on 9000)
 cd udp
-./udp_receiver --local-port 9000 --reply
+./udp_receiver
 
-# UDP sender (default interval 1000ms, local port defaults to remote+1)
+# UDP sender (sends to 127.0.0.1:9000)
 cd udp
-./udp_sender --remote-ip 127.0.0.1 --remote-port 9000 --message "ping" --interval-ms 500
-````
+./udp_sender
+```
 
 ### Common Functionality
 
@@ -88,20 +105,16 @@ cd common
 ./error_handling_example
 ```
 
-## Building Examples
-
-```bash
-# Build all examples
-mkdir build && cd build
-cmake ..
-make
-
-# Build specific example
-make echo_serial
-make chat_tcp_server
-```
-
 ## Example Categories
+
+### Tutorial Companions
+
+- **tutorials/**: Minimal tutorial programs kept in sync with the docs
+
+### Common Functionality
+
+- **logging_example**: Shows basic logger setup and logging hooks
+- **error_handling_example**: Shows `on_error(...)` callbacks and failed start/connect flows
 
 ### Serial Communication
 
@@ -112,15 +125,11 @@ make chat_tcp_server
 
 - **single-echo/**: TCP echo server and client for network echo testing
 - **single-chat/**: TCP chat server and client for network chat
+- **multi-chat/**: Multi-client chat server and client
 
 ### UDS Communication
 
 - **uds/**: Unix Domain Socket echo server and client for local IPC testing
-
-### Common Functionality
-
-- **logging_example**: Demonstrates logging system usage
-- **error_handling_example**: Shows error handling system usage
 
 ## Prerequisites
 
@@ -185,5 +194,6 @@ cd vcpkg
 
 - **Linux**: Use `/dev/ttyUSB0`, `/dev/ttyACM0` for serial ports
 - **Windows**: Use `COM3`, `COM4` for serial ports
+- **UDS**: Unix domain sockets are intended for Unix-like platforms
 
 For detailed information about each example, see the README.md files in each subdirectory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,21 +48,21 @@ socat - /tmp/ttyB
 ### TCP Communication
 
 ```bash
-# TCP echo server
+# TCP echo server (default: 8080)
 cd tcp/single-echo
-./echo_tcp_server 9000
+./echo_tcp_server
 
-# TCP echo client
+# TCP echo client (default: 127.0.0.1:8080)
 cd tcp/single-echo
-./echo_tcp_client 127.0.0.1 9000
+./echo_tcp_client
 
-# TCP chat server
+# TCP chat server (default: 8080)
 cd tcp/single-chat
-./chat_tcp_server 9000
+./chat_tcp_server
 
-# TCP chat client
+# TCP chat client (default: 127.0.0.1:8080)
 cd tcp/single-chat
-./chat_tcp_client 127.0.0.1 9000
+./chat_tcp_client
 ```
 
 ### UDS Communication

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -1,11 +1,11 @@
 # Common Functionality Examples
 
-Examples demonstrating common functionality and utilities provided by the unilink library.
+Small examples for logger configuration and error callback handling.
 
 ## Examples
 
-- **logging_example**: Demonstrates the logging system usage
-- **error_handling_example**: Shows error handling system usage
+- **logging_example**: Configures the logger and emits example log messages from builder callbacks
+- **error_handling_example**: Triggers expected startup/connection failures and prints `ErrorContext`
 
 ## Logging Example
 
@@ -15,21 +15,15 @@ Examples demonstrating common functionality and utilities provided by the unilin
 ```
 
 ### What it demonstrates
-- Setting log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-- Console and file output configuration
-- Async logging with batch processing
-- Log rotation and cleanup
-- Performance monitoring
+- Setting the logger level to `DEBUG`
+- Enabling console output
+- Emitting log messages with `UNILINK_LOG_INFO(...)`
+- Attaching logging hooks to TCP and Serial builders
 
 ### Expected Output
 ```
-=== Unilink Logging System Usage Example ===
-
-1. Logging system setup
-2. Basic logging examples
-3. Async logging demonstration
-4. Performance test
-5. Log rotation test
+[INFO] [main] [setup] Starting logging example...
+[INFO] [main] [cleanup] Example finished.
 ```
 
 ## Error Handling Example
@@ -40,69 +34,39 @@ Examples demonstrating common functionality and utilities provided by the unilin
 ```
 
 ### What it demonstrates
-- Error handler setup and configuration
-- Error callback registration
-- Different error levels and types
-- Error recovery mechanisms
-- Error statistics and monitoring
+- Using `.on_error(...)` with the current wrapper API
+- Reading `ErrorContext::code()` and `ErrorContext::message()`
+- Waiting on `start().get()` to observe expected failures
 
 ### Expected Output
 ```
-=== Unilink Error Handling System Usage Example ===
-
-1. Error handler setup
-2. Basic error handling
-3. Error recovery demonstration
-4. Error statistics
+--- Unilink Error Handling Example ---
+Server Error Detected!
+Server start failed as expected.
+Starting client connection attempt...
+Client Error Detected!
+Client connection failed as expected.
 ```
-
-## Key Features
-
-### Logging System
-- **Multiple output destinations**: Console, file, callback
-- **Async logging**: Non-blocking log processing
-- **Log rotation**: Automatic file rotation and cleanup
-- **Performance monitoring**: Log processing statistics
-- **Configurable levels**: DEBUG, INFO, WARNING, ERROR, CRITICAL
-
-### Error Handling System
-- **Centralized error management**: Single point for all errors
-- **Error categorization**: Different error types and levels
-- **Recovery mechanisms**: Automatic retry and fallback
-- **Error monitoring**: Statistics and reporting
-- **Custom error callbacks**: User-defined error handling
 
 ## Configuration
 
 ### Logging Configuration
 ```cpp
-// Set log level
+// Set log level and console output
 Logger::instance().set_level(LogLevel::DEBUG);
-
-// Enable file output
-Logger::instance().set_file_output("app.log");
-
-// Enable console output
-Logger::instance().enable_console_output();
-
-// Configure async logging
-Logger::instance().enable_async_logging();
+Logger::instance().set_console_output(true);
 ```
 
 ### Error Handling Configuration
 ```cpp
-// Set minimum error level
-ErrorHandler::instance().set_min_error_level(ErrorLevel::INFO);
-
-// Register error callback
-ErrorHandler::instance().register_callback([](const ErrorInfo& error) {
-    // Handle error
-});
+auto client = tcp_client("127.0.0.1", 1)
+    .on_error([](const ErrorContext& ctx) {
+        std::cout << ctx.message() << std::endl;
+    })
+    .build();
 ```
 
 ## Use Cases
 
-- **Application logging**: Comprehensive logging for applications
-- **Error monitoring**: Centralized error handling and reporting
-- **Debugging**: Detailed logging for development and debugging
-- **Production monitoring**: Error tracking and performance monitoring
+- Use `logging_example` as a starting point for logger setup.
+- Use `error_handling_example` as a starting point for `on_error(...)` callback wiring.

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -1,72 +1,23 @@
 # Common Functionality Examples
 
-Small examples for logger configuration and error callback handling.
+Small examples for logger configuration and callback-based error handling.
 
-## Examples
+## Included Examples
 
-- **logging_example**: Configures the logger and emits example log messages from builder callbacks
-- **error_handling_example**: Triggers expected startup/connection failures and prints `ErrorContext`
+| Example | Binary | Focus | Detail |
+|---------|--------|-------|--------|
+| Logging | `logging_example` | Minimal logger setup and log emission | [logging_example.md](logging_example.md) |
+| Error Handling | `error_handling_example` | `on_error(...)` callbacks and failed start/connect flows | [error_handling_example.md](error_handling_example.md) |
 
-## Logging Example
+## Quick Start
 
-### Usage
 ```bash
 ./logging_example
-```
-
-### What it demonstrates
-- Setting the logger level to `DEBUG`
-- Enabling console output
-- Emitting log messages with `UNILINK_LOG_INFO(...)`
-- Attaching logging hooks to TCP and Serial builders
-
-### Expected Output
-```
-[INFO] [main] [setup] Starting logging example...
-[INFO] [main] [cleanup] Example finished.
-```
-
-## Error Handling Example
-
-### Usage
-```bash
 ./error_handling_example
 ```
 
-### What it demonstrates
-- Using `.on_error(...)` with the current wrapper API
-- Reading `ErrorContext::code()` and `ErrorContext::message()`
-- Waiting on `start().get()` to observe expected failures
+## Notes
 
-### Expected Output
-```
---- Unilink Error Handling Example ---
-Server Error Detected!
-Server start failed as expected.
-Starting client connection attempt...
-Client Error Detected!
-Client connection failed as expected.
-```
-
-## Configuration
-
-### Logging Configuration
-```cpp
-// Set log level and console output
-Logger::instance().set_level(LogLevel::DEBUG);
-Logger::instance().set_console_output(true);
-```
-
-### Error Handling Configuration
-```cpp
-auto client = tcp_client("127.0.0.1", 1)
-    .on_error([](const ErrorContext& ctx) {
-        std::cout << ctx.message() << std::endl;
-    })
-    .build();
-```
-
-## Use Cases
-
-- Use `logging_example` as a starting point for logger setup.
-- Use `error_handling_example` as a starting point for `on_error(...)` callback wiring.
+- This file is intentionally just an index.
+- Expected output, code snippets, and usage details live in the per-example documents above.
+- Both examples use the current public API from `unilink/unilink.hpp`.

--- a/examples/common/error_handling_example.md
+++ b/examples/common/error_handling_example.md
@@ -1,6 +1,6 @@
 # Error Handling Example
 
-Demonstrates the comprehensive error handling system provided by the unilink library.
+Demonstrates the current `on_error(...)` callback flow with the wrapper API.
 
 ## Usage
 
@@ -10,174 +10,35 @@ Demonstrates the comprehensive error handling system provided by the unilink lib
 
 ## What it demonstrates
 
-- **Error handler setup**: Configuring the error handling system
-- **Error callback registration**: Custom error handling callbacks
-- **Different error levels**: Various error types and severity levels
-- **Error recovery mechanisms**: Automatic retry and fallback strategies
-- **Error statistics**: Error monitoring and reporting
+- Registering `.on_error(...)` on builders
+- Inspecting `ErrorContext::code()` and `ErrorContext::message()`
+- Handling expected failures from `start().get()`
 
 ## Expected Output
 
 ```
-=== Unilink Error Handling System Usage Example ===
-
-1. Error handler setup
-   - Setting minimum error level to INFO
-   - Registering error callback
-   - Configuring error handling
-
-2. Basic error handling
-   🚨 Error occurred: [INFO] [error_handling] [test] Test error message
-   🚨 Error occurred: [WARNING] [error_handling] [test] Test warning message
-   🚨 Error occurred: [ERROR] [error_handling] [test] Test error message
-   🚨 Error occurred: [CRITICAL] [error_handling] [test] Test critical message
-
-3. Error recovery demonstration
-   - Simulating recoverable error
-   - Attempting error recovery
-   - Successfully recovered from error
-
-4. Error statistics
-   - Total errors: 4
-   - Errors by level: INFO=1, WARNING=1, ERROR=1, CRITICAL=1
-   - Recovery attempts: 1
-   - Successful recoveries: 1
+--- Unilink Error Handling Example ---
+Server Error Detected!
+Server start failed as expected.
+Starting client connection attempt...
+Client Error Detected!
+Client connection failed as expected.
 ```
 
-## Key Features Demonstrated
+The exact message text depends on the platform and socket error returned by the OS.
 
-### Error Handler Setup
+## Key Snippet
+
 ```cpp
-// Set minimum error level
-ErrorHandler::instance().set_min_error_level(ErrorLevel::INFO);
-
-// Register error callback
-ErrorHandler::instance().register_callback([](const ErrorInfo& error) {
-    std::cout << "🚨 Error occurred: " << error.get_summary() << std::endl;
-});
+auto client = tcp_client("127.0.0.1", 1)
+    .on_error([](const ErrorContext& ctx) {
+        std::cout << "Code: " << static_cast<int>(ctx.code()) << std::endl;
+        std::cout << "Message: " << ctx.message() << std::endl;
+    })
+    .build();
 ```
-
-### Error Reporting
-```cpp
-// Report different types of errors
-ErrorHandler::instance().report_error(ErrorLevel::INFO, "component", "operation", "Info message");
-ErrorHandler::instance().report_error(ErrorLevel::WARNING, "component", "operation", "Warning message");
-ErrorHandler::instance().report_error(ErrorLevel::ERROR, "component", "operation", "Error message");
-ErrorHandler::instance().report_error(ErrorLevel::CRITICAL, "component", "operation", "Critical message");
-```
-
-### Error Recovery
-```cpp
-// Simulate recoverable error
-try {
-    // Simulate error condition
-    throw std::runtime_error("Simulated error");
-} catch (const std::exception& e) {
-    // Report error and attempt recovery
-    ErrorHandler::instance().report_error(ErrorLevel::ERROR, "component", "operation", e.what());
-    
-    // Attempt recovery
-    if (attempt_recovery()) {
-        ErrorHandler::instance().report_recovery("component", "operation", "Successfully recovered");
-    }
-}
-```
-
-## Error Levels
-
-### INFO
-- General information messages
-- Non-critical issues
-- Status updates
-
-### WARNING
-- Potential issues
-- Non-fatal errors
-- Attention required
-
-### ERROR
-- Serious errors
-- Operation failures
-- System issues
-
-### CRITICAL
-- Critical system errors
-- Fatal failures
-- Immediate attention required
-
-## Error Recovery Mechanisms
-
-### Automatic Retry
-- Configurable retry attempts
-- Exponential backoff
-- Retry limits
-
-### Fallback Strategies
-- Alternative implementations
-- Graceful degradation
-- Service substitution
-
-### Error Isolation
-- Error containment
-- System protection
-- Fault tolerance
-
-## Error Statistics
-
-The example demonstrates error statistics including:
-- **Total error count**: Number of errors reported
-- **Errors by level**: Breakdown by error severity
-- **Recovery attempts**: Number of recovery attempts
-- **Successful recoveries**: Number of successful recoveries
-- **Error rates**: Error frequency and patterns
 
 ## Use Cases
 
-### Application Error Handling
-- Centralized error management
-- Consistent error reporting
-- Error monitoring and alerting
-
-### System Monitoring
-- Error tracking and analysis
-- Performance monitoring
-- System health checks
-
-### Debugging and Development
-- Error logging and tracing
-- Debug information
-- Development support
-
-## Configuration Options
-
-### Error Levels
-- **Minimum level**: Only errors above this level are processed
-- **Level filtering**: Filter errors by severity
-- **Level-specific handling**: Different handling for different levels
-
-### Callback Configuration
-- **Custom callbacks**: User-defined error handling
-- **Multiple callbacks**: Support for multiple error handlers
-- **Callback priority**: Priority-based callback execution
-
-### Recovery Settings
-- **Retry attempts**: Number of retry attempts
-- **Retry intervals**: Time between retry attempts
-- **Recovery strategies**: Different recovery approaches
-
-## Troubleshooting
-
-### Error Callbacks Not Triggered
-- Check error level configuration
-- Verify callback registration
-- Ensure errors meet minimum level
-
-### Recovery Issues
-- Check recovery implementation
-- Verify error conditions
-- Ensure proper error handling
-
-### Performance Issues
-- Monitor error processing overhead
-- Optimize error handling code
-- Consider async error processing
+- Start from this file when you need callback-based error reporting around `start()`.
+- Extend it with retry or recovery policy in your application code rather than expecting that behavior from this example.

--- a/examples/common/logging_example.md
+++ b/examples/common/logging_example.md
@@ -1,6 +1,6 @@
 # Logging Example
 
-Demonstrates the comprehensive logging system provided by the unilink library.
+Demonstrates the current logger API at a minimal, runnable level.
 
 ## Usage
 
@@ -10,149 +10,29 @@ Demonstrates the comprehensive logging system provided by the unilink library.
 
 ## What it demonstrates
 
-- **Log level configuration**: Setting different log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-- **Multiple output destinations**: Console, file, and callback outputs
-- **Async logging**: Non-blocking log processing with batch operations
-- **Log rotation**: Automatic file rotation and cleanup
-- **Performance monitoring**: Log processing statistics and metrics
+- Setting the log level to `DEBUG`
+- Enabling console output
+- Emitting messages with `UNILINK_LOG_INFO(...)`
+- Attaching logging callbacks to example builders
 
 ## Expected Output
 
 ```
-=== Unilink Logging System Usage Example ===
-
-1. Logging system setup
-   - Setting log level to DEBUG
-   - Enabling file output: unilink_example.log
-   - Enabling console output
-   - Configuring async logging
-
-2. Basic logging examples
-   [DEBUG] [logging] [setup] Debug message
-   [INFO] [logging] [setup] Info message
-   [WARNING] [logging] [setup] Warning message
-   [ERROR] [logging] [setup] Error message
-   [CRITICAL] [logging] [setup] Critical message
-
-3. Async logging demonstration
-   - Enabling async logging with batch processing
-   - Sending multiple log messages
-   - Processing logs in batches
-
-4. Performance test
-   - Sending 1000 log messages
-   - Measuring processing time
-   - Calculating messages per second
-
-5. Log rotation test
-   - Testing log file rotation
-   - Verifying log file creation
-   - Checking log file cleanup
+[INFO] [main] [setup] Starting logging example...
+[INFO] [main] [cleanup] Example finished.
 ```
 
-## Key Features Demonstrated
+The exact output may vary if transport creation triggers additional callbacks on your platform.
 
-### Log Level Configuration
+## Key Snippet
+
 ```cpp
-// Set minimum log level
 Logger::instance().set_level(LogLevel::DEBUG);
-
-// Log messages at different levels
-Logger::instance().debug("component", "operation", "Debug message");
-Logger::instance().info("component", "operation", "Info message");
-Logger::instance().warning("component", "operation", "Warning message");
-Logger::instance().error("component", "operation", "Error message");
-Logger::instance().critical("component", "operation", "Critical message");
+Logger::instance().set_console_output(true);
+UNILINK_LOG_INFO("main", "setup", "Starting logging example...");
 ```
-
-### Output Configuration
-```cpp
-// Enable console output
-Logger::instance().enable_console_output();
-
-// Enable file output
-Logger::instance().set_file_output("app.log");
-
-// Enable callback output
-Logger::instance().set_callback_output([](LogLevel level, const std::string& message) {
-    // Custom callback handling
-});
-```
-
-### Async Logging
-```cpp
-// Enable async logging
-Logger::instance().enable_async_logging();
-
-// Configure async settings
-AsyncLogConfig config;
-config.max_queue_size = 10000;
-config.batch_size = 100;
-config.flush_interval = std::chrono::milliseconds(100);
-Logger::instance().configure_async_logging(config);
-```
-
-## Performance Testing
-
-The example includes performance testing that:
-- Sends a large number of log messages
-- Measures processing time
-- Calculates messages per second
-- Demonstrates async logging efficiency
-
-## Log File Management
-
-### Log Rotation
-- Automatic log file rotation when size limit is reached
-- Configurable rotation settings
-- Automatic cleanup of old log files
-
-### File Output
-- Logs are written to specified file
-- Configurable file path and naming
-- Automatic file creation and management
 
 ## Use Cases
 
-- **Application logging**: Comprehensive logging for applications
-- **Debugging**: Detailed logging for development and debugging
-- **Monitoring**: Log-based monitoring and alerting
-- **Auditing**: Log-based audit trails
-- **Performance analysis**: Log-based performance monitoring
-
-## Configuration Options
-
-### Log Levels
-- **DEBUG**: Detailed debugging information
-- **INFO**: General information messages
-- **WARNING**: Warning messages
-- **ERROR**: Error messages
-- **CRITICAL**: Critical error messages
-
-### Output Destinations
-- **Console**: Standard output/error
-- **File**: Log files with rotation
-- **Callback**: Custom callback functions
-
-### Async Settings
-- **Queue size**: Maximum number of queued log messages
-- **Batch size**: Number of messages processed in each batch
-- **Flush interval**: Time interval for flushing logs
-- **Backpressure**: Handling of queue overflow
-
-## Troubleshooting
-
-### Log Files Not Created
-- Check file permissions
-- Verify directory exists
-- Check disk space
-
-### Performance Issues
-- Adjust async settings
-- Increase queue size
-- Optimize batch processing
-
-### Log Level Issues
-- Verify log level configuration
-- Check if messages meet minimum level
-- Ensure proper log level usage
+- Start from this file when you need basic logger initialization.
+- Extend it if you want file output, rotation, or more complex logging policy.

--- a/examples/serial/README.md
+++ b/examples/serial/README.md
@@ -1,128 +1,83 @@
 # Serial Communication Examples
 
-Examples demonstrating serial communication using the unilink library.
+Serial examples using the current public API.
 
-## Examples
+## Included Examples
 
-- **echo/**: Serial echo server that echoes received data back to sender
-- **chat/**: Serial chat application for interactive communication
+- `echo/`: Echoes each received line back to the same serial link
+- `chat/`: Interactive two-way serial chat
 
 ## Common Usage
 
-```bash
-# Set serial port permissions (Linux)
-sudo chmod 666 /dev/ttyUSB0
+Both examples accept the same arguments:
 
-# Windows uses COM ports
-# COM3, COM4, etc.
+```bash
+./echo_serial <device> <baud_rate>
+./chat_serial <device> <baud_rate>
 ```
 
-## Testing with socat (Virtual Serial Ports)
+Examples:
 
-For testing without physical serial devices, you can use socat to create virtual serial port pairs:
-
-### Setup Virtual Serial Ports
 ```bash
-# Terminal 1: Create virtual serial pair
+# Linux
+./echo_serial /dev/ttyUSB0 115200
+./chat_serial /dev/ttyUSB0 115200
+
+# Windows
+./echo_serial COM3 9600
+./chat_serial COM3 9600
+```
+
+If arguments are omitted, the code defaults to `/dev/ttyUSB0` and `115200`.
+
+## Quick Test With `socat`
+
+```bash
+# Terminal 1
 socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
-# Creates: /tmp/ttyA <-> /tmp/ttyB
-```
 
-### Test Echo Server
-```bash
-# Terminal 2: Run echo server on first port
-cd serial/echo
+# Terminal 2
 ./echo_serial /tmp/ttyA 115200
 
-# Terminal 3: Connect to second port
-cd serial/echo
+# Terminal 3
 ./echo_serial /tmp/ttyB 115200
-
-# Type messages and see them echoed back
 ```
 
-### Test Chat Application
+For interactive chat instead of echo:
+
 ```bash
-# Terminal 2: Run chat server on first port
-cd serial/chat
+# Terminal 2
 ./chat_serial /tmp/ttyA 115200
 
-# Terminal 3: Connect to second port
-cd serial/chat
+# Terminal 3
 ./chat_serial /tmp/ttyB 115200
-
-# Start chatting between terminals
 ```
 
-### Advanced socat Testing
-```bash
-# Create multiple virtual ports with fixed paths
-socat -d -d pty,raw,echo=0,link=/tmp/ttyA1 pty,raw,echo=0,link=/tmp/ttyB1 &
-socat -d -d pty,raw,echo=0,link=/tmp/ttyA2 pty,raw,echo=0,link=/tmp/ttyB2 &
+## Notes
 
-# Test with different baud rates
-socat -d -d pty,raw,echo=0,link=/tmp/ttyA,ispeed=9600,ospeed=9600 pty,raw,echo=0,link=/tmp/ttyB,ispeed=9600,ospeed=9600
-```
-
-## Prerequisites
-
-- Serial port device connected (or socat for virtual testing)
-- Appropriate permissions to access serial port
-- Matching baud rate between device and application
-
-### Installing socat for Virtual Testing
-
-#### Ubuntu/Debian
-```bash
-sudo apt update
-sudo apt install socat
-```
-
-#### CentOS/RHEL/Fedora
-```bash
-sudo yum install socat
-# or
-sudo dnf install socat
-```
-
-
-#### Windows
-```bash
-# Via WSL (Windows Subsystem for Linux)
-wsl --install
-# Then in WSL:
-sudo apt install socat
-
-# Or via Cygwin
-# Download and install Cygwin, then install socat package
-```
+- These examples use `serial(...).on_connect(...).on_data(...).on_error(...).build()`.
+- `echo_serial` exits when you submit an empty line.
+- `chat_serial` exits on `/quit`.
+- On Linux, serial-device access often requires `dialout` or similar group membership.
 
 ## Troubleshooting
 
 ### Permission Denied
+
 ```bash
-# Add user to dialout group (Linux)
 sudo usermod -a -G dialout $USER
-# Log out and log back in
 ```
 
+Log out and back in after changing group membership.
+
 ### Device Not Found
-- Check if device is connected: `ls /dev/tty*`
-- Verify device path: `/dev/ttyUSB0`, `/dev/ttyACM0`, etc.
-- On Windows: Check Device Manager for COM ports
+
+- Check available devices with `ls /dev/tty*`
+- Verify the correct device path such as `/dev/ttyUSB0` or `/dev/ttyACM0`
+- On Windows, verify the COM port in Device Manager
 
 ### Connection Issues
-- Ensure baud rate matches device settings
-- Check if another application is using the port
-- Verify cable and device functionality
 
-## Platform-Specific Notes
-
-### Linux
-- Common devices: `/dev/ttyUSB0`, `/dev/ttyACM0`
-- May need udev rules for consistent device naming
-
-### Windows
-- Use COM ports: `COM3`, `COM4`, etc.
-- Check Device Manager for available ports
-
+- Make sure baud rates match on both sides
+- Verify another program is not already using the port
+- Recheck cable, adapter, and device wiring

--- a/examples/serial/chat/README.md
+++ b/examples/serial/chat/README.md
@@ -1,6 +1,6 @@
-# Serial Chat Application
+# Serial Chat Example
 
-An interactive serial chat application that allows real-time communication through a serial port.
+Interactive serial chat example using the current public API.
 
 ## Usage
 
@@ -8,7 +8,8 @@ An interactive serial chat application that allows real-time communication throu
 ./chat_serial <device> <baud_rate>
 ```
 
-### Examples
+Examples:
+
 ```bash
 # Linux
 ./chat_serial /dev/ttyUSB0 115200
@@ -17,102 +18,54 @@ An interactive serial chat application that allows real-time communication throu
 ./chat_serial COM3 9600
 ```
 
-## What it does
+If arguments are omitted, the example defaults to `/dev/ttyUSB0` and `115200`.
 
-- Connects to the specified serial device
-- Provides an interactive chat interface
-- Sends typed messages to the serial port
-- Displays received messages from the serial port
-- Handles connection status and errors
+## Behavior
+
+- Opens the configured serial device
+- Prints connection and error events
+- Sends each stdin line over the serial link
+- Prints received data as it arrives
+- Exits on `/quit`
 
 ## Expected Output
 
+```text
+Serial Chat started. Type messages to send.
+Type '/quit' to exit.
+> hello
+[RX] hello back
 ```
-2025-01-15 10:30:45.123 [INFO] [serial] [start] Starting device: /dev/ttyUSB0
-2025-01-15 10:30:45.124 [INFO] [serial] [STATE] Serial device connected
-Hello, this is a test message
-2025-01-15 10:30:45.125 [INFO] [serial] [TX] Hello, this is a test message
-2025-01-15 10:30:45.126 [INFO] [serial] [RX] Response from device
-```
 
-## How to use
+## Quick Test With `socat`
 
-1. **Start the application**:
-   ```bash
-   ./chat_serial /dev/ttyUSB0 115200
-   ```
-
-2. **Wait for connection**:
-   - The application will attempt to connect to the serial device
-   - You'll see connection status messages
-
-3. **Start chatting**:
-   - Type messages and press Enter to send
-   - Received messages will be displayed automatically
-   - Type `Ctrl+C` to exit
-
-## Testing with socat (Virtual Serial Ports)
-
-### Setup Virtual Serial Ports
 ```bash
-# Terminal 1: Create virtual serial pair
+# Terminal 1
 socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
-# Creates: /tmp/ttyA <-> /tmp/ttyB
 
-# Terminal 2: Run chat application on first port
+# Terminal 2
 ./chat_serial /tmp/ttyA 115200
 
-# Terminal 3: Connect to second port
+# Terminal 3
 ./chat_serial /tmp/ttyB 115200
-
-# Start chatting between terminals
 ```
 
-## Testing with Two Devices
+## Notes
 
-### Setup
-1. Connect two serial devices (or use USB-to-Serial adapters)
-2. Run chat application on both devices with different device paths
-
-### Example
-```bash
-# Device 1
-./chat_serial /dev/ttyUSB0 115200
-
-# Device 2  
-./chat_serial /dev/ttyUSB1 115200
-```
-
-## Features
-
-- **Interactive interface**: Real-time message exchange
-- **Connection monitoring**: Clear indication of connection status
-- **Error handling**: Graceful handling of connection issues
-- **Message logging**: All sent and received messages are logged
-- **Automatic reconnection**: Retries connection if disconnected
-
-## Use Cases
-
-- **Device communication**: Chat with embedded devices
-- **Debugging**: Interactive communication for testing
-- **Remote control**: Send commands to remote devices
-- **Data exchange**: Transfer data between devices
+- The example uses `serial(...).on_connect(...).on_disconnect(...).on_data(...).on_error(...).build()`.
+- The prompt is printed locally; incoming data is shown as `[RX] ...`.
+- For a simpler send/echo flow, use `examples/serial/echo/`.
 
 ## Troubleshooting
 
 ### No Messages Received
-- Check if the other device is connected and running
-- Verify baud rate matches on both devices
-- Ensure cables are properly connected
 
-### Connection Issues
-- Verify device path is correct
-- Check device permissions
-- Ensure device is not in use by another application
+- Check that the peer process is connected and running
+- Verify both sides use the same baud rate
+- Confirm the correct device path
 
 ### Permission Denied
+
 ```bash
-# Add user to dialout group
 sudo usermod -a -G dialout $USER
-# Log out and log back in
 ```

--- a/examples/serial/echo/README.md
+++ b/examples/serial/echo/README.md
@@ -1,6 +1,6 @@
-# Serial Echo Server
+# Serial Echo Example
 
-A serial echo server that receives data from a serial port and echoes it back to the sender.
+Serial echo example using the current public API.
 
 ## Usage
 
@@ -8,7 +8,8 @@ A serial echo server that receives data from a serial port and echoes it back to
 ./echo_serial <device> <baud_rate>
 ```
 
-### Examples
+Examples:
+
 ```bash
 # Linux
 ./echo_serial /dev/ttyUSB0 115200
@@ -17,82 +18,60 @@ A serial echo server that receives data from a serial port and echoes it back to
 ./echo_serial COM3 9600
 ```
 
-## What it does
+If arguments are omitted, the example defaults to `/dev/ttyUSB0` and `115200`.
 
-- Connects to the specified serial device
-- Automatically retries connection if it fails
-- Logs connection status and data flow
-- Echoes received data back to the sender
-- Handles connection drops and reconnection
+## Behavior
+
+- Opens the configured serial device
+- Logs connect, disconnect, RX, and TX events
+- Sends each line you type to the serial link
+- Prints incoming data and echoes it back if the peer reflects it
+- Exits when you submit an empty line
 
 ## Expected Output
 
-```
-2025-01-15 10:30:45.123 [INFO] [serial] [start] Starting device: /dev/ttyUSB0
-2025-01-15 10:30:45.124 [INFO] [serial] [STATE] Serial device connected
-2025-01-15 10:30:45.125 [INFO] [serial] [TX] SER 0
-2025-01-15 10:30:45.126 [INFO] [serial] [RX] SER 0
-2025-01-15 10:30:45.127 [INFO] [serial] [TX] SER 1
-2025-01-15 10:30:45.128 [INFO] [serial] [RX] SER 1
+```text
+[INFO] [serial] [main] Serial started successfully
+[INFO] [serial] [STATE] Serial device connected
+[INFO] [serial] [TX] hello
+[INFO] [serial] [RX] hello
 ```
 
-## Testing
+## Quick Test With `socat`
 
-### Using socat (Virtual Serial Ports)
 ```bash
-# Terminal 1: Create virtual serial pair
+# Terminal 1
 socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
-# Creates: /tmp/ttyA <-> /tmp/ttyB
 
-# Terminal 2: Run echo server
+# Terminal 2
 ./echo_serial /tmp/ttyA 115200
 
-# Terminal 3: Connect to second port
+# Terminal 3
 ./echo_serial /tmp/ttyB 115200
-
-# Type messages and see them echoed back
 ```
 
-### Using a Serial Terminal
-1. Connect a serial device (Arduino, USB-to-Serial adapter, etc.)
-2. Run the echo server: `./echo_serial /dev/ttyUSB0 115200`
-3. Open a serial terminal (minicom, screen, etc.) on the same device
-4. Send data from the terminal
-5. Observe the echoed data
+## Notes
 
-### Using Another Serial Device
-1. Connect two serial devices
-2. Run echo server on one device
-3. Send data from the other device
-4. Verify data is echoed back
-
-## Features
-
-- **Automatic reconnection**: Retries connection every 5 seconds if disconnected
-- **Connection status logging**: Clear indication of connection state
-- **Data logging**: All transmitted and received data is logged
-- **Error handling**: Graceful handling of connection errors
-- **Configurable parameters**: Device path and baud rate
+- The example uses `serial(...).on_connect(...).on_data(...).on_error(...).build()`.
+- It waits on `start().get()` before entering the send loop.
+- For interactive two-way chatting, use `examples/serial/chat/`.
 
 ## Troubleshooting
 
 ### Device Not Found
-```bash
-# Check available devices
-ls /dev/tty*
 
-# Check permissions
-ls -l /dev/ttyUSB0
+```bash
+ls /dev/tty*
 ```
 
 ### Permission Denied
+
 ```bash
-# Add user to dialout group
 sudo usermod -a -G dialout $USER
-# Log out and log back in
 ```
 
-### Connection Issues
-- Verify device is not in use by another application
-- Check baud rate matches device settings
-- Ensure cable and device are working properly
+### No Traffic
+
+- Verify both sides are using the same baud rate
+- Confirm the device is not already opened by another program
+- Check adapter and cable wiring

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -1,86 +1,88 @@
 # TCP Communication Examples
 
-Examples demonstrating TCP network communication using the unilink library.
+TCP examples using the current public API.
 
-## Examples
+## Included Examples
 
-- **single-echo/**: TCP echo server and client for network echo testing
-- **single-chat/**: TCP chat server and client for network chat
-- **multi-chat/**: Multi-client chat server and client
+- `single-echo/`: Single-client echo server and client
+- `single-chat/`: Single-client chat server and client
+- `multi-chat/`: Multi-client chat server and client
 
 ## Common Usage
 
 ```bash
-# Start server
-./server_example <port>
-
-# Connect client
-./client_example <host> <port>
-```
-
-## Network Configuration
-
-### Local Testing
-```bash
 # Server
-./echo_tcp_server 9000
+./server_binary <port>
 
-# Client (same machine)
-./echo_tcp_client 127.0.0.1 9000
+# Client
+./client_binary <host> <port>
 ```
 
-### Remote Testing
+Most binaries also provide sensible defaults when arguments are omitted:
+
+- Server examples default to port `8080`
+- Client examples default to `127.0.0.1:8080`
+
+## Quick Start
+
+### Echo
+
 ```bash
-# Server
-./echo_tcp_server 9000
+# Terminal 1
+./echo_tcp_server
 
-# Client (different machine)
-./echo_tcp_client 192.168.1.100 9000
+# Terminal 2
+./echo_tcp_client
 ```
 
-## Prerequisites
+### Single-Client Chat
 
-- Network connectivity between server and client
-- Available port (not in use by other applications)
-- Firewall configuration (if needed)
+```bash
+# Terminal 1
+./chat_tcp_server
+
+# Terminal 2
+./chat_tcp_client
+```
+
+### Multi-Client Chat
+
+```bash
+# Terminal 1
+./multi_chat_tcp_server
+
+# Terminal 2
+./multi_chat_tcp_client
+
+# Terminal 3
+./multi_chat_tcp_client
+```
+
+## Notes
+
+- These examples use the builder and wrapper API from `unilink/unilink.hpp`.
+- `single-echo` uses `.single_client()` and targeted replies with `send_to(...)`.
+- `single-chat` is intentionally single-client.
+- `multi-chat` uses `.unlimited_clients()` and `broadcast(...)`.
 
 ## Troubleshooting
 
 ### Port Already in Use
+
 ```bash
-# Check what's using the port
 netstat -tulpn | grep :9000
 # or
 lsof -i :9000
+```
 
-# Use a different port
+Run the server on another port if needed:
+
+```bash
 ./echo_tcp_server 9001
 ```
 
 ### Connection Refused
-- Verify server is running
-- Check firewall settings
-- Ensure correct IP address and port
 
-### Firewall Issues
-```bash
-# Linux - allow port through firewall
-sudo ufw allow 9000
-
-# Check firewall status
-sudo ufw status
-```
-
-## Example Workflows
-
-### Single Echo Server/Client
-1. Start server: `./echo_tcp_server 9000`
-2. Start client: `./echo_tcp_client 127.0.0.1 9000`
-3. Type messages in client
-4. Server echoes messages back
-
-### Single Chat Server/Client
-1. Start server: `./chat_tcp_server 9000`
-2. Start client: `./chat_tcp_client 127.0.0.1 9000`
-3. Type messages in client
-4. Server displays received messages
+- Verify the server is already running
+- Check the client host and port
+- Confirm firewall settings for remote connections

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -6,6 +6,7 @@ Examples demonstrating TCP network communication using the unilink library.
 
 - **single-echo/**: TCP echo server and client for network echo testing
 - **single-chat/**: TCP chat server and client for network chat
+- **multi-chat/**: Multi-client chat server and client
 
 ## Common Usage
 

--- a/examples/tcp/multi-chat/README.md
+++ b/examples/tcp/multi-chat/README.md
@@ -1,6 +1,6 @@
 # Multi-Client TCP Chat Server and Client
 
-Advanced TCP chat system supporting multiple simultaneous clients. The server broadcasts messages from one client to all connected clients.
+Multi-client TCP chat examples using the current public API.
 
 ## Server Usage
 
@@ -8,13 +8,14 @@ Advanced TCP chat system supporting multiple simultaneous clients. The server br
 ./multi_chat_tcp_server <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Default port 9000
-./multi_chat_tcp_server 9000
+# Default port is 8080 when omitted
+./multi_chat_tcp_server
 
 # Custom port
-./multi_chat_tcp_server 8080
+./multi_chat_tcp_server 9000
 ```
 
 ## Client Usage
@@ -23,162 +24,72 @@ Advanced TCP chat system supporting multiple simultaneous clients. The server br
 ./multi_chat_tcp_client <host> <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Local connection
+# Default target is 127.0.0.1:8080 when omitted
+./multi_chat_tcp_client
+
+# Explicit local connection
 ./multi_chat_tcp_client 127.0.0.1 9000
 
 # Remote connection
 ./multi_chat_tcp_client 192.168.1.100 9000
 ```
 
-## What it does
+## Behavior
 
-### Server
-- Listens on the specified port
-- Accepts multiple simultaneous client connections
-- Broadcasts messages from one client to all connected clients
-- Manages client connections and disconnections
-- Logs all connection events and messages
-
-### Client
-- Connects to the specified server
-- Sends messages to the server
-- Receives messages from all other clients
-- Displays messages with sender information
-- Handles connection status and errors
+- The server accepts multiple clients with `.unlimited_clients()`.
+- Join, leave, and chat messages are rebroadcast to all clients.
+- The server operator can send `[Admin]: ...` messages from stdin.
+- Clients send stdin lines and print every broadcast they receive.
 
 ## Expected Output
 
-### Server Output
-```
-2025-01-15 10:30:45.123 [INFO] [server] [start] Starting multi-chat server on port 9000
-2025-01-15 10:30:45.124 [INFO] [server] [STATE] Client 1 connected
-2025-01-15 10:30:45.125 [INFO] [server] [STATE] Client 2 connected
-2025-01-15 10:30:45.126 [INFO] [server] [RX] [Client 1] Hello everyone!
-2025-01-15 10:30:45.127 [INFO] [server] [BROADCAST] Broadcasting to 2 clients
-2025-01-15 10:30:45.128 [INFO] [server] [STATE] Client 1 disconnected
+Server:
+
+```text
+[INFO] [server] [main] Multi-Chat Server started on port 8080
+[INFO] [server] [STATE] Client 1 joined (IP: 127.0.0.1:...)
+[INFO] [server] [CHAT] [Client 1]: Hello everyone!
 ```
 
-### Client Output
+Client:
+
+```text
+*** Connected to Multi-Chat Server ***
+[Client 1]: Hello everyone!
 ```
-2025-01-15 10:30:45.123 [INFO] [client] [start] Connecting to 127.0.0.1:9000
-2025-01-15 10:30:45.124 [INFO] [client] [STATE] Connected
-2025-01-15 10:30:45.125 [INFO] [client] [RX] [Client 1] Hello everyone!
-2025-01-15 10:30:45.126 [INFO] [client] [TX] Hello back!
+
+## Quick Test
+
+```bash
+# Terminal 1
+./multi_chat_tcp_server
+
+# Terminal 2
+./multi_chat_tcp_client
+
+# Terminal 3
+./multi_chat_tcp_client
 ```
 
-## Testing Workflow
+## Notes
 
-### Multi-Client Testing
-1. **Start the server**:
-   ```bash
-   ./multi_chat_tcp_server 9000
-   ```
-
-2. **Start multiple clients** (in separate terminals):
-   ```bash
-   # Terminal 1
-   ./multi_chat_tcp_client 127.0.0.1 9000
-   
-   # Terminal 2
-   ./multi_chat_tcp_client 127.0.0.1 9000
-   
-   # Terminal 3
-   ./multi_chat_tcp_client 127.0.0.1 9000
-   ```
-
-3. **Start chatting**:
-   - Type messages in any client
-   - All other clients will receive the messages
-   - Messages are tagged with sender information
-
-### Network Testing
-1. **Start server on machine A**:
-   ```bash
-   ./multi_chat_tcp_server 9000
-   ```
-
-2. **Start clients on different machines**:
-   ```bash
-   # Machine B
-   ./multi_chat_tcp_client <machine_A_IP> 9000
-   
-   # Machine C
-   ./multi_chat_tcp_client <machine_A_IP> 9000
-   ```
-
-## Features
-
-### Server Features
-- **Multi-client support**: Handles multiple simultaneous connections
-- **Message broadcasting**: Sends messages from one client to all others
-- **Client management**: Tracks connected clients and their status
-- **Connection logging**: Logs all connection and disconnection events
-- **Message logging**: Logs all messages and broadcast events
-- **Signal handling**: Graceful shutdown with Ctrl+C
-
-### Client Features
-- **Connection management**: Connects to the multi-chat server
-- **Message sending**: Sends messages to the server
-- **Message reception**: Receives messages from all other clients
-- **Sender identification**: Messages show which client sent them
-- **Status logging**: Logs connection and message events
-- **Error handling**: Handles connection failures gracefully
-
-## Advanced Features
-
-### Client Identification
-- Each client is assigned a unique ID
-- Messages are tagged with sender information
-- Server tracks client connections and disconnections
-
-### Message Broadcasting
-- Server receives message from one client
-- Broadcasts to all other connected clients
-- Excludes the sender from receiving their own message
-
-### Connection Management
-- Automatic client disconnection handling
-- Server continues running when clients disconnect
-- New clients can join at any time
-
-## Use Cases
-
-- **Group chat**: Multi-user chat application
-- **Team communication**: Internal team chat system
-- **Remote collaboration**: Chat between team members
-- **Broadcasting**: Send messages to multiple recipients
-- **Real-time communication**: Instant messaging system
-
-## Performance Considerations
-
-### Server Capacity
-- Server can handle multiple clients simultaneously
-- Performance depends on system resources
-- Consider connection limits for production use
-
-### Network Bandwidth
-- All messages are broadcast to all clients
-- Consider bandwidth usage for large groups
-- Implement message filtering if needed
+- Clients receive the server's rebroadcast stream, including their own messages.
+- This is a lightweight sample, not a production chat service.
+- Both binaries use the public `unilink/unilink.hpp` API.
 
 ## Troubleshooting
 
 ### Client Connection Issues
-- Verify server is running
-- Check firewall settings
-- Ensure correct IP address and port
-- Check network connectivity
+
+- Verify the server is running first.
+- Check firewall settings.
+- Confirm the host and port are correct.
 
 ### Message Not Received
-- Verify client is connected to server
-- Check if other clients are connected
-- Ensure server is broadcasting messages
-- Check for network issues
 
-### Server Performance
-- Monitor server resource usage
-- Check connection limits
-- Consider server capacity for large groups
-- Implement connection pooling if needed
+- Verify the client is connected.
+- Check whether the server is still running.
+- Confirm another client or the server operator has sent data.

--- a/examples/tcp/single-chat/README.md
+++ b/examples/tcp/single-chat/README.md
@@ -1,6 +1,6 @@
 # TCP Chat Server and Client
 
-TCP chat server and client for network-based chat communication. The server displays messages from clients, and clients can send messages to the server.
+Single-client TCP chat examples using the current public API.
 
 ## Server Usage
 
@@ -8,13 +8,14 @@ TCP chat server and client for network-based chat communication. The server disp
 ./chat_tcp_server <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Default port 9000
-./chat_tcp_server 9000
+# Default port is 8080 when omitted
+./chat_tcp_server
 
 # Custom port
-./chat_tcp_server 8080
+./chat_tcp_server 9000
 ```
 
 ## Client Usage
@@ -23,135 +24,69 @@ TCP chat server and client for network-based chat communication. The server disp
 ./chat_tcp_client <host> <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Local connection
+# Default target is 127.0.0.1:8080 when omitted
+./chat_tcp_client
+
+# Explicit local connection
 ./chat_tcp_client 127.0.0.1 9000
 
 # Remote connection
 ./chat_tcp_client 192.168.1.100 9000
 ```
 
-## What it does
+## Behavior
 
-### Server
-- Listens on the specified port
-- Accepts client connections
-- Displays received messages from clients
-- Logs connection status and messages
-- Handles client disconnections
-
-### Client
-- Connects to the specified server
-- Sends typed messages to the server
-- Receives and displays messages from the server
-- Logs connection status and messages
+- The server runs in `.single_client()` mode.
+- Client messages are printed on the server console.
+- The server operator can type messages and send them back.
+- The client sends stdin lines and exits on `/quit`.
 
 ## Expected Output
 
-### Server Output
-```
-2025-01-15 10:30:45.123 [INFO] [server] [start] Starting TCP server on port 9000
-2025-01-15 10:30:45.124 [INFO] [server] [STATE] Client connected
-2025-01-15 10:30:45.125 [INFO] [server] [RX] Hello from client!
-2025-01-15 10:30:45.126 [INFO] [server] [TX] Server response
-2025-01-15 10:30:45.127 [INFO] [server] [STATE] Client disconnected
-```
+Server:
 
-### Client Output
-```
-2025-01-15 10:30:45.123 [INFO] [client] [start] Connecting to 127.0.0.1:9000
-2025-01-15 10:30:45.124 [INFO] [client] [STATE] Connected
-2025-01-15 10:30:45.125 [INFO] [client] [TX] Hello from client!
-2025-01-15 10:30:45.126 [INFO] [client] [RX] Server response
+```text
+[INFO] [server] [main] Server started on port 8080
+[INFO] [server] [STATE] Client connected: 127.0.0.1:...
+[Client] hello
 ```
 
-## Testing Workflow
+Client:
 
-### Local Testing
-1. **Start the server**:
-   ```bash
-   ./chat_tcp_server 9000
-   ```
+```text
+[INFO] [client] [STATE] Connected
+[Server] hello back
+```
 
-2. **Start the client** (in another terminal):
-   ```bash
-   ./chat_tcp_client 127.0.0.1 9000
-   ```
+## Quick Test
 
-3. **Start chatting**:
-   - Type messages in the client and press Enter
-   - Server will display received messages
-   - Server can also send messages to client
+```bash
+# Terminal 1
+./chat_tcp_server
 
-### Network Testing
-1. **Start server on machine A**:
-   ```bash
-   ./chat_tcp_server 9000
-   ```
+# Terminal 2
+./chat_tcp_client
+```
 
-2. **Start client on machine B**:
-   ```bash
-   ./chat_tcp_client <machine_A_IP> 9000
-   ```
+## Notes
 
-3. **Chat between machines**:
-   - Send messages from client to server
-   - Server displays messages and can respond
-
-## Features
-
-### Server Features
-- **Port binding**: Listens on specified port
-- **Client management**: Accepts and manages client connections
-- **Message display**: Shows received messages from clients
-- **Interactive input**: Server can type and send messages to clients
-- **Connection logging**: Logs all connection and message events
-- **Signal handling**: Graceful shutdown with Ctrl+C
-
-### Client Features
-- **Connection management**: Connects to specified server
-- **Interactive chat**: Type messages and send to server
-- **Message reception**: Receives and displays messages from server
-- **Status logging**: Logs connection and message events
-- **Error handling**: Handles connection failures gracefully
-
-## Use Cases
-
-- **Network chat**: Simple chat application over network
-- **Remote communication**: Chat between different machines
-- **Protocol testing**: Test custom chat protocols
-- **Debugging**: Debug network communication issues
-- **Remote control**: Send commands to remote systems
-
-## Advanced Usage
-
-### Multiple Clients
-The server can handle multiple clients, but only one at a time in this implementation. For true multi-client support, see the multi-chat example in the examples/tcp/multi-chat directory.
-
-### Custom Messages
-- Server can send custom messages to clients
-- Clients receive and display all server messages
-- Both sides can initiate conversations
+- This example is intentionally single-client.
+- For concurrent clients, see `examples/tcp/multi-chat/`.
+- Both binaries use the public `unilink/unilink.hpp` API.
 
 ## Troubleshooting
 
 ### Port Already in Use
+
 ```bash
-# Check what's using the port
 netstat -tulpn | grep :9000
-# Use a different port
-./chat_tcp_server 9001
 ```
 
 ### Connection Issues
-- Verify server is running
-- Check firewall settings
-- Ensure correct IP address and port
-- Check network connectivity
 
-### Message Not Received
-- Verify connection is established
-- Check if messages are being sent
-- Ensure both sides are running properly
-- Check for network issues
+- Verify the server is already listening.
+- Confirm the client host and port.
+- Check firewall settings for remote access.

--- a/examples/tcp/single-echo/README.md
+++ b/examples/tcp/single-echo/README.md
@@ -1,6 +1,6 @@
 # TCP Echo Server and Client
 
-TCP echo server and client for network communication testing. The server echoes back any data received from clients.
+TCP echo examples using the current builder and wrapper API.
 
 ## Server Usage
 
@@ -8,13 +8,14 @@ TCP echo server and client for network communication testing. The server echoes 
 ./echo_tcp_server <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Default port 9000
-./echo_tcp_server 9000
+# Default port is 8080 when omitted
+./echo_tcp_server
 
 # Custom port
-./echo_tcp_server 8080
+./echo_tcp_server 9000
 ```
 
 ## Client Usage
@@ -23,125 +24,81 @@ TCP echo server and client for network communication testing. The server echoes 
 ./echo_tcp_client <host> <port>
 ```
 
-### Examples
+Examples:
+
 ```bash
-# Local connection
+# Default target is 127.0.0.1:8080 when omitted
+./echo_tcp_client
+
+# Explicit local connection
 ./echo_tcp_client 127.0.0.1 9000
 
 # Remote connection
 ./echo_tcp_client 192.168.1.100 9000
 ```
 
-## What it does
+## Behavior
 
-### Server
-- Listens on the specified port
-- Accepts client connections
-- Echoes received data back to clients
-- Logs connection status and data flow
-- Handles multiple clients (one at a time)
-
-### Client
-- Connects to the specified server
-- Sends data to the server
-- Receives echoed data from the server
-- Logs connection status and data flow
+- The server binds a TCP port in single-client mode.
+- Each message received from the client is echoed back to that client.
+- The client reads stdin lines, sends them, and prints echoed responses.
+- Exit with `/quit` or `Ctrl+C`.
 
 ## Expected Output
 
-### Server Output
-```
-2025-01-15 10:30:45.123 [INFO] [server] [start] Starting TCP server on port 9000
-2025-01-15 10:30:45.124 [INFO] [server] [STATE] Client connected
-2025-01-15 10:30:45.125 [INFO] [server] [RX] Hello from client
-2025-01-15 10:30:45.126 [INFO] [server] [TX] Hello from client
-2025-01-15 10:30:45.127 [INFO] [server] [STATE] Client disconnected
-```
+Server:
 
-### Client Output
-```
-2025-01-15 10:30:45.123 [INFO] [client] [start] Connecting to 127.0.0.1:9000
-2025-01-15 10:30:45.124 [INFO] [client] [STATE] Connected
-2025-01-15 10:30:45.125 [INFO] [client] [TX] Hello from client
-2025-01-15 10:30:45.126 [INFO] [client] [RX] Hello from client
+```text
+[INFO] [server] [startup] Starting server on port 8080...
+[INFO] [server] [startup] Server started successfully. Waiting for client connections...
+[INFO] [server] [connect] Client 1 connected: 127.0.0.1:...
+[INFO] [server] [data] Client 1 message: hello
+[INFO] [server] [echo] Echoed to client 1
 ```
 
-## Testing Workflow
+Client:
 
-### Local Testing
-1. **Start the server**:
-   ```bash
-   ./echo_tcp_server 9000
-   ```
+```text
+[INFO] [client] [startup] Connecting to 127.0.0.1:8080...
+[INFO] [client] [connect] Connected to server
+[INFO] [client] [send] Sent: hello
+[INFO] [client] [data] Received: hello
+```
 
-2. **Start the client** (in another terminal):
-   ```bash
-   ./echo_tcp_client 127.0.0.1 9000
-   ```
+## Quick Test
 
-3. **Send messages**:
-   - Type messages in the client
-   - Server will echo them back
-   - Observe the logging output
+```bash
+# Terminal 1
+./echo_tcp_server
 
-### Network Testing
-1. **Start server on machine A**:
-   ```bash
-   ./echo_tcp_server 9000
-   ```
+# Terminal 2
+./echo_tcp_client
+```
 
-2. **Start client on machine B**:
-   ```bash
-   ./echo_tcp_client <machine_A_IP> 9000
-   ```
+## Notes
 
-## Features
-
-### Server Features
-- **Port binding**: Listens on specified port
-- **Client handling**: Accepts and manages client connections
-- **Data echoing**: Sends received data back to client
-- **Connection logging**: Logs all connection events
-- **Error handling**: Graceful handling of connection errors
-
-### Client Features
-- **Connection management**: Connects to specified server
-- **Data transmission**: Sends data to server
-- **Data reception**: Receives echoed data from server
-- **Status logging**: Logs connection and data events
-- **Error handling**: Handles connection failures
-
-## Use Cases
-
-- **Network testing**: Verify network connectivity and latency
-- **Protocol testing**: Test custom protocols over TCP
-- **Load testing**: Test server performance under load
-- **Debugging**: Debug network communication issues
+- The server example uses `.single_client()`.
+- The client example uses retry settings through the builder API.
+- Both examples are built from the public `unilink/unilink.hpp` interface.
 
 ## Troubleshooting
 
 ### Port Already in Use
+
 ```bash
-# Check what's using the port
 netstat -tulpn | grep :9000
 # or
 lsof -i :9000
+```
 
-# Use a different port
+Start the server on another port if needed:
+
+```bash
 ./echo_tcp_server 9001
 ```
 
 ### Connection Refused
-- Verify server is running
-- Check firewall settings
-- Ensure correct IP address and port
-- Check if port is accessible
 
-### Firewall Issues
-```bash
-# Linux - allow port through firewall
-sudo ufw allow 9000
-
-# Check firewall status
-sudo ufw status
-```
+- Verify the server is running.
+- Check the host and port.
+- Check firewall rules if connecting across machines.

--- a/examples/tutorials/BUILD_INSTRUCTIONS.md
+++ b/examples/tutorials/BUILD_INSTRUCTIONS.md
@@ -2,50 +2,33 @@
 
 Quick guide to compile and run tutorial examples.
 
-## Quick Build (Recommended)
+## Quick Build
 
-From project root:
+From the project root:
 
-\`\`\`bash
-# Configure (first time only)
+```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-
-# Build tutorial examples
-cmake --build build --target tutorial_simple_client
-cmake --build build --target tutorial_my_first_client
-cmake --build build --target tutorial_echo_server
-cmake --build build --target tutorial_chat_server
-
-# Or build all at once
-cmake --build build -j
-\`\`\`
+cmake --build build --target tutorial_simple_client tutorial_my_first_client tutorial_echo_server tutorial_chat_server
+```
 
 ## Run Examples
 
-\`\`\`bash
-# Simple client (needs server on port 8080)
-./build/examples/tutorials/tutorial_simple_client
+```bash
+# Simple client (needs a server on port 8080)
+./build/bin/tutorial_simple_client
 
-# My first client
-./build/examples/tutorials/tutorial_my_first_client [host] [port]
+# Interactive client
+./build/bin/tutorial_my_first_client [host] [port]
 
-# Echo server
-./build/examples/tutorials/tutorial_echo_server [port]
+# Echo server (fixed to port 8080)
+./build/bin/tutorial_echo_server
 
-# Chat server
-./build/examples/tutorials/tutorial_chat_server [port]
-\`\`\`
+# Chat server (fixed to port 8080)
+./build/bin/tutorial_chat_server
+```
 
-## Manual Compilation
+## Notes
 
-If CMake is not available:
-
-\`\`\`bash
-g++ -std=c++17 getting_started/simple_client.cpp \\
-    -I../../unilink \\
-    -L../../build \\
-    -lunilink -lboost_system -pthread \\
-    -o simple_client
-\`\`\`
-
-See [README.md](README.md) for detailed instructions.
+- Tutorial binaries are currently emitted under `build/bin/`.
+- `tutorial_echo_server` and `tutorial_chat_server` do not parse CLI port arguments.
+- See [README.md](README.md) for example workflows.

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,102 +1,31 @@
 # Tutorial Examples
 
-Ready-to-compile examples that mirror the tutorial documentation.
+Ready-to-compile example sources that mirror the tutorial documentation.
 
 ## Included Examples
 
-### Getting Started
+| Area | File | Tutorial |
+|------|------|----------|
+| Getting Started | `getting_started/simple_client.cpp` | [01_getting_started.md](../../docs/tutorials/01_getting_started.md) |
+| Getting Started | `getting_started/my_first_client.cpp` | [01_getting_started.md](../../docs/tutorials/01_getting_started.md) |
+| TCP Server | `tcp_server/echo_server.cpp` | [02_tcp_server.md](../../docs/tutorials/02_tcp_server.md) |
+| TCP Server | `tcp_server/chat_server.cpp` | [02_tcp_server.md](../../docs/tutorials/02_tcp_server.md) |
 
-| Example | File | Description | Tutorial Link |
-|---------|------|-------------|---------------|
-| **Simple Client** | `simple_client.cpp` | Minimal one-shot client | [Getting Started](../../docs/tutorials/01_getting_started.md) |
-| **My First Client** | `my_first_client.cpp` | Interactive client with callbacks and retries | [Getting Started](../../docs/tutorials/01_getting_started.md) |
+## Build And Run
 
-### TCP Server
+- Build and binary-path details: [BUILD_INSTRUCTIONS.md](BUILD_INSTRUCTIONS.md)
+- Tutorial walkthroughs: [docs/tutorials/](../../docs/tutorials/)
 
-| Example | File | Description | Tutorial Link |
-|---------|------|-------------|---------------|
-| **Echo Server** | `echo_server.cpp` | Fixed-port echo server on `8080` | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
-| **Chat Server** | `chat_server.cpp` | Fixed-port multi-client chat server on `8080` | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
+## Related Protocol Examples
 
-## Quick Start
+Not every tutorial has a dedicated file under `examples/tutorials/`.
 
-### Build All Tutorial Examples
-
-```bash
-cd build
-cmake --build . --target tutorial_simple_client tutorial_my_first_client tutorial_echo_server tutorial_chat_server
-```
-
-### Run Examples
-
-#### Simple Client
-
-```bash
-# Terminal 1
-nc -l 8080
-
-# Terminal 2
-./build/bin/tutorial_simple_client
-```
-
-`tutorial_simple_client` connects once, sends `Hello, Unilink!`, and exits.
-
-#### My First Client
-
-```bash
-# Terminal 1
-nc -l 8080
-
-# Terminal 2
-./build/bin/tutorial_my_first_client
-
-# Custom target
-./build/bin/tutorial_my_first_client 192.168.1.100 9000
-```
-
-#### Echo Server
-
-```bash
-# Terminal 1
-./build/bin/tutorial_echo_server
-
-# Terminal 2
-nc localhost 8080
-```
-
-#### Chat Server
-
-```bash
-# Terminal 1
-./build/bin/tutorial_chat_server
-
-# Terminal 2
-telnet localhost 8080
-
-# Terminal 3
-telnet localhost 8080
-```
-
-Available commands inside the chat example:
-
-```text
-/nick Alice
-/list
-/help
-/quit
-Hello everyone!
-```
-
-## Additional Protocol Tutorials
-
-Not every tutorial has dedicated files under `examples/tutorials/`.
-
-- Serial tutorial examples live under [examples/serial/README.md](../../examples/serial/README.md)
-- UDP tutorial examples live under [examples/udp/README.md](../../examples/udp/README.md)
-- UDS tutorial examples live under [examples/uds/README.md](../../examples/uds/README.md)
+- Serial examples: [../serial/README.md](../serial/README.md)
+- UDP examples: [../udp/README.md](../udp/README.md)
+- UDS examples: [../uds/README.md](../uds/README.md)
 
 ## Notes
 
+- This file is intentionally an index to reduce duplication with the tutorial docs and `BUILD_INSTRUCTIONS.md`.
 - Tutorial binaries are emitted under `build/bin/` in the current build setup.
-- `tutorial_echo_server` and `tutorial_chat_server` are fixed to port `8080`; they do not parse CLI port arguments.
 - All tutorial examples use the public `unilink/unilink.hpp` API.

--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -1,321 +1,102 @@
 # Tutorial Examples
 
-Ready-to-compile examples from the unilink tutorials.
+Ready-to-compile examples that mirror the tutorial documentation.
 
----
-
-## 📚 Included Examples
+## Included Examples
 
 ### Getting Started
 
 | Example | File | Description | Tutorial Link |
 |---------|------|-------------|---------------|
-| **Simple Client** | `simple_client.cpp` | Minimal 30-second example | [Getting Started](../../docs/tutorials/01_getting_started.md) |
-| **My First Client** | `my_first_client.cpp` | Complete first application | [Getting Started](../../docs/tutorials/01_getting_started.md) |
+| **Simple Client** | `simple_client.cpp` | Minimal one-shot client | [Getting Started](../../docs/tutorials/01_getting_started.md) |
+| **My First Client** | `my_first_client.cpp` | Interactive client with callbacks and retries | [Getting Started](../../docs/tutorials/01_getting_started.md) |
 
 ### TCP Server
 
 | Example | File | Description | Tutorial Link |
 |---------|------|-------------|---------------|
-| **Echo Server** | `echo_server.cpp` | Basic echo server | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
-| **Chat Server** | `chat_server.cpp` | Multi-client chat server | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
+| **Echo Server** | `echo_server.cpp` | Fixed-port echo server on `8080` | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
+| **Chat Server** | `chat_server.cpp` | Fixed-port multi-client chat server on `8080` | [TCP Server](../../docs/tutorials/02_tcp_server.md) |
 
----
-
-## 🚀 Quick Start
+## Quick Start
 
 ### Build All Tutorial Examples
 
 ```bash
-# From project root
 cd build
 cmake --build . --target tutorial_simple_client tutorial_my_first_client tutorial_echo_server tutorial_chat_server
-
-# Or build all examples
-cmake --build .
 ```
 
 ### Run Examples
 
-#### 1. Simple Client (30 seconds)
+#### Simple Client
 
-**Terminal 1** (Start a test server):
 ```bash
+# Terminal 1
 nc -l 8080
+
+# Terminal 2
+./build/bin/tutorial_simple_client
 ```
 
-**Terminal 2** (Run client):
+`tutorial_simple_client` connects once, sends `Hello, Unilink!`, and exits.
+
+#### My First Client
+
 ```bash
-./build/examples/tutorials/tutorial_simple_client
-```
-
-Type messages in Terminal 1 to send to the client!
-
----
-
-#### 2. My First Client
-
-**Terminal 1** (Start a test server):
-```bash
+# Terminal 1
 nc -l 8080
+
+# Terminal 2
+./build/bin/tutorial_my_first_client
+
+# Custom target
+./build/bin/tutorial_my_first_client 192.168.1.100 9000
 ```
 
-**Terminal 2** (Run client with custom host/port):
+#### Echo Server
+
 ```bash
-# Default: localhost:8080
-./build/examples/tutorials/tutorial_my_first_client
+# Terminal 1
+./build/bin/tutorial_echo_server
 
-# Custom server
-./build/examples/tutorials/tutorial_my_first_client 192.168.1.100 9000
-```
-
----
-
-#### 3. Echo Server
-
-**Terminal 1** (Run echo server):
-```bash
-./build/examples/tutorials/tutorial_echo_server 8080
-```
-
-**Terminal 2** (Connect with netcat):
-```bash
+# Terminal 2
 nc localhost 8080
 ```
 
-Type messages - they will be echoed back!
+#### Chat Server
 
-**Or use telnet**:
 ```bash
+# Terminal 1
+./build/bin/tutorial_chat_server
+
+# Terminal 2
+telnet localhost 8080
+
+# Terminal 3
 telnet localhost 8080
 ```
 
----
+Available commands inside the chat example:
 
-#### 4. Chat Server
-
-**Terminal 1** (Run chat server):
-```bash
-./build/examples/tutorials/tutorial_chat_server 8080
+```text
+/nick Alice
+/list
+/help
+/quit
+Hello everyone!
 ```
-
-**Terminal 2, 3, 4...** (Connect multiple clients):
-```bash
-telnet localhost 8080
-```
-
-**Chat Commands**:
-```
-/nick Alice          # Change your nickname
-/list                # List all users
-/help                # Show help
-/quit                # Disconnect
-Hello everyone!      # Send a message
-```
-
----
-
-## 📖 Corresponding Tutorials
-
-Each example corresponds to a tutorial in the documentation:
-
-### Getting Started
-- **Documentation**: [docs/tutorials/01_getting_started.md](../../docs/tutorials/01_getting_started.md)
-- **Examples**: 
-  - `simple_client.cpp` - The 30-second example
-  - `my_first_client.cpp` - Complete walkthrough
-
-**What You'll Learn**:
-- Creating your first TCP client
-- Connecting to a server
-- Sending and receiving data
-- Handling connection events
-
----
-
-### Building a TCP Server
-- **Documentation**: [docs/tutorials/02_tcp_server.md](../../docs/tutorials/02_tcp_server.md)
-- **Examples**:
-  - `echo_server.cpp` - Basic echo server
-  - `chat_server.cpp` - Complete chat server
-
-**What You'll Learn**:
-- Creating a TCP server
-- Accepting multiple clients
-- Broadcasting messages
-- Implementing commands
-
----
 
 ## Additional Protocol Tutorials
 
-Not every tutorial has dedicated files under `examples/tutorials/`. The Serial and UDP tutorials intentionally reuse the protocol-specific example directories instead of duplicating near-identical sample programs.
+Not every tutorial has dedicated files under `examples/tutorials/`.
 
-### Serial Communication
-- **Documentation**: [docs/tutorials/04_serial_communication.md](../../docs/tutorials/04_serial_communication.md)
-- **Examples**: [examples/serial/README.md](../../examples/serial/README.md)
+- Serial tutorial examples live under [examples/serial/README.md](../../examples/serial/README.md)
+- UDP tutorial examples live under [examples/udp/README.md](../../examples/udp/README.md)
+- UDS tutorial examples live under [examples/uds/README.md](../../examples/uds/README.md)
 
-### UDP Communication
-- **Documentation**: [docs/tutorials/05_udp_communication.md](../../docs/tutorials/05_udp_communication.md)
-- **Examples**: [examples/udp/README.md](../../examples/udp/README.md)
+## Notes
 
----
-
-## 🔨 Manual Compilation
-
-If you prefer to compile manually:
-
-```bash
-# Simple client
-g++ -std=c++17 getting_started/simple_client.cpp \
-    -o simple_client \
-    -I../../unilink \
-    -L../../build \
-    -lunilink \
-    -lboost_system \
-    -pthread
-
-# Echo server
-g++ -std=c++17 tcp_server/echo_server.cpp \
-    -o echo_server \
-    -I../../unilink \
-    -L../../build \
-    -lunilink \
-    -lboost_system \
-    -pthread
-
-# Chat server
-g++ -std=c++17 tcp_server/chat_server.cpp \
-    -o chat_server \
-    -I../../unilink \
-    -L../../build \
-    -lunilink \
-    -lboost_system \
-    -pthread
-```
-
----
-
-## 🧪 Testing Examples
-
-### Test Simple Client
-
-1. Start test server:
-   ```bash
-   echo "Hello from server" | nc -l 8080
-   ```
-
-2. Run client:
-   ```bash
-   ./tutorial_simple_client
-   ```
-
-3. Expected output:
-   ```
-   Connected!
-   Received: Hello from server
-   ```
-
----
-
-### Test Echo Server
-
-1. Run echo server:
-   ```bash
-   ./tutorial_echo_server 8080
-   ```
-
-2. Connect and test:
-   ```bash
-   echo "Test message" | nc localhost 8080
-   ```
-
-3. Expected output:
-   ```
-   Welcome to Echo Server!
-   Echo: Test message
-   ```
-
----
-
-### Test Chat Server
-
-1. Run chat server:
-   ```bash
-   ./tutorial_chat_server 8080
-   ```
-
-2. Connect multiple clients and chat:
-   ```bash
-   # Client 1
-   telnet localhost 8080
-   /nick Alice
-   Hello everyone!
-   
-   # Client 2
-   telnet localhost 8080
-   /nick Bob
-   Hi Alice!
-   ```
-
----
-
-## 💡 Tips
-
-### Debugging
-
-Enable debug logging in the examples:
-
-```cpp
-// Add at the beginning of main()
-unilink::diagnostics::Logger::instance().set_level(unilink::diagnostics::LogLevel::DEBUG);
-unilink::diagnostics::Logger::instance().set_console_output(true);
-```
-
-### Testing Without netcat
-
-If you don't have netcat, use the provided echo server:
-
-```bash
-# Terminal 1: Run echo server
-./tutorial_echo_server 8080
-
-# Terminal 2: Run client
-./tutorial_my_first_client 127.0.0.1 8080
-```
-
-### Port Already in Use?
-
-If you see "Address already in use":
-
-```bash
-# Find what's using the port
-lsof -i :8080
-
-# Use a different port
-./tutorial_echo_server 8081
-./tutorial_my_first_client 127.0.0.1 8081
-```
-
----
-
-## 📚 Next Steps
-
-After trying these examples:
-
-1. **Read the Tutorials**: [docs/tutorials/](../../docs/tutorials/)
-2. **Explore API Guide**: [docs/reference/api_guide.md](../../docs/reference/api_guide.md)
-3. **Learn Best Practices**: [docs/guides/core/best_practices.md](../../docs/guides/core/best_practices.md)
-4. **Build Your Own**: Modify these examples or create new ones!
-
----
-
-## 🆘 Need Help?
-
-- **Can't compile?** See [Troubleshooting Guide](../../docs/guides/core/troubleshooting.md#compilation-errors)
-- **Connection issues?** See [Troubleshooting Guide](../../docs/guides/core/troubleshooting.md#connection-issues)
-- **Questions?** Check the [Documentation Index](../../docs/index.md)
-
----
-
-**Happy Coding!** 🚀
+- Tutorial binaries are emitted under `build/bin/` in the current build setup.
+- `tutorial_echo_server` and `tutorial_chat_server` are fixed to port `8080`; they do not parse CLI port arguments.
+- All tutorial examples use the public `unilink/unilink.hpp` API.

--- a/examples/udp/README.md
+++ b/examples/udp/README.md
@@ -1,60 +1,45 @@
 # UDP Sender and Receiver
 
-UDP sender/receiver examples using the unilink UDP builder. The receiver listens on a local port and optionally replies to the first peer it learns. The sender pushes periodic messages and prints replies.
+Minimal UDP examples using the current builder API from `unilink/unilink.hpp`.
+
+These programs are intentionally small. They do not parse command-line options.
 
 ## Receiver Usage
 
 ```bash
-./udp_receiver --local-port <port> [--local-ip <ip>] [--reply]
+./udp_receiver
 ```
 
-### Examples
-
-```bash
-# Listen on port 9000, reply to the first peer
-./udp_receiver --local-port 9000 --reply
-
-# Bind to a specific interface without replying
-./udp_receiver --local-port 9000 --local-ip 0.0.0.0
-```
+The receiver binds to local port `9000` and prints incoming datagrams.
 
 ## Sender Usage
 
 ```bash
-./udp_sender --remote-ip <ip> --remote-port <port> [--local-port <port>] [--local-ip <ip>] \
-  [--interval-ms <ms>] [--count <n>] [--message <text>]
+./udp_sender
 ```
 
-### Examples
-
-```bash
-# Send "ping" every 500ms to the receiver, using local port 9001
-./udp_sender --remote-ip 127.0.0.1 --remote-port 9000 --local-port 9001 --interval-ms 500 --message "ping"
-
-# Send five messages then exit (local port defaults to remote+1)
-./udp_sender --remote-ip 127.0.0.1 --remote-port 9000 --count 5
-```
+The sender uses an ephemeral local port and sends user-entered messages to `127.0.0.1:9000`.
 
 ## Quick Start (Two Terminals)
 
-**Terminal 1: Receiver (reply enabled)**
+**Terminal 1: Receiver**
 
 ```bash
 cd examples/udp
-./udp_receiver --local-port 9000 --reply
+./udp_receiver
 ```
 
 **Terminal 2: Sender**
 
 ```bash
 cd examples/udp
-./udp_sender --remote-ip 127.0.0.1 --remote-port 9000 --local-port 9001 --message "ping" --interval-ms 500
+./udp_sender
 ```
 
-You should see the receiver log inbound packets and reply once the first peer is learned. The sender logs every transmit and prints any replies.
+Type lines into the sender terminal. Each line is sent immediately, and the receiver prints it.
 
 ## Notes
 
-- The receiver only replies after the first peer is learned; writes before that are ignored by design.
-- The sender's `--count` defaults to `0` (infinite). Use a positive value to stop after a fixed number of sends.
-- Default local port for the sender is `remote-port + 1`, matching the documented 9000/9001 example pairing.
+- `udp_receiver.cpp` is the simplest "bind and print" example.
+- `udp_sender.cpp` is the simplest "set remote endpoint and send" example.
+- If you need argument parsing or richer UDP workflows, use these files as a starting point rather than expecting a CLI tool.

--- a/examples/uds/README.md
+++ b/examples/uds/README.md
@@ -1,0 +1,41 @@
+# UDS Echo Examples
+
+Unix domain socket examples using the current wrapper and builder API.
+
+## Binaries
+
+- `echo_uds_server`
+- `echo_uds_client`
+
+## Usage
+
+```bash
+./echo_uds_server [socket_path]
+./echo_uds_client [socket_path]
+```
+
+If `socket_path` is omitted, both examples use `/tmp/unilink_echo.sock`.
+
+## Quick Start
+
+**Terminal 1**
+
+```bash
+cd examples/uds
+./echo_uds_server
+```
+
+**Terminal 2**
+
+```bash
+cd examples/uds
+./echo_uds_client
+```
+
+Type lines in the client terminal. The server prints each message and echoes it back to the same client.
+
+## Notes
+
+- These examples target Unix-like platforms where UDS is available.
+- The source uses `unilink::uds_server(...)` and `unilink::uds_client(...)` from `unilink/unilink.hpp`.
+- If an old socket file is left behind after a crash, remove it before restarting the server.

--- a/examples/uds/echo_uds_client.cc
+++ b/examples/uds/echo_uds_client.cc
@@ -14,48 +14,35 @@
  * limitations under the License.
  */
 
-#include <chrono>
 #include <iostream>
 #include <string>
-#include <thread>
-#include <vector>
 
-#include "unilink/config/uds_config.hpp"
-#include "unilink/factory/channel_factory.hpp"
-#include "unilink/interface/channel.hpp"
+#include "unilink/unilink.hpp"
 
 using namespace unilink;
 
-int main() {
-  config::UdsClientConfig cfg;
-  cfg.socket_path = "/tmp/unilink_echo.sock";
+int main(int argc, char** argv) {
+  const std::string socket_path = (argc > 1) ? argv[1] : "/tmp/unilink_echo.sock";
 
-  auto client = factory::ChannelFactory::create(cfg);
+  auto client =
+      unilink::uds_client(socket_path)
+          .on_connect([](const unilink::ConnectionContext&) { std::cout << "Connected to UDS server" << std::endl; })
+          .on_disconnect(
+              [](const unilink::ConnectionContext&) { std::cout << "Disconnected from UDS server" << std::endl; })
+          .on_data([](const unilink::MessageContext& ctx) { std::cout << "[Server] " << ctx.data() << std::endl; })
+          .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "[Error] " << ctx.message() << std::endl; })
+          .build();
 
-  client->on_state(
-      [](base::LinkState state) { std::cout << "Client state changed to: " << base::to_cstr(state) << std::endl; });
+  if (!client || !client->start().get()) {
+    std::cerr << "Failed to connect to UDS server at " << socket_path << std::endl;
+    return 1;
+  }
 
-  client->on_bytes([](memory::ConstByteSpan data) {
-    std::string msg(reinterpret_cast<const char*>(data.data()), data.size());
-    std::cout << "Received echo: " << msg << std::endl;
-  });
-
-  std::cout << "Connecting to UDS server at " << cfg.socket_path << "..." << std::endl;
-  client->start();
-
-  // Simple loop to send messages
+  std::cout << "Connected to " << socket_path << ". Type messages or '/quit'." << std::endl;
   std::string input;
-  while (true) {
-    std::cout << "Enter message (or 'exit' to quit): ";
-    std::getline(std::cin, input);
-    if (input == "exit") break;
-
-    if (client->is_connected()) {
-      client->async_write_copy(memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(input.data()), input.size()));
-    } else {
-      std::cout << "Client is not connected yet, trying again in 1s..." << std::endl;
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
+  while (std::getline(std::cin, input)) {
+    if (input == "/quit") break;
+    client->send(input);
   }
 
   client->stop();

--- a/examples/uds/echo_uds_server.cc
+++ b/examples/uds/echo_uds_server.cc
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-#include <csignal>
 #include <iostream>
+#include <memory>
 #include <string>
-#include <vector>
 
-#include "unilink/config/uds_config.hpp"
-#include "unilink/factory/channel_factory.hpp"
-#include "unilink/transport/uds/uds_server.hpp"
+#include "unilink/unilink.hpp"
 
 using namespace unilink;
 
-int main() {
-  config::UdsServerConfig cfg;
-  cfg.socket_path = "/tmp/unilink_echo.sock";
+int main(int argc, char** argv) {
+  const std::string socket_path = (argc > 1) ? argv[1] : "/tmp/unilink_echo.sock";
 
-  auto server = std::static_pointer_cast<transport::UdsServer>(factory::ChannelFactory::create(cfg));
+  std::unique_ptr<unilink::UdsServer> server;
+  server =
+      unilink::uds_server(socket_path)
+          .unlimited_clients()
+          .on_connect([](const unilink::ConnectionContext& ctx) {
+            std::cout << "Client connected: " << ctx.client_id() << " info=" << ctx.client_info() << std::endl;
+          })
+          .on_data([&server](const unilink::MessageContext& ctx) {
+            std::cout << "Received: " << ctx.data() << std::endl;
+            if (server) {
+              server->send_to(ctx.client_id(), ctx.data());
+            }
+          })
+          .on_disconnect([](const unilink::ConnectionContext& ctx) {
+            std::cout << "Client disconnected: " << ctx.client_id() << std::endl;
+          })
+          .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "[Error] " << ctx.message() << std::endl; })
+          .build();
 
-  server->on_multi_connect([](size_t client_id, const std::string& info) {
-    std::cout << "Client " << client_id << " connected: " << info << std::endl;
-  });
+  if (!server || !server->start().get()) {
+    std::cerr << "Failed to start UDS server on " << socket_path << std::endl;
+    return 1;
+  }
 
-  server->on_multi_data([server](size_t client_id, const std::vector<uint8_t>& data) {
-    std::string msg(data.begin(), data.end());
-    std::cout << "Received from client " << client_id << ": " << msg << std::endl << std::flush;
-
-    // Echo back
-    server->send_to_client(client_id, data);
-  });
-
-  server->on_multi_disconnect(
-      [](size_t client_id) { std::cout << "Client " << client_id << " disconnected" << std::endl; });
-
-  std::cout << "Starting UDS Echo Server on " << cfg.socket_path << "..." << std::endl;
-  server->start();
-
-  std::cout << "Press Enter to stop..." << std::endl;
+  std::cout << "UDS echo server listening on " << socket_path << ". Press Enter to stop..." << std::endl;
   std::cin.get();
 
   server->stop();


### PR DESCRIPTION
## Summary
Align the examples and documentation with the current public API, reduce duplicated example guidance, and improve consistency across the README, tutorial docs, and API reference.

## Changes
- updated `examples/` documentation to match the current builder/wrapper API and actual runtime behavior
- modernized the UDS example sources to use `unilink/unilink.hpp` instead of older low-level patterns, and added a dedicated UDS example README
- added `examples/common` to the top-level examples build so the documented binaries are actually built
- simplified high-level example index files so they act as indexes instead of repeating details from per-example documents
- corrected tutorial companion docs and build instructions to use the current binary output path and actual executable behavior
- refreshed `docs/reference/api_guide.md` examples and method tables to better reflect current start/lifecycle patterns and builder options
- updated top-level documentation indexes to expose the current example layout, including UDS and common examples

## Related Issues
- Fixes #N/A
- Related to #N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Additional Notes
- Validation used for this update:
  - `git diff --check`
  - `cmake -S . -B build`
  - `cmake --build build --target echo_uds_server echo_uds_client udp_sender udp_receiver logging_example error_handling_example -j 4`
  - `cmake --build build --target tutorial_simple_client tutorial_my_first_client tutorial_echo_server tutorial_chat_server echo_tcp_server echo_tcp_client chat_tcp_server chat_tcp_client multi_chat_tcp_server multi_chat_tcp_client -j 4`
  - `ctest --test-dir build -L docs_snippets --output-on-failure`
- The remaining transport-layer example in `docs/reference/api_guide.md` is intentional and documented as an advanced path below the main wrapper API.
