### PR TITLE
refactor: enhance UDS and serial wrapper functionality, add advanced UDS tests

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -130,7 +130,7 @@ foreach(test_file test_pool_limits.cpp)
 endforeach()
 
 # Wrapper tests (separate executables)
-foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_serial_advanced.cc test_udp_stop_perf.cc test_udp_options.cc test_udp_failure.cc test_udp_state.cpp test_tcp_client_error_mapping.cc)
+foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_serial_advanced.cc test_udp_stop_perf.cc test_udp_options.cc test_udp_failure.cc test_udp_state.cpp test_tcp_client_error_mapping.cc test_uds_advanced.cc)
   get_filename_component(test_name ${test_file} NAME_WE)
   add_executable(run_unit_${test_name} ${CMAKE_CURRENT_SOURCE_DIR}/wrapper/${test_file})
   target_link_libraries(run_unit_${test_name}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -130,7 +130,7 @@ foreach(test_file test_pool_limits.cpp)
 endforeach()
 
 # Wrapper tests (separate executables)
-foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_serial_advanced.cc test_udp_stop_perf.cc test_udp_options.cc test_udp_failure.cc test_udp_state.cpp test_tcp_client_error_mapping.cc test_uds_advanced.cc)
+foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_serial_advanced.cc test_udp_stop_perf.cc test_udp_options.cc test_udp_failure.cc test_udp_state.cpp test_tcp_client_error_mapping.cc test_uds_advanced.cc test_udp_server_advanced.cc)
   get_filename_component(test_name ${test_file} NAME_WE)
   add_executable(run_unit_${test_name} ${CMAKE_CURRENT_SOURCE_DIR}/wrapper/${test_file})
   target_link_libraries(run_unit_${test_name}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -129,7 +129,7 @@ foreach(test_file test_pool_limits.cpp)
   )
 endforeach()
 
-# Wrapper tests (separate executables)
+# Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_serial_advanced.cc test_udp_stop_perf.cc test_udp_options.cc test_udp_failure.cc test_udp_state.cpp test_tcp_client_error_mapping.cc test_uds_advanced.cc test_udp_server_advanced.cc)
   get_filename_component(test_name ${test_file} NAME_WE)
   add_executable(run_unit_${test_name} ${CMAKE_CURRENT_SOURCE_DIR}/wrapper/${test_file})
@@ -149,7 +149,7 @@ foreach(test_file test_tcp_server_advanced.cc test_tcp_client_advanced.cc test_s
 
   gtest_discover_tests(run_unit_${test_name}
     PROPERTIES
-      LABELS "unit_wrapper_tcp"
+      LABELS "unit_wrapper"
       TIMEOUT 120
       RESOURCE_LOCK "tcp_port_allocation"
   )

--- a/test/unit/wrapper/test_serial_advanced.cc
+++ b/test/unit/wrapper/test_serial_advanced.cc
@@ -156,6 +156,8 @@ TEST_F(SerialWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
   EXPECT_TRUE(serial.is_connected());
 
   serial.stop();
+  ioc.restart();
+  ioc.run_for(50ms);
 }
 
 TEST_F(SerialWrapperAdvancedTest, StartFutureReflectsTransportFailure) {
@@ -178,4 +180,6 @@ TEST_F(SerialWrapperAdvancedTest, StartFutureReflectsTransportFailure) {
   EXPECT_FALSE(serial.is_connected());
 
   serial.stop();
+  ioc.restart();
+  ioc.run_for(50ms);
 }

--- a/test/unit/wrapper/test_serial_advanced.cc
+++ b/test/unit/wrapper/test_serial_advanced.cc
@@ -17,17 +17,83 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
 
 #include "test/utils/test_utils.hpp"
+#include "unilink/config/serial_config.hpp"
+#include "unilink/interface/iserial_port.hpp"
+#include "unilink/transport/serial/serial.hpp"
 #include "unilink/unilink.hpp"
 
 using namespace unilink;
 using namespace unilink::test;
 using namespace std::chrono_literals;
+
+namespace {
+
+class FakeSerialPort : public interface::SerialPortInterface {
+ public:
+  explicit FakeSerialPort(boost::asio::io_context& ioc, boost::system::error_code open_ec = {})
+      : ioc_(ioc), open_ec_(open_ec) {}
+
+  void open(const std::string&, boost::system::error_code& ec) override {
+    ec = open_ec_;
+    open_ = !ec;
+  }
+
+  bool is_open() const override { return open_; }
+
+  void close(boost::system::error_code& ec) override {
+    open_ = false;
+    ec.clear();
+    emit_operation_aborted();
+  }
+
+  void set_option(const boost::asio::serial_port_base::baud_rate&, boost::system::error_code& ec) override {
+    ec.clear();
+  }
+  void set_option(const boost::asio::serial_port_base::character_size&, boost::system::error_code& ec) override {
+    ec.clear();
+  }
+  void set_option(const boost::asio::serial_port_base::stop_bits&, boost::system::error_code& ec) override {
+    ec.clear();
+  }
+  void set_option(const boost::asio::serial_port_base::parity&, boost::system::error_code& ec) override { ec.clear(); }
+  void set_option(const boost::asio::serial_port_base::flow_control&, boost::system::error_code& ec) override {
+    ec.clear();
+  }
+
+  void async_read_some(const boost::asio::mutable_buffer&,
+                       std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    read_handler_ = std::move(handler);
+  }
+
+  void async_write(const boost::asio::const_buffer& buffer,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    auto size = buffer.size();
+    boost::asio::post(ioc_, [handler = std::move(handler), size]() { handler({}, size); });
+  }
+
+ private:
+  void emit_operation_aborted() {
+    if (!read_handler_) return;
+    auto handler = std::move(read_handler_);
+    boost::asio::post(
+        ioc_, [handler = std::move(handler)]() { handler(make_error_code(boost::asio::error::operation_aborted), 0); });
+  }
+
+  boost::asio::io_context& ioc_;
+  boost::system::error_code open_ec_;
+  bool open_{false};
+  std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
+};
+
+}  // namespace
 
 class SerialWrapperAdvancedTest : public ::testing::Test {
  protected:
@@ -71,4 +137,45 @@ TEST_F(SerialWrapperAdvancedTest, ConfigurationSetters) {
   // Should be able to start with these settings
   serial->start();
   serial->stop();
+}
+
+TEST_F(SerialWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
+  boost::asio::io_context ioc;
+
+  config::SerialConfig cfg;
+  cfg.device = "fake";
+  cfg.baud_rate = 9600;
+  cfg.reopen_on_error = false;
+
+  auto transport_serial = transport::Serial::create(cfg, std::make_unique<FakeSerialPort>(ioc), ioc);
+  wrapper::Serial serial(std::static_pointer_cast<interface::Channel>(transport_serial));
+
+  serial.auto_manage(true);
+  ioc.run_for(50ms);
+
+  EXPECT_TRUE(serial.is_connected());
+
+  serial.stop();
+}
+
+TEST_F(SerialWrapperAdvancedTest, StartFutureReflectsTransportFailure) {
+  boost::asio::io_context ioc;
+
+  config::SerialConfig cfg;
+  cfg.device = "fake";
+  cfg.baud_rate = 9600;
+  cfg.reopen_on_error = false;
+
+  auto transport_serial = transport::Serial::create(
+      cfg, std::make_unique<FakeSerialPort>(ioc, make_error_code(boost::asio::error::access_denied)), ioc);
+  wrapper::Serial serial(std::static_pointer_cast<interface::Channel>(transport_serial));
+
+  auto started = serial.start();
+  ioc.run_for(50ms);
+
+  ASSERT_EQ(started.wait_for(100ms), std::future_status::ready);
+  EXPECT_FALSE(started.get());
+  EXPECT_FALSE(serial.is_connected());
+
+  serial.stop();
 }

--- a/test/unit/wrapper/test_udp_options.cc
+++ b/test/unit/wrapper/test_udp_options.cc
@@ -18,11 +18,13 @@
 #include <gtest/gtest.h>
 
 #include <boost/asio.hpp>
+#include <chrono>
 #include <memory>
 
 #include "test_utils.hpp"
 #include "unilink/builder/udp_builder.hpp"
 #include "unilink/config/udp_config.hpp"
+#include "unilink/transport/udp/udp.hpp"
 #include "unilink/wrapper/udp/udp.hpp"
 
 using namespace unilink::wrapper;
@@ -65,6 +67,63 @@ TEST_F(UdpOptionsTest, ConstructorWithExternalContext) {
 
   // Should not throw
   udp.auto_manage(false);
+}
+
+TEST_F(UdpOptionsTest, AutoManageStartsInjectedTransport) {
+  using namespace std::chrono_literals;
+
+  UdpConfig sender_cfg;
+  sender_cfg.local_port = 0;
+  sender_cfg.remote_address = "127.0.0.1";
+  const uint16_t receiver_port = TestUtils::getAvailableTestPort();
+  sender_cfg.remote_port = receiver_port;
+
+  UdpConfig receiver_cfg;
+  receiver_cfg.local_address = "127.0.0.1";
+  receiver_cfg.local_port = receiver_port;
+
+  boost::asio::io_context sender_ioc;
+  boost::asio::io_context receiver_ioc;
+
+  auto sender_transport = unilink::transport::UdpChannel::create(sender_cfg, sender_ioc);
+  auto receiver_transport = unilink::transport::UdpChannel::create(receiver_cfg, receiver_ioc);
+
+  Udp receiver(std::static_pointer_cast<unilink::interface::Channel>(receiver_transport));
+  auto receiver_started = receiver.start();
+  receiver_ioc.run_for(50ms);
+  ASSERT_EQ(receiver_started.wait_for(100ms), std::future_status::ready);
+  EXPECT_TRUE(receiver_started.get());
+
+  Udp sender(std::static_pointer_cast<unilink::interface::Channel>(sender_transport));
+  sender.auto_manage(true);
+  sender_ioc.run_for(50ms);
+
+  EXPECT_TRUE(sender.is_connected());
+
+  sender.stop();
+  receiver.stop();
+}
+
+TEST_F(UdpOptionsTest, StartFutureReflectsBindFailure) {
+  using namespace std::chrono_literals;
+
+  boost::asio::io_context guard_ioc;
+  boost::asio::ip::udp::socket occupied_socket(guard_ioc);
+  occupied_socket.open(boost::asio::ip::udp::v4());
+  occupied_socket.bind({boost::asio::ip::make_address("127.0.0.1"), 0});
+
+  UdpConfig cfg;
+  cfg.local_address = "127.0.0.1";
+  cfg.local_port = occupied_socket.local_endpoint().port();
+
+  Udp udp(cfg);
+  auto started = udp.start();
+
+  ASSERT_EQ(started.wait_for(2s), std::future_status::ready);
+  EXPECT_FALSE(started.get());
+  EXPECT_FALSE(udp.is_connected());
+
+  udp.stop();
 }
 
 TEST_F(UdpOptionsTest, BuilderCoverageForUdpSocketOptions) {

--- a/test/unit/wrapper/test_udp_server_advanced.cc
+++ b/test/unit/wrapper/test_udp_server_advanced.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <chrono>
+
+#include "unilink/config/udp_config.hpp"
+#include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/udp/udp_server.hpp"
+
+using namespace unilink;
+using namespace std::chrono_literals;
+
+TEST(UdpServerWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
+  config::UdpConfig cfg;
+  cfg.local_address = "127.0.0.1";
+  cfg.local_port = 0;
+
+  boost::asio::io_context ioc;
+  auto transport_server = transport::UdpChannel::create(cfg, ioc);
+  wrapper::UdpServer server(std::static_pointer_cast<interface::Channel>(transport_server));
+
+  server.auto_manage(true);
+  ioc.run_for(50ms);
+
+  EXPECT_TRUE(server.is_listening());
+
+  server.stop();
+}
+
+TEST(UdpServerWrapperAdvancedTest, StartFutureReflectsBindFailure) {
+  boost::asio::io_context guard_ioc;
+  boost::asio::ip::udp::socket occupied_socket(guard_ioc);
+  occupied_socket.open(boost::asio::ip::udp::v4());
+  occupied_socket.bind({boost::asio::ip::make_address("127.0.0.1"), 0});
+
+  config::UdpConfig cfg;
+  cfg.local_address = "127.0.0.1";
+  cfg.local_port = occupied_socket.local_endpoint().port();
+
+  wrapper::UdpServer server(cfg);
+  auto started = server.start();
+
+  ASSERT_EQ(started.wait_for(2s), std::future_status::ready);
+  EXPECT_FALSE(started.get());
+  EXPECT_FALSE(server.is_listening());
+
+  server.stop();
+}

--- a/test/unit/wrapper/test_udp_state.cpp
+++ b/test/unit/wrapper/test_udp_state.cpp
@@ -35,19 +35,16 @@ class UdpStateTest : public ::testing::Test {};
 TEST_F(UdpStateTest, BindConflict) {
   using namespace std::chrono_literals;
 
-  uint16_t port = TestUtils::getAvailableTestPort();
+  boost::asio::io_context guard_ioc;
+  boost::asio::ip::udp::socket occupied_socket(guard_ioc);
+  occupied_socket.open(boost::asio::ip::udp::v4());
+  occupied_socket.bind({boost::asio::ip::make_address("127.0.0.1"), 0});
 
-  UdpConfig cfg1;
-  cfg1.local_address = "127.0.0.1";
-  cfg1.local_port = port;
-  Udp udp1(cfg1);
-  auto udp1_started = udp1.start();
-  ASSERT_EQ(udp1_started.wait_for(2s), std::future_status::ready);
-  EXPECT_TRUE(udp1_started.get());
+  const uint16_t port = occupied_socket.local_endpoint().port();
 
   UdpConfig cfg2;
   cfg2.local_address = "127.0.0.1";
-  cfg2.local_port = port;  // Same port
+  cfg2.local_port = port;  // Same port already occupied by a live UDP socket
   Udp udp2(cfg2);
 
   auto udp2_started = udp2.start();
@@ -57,7 +54,6 @@ TEST_F(UdpStateTest, BindConflict) {
   // Verify it did not successfully start/connect
   EXPECT_FALSE(udp2.is_connected());
 
-  udp1.stop();
   udp2.stop();
 }
 

--- a/test/unit/wrapper/test_uds_advanced.cc
+++ b/test/unit/wrapper/test_uds_advanced.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <chrono>
+#include <memory>
+
+#include "test/mocks/mock_uds_acceptor.hpp"
+#include "test/mocks/mock_uds_socket.hpp"
+#include "test_utils.hpp"
+#include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/transport/uds/uds_server.hpp"
+#include "unilink/wrapper/uds_client/uds_client.hpp"
+#include "unilink/wrapper/uds_server/uds_server.hpp"
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using namespace std::chrono_literals;
+
+namespace unilink::wrapper {
+namespace {
+
+TEST(UdsClientWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
+  boost::asio::io_context ioc;
+  config::UdsClientConfig cfg;
+  cfg.socket_path = test::TestUtils::makeUniqueUdsSocketPath("uwc").string();
+
+  auto* mock_socket = new test::mocks::MockUdsSocket();
+  auto transport_client =
+      transport::UdsClient::create(cfg, std::unique_ptr<interface::UdsSocketInterface>(mock_socket), ioc);
+
+  EXPECT_CALL(*mock_socket, async_connect(_, _)).WillOnce(Invoke([&ioc](const auto&, auto handler) {
+    boost::asio::post(ioc, [handler]() { handler({}); });
+  }));
+  EXPECT_CALL(*mock_socket, async_read_some(_, _)).WillRepeatedly(Invoke([](const auto&, auto) {}));
+
+  UdsClient client(std::static_pointer_cast<interface::Channel>(transport_client));
+  client.auto_manage(true);
+
+  ioc.restart();
+  ioc.run_for(100ms);
+
+  EXPECT_TRUE(client.is_connected());
+}
+
+TEST(UdsClientWrapperAdvancedTest, StartFutureReflectsTransportFailure) {
+  boost::asio::io_context ioc;
+  config::UdsClientConfig cfg;
+  cfg.socket_path = test::TestUtils::makeUniqueUdsSocketPath("uwc-fail").string();
+
+  auto* mock_socket = new test::mocks::MockUdsSocket();
+  auto transport_client =
+      transport::UdsClient::create(cfg, std::unique_ptr<interface::UdsSocketInterface>(mock_socket), ioc);
+
+  EXPECT_CALL(*mock_socket, async_connect(_, _)).WillOnce(Invoke([&ioc](const auto&, auto handler) {
+    boost::asio::post(ioc, [handler]() { handler(make_error_code(boost::asio::error::connection_refused)); });
+  }));
+
+  UdsClient client(std::static_pointer_cast<interface::Channel>(transport_client));
+  auto started = client.start();
+
+  ioc.restart();
+  ioc.run_for(100ms);
+
+  ASSERT_EQ(started.wait_for(0ms), std::future_status::ready);
+  EXPECT_FALSE(started.get());
+}
+
+TEST(UdsServerWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
+  boost::asio::io_context ioc;
+  config::UdsServerConfig cfg;
+  cfg.socket_path = test::TestUtils::makeUniqueUdsSocketPath("uws").string();
+  test::TestUtils::removeFileIfExists(cfg.socket_path);
+
+  auto* mock_acceptor = new test::mocks::MockUdsAcceptor();
+  auto transport_server =
+      transport::UdsServer::create(cfg, std::unique_ptr<interface::UdsAcceptorInterface>(mock_acceptor), ioc);
+
+  EXPECT_CALL(*mock_acceptor, open(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, bind(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, listen(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, async_accept(_)).WillOnce(Invoke([](auto) {}));
+
+  UdsServer server(std::static_pointer_cast<interface::Channel>(transport_server));
+  server.auto_manage(true);
+
+  ioc.restart();
+  ioc.poll();
+
+  EXPECT_TRUE(server.is_listening());
+}
+
+TEST(UdsServerWrapperAdvancedTest, StartFutureReflectsBindFailure) {
+  boost::asio::io_context ioc;
+  config::UdsServerConfig cfg;
+  cfg.socket_path = test::TestUtils::makeUniqueUdsSocketPath("uws-fail").string();
+  test::TestUtils::removeFileIfExists(cfg.socket_path);
+
+  auto* mock_acceptor = new test::mocks::MockUdsAcceptor();
+  auto transport_server =
+      transport::UdsServer::create(cfg, std::unique_ptr<interface::UdsAcceptorInterface>(mock_acceptor), ioc);
+
+  EXPECT_CALL(*mock_acceptor, open(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, bind(_, _)).WillOnce(Invoke([](const auto&, boost::system::error_code& ec) {
+    ec = make_error_code(boost::asio::error::address_in_use);
+  }));
+
+  UdsServer server(std::static_pointer_cast<interface::Channel>(transport_server));
+  auto started = server.start();
+
+  ioc.restart();
+  ioc.poll();
+
+  ASSERT_EQ(started.wait_for(0ms), std::future_status::ready);
+  EXPECT_FALSE(started.get());
+  EXPECT_FALSE(server.is_listening());
+}
+
+}  // namespace
+}  // namespace unilink::wrapper

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -98,6 +98,9 @@ struct Serial::Impl {
 
     channel->start();
     if (use_external_context && manage_external_context && !external_thread.joinable()) {
+      if (external_ioc && external_ioc->stopped()) {
+        external_ioc->restart();
+      }
       external_thread = std::thread([ioc = external_ioc]() {
         boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard(ioc->get_executor());
         ioc->run();
@@ -290,7 +293,10 @@ void Serial::set_retry_interval(std::chrono::milliseconds i) {
 
 config::SerialConfig Serial::build_config() const { return get_impl()->build_config(); }
 
-void Serial::set_manage_external_context(bool m) { impl_->manage_external_context = m; }
+Serial& Serial::set_manage_external_context(bool m) {
+  impl_->manage_external_context = m;
+  return *this;
+}
 
 }  // namespace wrapper
 }  // namespace unilink

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -21,8 +21,10 @@
 #include <boost/asio/io_context.hpp>
 #include <cctype>
 #include <iostream>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
@@ -39,6 +41,7 @@ std::string to_lower(std::string s) {
 }  // namespace
 
 struct Serial::Impl {
+  mutable std::mutex mutex_;
   std::string device;
   uint32_t baud_rate;
   std::shared_ptr<interface::Channel> channel;
@@ -46,10 +49,11 @@ struct Serial::Impl {
   bool use_external_context{false};
   bool manage_external_context{false};
   std::thread external_thread;
+  std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
-  // Start notification
-  std::promise<bool> start_promise_;
-  bool start_promise_fulfilled_{false};
+  std::vector<std::promise<bool>> pending_promises_;
+  std::atomic<bool> started_{false};
+  std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
   // Event handlers (Context based)
   MessageHandler data_handler{nullptr};
@@ -62,7 +66,6 @@ struct Serial::Impl {
 
   // Configuration
   bool auto_manage = false;
-  bool started = false;
   int data_bits = 8;
   int stop_bits = 1;
   std::string parity = "none";
@@ -81,59 +84,87 @@ struct Serial::Impl {
     }
   }
 
+  void fulfill_all_locked(bool value) {
+    for (auto& promise : pending_promises_) {
+      try {
+        promise.set_value(value);
+      } catch (...) {
+      }
+    }
+    pending_promises_.clear();
+  }
+
   std::future<bool> start() {
-    if (started) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
     }
 
-    start_promise_ = std::promise<bool>();
-    start_promise_fulfilled_ = false;
+    std::promise<bool> p;
+    auto future = p.get_future();
+    pending_promises_.emplace_back(std::move(p));
+
+    if (started_.exchange(true)) {
+      return future;
+    }
 
     if (!channel) {
       channel = factory::ChannelFactory::create(build_config(), external_ioc);
       setup_internal_handlers();
     }
 
+    lock.unlock();
     channel->start();
     if (use_external_context && manage_external_context && !external_thread.joinable()) {
       if (external_ioc && external_ioc->stopped()) {
         external_ioc->restart();
       }
+      work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+          boost::asio::make_work_guard(*external_ioc));
       external_thread = std::thread([ioc = external_ioc]() {
-        boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard(ioc->get_executor());
-        ioc->run();
+        try {
+          ioc->run();
+        } catch (...) {
+        }
       });
     }
 
-    started = true;
-    return start_promise_.get_future();
+    return future;
   }
 
   void stop() {
-    if (!started) return;
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!started_.exchange(false)) {
+      fulfill_all_locked(false);
+      return;
+    }
 
     if (channel) {
       channel->on_bytes(nullptr);
       channel->on_state(nullptr);
+      lock.unlock();
       channel->stop();
+      lock.lock();
+    }
+
+    if (work_guard_) {
+      work_guard_.reset();
     }
 
     if (use_external_context && manage_external_context && external_thread.joinable()) {
       if (external_ioc) external_ioc->stop();
-      external_thread.join();
-    }
-
-    started = false;
-
-    if (!start_promise_fulfilled_) {
-      try {
-        start_promise_.set_value(false);
-      } catch (...) {
+      if (std::this_thread::get_id() != external_thread.get_id()) {
+        lock.unlock();
+        external_thread.join();
+        lock.lock();
+      } else {
+        external_thread.detach();
       }
-      start_promise_fulfilled_ = true;
     }
+
+    fulfill_all_locked(false);
 
     if (framer) framer->reset();
   }
@@ -141,38 +172,67 @@ struct Serial::Impl {
   void setup_internal_handlers() {
     if (!channel) return;
 
-    channel->on_bytes([this](memory::ConstByteSpan data) {
+    std::weak_ptr<bool> weak_alive = alive_marker_;
+
+    channel->on_bytes([this, weak_alive](memory::ConstByteSpan data) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
       // 1. Raw data handler
-      if (data_handler) {
+      MessageHandler handler;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handler = data_handler;
+      }
+      if (handler) {
         std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
-        data_handler(MessageContext(0, str_data));
+        handler(MessageContext(0, str_data));
       }
 
       // 2. Framer integration
+      std::lock_guard<std::mutex> lock(mutex_);
       if (framer) {
         framer->push_bytes(data);
       }
     });
 
-    channel->on_state([this](base::LinkState state) {
+    channel->on_state([this, weak_alive](base::LinkState state) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
       switch (state) {
-        case base::LinkState::Connected:
-          if (!start_promise_fulfilled_) {
-            start_promise_.set_value(true);
-            start_promise_fulfilled_ = true;
+        case base::LinkState::Connected: {
+          ConnectionHandler handler;
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            fulfill_all_locked(true);
+            handler = connect_handler;
           }
-          if (connect_handler) connect_handler(ConnectionContext(0));
+          if (handler) handler(ConnectionContext(0));
           break;
+        }
         case base::LinkState::Closed:
-          if (disconnect_handler) disconnect_handler(ConnectionContext(0));
-          break;
         case base::LinkState::Error:
-          if (!start_promise_fulfilled_) {
-            start_promise_.set_value(false);
-            start_promise_fulfilled_ = true;
+        case base::LinkState::Idle: {
+          ConnectionHandler disconnect_handler_snapshot;
+          ErrorHandler error_handler_snapshot;
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            fulfill_all_locked(false);
+            if (state == base::LinkState::Error) {
+              error_handler_snapshot = error_handler;
+            } else {
+              disconnect_handler_snapshot = disconnect_handler;
+            }
           }
-          if (error_handler) error_handler(ErrorContext(ErrorCode::IoError, "Connection error"));
+          if (disconnect_handler_snapshot) {
+            disconnect_handler_snapshot(ConnectionContext(0));
+          }
+          if (error_handler_snapshot) {
+            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+          }
           break;
+        }
         default:
           break;
       }
@@ -180,24 +240,36 @@ struct Serial::Impl {
   }
 
   void set_framer(std::unique_ptr<framer::IFramer> f) {
+    std::lock_guard<std::mutex> lock(mutex_);
     framer = std::move(f);
     if (framer && message_handler) {
       framer->set_on_message([this](memory::ConstByteSpan msg) {
-        if (message_handler) {
+        MessageHandler handler;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          handler = message_handler;
+        }
+        if (handler) {
           std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-          message_handler(MessageContext(0, str_msg));
+          handler(MessageContext(0, str_msg));
         }
       });
     }
   }
 
   void on_message(MessageHandler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
     message_handler = std::move(handler);
     if (framer) {
       framer->set_on_message([this](memory::ConstByteSpan msg) {
-        if (message_handler) {
+        MessageHandler callback;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          callback = message_handler;
+        }
+        if (callback) {
           std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-          message_handler(MessageContext(0, str_msg));
+          callback(MessageContext(0, str_msg));
         }
       });
     }
@@ -274,7 +346,7 @@ void Serial::on_message(MessageHandler h) { impl_->on_message(std::move(h)); }
 
 ChannelInterface& Serial::auto_manage(bool m) {
   impl_->auto_manage = m;
-  if (impl_->auto_manage && !impl_->started) start();
+  if (impl_->auto_manage && !impl_->started_.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -82,7 +82,7 @@ class UNILINK_API Serial : public ChannelInterface {
   void set_parity(const std::string& parity);
   void set_flow_control(const std::string& flow_control);
   void set_retry_interval(std::chrono::milliseconds interval);
-  void set_manage_external_context(bool manage);
+  Serial& set_manage_external_context(bool manage);
 
   // Expose mapped config for testing/inspection
   config::SerialConfig build_config() const;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -229,7 +229,7 @@ struct TcpClient::Impl {
             }
           }
           if (!handled) {
-            error_handler_(ErrorContext(ErrorCode::IoError, "Connection state error"));
+            error_handler_(ErrorContext(ErrorCode::IoError, "Connection error"));
           }
         }
       }
@@ -279,18 +279,22 @@ void TcpClient::send_line(std::string_view line) { impl_->send(std::string(line)
 bool TcpClient::is_connected() const { return get_impl()->is_connected(); }
 
 ChannelInterface& TcpClient::on_data(MessageHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->data_handler_ = std::move(h);
   return *this;
 }
 ChannelInterface& TcpClient::on_connect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->connect_handler_ = std::move(h);
   return *this;
 }
 ChannelInterface& TcpClient::on_disconnect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->disconnect_handler_ = std::move(h);
   return *this;
 }
 ChannelInterface& TcpClient::on_error(ErrorHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->error_handler_ = std::move(h);
   return *this;
 }

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -45,8 +45,9 @@ struct TcpServer::Impl {
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
   std::vector<std::promise<bool>> pending_promises_;
-  bool started_{false};
+  std::atomic<bool> started_{false};
   std::atomic<bool> is_listening_{false};
+  std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
   // Configuration
   bool auto_manage_{false};
@@ -119,8 +120,7 @@ struct TcpServer::Impl {
     }
   }
 
-  void fulfill_all(bool value) {
-    std::lock_guard<std::mutex> lock(mutex_);
+  void fulfill_all_locked(bool value) {
     for (auto& p : pending_promises_) {
       try {
         p.set_value(value);
@@ -131,8 +131,8 @@ struct TcpServer::Impl {
   }
 
   std::future<bool> start() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (is_listening_) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (is_listening_.load()) {
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
@@ -140,7 +140,7 @@ struct TcpServer::Impl {
     std::promise<bool> p;
     auto f = p.get_future();
     pending_promises_.push_back(std::move(p));
-    if (started_) return f;
+    if (started_.exchange(true)) return f;
 
     if (!channel_) {
       config::TcpServerConfig config;
@@ -163,10 +163,14 @@ struct TcpServer::Impl {
         }
       }
     }
+    lock.unlock();
     channel_->start();
     if (use_external_context_ && manage_external_context_ && !external_thread_.joinable()) {
+      if (external_ioc_ && external_ioc_->stopped()) {
+        external_ioc_->restart();
+      }
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
-          external_ioc_->get_executor());
+          boost::asio::make_work_guard(*external_ioc_));
       external_thread_ = std::thread([ioc = external_ioc_]() {
         try {
           ioc->run();
@@ -174,7 +178,6 @@ struct TcpServer::Impl {
         }
       });
     }
-    started_ = true;
     return f;
   }
 
@@ -182,14 +185,9 @@ struct TcpServer::Impl {
     bool should_join = false;
     {
       std::unique_lock<std::mutex> lock(mutex_);
-      if (!started_) {
-        for (auto& p : pending_promises_) {
-          try {
-            p.set_value(false);
-          } catch (...) {
-          }
-        }
-        pending_promises_.clear();
+      if (!started_.exchange(false)) {
+        is_listening_ = false;
+        fulfill_all_locked(false);
         return;
       }
       if (channel_) {
@@ -197,25 +195,24 @@ struct TcpServer::Impl {
         channel_->on_state(nullptr);
         auto transport_server = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
         if (transport_server) transport_server->request_stop();
+        lock.unlock();
         channel_->stop();
+        lock.lock();
       }
       if (use_external_context_ && manage_external_context_) {
         if (work_guard_) work_guard_.reset();
         should_join = true;
       }
-      for (auto& p : pending_promises_) {
-        try {
-          p.set_value(false);
-        } catch (...) {
-        }
-      }
-      pending_promises_.clear();
-      started_ = false;
+      fulfill_all_locked(false);
       is_listening_ = false;
     }
     if (should_join && external_thread_.joinable()) {
       try {
-        external_thread_.join();
+        if (std::this_thread::get_id() != external_thread_.get_id()) {
+          external_thread_.join();
+        } else {
+          external_thread_.detach();
+        }
       } catch (...) {
       }
     }
@@ -225,28 +222,47 @@ struct TcpServer::Impl {
 
   void setup_internal_handlers() {
     if (!channel_) return;
+    std::weak_ptr<bool> weak_alive = alive_marker_;
     auto transport_server = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
     if (transport_server) {
-      transport_server->on_multi_connect([this](size_t id, const std::string& info) {
+      transport_server->on_multi_connect([this, weak_alive](size_t id, const std::string& info) {
+        auto alive = weak_alive.lock();
+        if (!alive) return;
+
+        ConnectionHandler handler;
         {
           std::lock_guard<std::mutex> lock(mutex_);
           if (framer_factory_) {
             auto framer = framer_factory_();
             if (framer) {
               framer->set_on_message([this, id](memory::ConstByteSpan msg) {
-                if (on_message_) {
+                MessageHandler on_message_handler;
+                {
+                  std::lock_guard<std::mutex> lock(mutex_);
+                  on_message_handler = on_message_;
+                }
+                if (on_message_handler) {
                   std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-                  on_message_(MessageContext(id, str_msg));
+                  on_message_handler(MessageContext(id, str_msg));
                 }
               });
               framers_[id] = std::move(framer);
             }
           }
+          handler = on_client_connect_;
         }
-        if (on_client_connect_) on_client_connect_(ConnectionContext(id, info));
+        if (handler) handler(ConnectionContext(id, info));
       });
-      transport_server->on_multi_data([this](size_t id, const std::string& data) {
-        if (on_data_) on_data_(MessageContext(id, data));
+      transport_server->on_multi_data([this, weak_alive](size_t id, const std::string& data) {
+        auto alive = weak_alive.lock();
+        if (!alive) return;
+
+        MessageHandler handler;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          handler = on_data_;
+        }
+        if (handler) handler(MessageContext(id, data));
 
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = framers_.find(id);
@@ -255,23 +271,40 @@ struct TcpServer::Impl {
           it->second->push_bytes(memory::ConstByteSpan(binary_view.first, binary_view.second));
         }
       });
-      transport_server->on_multi_disconnect([this](size_t id) {
+      transport_server->on_multi_disconnect([this, weak_alive](size_t id) {
+        auto alive = weak_alive.lock();
+        if (!alive) return;
+
+        ConnectionHandler handler;
         {
           std::lock_guard<std::mutex> lock(mutex_);
           framers_.erase(id);
+          handler = on_client_disconnect_;
         }
-        if (on_client_disconnect_) on_client_disconnect_(ConnectionContext(id));
+        if (handler) handler(ConnectionContext(id));
       });
     }
-    channel_->on_state([this](base::LinkState state) {
+    channel_->on_state([this, weak_alive](base::LinkState state) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
       if (state == base::LinkState::Listening) {
         is_listening_ = true;
-        fulfill_all(true);
-      } else if (state == base::LinkState::Error || state == base::LinkState::Closed) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        fulfill_all_locked(true);
+      } else if (state == base::LinkState::Error || state == base::LinkState::Closed ||
+                 state == base::LinkState::Idle) {
+        ErrorHandler handler;
         is_listening_ = false;
-        fulfill_all(false);
-        if (state == base::LinkState::Error && on_error_) {
-          on_error_(ErrorContext(ErrorCode::IoError, "Server disconnected"));
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          fulfill_all_locked(false);
+          if (state == base::LinkState::Error) {
+            handler = on_error_;
+          }
+        }
+        if (handler) {
+          handler(ErrorContext(ErrorCode::IoError, "Server disconnected"));
         }
       }
     });
@@ -308,18 +341,22 @@ bool TcpServer::send_to(size_t client_id, std::string_view data) {
 }
 
 ServerInterface& TcpServer::on_client_connect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->on_client_connect_ = std::move(h);
   return *this;
 }
 ServerInterface& TcpServer::on_client_disconnect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->on_client_disconnect_ = std::move(h);
   return *this;
 }
 ServerInterface& TcpServer::on_data(MessageHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->on_data_ = std::move(h);
   return *this;
 }
 ServerInterface& TcpServer::on_error(ErrorHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->on_error_ = std::move(h);
   return *this;
 }
@@ -348,7 +385,7 @@ std::vector<size_t> TcpServer::get_connected_clients() const {
 
 TcpServer& TcpServer::auto_manage(bool m) {
   impl_->auto_manage_ = m;
-  if (impl_->auto_manage_ && !impl_->started_) start();
+  if (impl_->auto_manage_ && !impl_->started_.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -24,8 +24,10 @@
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <iostream>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
@@ -35,12 +37,14 @@ namespace unilink {
 namespace wrapper {
 
 struct Udp::Impl {
+  mutable std::mutex mutex_;
   config::UdpConfig cfg;
   std::shared_ptr<interface::Channel> channel;
   std::shared_ptr<boost::asio::io_context> external_ioc;
   bool use_external_context{false};
   bool manage_external_context{false};
   std::thread external_thread;
+  std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard;
 
   // Event handlers (Context based)
   MessageHandler data_handler{nullptr};
@@ -52,9 +56,9 @@ struct Udp::Impl {
   std::unique_ptr<framer::IFramer> framer{nullptr};
 
   bool auto_manage{false};
-  bool started{false};
-
-  std::shared_ptr<std::promise<bool>> start_promise;
+  std::vector<std::promise<bool>> pending_promises;
+  std::atomic<bool> started{false};
+  std::shared_ptr<bool> alive_marker{std::make_shared<bool>(true)};
 
   explicit Impl(const config::UdpConfig& config) : cfg(config) {}
   Impl(const config::UdpConfig& config, std::shared_ptr<boost::asio::io_context> ioc)
@@ -68,11 +72,30 @@ struct Udp::Impl {
     }
   }
 
+  void fulfill_all_locked(bool value) {
+    for (auto& promise : pending_promises) {
+      try {
+        promise.set_value(value);
+      } catch (...) {
+      }
+    }
+    pending_promises.clear();
+  }
+
   std::future<bool> start() {
-    if (started) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
+    }
+
+    std::promise<bool> p;
+    auto future = p.get_future();
+    pending_promises.emplace_back(std::move(p));
+
+    if (started.exchange(true)) {
+      return future;
     }
 
     if (!channel) {
@@ -80,91 +103,126 @@ struct Udp::Impl {
       setup_internal_handlers();
     }
 
-    start_promise = std::make_shared<std::promise<bool>>();
-    auto fut = start_promise->get_future();
-
+    lock.unlock();
     channel->start();
     if (use_external_context && manage_external_context && !external_thread.joinable()) {
       if (external_ioc->stopped()) external_ioc->restart();
-      external_thread = std::thread([ioc = external_ioc]() {
-        boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard(ioc->get_executor());
-        ioc->run();
+      work_guard = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+          boost::asio::make_work_guard(*external_ioc));
+      external_thread = std::thread([this, ioc = external_ioc]() {
+        try {
+          ioc->run();
+        } catch (...) {
+        }
       });
     }
-
-    started = true;
-    return fut;
+    return future;
   }
 
   void stop() {
-    if (!started) return;
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!started.exchange(false)) {
+      fulfill_all_locked(false);
+      return;
+    }
 
     if (channel) {
       channel->on_bytes(nullptr);
       channel->on_state(nullptr);
+      lock.unlock();
       channel->stop();
+      lock.lock();
+    }
+
+    if (work_guard) {
+      work_guard.reset();
     }
 
     if (use_external_context && manage_external_context && external_thread.joinable()) {
-      if (external_ioc) external_ioc->stop();
-      external_thread.join();
+      if (external_ioc) {
+        external_ioc->stop();
+      }
+      if (std::this_thread::get_id() != external_thread.get_id()) {
+        lock.unlock();
+        external_thread.join();
+        lock.lock();
+      } else {
+        external_thread.detach();
+      }
     }
 
-    started = false;
+    fulfill_all_locked(false);
 
-    if (framer) framer->reset();
-
-    if (start_promise) {
-      try {
-        start_promise->set_value(false);
-      } catch (...) {
-      }
-      start_promise.reset();
+    if (framer) {
+      framer->reset();
     }
   }
 
   void setup_internal_handlers() {
     if (!channel) return;
 
-    channel->on_bytes([this](memory::ConstByteSpan data) {
+    std::weak_ptr<bool> weak_alive = alive_marker;
+
+    channel->on_bytes([this, weak_alive](memory::ConstByteSpan data) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
       // 1. Raw data handler
-      if (data_handler) {
+      MessageHandler handler;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handler = data_handler;
+      }
+      if (handler) {
         std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
-        data_handler(MessageContext(0, str_data));
+        handler(MessageContext(0, str_data));
       }
 
       // 2. Framer integration
+      std::lock_guard<std::mutex> lock(mutex_);
       if (framer) {
         framer->push_bytes(data);
       }
     });
 
-    channel->on_state([this](base::LinkState state) {
+    channel->on_state([this, weak_alive](base::LinkState state) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
       switch (state) {
         case base::LinkState::Connected:
-        case base::LinkState::Listening:
-          if (start_promise) {
-            try {
-              start_promise->set_value(true);
-            } catch (...) {
-            }
-            start_promise.reset();
+        case base::LinkState::Listening: {
+          ConnectionHandler handler;
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            fulfill_all_locked(true);
+            handler = connect_handler;
           }
-          if (connect_handler) connect_handler(ConnectionContext(0));
+          if (handler) handler(ConnectionContext(0));
           break;
+        }
         case base::LinkState::Closed:
-          if (disconnect_handler) disconnect_handler(ConnectionContext(0));
-          break;
         case base::LinkState::Error:
-          if (start_promise) {
-            try {
-              start_promise->set_value(false);
-            } catch (...) {
+        case base::LinkState::Idle: {
+          ConnectionHandler disconnect_handler_snapshot;
+          ErrorHandler error_handler_snapshot;
+          {
+            std::lock_guard<std::mutex> lock(mutex_);
+            fulfill_all_locked(false);
+            if (state == base::LinkState::Error) {
+              error_handler_snapshot = error_handler;
+            } else {
+              disconnect_handler_snapshot = disconnect_handler;
             }
-            start_promise.reset();
           }
-          if (error_handler) error_handler(ErrorContext(ErrorCode::IoError, "Connection error"));
+          if (disconnect_handler_snapshot) {
+            disconnect_handler_snapshot(ConnectionContext(0));
+          }
+          if (error_handler_snapshot) {
+            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+          }
           break;
+        }
         default:
           break;
       }
@@ -172,24 +230,36 @@ struct Udp::Impl {
   }
 
   void set_framer(std::unique_ptr<framer::IFramer> f) {
+    std::lock_guard<std::mutex> lock(mutex_);
     framer = std::move(f);
     if (framer && message_handler) {
       framer->set_on_message([this](memory::ConstByteSpan msg) {
-        if (message_handler) {
+        MessageHandler handler;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          handler = message_handler;
+        }
+        if (handler) {
           std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-          message_handler(MessageContext(0, str_msg));
+          handler(MessageContext(0, str_msg));
         }
       });
     }
   }
 
   void on_message(MessageHandler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
     message_handler = std::move(handler);
     if (framer) {
       framer->set_on_message([this](memory::ConstByteSpan msg) {
-        if (message_handler) {
+        MessageHandler callback;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          callback = message_handler;
+        }
+        if (callback) {
           std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-          message_handler(MessageContext(0, str_msg));
+          callback(MessageContext(0, str_msg));
         }
       });
     }
@@ -240,7 +310,7 @@ void Udp::on_message(MessageHandler h) { impl_->on_message(std::move(h)); }
 
 ChannelInterface& Udp::auto_manage(bool m) {
   impl_->auto_manage = m;
-  if (impl_->auto_manage && !impl_->started) start();
+  if (impl_->auto_manage && !impl_->started.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -166,9 +166,14 @@ struct UdpServer::Impl {
             auto framer = framer_factory();
             if (framer) {
               framer->set_on_message([this, client_id](memory::ConstByteSpan msg) {
-                if (on_message) {
+                MessageHandler on_message_handler;
+                {
+                  std::lock_guard<std::mutex> lock(mutex);
+                  on_message_handler = on_message;
+                }
+                if (on_message_handler) {
                   std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-                  on_message(MessageContext(client_id, str_msg));
+                  on_message_handler(MessageContext(client_id, str_msg));
                 }
               });
               client_framers[client_id] = std::shared_ptr<framer::IFramer>(std::move(framer));
@@ -222,7 +227,7 @@ struct UdpServer::Impl {
       }
 
       if (error_handler_copy) {
-        error_handler_copy(ErrorContext(ErrorCode::IoError, "UDP Transport Error"));
+        error_handler_copy(ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
   }
@@ -368,21 +373,25 @@ bool UdpServer::send_to(size_t client_id, std::string_view data) {
 }
 
 ServerInterface& UdpServer::on_client_connect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->on_connect = std::move(h);
   return *this;
 }
 
 ServerInterface& UdpServer::on_client_disconnect(ConnectionHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->on_disconnect = std::move(h);
   return *this;
 }
 
 ServerInterface& UdpServer::on_data(MessageHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->on_data = std::move(h);
   return *this;
 }
 
 ServerInterface& UdpServer::on_error(ErrorHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->on_error = std::move(h);
   return *this;
 }
@@ -392,7 +401,10 @@ void UdpServer::set_framer_factory(FramerFactory factory) {
   impl_->framer_factory = std::move(factory);
 }
 
-void UdpServer::on_message(MessageHandler h) { impl_->on_message = std::move(h); }
+void UdpServer::on_message(MessageHandler h) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  impl_->on_message = std::move(h);
+}
 
 size_t UdpServer::get_client_count() const {
   std::lock_guard<std::mutex> lock(impl_->mutex);

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -23,6 +23,7 @@
 #include <map>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
@@ -41,8 +42,9 @@ struct UdpServer::Impl {
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard;
 
   mutable std::mutex mutex;
-  bool started{false};
-  std::shared_ptr<std::promise<bool>> start_promise;
+  std::vector<std::promise<bool>> pending_promises;
+  std::atomic<bool> started{false};
+  std::atomic<bool> is_listening{false};
 
   // Virtual Session Management
   size_t next_client_id{1};
@@ -52,6 +54,7 @@ struct UdpServer::Impl {
   std::map<size_t, std::chrono::steady_clock::time_point> session_activity;
   std::chrono::milliseconds session_timeout{30000};  // Default 30s
   std::unique_ptr<boost::asio::steady_timer> reaper_timer;
+  bool auto_manage{false};
 
   ConnectionHandler on_connect{nullptr};
   ConnectionHandler on_disconnect{nullptr};
@@ -65,6 +68,10 @@ struct UdpServer::Impl {
   explicit Impl(const config::UdpConfig& config) : cfg(config) {}
   Impl(const config::UdpConfig& config, std::shared_ptr<boost::asio::io_context> ioc)
       : cfg(config), external_ioc(std::move(ioc)), use_external_context(external_ioc != nullptr) {}
+  explicit Impl(std::shared_ptr<interface::Channel> ch)
+      : channel(std::dynamic_pointer_cast<transport::UdpChannel>(ch)) {
+    setup_internal_handlers();
+  }
 
   ~Impl() {
     *is_alive = false;
@@ -74,8 +81,18 @@ struct UdpServer::Impl {
     }
   }
 
+  void fulfill_all_locked(bool value) {
+    for (auto& promise : pending_promises) {
+      try {
+        promise.set_value(value);
+      } catch (...) {
+      }
+    }
+    pending_promises.clear();
+  }
+
   void schedule_reaper() {
-    if (!started || !reaper_timer) return;
+    if (!started.load() || !reaper_timer) return;
 
     // Run reaper at interval proportional to timeout (min 100ms, max 5s)
     auto interval =
@@ -132,6 +149,8 @@ struct UdpServer::Impl {
     channel->on_bytes_from([this](memory::ConstByteSpan data, const boost::asio::ip::udp::endpoint& ep) {
       size_t client_id = 0;
       bool is_new = false;
+      ConnectionHandler connect_handler_copy{nullptr};
+      MessageHandler data_handler_copy{nullptr};
 
       {
         std::lock_guard<std::mutex> lock(mutex);
@@ -159,15 +178,17 @@ struct UdpServer::Impl {
           client_id = it->second;
         }
         session_activity[client_id] = std::chrono::steady_clock::now();
+        connect_handler_copy = on_connect;
+        data_handler_copy = on_data;
       }
 
-      if (is_new && on_connect) {
-        on_connect(ConnectionContext(client_id, ep.address().to_string() + ":" + std::to_string(ep.port())));
+      if (is_new && connect_handler_copy) {
+        connect_handler_copy(ConnectionContext(client_id, ep.address().to_string() + ":" + std::to_string(ep.port())));
       }
 
-      if (on_data) {
+      if (data_handler_copy) {
         std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
-        on_data(MessageContext(client_id, str_data));
+        data_handler_copy(MessageContext(client_id, str_data));
       }
 
       // Push to framer
@@ -188,22 +209,13 @@ struct UdpServer::Impl {
       ErrorHandler error_handler_copy{nullptr};
       if (state == base::LinkState::Listening || state == base::LinkState::Connected) {
         std::lock_guard<std::mutex> lock(mutex);
-        if (start_promise) {
-          try {
-            start_promise->set_value(true);
-          } catch (...) {
-          }
-          start_promise.reset();
-        }
-      } else if (state == base::LinkState::Error || state == base::LinkState::Closed) {
+        is_listening = true;
+        fulfill_all_locked(true);
+      } else if (state == base::LinkState::Error || state == base::LinkState::Closed ||
+                 state == base::LinkState::Idle) {
         std::lock_guard<std::mutex> lock(mutex);
-        if (start_promise) {
-          try {
-            start_promise->set_value(false);
-          } catch (...) {
-          }
-          start_promise.reset();
-        }
+        is_listening = false;
+        fulfill_all_locked(false);
         if (state == base::LinkState::Error) {
           error_handler_copy = on_error;
         }
@@ -216,47 +228,45 @@ struct UdpServer::Impl {
   }
 
   std::future<bool> start() {
-    std::future<bool> fut;
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      if (started) {
-        std::promise<bool> p;
-        p.set_value(true);
-        return p.get_future();
-      }
-
-      start_promise = std::make_shared<std::promise<bool>>();
-      fut = start_promise->get_future();
-
-      if (!channel) {
-        channel = std::dynamic_pointer_cast<transport::UdpChannel>(factory::ChannelFactory::create(cfg, external_ioc));
-        setup_internal_handlers();
-      }
+    std::unique_lock<std::mutex> lock(mutex);
+    if (is_listening.load()) {
+      std::promise<bool> p;
+      p.set_value(true);
+      return p.get_future();
     }
 
+    std::promise<bool> p;
+    auto fut = p.get_future();
+    pending_promises.emplace_back(std::move(p));
+
+    if (started.exchange(true)) {
+      return fut;
+    }
+
+    if (!channel) {
+      channel = std::dynamic_pointer_cast<transport::UdpChannel>(factory::ChannelFactory::create(cfg, external_ioc));
+      setup_internal_handlers();
+    }
+
+    lock.unlock();
     channel->start();
 
-    {
-      std::lock_guard<std::mutex> lock(mutex);
-      if (use_external_context && manage_external_context && !external_thread.joinable()) {
-        if (external_ioc->stopped()) external_ioc->restart();
-        work_guard = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
-            external_ioc->get_executor());
-        external_thread = std::thread([ioc = external_ioc]() {
-          try {
-            ioc->run();
-          } catch (...) {
-          }
-        });
-      }
+    lock.lock();
+    if (use_external_context && manage_external_context && !external_thread.joinable()) {
+      if (external_ioc->stopped()) external_ioc->restart();
+      work_guard = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+          external_ioc->get_executor());
+      external_thread = std::thread([ioc = external_ioc]() {
+        try {
+          ioc->run();
+        } catch (...) {
+        }
+      });
+    }
 
-      started = true;
-
-      // Start Reaper Timer
-      if (channel) {
-        reaper_timer = std::make_unique<boost::asio::steady_timer>(channel->get_executor());
-        schedule_reaper();
-      }
+    if (channel) {
+      reaper_timer = std::make_unique<boost::asio::steady_timer>(channel->get_executor());
+      schedule_reaper();
     }
 
     return fut;
@@ -265,13 +275,19 @@ struct UdpServer::Impl {
   void stop() {
     bool should_join = false;
     {
-      std::lock_guard<std::mutex> lock(mutex);
-      if (!started) return;
+      std::unique_lock<std::mutex> lock(mutex);
+      if (!started.exchange(false)) {
+        is_listening = false;
+        fulfill_all_locked(false);
+        return;
+      }
 
       if (channel) {
         channel->on_bytes_from(nullptr);
         channel->on_state(nullptr);
+        lock.unlock();
         channel->stop();
+        lock.lock();
       }
 
       if (reaper_timer) {
@@ -284,24 +300,22 @@ struct UdpServer::Impl {
         should_join = true;
       }
 
-      started = false;
+      is_listening = false;
       endpoint_to_id.clear();
       id_to_endpoint.clear();
       client_framers.clear();
       session_activity.clear();
       next_client_id = 1;
-      if (start_promise) {
-        try {
-          start_promise->set_value(false);
-        } catch (...) {
-        }
-        start_promise.reset();
-      }
+      fulfill_all_locked(false);
     }
 
     if (should_join) {
       try {
-        external_thread.join();
+        if (std::this_thread::get_id() != external_thread.get_id()) {
+          external_thread.join();
+        } else {
+          external_thread.detach();
+        }
       } catch (...) {
       }
     }
@@ -319,16 +333,16 @@ UdpServer::UdpServer(const config::UdpConfig& cfg) : impl_(std::make_unique<Impl
 UdpServer::UdpServer(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> ioc)
     : impl_(std::make_unique<Impl>(cfg, ioc)) {}
 
+UdpServer::UdpServer(std::shared_ptr<interface::Channel> ch) : impl_(std::make_unique<Impl>(std::move(ch))) {}
+
 UdpServer::~UdpServer() = default;
+
+UdpServer::UdpServer(UdpServer&&) noexcept = default;
+UdpServer& UdpServer::operator=(UdpServer&&) noexcept = default;
 
 std::future<bool> UdpServer::start() { return impl_->start(); }
 void UdpServer::stop() { impl_->stop(); }
-bool UdpServer::is_listening() const {
-  std::lock_guard<std::mutex> lock(impl_->mutex);
-  return impl_->started && impl_->channel &&
-         (impl_->channel->is_connected() ||
-          impl_->channel->local_endpoint().port() != 0);  // UdpChannel is_connected might mean remote is set
-}
+bool UdpServer::is_listening() const { return impl_->is_listening.load(); }
 
 bool UdpServer::broadcast(std::string_view data) {
   std::lock_guard<std::mutex> lock(impl_->mutex);
@@ -392,6 +406,14 @@ std::vector<size_t> UdpServer::get_connected_clients() const {
     ids.push_back(pair.first);
   }
   return ids;
+}
+
+UdpServer& UdpServer::auto_manage(bool m) {
+  impl_->auto_manage = m;
+  if (impl_->auto_manage && !impl_->started.load()) {
+    start();
+  }
+  return *this;
 }
 
 UdpServer& UdpServer::set_session_timeout(std::chrono::milliseconds timeout) {

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -26,6 +26,10 @@
 #include "unilink/wrapper/iserver.hpp"
 
 namespace unilink {
+namespace interface {
+class Channel;
+}
+
 namespace wrapper {
 
 /**
@@ -36,7 +40,14 @@ class UNILINK_API UdpServer : public ServerInterface {
   explicit UdpServer(uint16_t port);
   explicit UdpServer(const config::UdpConfig& cfg);
   UdpServer(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> external_ioc);
+  explicit UdpServer(std::shared_ptr<interface::Channel> channel);
   ~UdpServer() override;
+
+  UdpServer(UdpServer&&) noexcept;
+  UdpServer& operator=(UdpServer&&) noexcept;
+
+  UdpServer(const UdpServer&) = delete;
+  UdpServer& operator=(const UdpServer&) = delete;
 
   // Lifecycle
   std::future<bool> start() override;
@@ -62,6 +73,7 @@ class UNILINK_API UdpServer : public ServerInterface {
   std::vector<size_t> get_connected_clients() const override;
 
   // UDP specific
+  UdpServer& auto_manage(bool manage = true);
   UdpServer& set_session_timeout(std::chrono::milliseconds timeout);
   UdpServer& set_manage_external_context(bool manage);
 

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -118,6 +118,9 @@ struct UdsClient::Impl {
       if (use_external_context_) {
         channel_ = factory::ChannelFactory::create(cfg, external_ioc_);
         if (manage_external_context_ && !external_thread_.joinable()) {
+          if (external_ioc_ && external_ioc_->stopped()) {
+            external_ioc_->restart();
+          }
           work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
               boost::asio::make_work_guard(*external_ioc_));
           external_thread_ = std::thread([this]() {
@@ -196,7 +199,17 @@ struct UdsClient::Impl {
         if (handler) {
           handler(ConnectionContext(0, "connected"));
         }
-      } else if (state == base::LinkState::Error || state == base::LinkState::Idle) {
+      } else if (state == base::LinkState::Error) {
+        ErrorHandler handler;
+        {
+          std::lock_guard<std::mutex> lock(mutex_);
+          fulfill_all_locked(false);
+          handler = error_handler_;
+        }
+        if (handler) {
+          handler(ErrorContext(ErrorCode::IoError, "Connection error"));
+        }
+      } else if (state == base::LinkState::Closed || state == base::LinkState::Idle) {
         ConnectionHandler handler;
         {
           std::lock_guard<std::mutex> lock(mutex_);
@@ -319,6 +332,9 @@ void UdsClient::on_message(MessageHandler h) { impl_->on_message(std::move(h)); 
 
 ChannelInterface& UdsClient::auto_manage(bool manage) {
   impl_->auto_manage_ = manage;
+  if (impl_->auto_manage_ && !impl_->started_.load()) {
+    start();
+  }
   return *this;
 }
 

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -197,7 +197,7 @@ struct UdsClient::Impl {
           handler = connect_handler_;
         }
         if (handler) {
-          handler(ConnectionContext(0, "connected"));
+          handler(ConnectionContext(0));
         }
       } else if (state == base::LinkState::Error) {
         ErrorHandler handler;
@@ -217,7 +217,7 @@ struct UdsClient::Impl {
           handler = disconnect_handler_;
         }
         if (handler) {
-          handler(ConnectionContext(0, "disconnected"));
+          handler(ConnectionContext(0));
         }
       }
     });

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -42,8 +42,9 @@ struct UdsServer::Impl {
   std::thread external_thread_;
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
-  std::promise<bool> start_promise_;
+  std::vector<std::promise<bool>> pending_promises_;
   std::atomic<bool> started_{false};
+  std::atomic<bool> is_listening_{false};
   std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
   ConnectionHandler client_connect_handler_{nullptr};
@@ -79,16 +80,31 @@ struct UdsServer::Impl {
     }
   }
 
+  void fulfill_all_locked(bool value) {
+    for (auto& p : pending_promises_) {
+      try {
+        p.set_value(value);
+      } catch (...) {
+      }
+    }
+    pending_promises_.clear();
+  }
+
   std::future<bool> start() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (started_) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (is_listening_.load()) {
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
     }
 
-    start_promise_ = std::promise<bool>();
-    auto f = start_promise_.get_future();
+    std::promise<bool> p;
+    auto f = p.get_future();
+    pending_promises_.emplace_back(std::move(p));
+
+    if (started_.exchange(true)) {
+      return f;
+    }
 
     if (!server_) {
       config::UdsServerConfig cfg;
@@ -98,6 +114,9 @@ struct UdsServer::Impl {
       if (use_external_context_) {
         server_ = std::dynamic_pointer_cast<transport::UdsServer>(factory::ChannelFactory::create(cfg, external_ioc_));
         if (manage_external_context_ && !external_thread_.joinable()) {
+          if (external_ioc_ && external_ioc_->stopped()) {
+            external_ioc_->restart();
+          }
           work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
               boost::asio::make_work_guard(*external_ioc_));
           external_thread_ = std::thread([this]() {
@@ -113,15 +132,15 @@ struct UdsServer::Impl {
       setup_internal_handlers();
     }
 
+    lock.unlock();
     server_->start();
-    started_ = true;
-    start_promise_.set_value(true);
     return f;
   }
 
   void stop() {
     std::unique_lock<std::mutex> lock(mutex_);
     if (!started_.exchange(false)) {
+      fulfill_all_locked(false);
       return;
     }
 
@@ -151,6 +170,8 @@ struct UdsServer::Impl {
       }
     }
 
+    is_listening_ = false;
+    fulfill_all_locked(false);
     server_.reset();
   }
 
@@ -158,6 +179,31 @@ struct UdsServer::Impl {
     if (!server_) return;
 
     std::weak_ptr<bool> weak_alive = alive_marker_;
+
+    server_->on_state([weak_alive, this](base::LinkState state) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+
+      ErrorHandler error_handler;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state == base::LinkState::Listening || state == base::LinkState::Connected) {
+          is_listening_ = true;
+          fulfill_all_locked(true);
+        } else if (state == base::LinkState::Error || state == base::LinkState::Closed ||
+                   state == base::LinkState::Idle) {
+          is_listening_ = false;
+          fulfill_all_locked(false);
+          if (state == base::LinkState::Error) {
+            error_handler = error_handler_;
+          }
+        }
+      }
+
+      if (error_handler) {
+        error_handler(ErrorContext(ErrorCode::IoError, "Server state error"));
+      }
+    });
 
     server_->on_multi_connect([weak_alive, this](size_t client_id, const std::string& info) {
       auto alive = weak_alive.lock();
@@ -250,9 +296,7 @@ std::future<bool> UdsServer::start() { return impl_->start(); }
 
 void UdsServer::stop() { impl_->stop(); }
 
-bool UdsServer::is_listening() const {
-  return impl_->started_.load() && impl_->server_ && impl_->server_->is_connected();
-}
+bool UdsServer::is_listening() const { return impl_->is_listening_.load(); }
 
 bool UdsServer::broadcast(std::string_view data) {
   if (impl_->server_) {
@@ -312,6 +356,9 @@ std::vector<size_t> UdsServer::get_connected_clients() const {
 
 UdsServer& UdsServer::auto_manage(bool manage) {
   impl_->auto_manage_ = manage;
+  if (impl_->auto_manage_ && !impl_->started_.load()) {
+    start();
+  }
   return *this;
 }
 

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -201,7 +201,7 @@ struct UdsServer::Impl {
       }
 
       if (error_handler) {
-        error_handler(ErrorContext(ErrorCode::IoError, "Server state error"));
+        error_handler(ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
 
@@ -215,9 +215,14 @@ struct UdsServer::Impl {
           auto framer = framer_factory_();
           if (framer) {
             framer->set_on_message([this, client_id](memory::ConstByteSpan msg) {
-              if (on_message_) {
+              MessageHandler on_message_handler;
+              {
+                std::lock_guard<std::mutex> lock(mutex_);
+                on_message_handler = on_message_;
+              }
+              if (on_message_handler) {
                 std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
-                on_message_(MessageContext(client_id, str_msg));
+                on_message_handler(MessageContext(client_id, str_msg));
               }
             });
             framers_[client_id] = std::move(framer);


### PR DESCRIPTION
## Summary

This PR improves consistency across the wrapper layer by aligning lifecycle behavior, callback handling, error propagation, and wrapper test organization across TCP, UDP, UDS, and Serial wrappers.

## Changes

- Aligned wrapper lifecycle semantics for `TcpServer`, `Udp`, `UdpServer`, `UdsClient`, `UdsServer`, and `Serial` so `auto_manage()`, `start()`, `stop()`, and externally managed `io_context` flows behave consistently.
- Updated wrapper start-state tracking to use pending promise resolution based on actual transport state transitions instead of immediate success paths, and fixed restart handling for managed external `io_context` instances.
- Hardened callback handling by snapshotting handlers before invocation, improving thread-safety around handler replacement, and reducing late-callback / stop-time race risks.
- Unified client and server callback surface details, including more consistent `ConnectionContext` usage and normalized generic wrapper error messages such as `Connection error` and `Server error`.
- Improved wrapper test coverage for UDS, UDP, UDP server, and Serial wrapper lifecycle/error scenarios using injected transports and more deterministic bind-conflict coverage.
- Standardized wrapper test labeling in CTest so wrapper tests are grouped under `unit_wrapper` rather than legacy TCP-specific labeling.

## Related Issues

- Fixes #N/A
- Related to wrapper API consistency, lifecycle correctness, and wrapper test stability improvements

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement

## Additional Notes

- Formatting was verified against the repository root `.clang-format`.
- Full test validation completed successfully with `ctest --test-dir build --output-on-failure`.
- Final test result: `381/381` tests passed.
- Wrapper-specific lifecycle and regression coverage was also revalidated through the updated advanced wrapper test binaries.
