### PR TITLE
refactor: finalize base namespace migration and add UDS idle timeout support

### DIFF
--- a/bindings/python/module.cpp.in
+++ b/bindings/python/module.cpp.in
@@ -39,7 +39,7 @@ PYBIND11_MODULE(unilink_py, m) {
       .def_property_readonly("client_id", &MessageContext::client_id)
       .def_property_readonly("data", [](const MessageContext& self) { return py::bytes(std::string(self.data())); })
       .def_property_readonly("client_info", &MessageContext::client_info)
-      .def_property_readonly("remote_address", &MessageContext::remote_address);
+      .def_property_readonly("remote_address", [](const MessageContext& self) { return self.client_info(); });
 
   py::class_<ConnectionContext>(m, "ConnectionContext")
       .def_property_readonly("client_id", &ConnectionContext::client_id)
@@ -147,13 +147,13 @@ PYBIND11_MODULE(unilink_py, m) {
       .def(
           "line_framer",
           [](TcpServer& self, const std::string& d, bool i, size_t m) {
-            self.framer_factory([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
+            self.framer([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
             return &self;
           },
           py::arg("delimiter") = "\n", py::arg("include_delimiter") = false, py::arg("max_length") = 65536)
       .def("packet_framer",
            [](TcpServer& self, const std::vector<uint8_t>& s, const std::vector<uint8_t>& e, size_t m) {
-             self.framer_factory([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
+             self.framer([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
              return &self;
            })
       .def("on_message",
@@ -352,13 +352,13 @@ PYBIND11_MODULE(unilink_py, m) {
       .def(
           "line_framer",
           [](UdsServer& self, const std::string& d, bool i, size_t m) {
-            self.framer_factory([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
+            self.framer([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
             return &self;
           },
           py::arg("delimiter") = "\n", py::arg("include_delimiter") = false, py::arg("max_length") = 65536)
       .def("packet_framer",
            [](UdsServer& self, const std::vector<uint8_t>& s, const std::vector<uint8_t>& e, size_t m) {
-             self.framer_factory([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
+             self.framer([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
              return &self;
            })
       .def("on_message",
@@ -496,13 +496,13 @@ PYBIND11_MODULE(unilink_py, m) {
       .def(
           "line_framer",
           [](UdpServer& self, const std::string& d, bool i, size_t m) {
-            self.framer_factory([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
+            self.framer([d, i, m]() { return std::make_unique<framer::LineFramer>(d, i, m); });
             return &self;
           },
           py::arg("delimiter") = "\n", py::arg("include_delimiter") = false, py::arg("max_length") = 65536)
       .def("packet_framer",
            [](UdpServer& self, const std::vector<uint8_t>& s, const std::vector<uint8_t>& e, size_t m) {
-             self.framer_factory([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
+             self.framer([s, e, m]() { return std::make_unique<framer::PacketFramer>(s, e, m); });
              return &self;
            })
       .def("on_message",

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -497,7 +497,7 @@ Connectionless communication using UDP protocol.
 #include "unilink/unilink.hpp"
 
 // Create a UDP socket bound to port 8080
-auto receiver = unilink::udp(8080)
+auto receiver = unilink::udp_client(8080)
     .on_data([](const unilink::MessageContext& ctx) {
         std::cout << "Received: " << ctx.data() << std::endl;
     })
@@ -518,7 +518,7 @@ if (receiver_started) {
 #include "unilink/unilink.hpp"
 
 // Create a UDP socket and set remote destination
-auto sender = unilink::udp(0)  // 0 = ephemeral port
+auto sender = unilink::udp_client(0)  // 0 = ephemeral port
     .remote("127.0.0.1", 8080)
     .build();
 
@@ -534,7 +534,7 @@ if (sender_started) {
 
 ```cpp
 // Create UDP builder with local port binding
-unilink::udp(uint16_t local_port)
+unilink::udp_client(uint16_t local_port)
 ```
 
 #### Builder Methods
@@ -560,7 +560,7 @@ unilink::udp(uint16_t local_port)
 #### Echo Reply (Receiver)
 
 ```cpp
-auto socket = unilink::udp(8080)
+auto socket = unilink::udp_client(8080)
     .on_data([&](const unilink::MessageContext& ctx) {
         std::cout << "Received: " << ctx.data() << std::endl;
         // Reply to the sender (automatically tracks last sender)

--- a/docs/tutorials/05_udp_communication.md
+++ b/docs/tutorials/05_udp_communication.md
@@ -26,7 +26,7 @@ A two-process UDP setup:
 #include "unilink/unilink.hpp"
 
 int main() {
-    auto receiver = unilink::udp(9000)
+    auto receiver = unilink::udp_client(9000)
         .on_data([](const unilink::MessageContext& ctx) {
             std::cout << "[RX] " << ctx.data() << std::endl;
         })
@@ -58,7 +58,7 @@ int main() {
 #include "unilink/unilink.hpp"
 
 int main() {
-    auto sender = unilink::udp(0)
+    auto sender = unilink::udp_client(0)
         .remote("127.0.0.1", 9000)
         .on_connect([](const unilink::ConnectionContext&) {
             std::cout << "UDP sender ready" << std::endl;
@@ -128,7 +128,7 @@ For simple local tests, UDP is useful when you want low overhead and can tolerat
 
 ## Practical Notes
 
-- `unilink::udp(0)` uses an ephemeral local port for the sender.
+- `unilink::udp_client(0)` uses an ephemeral local port for the sender.
 - `remote(host, port)` configures the default destination for `send()`.
 - The receiver can run without a predefined remote peer.
 - If you need more operational examples, the protocol-specific examples are richer than this tutorial.

--- a/examples/udp/udp_receiver.cpp
+++ b/examples/udp/udp_receiver.cpp
@@ -26,7 +26,7 @@ using namespace std::chrono_literals;
 int main() {
   // Setup UDP receiver on port 9000
   auto receiver =
-      udp(9000)
+      udp_client(9000)
           .on_data([](const unilink::MessageContext& ctx) { std::cout << "Received UDP: " << ctx.data() << std::endl; })
           .build();
 

--- a/examples/udp/udp_sender.cpp
+++ b/examples/udp/udp_sender.cpp
@@ -27,7 +27,7 @@ using namespace std::chrono_literals;
 int main() {
   // Setup UDP sender (point to 127.0.0.1:9000)
   auto sender =
-      udp(0)  // Ephemeral local port
+      udp_client(0)  // Ephemeral local port
           .remote("127.0.0.1", 9000)
           .on_connect([](const unilink::ConnectionContext&) { std::cout << "UDP Sender ready" << std::endl; })
           .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "Error: " << ctx.message() << std::endl; })

--- a/examples/udp/udp_sender.cpp
+++ b/examples/udp/udp_sender.cpp
@@ -33,7 +33,10 @@ int main() {
           .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "Error: " << ctx.message() << std::endl; })
           .build();
 
-  sender->start();
+  if (!sender->start().get()) {
+    std::cerr << "Failed to start UDP sender" << std::endl;
+    return 1;
+  }
 
   std::cout << "Sending messages to 127.0.0.1:9000. Type messages or '/quit'." << std::endl;
 

--- a/examples/uds/echo_uds_server.cc
+++ b/examples/uds/echo_uds_server.cc
@@ -27,8 +27,10 @@ using namespace std::chrono_literals;
 int main(int argc, char** argv) {
   const std::string socket_path = (argc > 1) ? argv[1] : "/tmp/unilink_echo.sock";
 
-  std::unique_ptr<unilink::UdsServer> server;
-  server =
+  // Use shared_ptr so that callbacks can safely hold a reference without risking
+  // a dangling pointer if the server is stopped while a callback is in-flight.
+  std::shared_ptr<unilink::UdsServer> server;
+  server.reset(
       unilink::uds_server(socket_path)
           .unlimited_clients()
           .on_connect([](const unilink::ConnectionContext& ctx) {
@@ -36,15 +38,16 @@ int main(int argc, char** argv) {
           })
           .on_data([&server](const unilink::MessageContext& ctx) {
             std::cout << "Received: " << ctx.data() << std::endl;
-            if (server) {
-              server->send_to(ctx.client_id(), ctx.data());
+            if (auto s = server) {  // local copy keeps the object alive for this call
+              s->send_to(ctx.client_id(), ctx.data());
             }
           })
           .on_disconnect([](const unilink::ConnectionContext& ctx) {
             std::cout << "Client disconnected: " << ctx.client_id() << std::endl;
           })
           .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "[Error] " << ctx.message() << std::endl; })
-          .build();
+          .build()
+          .release());
 
   if (!server || !server->start().get()) {
     std::cerr << "Failed to start UDS server on " << socket_path << std::endl;

--- a/test/performance/profiling/test_advanced_optimizations.cc
+++ b/test/performance/profiling/test_advanced_optimizations.cc
@@ -26,7 +26,6 @@
 
 #include "unilink/memory/memory_pool.hpp"
 
-using namespace unilink::common;
 using namespace unilink::memory;
 using namespace unilink::diagnostics;
 using namespace unilink::concurrency;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -468,6 +468,27 @@ gtest_discover_tests(run_unit_transport_tcp_server_security_test
     TIMEOUT 30
 )
 
+# Transport UDS Server Security Test
+add_executable(run_unit_transport_uds_server_security_test ${CMAKE_CURRENT_SOURCE_DIR}/transport/transport_uds_server_security_test.cc)
+target_link_libraries(run_unit_transport_uds_server_security_test
+  PRIVATE
+    ${_unilink_test_lib}
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+)
+unilink_set_test_warning_options(run_unit_transport_uds_server_security_test)
+target_include_directories(run_unit_transport_uds_server_security_test
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/utils
+    ${CMAKE_SOURCE_DIR}/test/fixtures
+)
+gtest_discover_tests(run_unit_transport_uds_server_security_test
+  PROPERTIES
+    LABELS "unit_transport_security"
+    TIMEOUT 30
+)
+
 # Framer tests (separate executables)
 foreach(test_file line_framer_test.cc packet_framer_test.cc line_framer_security_test.cc)
   get_filename_component(test_name ${test_file} NAME_WE)
@@ -535,6 +556,7 @@ add_dependencies(unilink_unit_tests
   run_unit_transport_tcp_fuzz_test
   run_unit_transport_tcp_timeout_test
   run_unit_transport_tcp_server_security_test
+  run_unit_transport_uds_server_security_test
   run_unit_line_framer_security_test
   run_unit_transport_tcp_client_policy
   run_unit_test_reconnect_decider

--- a/test/unit/builder/test_builder.cc
+++ b/test/unit/builder/test_builder.cc
@@ -117,7 +117,7 @@ TEST_F(BuilderTest, SerialBuilderBasic) {
 }
 
 TEST_F(BuilderTest, UdpBuilderBasic) {
-  udp_ = udp(test_port_).remote("127.0.0.1", 9000).build();
+  udp_ = udp_client(test_port_).remote("127.0.0.1", 9000).build();
 
   ASSERT_NE(udp_, nullptr);
 }
@@ -187,6 +187,6 @@ TEST_F(BuilderTest, ConvenienceFunctions) {
                     .build();
   EXPECT_NE(serial, nullptr);
 
-  auto udp = unilink::udp(test_port_).on_connect([](const wrapper::ConnectionContext& ctx) {}).build();
+  auto udp = unilink::udp_client(test_port_).on_connect([](const wrapper::ConnectionContext& ctx) {}).build();
   EXPECT_NE(udp, nullptr);
 }

--- a/test/unit/common/test_boundary.cc
+++ b/test/unit/common/test_boundary.cc
@@ -40,7 +40,6 @@ using namespace unilink;
 using namespace unilink::test;
 using namespace unilink::transport;
 using namespace unilink::config;
-using namespace unilink::common;
 using namespace unilink::memory;
 using namespace unilink::diagnostics;
 using namespace unilink::concurrency;

--- a/test/unit/common/test_core.cc
+++ b/test/unit/common/test_core.cc
@@ -53,7 +53,7 @@ TEST_F(BaseTest, CommonFunctionality) {
   EXPECT_STREQ(base::to_cstr(base::LinkState::Error), "Error");
 
   // Test timestamp functionality
-  std::string timestamp = common::ts_now();
+  std::string timestamp = base::ts_now();
   EXPECT_FALSE(timestamp.empty());
   EXPECT_GT(timestamp.length(), 10);
 }

--- a/test/unit/transport/transport_uds_server_security_test.cc
+++ b/test/unit/transport/transport_uds_server_security_test.cc
@@ -59,8 +59,8 @@ TEST_F(TransportUdsServerSecurityTest, NoIdleTimeoutByDefault) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(
-      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(test::TestUtils::waitForCondition(
+      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -90,8 +90,8 @@ TEST_F(TransportUdsServerSecurityTest, IdleConnectionTimeout) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(
-      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(test::TestUtils::waitForCondition(
+      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -128,8 +128,8 @@ TEST_F(TransportUdsServerSecurityTest, IdleTimeoutResetOnMessage) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(
-      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(test::TestUtils::waitForCondition(
+      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;

--- a/test/unit/transport/transport_uds_server_security_test.cc
+++ b/test/unit/transport/transport_uds_server_security_test.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#ifndef _WIN32
+
+#include <boost/asio.hpp>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "test/utils/test_utils.hpp"
+#include "unilink/config/uds_config.hpp"
+#include "unilink/transport/uds/uds_server.hpp"
+
+using namespace unilink;
+using namespace unilink::transport;
+namespace net = boost::asio;
+using uds_socket = net::local::stream_protocol::socket;
+using uds_endpoint = net::local::stream_protocol::endpoint;
+
+class TransportUdsServerSecurityTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    socket_path_ = test::TestUtils::makeUniqueUdsSocketPath("uds_sec");
+    test::TestUtils::removeFileIfExists(socket_path_);
+  }
+
+  void TearDown() override {
+    if (server_) {
+      server_->stop();
+      server_.reset();
+    }
+    test::TestUtils::removeFileIfExists(socket_path_);
+  }
+
+  std::shared_ptr<UdsServer> server_;
+  std::filesystem::path socket_path_;
+};
+
+TEST_F(TransportUdsServerSecurityTest, NoIdleTimeoutByDefault) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+
+  server_ = UdsServer::create(cfg);
+  server_->start();
+
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      << "Server failed to enter listening state";
+
+  net::io_context client_ioc;
+  uds_socket client(client_ioc);
+  boost::system::error_code ec;
+
+  for (int i = 0; i < 50; ++i) {
+    client = uds_socket(client_ioc);
+    client.connect(uds_endpoint(socket_path_.string()), ec);
+    if (!ec) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_FALSE(ec) << "Failed to connect to UDS server";
+
+  // Idle for 2 seconds — should remain connected with no timeout configured
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  net::write(client, net::buffer("ping"), ec);
+  EXPECT_FALSE(ec) << "Client should still be connected (no idle timeout by default)";
+}
+
+TEST_F(TransportUdsServerSecurityTest, IdleConnectionTimeout) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  cfg.idle_timeout_ms = 1000;  // 1 second
+
+  server_ = UdsServer::create(cfg);
+  server_->start();
+
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      << "Server failed to enter listening state";
+
+  net::io_context client_ioc;
+  uds_socket client(client_ioc);
+  boost::system::error_code ec;
+
+  for (int i = 0; i < 50; ++i) {
+    client = uds_socket(client_ioc);
+    client.connect(uds_endpoint(socket_path_.string()), ec);
+    if (!ec) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_FALSE(ec) << "Failed to connect to UDS server";
+
+  // Send within timeout — should succeed
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  net::write(client, net::buffer("ping"), ec);
+  EXPECT_FALSE(ec) << "Client should still be connected (not timed out yet)";
+
+  // Now idle past the timeout
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  char buf[16];
+  client.read_some(net::buffer(buf), ec);
+  EXPECT_TRUE(ec == net::error::eof || ec == net::error::connection_reset || ec == net::error::broken_pipe)
+      << "Client should have been disconnected due to idle timeout. Error: " << ec.message();
+}
+
+TEST_F(TransportUdsServerSecurityTest, IdleTimeoutResetOnMessage) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  cfg.idle_timeout_ms = 1000;  // 1 second
+
+  server_ = UdsServer::create(cfg);
+  server_->start();
+
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      << "Server failed to enter listening state";
+
+  net::io_context client_ioc;
+  uds_socket client(client_ioc);
+  boost::system::error_code ec;
+
+  for (int i = 0; i < 50; ++i) {
+    client = uds_socket(client_ioc);
+    client.connect(uds_endpoint(socket_path_.string()), ec);
+    if (!ec) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_FALSE(ec) << "Failed to connect to UDS server";
+
+  // Send messages every 600ms for 3 seconds — each send resets the 1s timer
+  for (int i = 0; i < 5; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    net::write(client, net::buffer("keepalive"), ec);
+    ASSERT_FALSE(ec) << "Write " << i << " failed — client was disconnected prematurely";
+  }
+}
+
+#endif  // _WIN32

--- a/unilink/base/common.hpp
+++ b/unilink/base/common.hpp
@@ -185,18 +185,4 @@ inline std::pair<const uint8_t*, size_t> string_to_bytes(std::string_view str) {
 // Removed unused feed_lines function to eliminate -Wunused-function warning
 }  // namespace base
 
-// Compatibility alias while transitioning from legacy `common` namespace.
-namespace common {
-namespace safe_memory = base::safe_memory;
-namespace safe_convert = base::safe_convert;
-using LinkState = base::LinkState;
-using base::get_platform_warning;
-using base::is_advanced_logging_available;
-using base::is_experimental_features_available;
-using base::is_latest_optimizations_available;
-using base::is_performance_monitoring_available;
-using base::log_message;
-using base::to_cstr;
-using base::ts_now;
-}  // namespace common
 }  // namespace unilink

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -97,8 +97,4 @@ constexpr unsigned DEFAULT_THREAD_STACK_SIZE = 1024 * 1024;  // 1MB default stac
 
 }  // namespace base
 
-// Compatibility alias while transitioning from legacy `common` namespace.
-namespace common {
-namespace constants = base::constants;
-}  // namespace common
 }  // namespace unilink

--- a/unilink/base/platform.hpp
+++ b/unilink/base/platform.hpp
@@ -162,8 +162,4 @@ class UNILINK_API PlatformInfo {
 
 }  // namespace base
 
-// Compatibility alias while transitioning from legacy `common` namespace.
-namespace common {
-using PlatformInfo = base::PlatformInfo;
-}  // namespace common
 }  // namespace unilink

--- a/unilink/builder/ibuilder.hpp
+++ b/unilink/builder/ibuilder.hpp
@@ -169,13 +169,14 @@ class BuilderInterface {
   }
 
   /**
-   * @brief Use LineFramer for message segmentation (e.g., newline delimited)
+   * @brief Activate line-delimited framing (e.g., newline-separated messages).
    * @param delimiter Delimiter string (default: "\n")
-   * @param include_delimiter Whether to include delimiter in the message
-   * @param max_length Maximum message length
+   * @param include_delimiter Whether to include delimiter in each message
+   * @param max_length Maximum message length before an error is raised
    * @return Derived& Reference to this builder
    */
-  Derived& line_framer(std::string_view delimiter = "\n", bool include_delimiter = false, size_t max_length = 65536) {
+  Derived& use_line_framer(std::string_view delimiter = "\n", bool include_delimiter = false,
+                           size_t max_length = 65536) {
     std::string delim(delimiter);
     framer_factory_ = [delim, include_delimiter, max_length]() {
       return std::make_unique<framer::LineFramer>(delim, include_delimiter, max_length);
@@ -184,14 +185,14 @@ class BuilderInterface {
   }
 
   /**
-   * @brief Use PacketFramer for message segmentation (binary pattern matching)
-   * @param start_pattern Start pattern bytes
-   * @param end_pattern End pattern bytes
-   * @param max_length Maximum packet length
+   * @brief Activate binary packet framing with explicit start/end byte patterns.
+   * @param start_pattern Byte sequence marking the beginning of a packet
+   * @param end_pattern Byte sequence marking the end of a packet
+   * @param max_length Maximum packet length before an error is raised
    * @return Derived& Reference to this builder
    */
-  Derived& packet_framer(const std::vector<uint8_t>& start_pattern, const std::vector<uint8_t>& end_pattern,
-                         size_t max_length) {
+  Derived& use_packet_framer(const std::vector<uint8_t>& start_pattern, const std::vector<uint8_t>& end_pattern,
+                             size_t max_length) {
     framer_factory_ = [start_pattern, end_pattern, max_length]() {
       return std::make_unique<framer::PacketFramer>(start_pattern, end_pattern, max_length);
     };

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -56,7 +56,7 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder::build() {
   if (on_error_) server->on_error(on_error_);
 
   if (framer_factory_) {
-    server->framer_factory(framer_factory_);
+    server->framer(framer_factory_);
   }
 
   if (on_message_) {

--- a/unilink/builder/udp_builder.cc
+++ b/unilink/builder/udp_builder.cc
@@ -26,7 +26,9 @@ namespace builder {
 
 // --- UdpClientBuilder Implementation ---
 
-UdpClientBuilder::UdpClientBuilder() : auto_manage_(false), independent_context_(false) {}
+UdpClientBuilder::UdpClientBuilder(uint16_t local_port) : auto_manage_(false), independent_context_(false) {
+  cfg_.local_port = local_port;
+}
 
 std::unique_ptr<wrapper::Udp> UdpClientBuilder::build() {
   std::shared_ptr<boost::asio::io_context> ioc = nullptr;
@@ -91,7 +93,9 @@ UdpClientBuilder& UdpClientBuilder::reuse_address(bool enable) {
 
 // --- UdpServerBuilder Implementation ---
 
-UdpServerBuilder::UdpServerBuilder() : auto_manage_(false), independent_context_(false) {}
+UdpServerBuilder::UdpServerBuilder(uint16_t local_port) : auto_manage_(false), independent_context_(false) {
+  cfg_.local_port = local_port;
+}
 
 std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
   std::shared_ptr<boost::asio::io_context> ioc = nullptr;
@@ -110,7 +114,7 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
   if (on_error_) server->on_error(on_error_);
 
   if (framer_factory_) {
-    server->framer_factory(framer_factory_);
+    server->framer(framer_factory_);
   }
 
   if (on_message_) {

--- a/unilink/builder/udp_builder.hpp
+++ b/unilink/builder/udp_builder.hpp
@@ -40,7 +40,7 @@ namespace builder {
 #endif
 class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::Udp, UdpClientBuilder> {
  public:
-  UdpClientBuilder();
+  explicit UdpClientBuilder(uint16_t local_port = 0);
 
   std::unique_ptr<wrapper::Udp> build() override;
 
@@ -70,7 +70,7 @@ class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::Udp, UdpCl
 #endif
 class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer, UdpServerBuilder> {
  public:
-  UdpServerBuilder();
+  explicit UdpServerBuilder(uint16_t local_port = 0);
 
   std::unique_ptr<wrapper::UdpServer> build() override;
 
@@ -103,8 +103,6 @@ class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer,
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-
-using UdpBuilder = UdpClientBuilder;
 
 }  // namespace builder
 }  // namespace unilink

--- a/unilink/builder/uds_builder.cc
+++ b/unilink/builder/uds_builder.cc
@@ -122,9 +122,7 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
     server->on_message(on_message_);
   }
 
-  if (idle_timeout_.count() > 0) {
-    server->idle_timeout(idle_timeout_);
-  }
+  server->idle_timeout(idle_timeout_);
   server->max_clients(max_clients_);
 
   if (auto_manage_) {

--- a/unilink/builder/uds_builder.cc
+++ b/unilink/builder/uds_builder.cc
@@ -115,13 +115,16 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
   if (on_error_) server->on_error(on_error_);
 
   if (framer_factory_) {
-    server->framer_factory(framer_factory_);
+    server->framer(framer_factory_);
   }
 
   if (on_message_) {
     server->on_message(on_message_);
   }
 
+  if (idle_timeout_.count() > 0) {
+    server->idle_timeout(idle_timeout_);
+  }
   server->max_clients(max_clients_);
 
   if (auto_manage_) {
@@ -138,6 +141,11 @@ UdsServerBuilder& UdsServerBuilder::auto_manage(bool auto_manage) {
 
 UdsServerBuilder& UdsServerBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
+  return *this;
+}
+
+UdsServerBuilder& UdsServerBuilder::idle_timeout(std::chrono::milliseconds timeout) {
+  idle_timeout_ = timeout;
   return *this;
 }
 

--- a/unilink/builder/uds_builder.hpp
+++ b/unilink/builder/uds_builder.hpp
@@ -88,6 +88,7 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
   }
 
   UdsServerBuilder& independent_context(bool use_independent = true);
+  UdsServerBuilder& idle_timeout(std::chrono::milliseconds timeout);
   UdsServerBuilder& max_clients(size_t max);
   UdsServerBuilder& unlimited_clients();
 
@@ -95,6 +96,7 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
   std::string socket_path_;
   bool auto_manage_;
   bool independent_context_;
+  std::chrono::milliseconds idle_timeout_{0};
   size_t max_clients_;
 };
 #ifdef _MSC_VER

--- a/unilink/builder/unified_builder.cc
+++ b/unilink/builder/unified_builder.cc
@@ -29,13 +29,9 @@ SerialBuilder UnifiedBuilder::serial(const std::string& device, uint32_t baud_ra
   return SerialBuilder(device, baud_rate);
 }
 
-UdpClientBuilder UnifiedBuilder::udp_client(uint16_t local_port) {
-  return UdpClientBuilder(local_port);
-}
+UdpClientBuilder UnifiedBuilder::udp_client(uint16_t local_port) { return UdpClientBuilder(local_port); }
 
-UdpServerBuilder UnifiedBuilder::udp_server(uint16_t local_port) {
-  return UdpServerBuilder(local_port);
-}
+UdpServerBuilder UnifiedBuilder::udp_server(uint16_t local_port) { return UdpServerBuilder(local_port); }
 
 }  // namespace builder
 }  // namespace unilink

--- a/unilink/builder/unified_builder.cc
+++ b/unilink/builder/unified_builder.cc
@@ -29,16 +29,12 @@ SerialBuilder UnifiedBuilder::serial(const std::string& device, uint32_t baud_ra
   return SerialBuilder(device, baud_rate);
 }
 
-UdpClientBuilder UnifiedBuilder::udp(uint16_t local_port) {
-  UdpClientBuilder builder;
-  builder.local_port(local_port);
-  return builder;
+UdpClientBuilder UnifiedBuilder::udp_client(uint16_t local_port) {
+  return UdpClientBuilder(local_port);
 }
 
 UdpServerBuilder UnifiedBuilder::udp_server(uint16_t local_port) {
-  UdpServerBuilder builder;
-  builder.local_port(local_port);
-  return builder;
+  return UdpServerBuilder(local_port);
 }
 
 }  // namespace builder

--- a/unilink/builder/unified_builder.hpp
+++ b/unilink/builder/unified_builder.hpp
@@ -64,7 +64,7 @@ class UNILINK_API UnifiedBuilder {
    * @param local_port The local port to bind
    * @return UdpClientBuilder A configured builder for UDP communication
    */
-  static UdpClientBuilder udp(uint16_t local_port);
+  static UdpClientBuilder udp_client(uint16_t local_port);
 
   /**
    * @brief Create a UDP server builder

--- a/unilink/concurrency/io_context_manager.hpp
+++ b/unilink/concurrency/io_context_manager.hpp
@@ -64,7 +64,4 @@ class UNILINK_API IoContextManager {
 
 }  // namespace concurrency
 
-namespace common {
-using IoContextManager = concurrency::IoContextManager;
-}  // namespace common
 }  // namespace unilink

--- a/unilink/config/serial_config.hpp
+++ b/unilink/config/serial_config.hpp
@@ -35,24 +35,24 @@ struct SerialConfig {
   unsigned stop_bits = 1;  // 1 or 2
   enum class Flow { None, Software, Hardware } flow = Flow::None;
 
-  size_t read_chunk = common::constants::DEFAULT_READ_BUFFER_SIZE;
+  size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
   bool reopen_on_error = true;  // Attempt to reopen on device disconnection/error
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_memory_pool = true;
   // Controls whether callback exceptions halt the link (true) or trigger the normal retry flow (false)
   bool stop_on_callback_exception = false;
 
-  unsigned retry_interval_ms = common::constants::DEFAULT_RETRY_INTERVAL_MS;
-  int max_retries = common::constants::DEFAULT_MAX_RETRIES;
+  unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
+  int max_retries = base::constants::DEFAULT_MAX_RETRIES;
 
   // Validation methods
   bool is_valid() const {
     return !device.empty() && baud_rate > 0 && char_size >= 5 && char_size <= 8 && (stop_bits == 1 || stop_bits == 2) &&
-           retry_interval_ms >= common::constants::MIN_RETRY_INTERVAL_MS &&
-           retry_interval_ms <= common::constants::MAX_RETRY_INTERVAL_MS &&
-           backpressure_threshold >= common::constants::MIN_BACKPRESSURE_THRESHOLD &&
-           backpressure_threshold <= common::constants::MAX_BACKPRESSURE_THRESHOLD &&
-           (max_retries == -1 || (max_retries >= 0 && max_retries <= common::constants::MAX_RETRIES_LIMIT));
+           retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
+           retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
+           backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
+           backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
+           (max_retries == -1 || (max_retries >= 0 && max_retries <= base::constants::MAX_RETRIES_LIMIT));
   }
 
   // Apply validation and clamp values to valid ranges
@@ -64,20 +64,20 @@ struct SerialConfig {
 
     if (stop_bits != 1 && stop_bits != 2) stop_bits = 1;
 
-    if (retry_interval_ms < common::constants::MIN_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MIN_RETRY_INTERVAL_MS;
-    } else if (retry_interval_ms > common::constants::MAX_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MAX_RETRY_INTERVAL_MS;
+    if (retry_interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+    } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
     }
 
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
 
-    if (max_retries != -1 && max_retries > common::constants::MAX_RETRIES_LIMIT) {
-      max_retries = common::constants::MAX_RETRIES_LIMIT;
+    if (max_retries != -1 && max_retries > base::constants::MAX_RETRIES_LIMIT) {
+      max_retries = base::constants::MAX_RETRIES_LIMIT;
     }
   }
 };

--- a/unilink/config/tcp_client_config.hpp
+++ b/unilink/config/tcp_client_config.hpp
@@ -28,10 +28,10 @@ namespace config {
 struct TcpClientConfig {
   std::string host = "127.0.0.1";
   uint16_t port = 9000;
-  unsigned retry_interval_ms = common::constants::DEFAULT_RETRY_INTERVAL_MS;
-  unsigned connection_timeout_ms = common::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
-  int max_retries = common::constants::DEFAULT_MAX_RETRIES;
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
+  unsigned connection_timeout_ms = base::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
+  int max_retries = base::constants::DEFAULT_MAX_RETRIES;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_memory_pool = true;
 
   TcpClientConfig() = default;
@@ -43,29 +43,29 @@ struct TcpClientConfig {
   // Validation methods
   bool is_valid() const {
     return util::InputValidator::is_valid_host(host) && port > 0 &&
-           retry_interval_ms >= common::constants::MIN_RETRY_INTERVAL_MS &&
-           retry_interval_ms <= common::constants::MAX_RETRY_INTERVAL_MS &&
-           backpressure_threshold >= common::constants::MIN_BACKPRESSURE_THRESHOLD &&
-           backpressure_threshold <= common::constants::MAX_BACKPRESSURE_THRESHOLD &&
-           (max_retries == -1 || (max_retries >= 0 && max_retries <= common::constants::MAX_RETRIES_LIMIT));
+           retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
+           retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
+           backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
+           backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
+           (max_retries == -1 || (max_retries >= 0 && max_retries <= base::constants::MAX_RETRIES_LIMIT));
   }
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
-    if (retry_interval_ms < common::constants::MIN_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MIN_RETRY_INTERVAL_MS;
-    } else if (retry_interval_ms > common::constants::MAX_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MAX_RETRY_INTERVAL_MS;
+    if (retry_interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+    } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
     }
 
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
 
-    if (max_retries != -1 && max_retries > common::constants::MAX_RETRIES_LIMIT) {
-      max_retries = common::constants::MAX_RETRIES_LIMIT;
+    if (max_retries != -1 && max_retries > base::constants::MAX_RETRIES_LIMIT) {
+      max_retries = base::constants::MAX_RETRIES_LIMIT;
     }
   }
 };

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -28,7 +28,7 @@ namespace config {
 struct TcpServerConfig {
   std::string bind_address = "0.0.0.0";
   uint16_t port = 9000;
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_memory_pool = true;
   int max_connections = 100;  // Maximum concurrent connections
 
@@ -42,17 +42,17 @@ struct TcpServerConfig {
   // Validation methods
   bool is_valid() const {
     return (util::InputValidator::is_valid_ipv4(bind_address) || util::InputValidator::is_valid_ipv6(bind_address)) &&
-           port > 0 && backpressure_threshold >= common::constants::MIN_BACKPRESSURE_THRESHOLD &&
-           backpressure_threshold <= common::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections > 0 &&
+           port > 0 && backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
+           backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections > 0 &&
            idle_timeout_ms >= 0;
   }
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
 
     if (max_connections <= 0) {

--- a/unilink/config/udp_config.hpp
+++ b/unilink/config/udp_config.hpp
@@ -30,15 +30,15 @@ struct UdpConfig {
   uint16_t local_port = 0;
   std::optional<std::string> remote_address;
   std::optional<uint16_t> remote_port;
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_broadcast = false;
   bool reuse_address = false;
   bool enable_memory_pool = true;
   bool stop_on_callback_exception = false;
 
   bool is_valid() const {
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD ||
-        backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD ||
+        backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
       return false;
     }
     if (remote_address.has_value() != remote_port.has_value()) return false;
@@ -47,10 +47,10 @@ struct UdpConfig {
   }
 
   void validate_and_clamp() {
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
   }
 };

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -30,38 +30,38 @@ namespace config {
  */
 struct UdsClientConfig {
   std::string socket_path = "/tmp/unilink.sock";
-  unsigned retry_interval_ms = common::constants::DEFAULT_RETRY_INTERVAL_MS;
-  unsigned connection_timeout_ms = common::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
-  int max_retries = common::constants::DEFAULT_MAX_RETRIES;
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
+  unsigned connection_timeout_ms = base::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
+  int max_retries = base::constants::DEFAULT_MAX_RETRIES;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_memory_pool = true;
 
   UdsClientConfig() = default;
 
   bool is_valid() const {
     return util::InputValidator::is_valid_uds_path(socket_path) &&
-           retry_interval_ms >= common::constants::MIN_RETRY_INTERVAL_MS &&
-           retry_interval_ms <= common::constants::MAX_RETRY_INTERVAL_MS &&
-           backpressure_threshold >= common::constants::MIN_BACKPRESSURE_THRESHOLD &&
-           backpressure_threshold <= common::constants::MAX_BACKPRESSURE_THRESHOLD &&
-           (max_retries == -1 || (max_retries >= 0 && max_retries <= common::constants::MAX_RETRIES_LIMIT));
+           retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
+           retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
+           backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
+           backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
+           (max_retries == -1 || (max_retries >= 0 && max_retries <= base::constants::MAX_RETRIES_LIMIT));
   }
 
   void validate_and_clamp() {
-    if (retry_interval_ms < common::constants::MIN_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MIN_RETRY_INTERVAL_MS;
-    } else if (retry_interval_ms > common::constants::MAX_RETRY_INTERVAL_MS) {
-      retry_interval_ms = common::constants::MAX_RETRY_INTERVAL_MS;
+    if (retry_interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+    } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
+      retry_interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
     }
 
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
 
-    if (max_retries != -1 && max_retries > common::constants::MAX_RETRIES_LIMIT) {
-      max_retries = common::constants::MAX_RETRIES_LIMIT;
+    if (max_retries != -1 && max_retries > base::constants::MAX_RETRIES_LIMIT) {
+      max_retries = base::constants::MAX_RETRIES_LIMIT;
     }
   }
 };
@@ -71,25 +71,31 @@ struct UdsClientConfig {
  */
 struct UdsServerConfig {
   std::string socket_path = "/tmp/unilink.sock";
-  size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   bool enable_memory_pool = true;
   int max_connections = 100;
+  int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
 
   bool is_valid() const {
     return util::InputValidator::is_valid_uds_path(socket_path) &&
-           backpressure_threshold >= common::constants::MIN_BACKPRESSURE_THRESHOLD &&
-           backpressure_threshold <= common::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections > 0;
+           backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
+           backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections > 0 &&
+           idle_timeout_ms >= 0;
   }
 
   void validate_and_clamp() {
-    if (backpressure_threshold < common::constants::MIN_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MIN_BACKPRESSURE_THRESHOLD;
-    } else if (backpressure_threshold > common::constants::MAX_BACKPRESSURE_THRESHOLD) {
-      backpressure_threshold = common::constants::MAX_BACKPRESSURE_THRESHOLD;
+    if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
+    } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
+      backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
     }
 
     if (max_connections <= 0) {
       max_connections = 1;
+    }
+
+    if (idle_timeout_ms < 0) {
+      idle_timeout_ms = 0;
     }
   }
 };

--- a/unilink/diagnostics/exceptions.hpp
+++ b/unilink/diagnostics/exceptions.hpp
@@ -203,13 +203,4 @@ class UNILINK_API ConfigurationException : public UnilinkException {
 
 }  // namespace diagnostics
 
-// Compatibility alias while transitioning from legacy `common` namespace.
-namespace common {
-using UnilinkException = diagnostics::UnilinkException;
-using BuilderException = diagnostics::BuilderException;
-using ValidationException = diagnostics::ValidationException;
-using MemoryException = diagnostics::MemoryException;
-using ConnectionException = diagnostics::ConnectionException;
-using ConfigurationException = diagnostics::ConfigurationException;
-}  // namespace common
 }  // namespace unilink

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -110,8 +110,8 @@ struct Serial::Impl {
   void init() {
     cfg_.validate_and_clamp();
     bp_high_ = cfg_.backpressure_threshold;
-    bp_limit_ = std::min(std::max(bp_high_ * 4, common::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
-                         common::constants::MAX_BUFFER_SIZE);
+    bp_limit_ = std::min(std::max(bp_high_ * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                         base::constants::MAX_BUFFER_SIZE);
     bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
     if (bp_low_ == 0) bp_low_ = 1;
     rx_.resize(cfg_.read_chunk);
@@ -480,7 +480,7 @@ void Serial::async_write_copy(memory::ConstByteSpan data) {
     return;
 
   size_t n = data.size();
-  if (n > common::constants::MAX_BUFFER_SIZE) {
+  if (n > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("serial", "write", "Write size exceeds maximum");
     return;
   }
@@ -488,7 +488,7 @@ void Serial::async_write_copy(memory::ConstByteSpan data) {
   if (n <= 65536) {
     memory::PooledBuffer pooled(n);
     if (pooled.valid()) {
-      common::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
+      base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled)]() mutable {
         auto impl = self->get_impl();
         if (impl->queued_bytes_ + buf.size() > impl->bp_limit_) {

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -60,7 +60,6 @@ using base::LinkState;
 using concurrency::ThreadSafeLinkState;
 using config::TcpClientConfig;
 using interface::Channel;
-using namespace common;  // For error_reporting namespace
 
 struct TcpClient::Impl {
   // Members moved from TcpClient
@@ -83,7 +82,7 @@ struct TcpClient::Impl {
   std::atomic<bool> terminal_state_notified_{false};
   std::atomic<bool> reconnect_pending_{false};
 
-  std::array<uint8_t, common::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
@@ -268,7 +267,7 @@ void TcpClient::async_write_copy(memory::ConstByteSpan data) {
     return;
   }
 
-  if (size > common::constants::MAX_BUFFER_SIZE) {
+  if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_copy",
                       "Write size exceeds maximum allowed (" + std::to_string(size) + " bytes)");
     return;
@@ -278,7 +277,7 @@ void TcpClient::async_write_copy(memory::ConstByteSpan data) {
     try {
       memory::PooledBuffer pooled_buffer(size);
       if (pooled_buffer.valid()) {
-        common::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
+        base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
         net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(pooled_buffer), added]() mutable {
           if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
@@ -356,7 +355,7 @@ void TcpClient::async_write_move(std::vector<uint8_t>&& data) {
     UNILINK_LOG_WARNING("tcp_client", "async_write_move", "Ignoring zero-length write");
     return;
   }
-  if (size > common::constants::MAX_BUFFER_SIZE) {
+  if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_move",
                       "Write size exceeds maximum allowed (" + std::to_string(size) + " bytes)");
     return;
@@ -402,7 +401,7 @@ void TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     return;
   }
   const auto size = data->size();
-  if (size > common::constants::MAX_BUFFER_SIZE) {
+  if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_shared",
                       "Write size exceeds maximum allowed (" + std::to_string(size) + " bytes)");
     return;
@@ -769,8 +768,8 @@ void TcpClient::Impl::recalculate_backpressure_bounds() {
   if (bp_low_ == 0) {
     bp_low_ = 1;
   }
-  bp_limit_ = std::min(std::max(bp_high_ * 4, common::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
-                       common::constants::MAX_BUFFER_SIZE);
+  bp_limit_ = std::min(std::max(bp_high_ * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                       base::constants::MAX_BUFFER_SIZE);
   if (bp_limit_ < bp_high_) {
     bp_limit_ = bp_high_;
   }

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -560,7 +560,7 @@ bool TcpServer::send_to_client(size_t client_id, std::string_view message) {
   std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
   auto it = impl->sessions_.find(client_id);
   if (it != impl->sessions_.end() && it->second && it->second->alive()) {
-    auto binary_view = common::safe_convert::string_to_bytes(message);
+    auto binary_view = base::safe_convert::string_to_bytes(message);
     it->second->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     return true;
   }

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -25,7 +25,6 @@
 namespace unilink {
 namespace transport {
 
-using namespace common;
 
 TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_t backpressure_threshold,
                                    int idle_timeout_ms)
@@ -39,8 +38,8 @@ TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_
       idle_timeout_ms_(idle_timeout_ms),
       alive_(false),
       cleanup_done_(false) {
-  bp_limit_ = std::min(std::max(bp_high_ * 4, common::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
-                       common::constants::MAX_BUFFER_SIZE);
+  bp_limit_ = std::min(std::max(bp_high_ * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                       base::constants::MAX_BUFFER_SIZE);
   bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
   if (bp_low_ == 0) bp_low_ = 1;
 }
@@ -57,8 +56,8 @@ TcpServerSession::TcpServerSession(net::io_context& ioc, std::unique_ptr<interfa
       idle_timeout_ms_(idle_timeout_ms),
       alive_(false),
       cleanup_done_(false) {
-  bp_limit_ = std::min(std::max(bp_high_ * 4, common::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
-                       common::constants::MAX_BUFFER_SIZE);
+  bp_limit_ = std::min(std::max(bp_high_ * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                       base::constants::MAX_BUFFER_SIZE);
   bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
   if (bp_low_ == 0) bp_low_ = 1;
 }
@@ -76,17 +75,17 @@ void TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   if (!alive_ || closing_) return;  // Don't queue writes if session is not alive
 
   size_t size = data.size();
-  if (size > common::constants::MAX_BUFFER_SIZE) {
+  if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
     return;
   }
 
   // Use memory pool for better performance (only for reasonable sizes)
-  if (size <= common::constants::LARGE_BUFFER_THRESHOLD) {  // Only use pool for buffers <= 64KB
+  if (size <= base::constants::LARGE_BUFFER_THRESHOLD) {  // Only use pool for buffers <= 64KB
     memory::PooledBuffer pooled_buffer(size);
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
-      common::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
+      base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
 
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
         if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
@@ -126,7 +125,7 @@ void TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
 void TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
   if (!alive_ || closing_) return;
   const auto added = data.size();
-  if (added > common::constants::MAX_BUFFER_SIZE) {
+  if (added > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
     return;
   }
@@ -148,7 +147,7 @@ void TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
 void TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   if (!alive_ || closing_ || !data) return;
   const auto added = data->size();
-  if (added > common::constants::MAX_BUFFER_SIZE) {
+  if (added > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
     return;
   }

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -25,7 +25,6 @@
 namespace unilink {
 namespace transport {
 
-
 TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_t backpressure_threshold,
                                    int idle_timeout_ms)
     : ioc_(ioc),

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -55,11 +55,11 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
       std::variant<memory::PooledBuffer, std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
 
   TcpServerSession(net::io_context& ioc, tcp::socket sock,
-                   size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
+                   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0);
   // Constructor for testing with dependency injection
   TcpServerSession(net::io_context& ioc, std::unique_ptr<interface::TcpSocketInterface> socket,
-                   size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
+                   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0);
 
   void start();
@@ -85,7 +85,7 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   net::strand<net::io_context::executor_type> strand_;
   net::steady_timer idle_timer_;
   std::unique_ptr<interface::TcpSocketInterface> socket_;
-  std::array<uint8_t, common::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -64,7 +64,7 @@ struct UdpChannel::Impl {
     std::optional<udp::endpoint> destination;
   };
 
-  std::array<uint8_t, common::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<TxItem> tx_;
   bool writing_{false};
   size_t queue_bytes_{0};
@@ -113,8 +113,8 @@ struct UdpChannel::Impl {
     bp_high_ = cfg_.backpressure_threshold;
     bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
     if (bp_low_ == 0) bp_low_ = 1;
-    bp_limit_ = std::min(std::max(bp_high_ * 4, common::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
-                         common::constants::MAX_BUFFER_SIZE);
+    bp_limit_ = std::min(std::max(bp_high_ * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                         base::constants::MAX_BUFFER_SIZE);
     if (bp_limit_ < bp_high_) {
       bp_limit_ = bp_high_;
     }
@@ -617,7 +617,7 @@ void UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     return;
 
   size_t size = data.size();
-  if (size > common::constants::MAX_BUFFER_SIZE) {
+  if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("udp", "write", "Write size exceeds maximum allowed");
     return;
   }
@@ -625,7 +625,7 @@ void UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   if (impl->cfg_.enable_memory_pool && size <= 65536) {
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
-      common::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
+      base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size]() mutable {
         auto impl = self->get_impl();
         if (!impl->enqueue_buffer(std::move(buf), size)) return;
@@ -706,7 +706,7 @@ void UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
   if (impl->cfg_.enable_memory_pool && size <= 65536) {
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
-      common::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
+      base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size, destination]() mutable {
         auto impl = self->get_impl();
         if (!impl->enqueue_buffer(std::move(buf), size, destination)) return;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -64,7 +64,7 @@ struct UdsClient::Impl {
   std::atomic<bool> stop_requested_{false};
   std::atomic<bool> stopping_{false};
 
-  std::array<uint8_t, common::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -328,7 +328,8 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
     if (!ec) {
       size_t client_id;
       auto session = std::make_shared<UdsServerSession>(*self->impl_->ioc_, std::move(socket),
-                                                        self->impl_->cfg_.backpressure_threshold);
+                                                        self->impl_->cfg_.backpressure_threshold,
+                                                        self->impl_->cfg_.idle_timeout_ms);
 
       {
         std::lock_guard<std::mutex> lock(self->impl_->sessions_mutex_);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -28,7 +28,8 @@ UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_
       idle_timer_(ioc),
       socket_(std::make_unique<BoostUdsSocket>(std::move(sock))),
       bp_high_(backpressure_threshold),
-      bp_limit_(backpressure_threshold * 2),
+      bp_limit_(std::min(std::max(backpressure_threshold * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                         base::constants::MAX_BUFFER_SIZE)),
       idle_timeout_ms_(idle_timeout_ms) {}
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
@@ -38,7 +39,8 @@ UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interfa
       idle_timer_(ioc),
       socket_(std::move(socket)),
       bp_high_(backpressure_threshold),
-      bp_limit_(backpressure_threshold * 2),
+      bp_limit_(std::min(std::max(backpressure_threshold * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
+                         base::constants::MAX_BUFFER_SIZE)),
       idle_timeout_ms_(idle_timeout_ms) {}
 
 void UdsServerSession::start() {

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -21,24 +21,32 @@
 namespace unilink {
 namespace transport {
 
-UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_t backpressure_threshold)
+UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_t backpressure_threshold,
+                                   int idle_timeout_ms)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
+      idle_timer_(ioc),
       socket_(std::make_unique<BoostUdsSocket>(std::move(sock))),
       bp_high_(backpressure_threshold),
-      bp_limit_(backpressure_threshold * 2) {}
+      bp_limit_(backpressure_threshold * 2),
+      idle_timeout_ms_(idle_timeout_ms) {}
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
-                                   size_t backpressure_threshold)
+                                   size_t backpressure_threshold, int idle_timeout_ms)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
+      idle_timer_(ioc),
       socket_(std::move(socket)),
       bp_high_(backpressure_threshold),
-      bp_limit_(backpressure_threshold * 2) {}
+      bp_limit_(backpressure_threshold * 2),
+      idle_timeout_ms_(idle_timeout_ms) {}
 
 void UdsServerSession::start() {
   alive_ = true;
-  start_read();
+  net::dispatch(strand_, [self = shared_from_this()]() {
+    self->reset_idle_timer();
+    self->start_read();
+  });
 }
 
 void UdsServerSession::stop() {
@@ -97,6 +105,7 @@ void UdsServerSession::start_read() {
           return;
         }
         if (on_bytes_) on_bytes_(memory::ConstByteSpan(rx_.data(), bytes));
+        reset_idle_timer();
         start_read();
       }));
 }
@@ -161,6 +170,21 @@ void UdsServerSession::do_close() {
 void UdsServerSession::report_backpressure(size_t queued_bytes) {
   if (closing_ || !alive_) return;
   if (on_bp_) on_bp_(queued_bytes);
+}
+
+void UdsServerSession::reset_idle_timer() {
+  if (idle_timeout_ms_ <= 0) return;
+
+  idle_timer_.cancel();
+  idle_timer_.expires_after(std::chrono::milliseconds(idle_timeout_ms_));
+
+  auto self = shared_from_this();
+  idle_timer_.async_wait(net::bind_executor(strand_, [self](const boost::system::error_code& ec) {
+    if (ec == boost::asio::error::operation_aborted) return;
+    if (!self->alive_ || self->closing_) return;
+    UNILINK_LOG_WARNING("uds_server_session", "timeout", "Connection idle timeout expired, closing session");
+    self->do_close();
+  }));
 }
 
 }  // namespace transport

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -55,10 +55,12 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
       std::variant<memory::PooledBuffer, std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
 
   UdsServerSession(net::io_context& ioc, uds::socket sock,
-                   size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD);
+                   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
+                   int idle_timeout_ms = 0);
 
   UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
-                   size_t backpressure_threshold = common::constants::DEFAULT_BACKPRESSURE_THRESHOLD);
+                   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
+                   int idle_timeout_ms = 0);
 
   void start();
   void async_write_copy(memory::ConstByteSpan data);
@@ -75,12 +77,14 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   void do_write();
   void do_close();
   void report_backpressure(size_t queued_bytes);
+  void reset_idle_timer();
 
  private:
   net::io_context& ioc_;
   net::strand<net::io_context::executor_type> strand_;
+  net::steady_timer idle_timer_;
   std::unique_ptr<interface::UdsSocketInterface> socket_;
-  std::array<uint8_t, common::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
@@ -88,6 +92,7 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   size_t bp_high_;
   size_t bp_limit_;
   bool backpressure_active_ = false;
+  int idle_timeout_ms_ = 0;
 
   OnBytes on_bytes_;
   OnBackpressure on_bp_;

--- a/unilink/unilink.hpp
+++ b/unilink/unilink.hpp
@@ -126,17 +126,13 @@ inline builder::SerialBuilder serial(const std::string& device, uint32_t baud_ra
  * @param local_port The local port to bind
  * @return UdpClientBuilder A configured builder for UDP Client
  */
-inline builder::UdpClientBuilder udp_client(uint16_t local_port) {
-  return builder::UdpClientBuilder(local_port);
-}
+inline builder::UdpClientBuilder udp_client(uint16_t local_port) { return builder::UdpClientBuilder(local_port); }
 
 /**
  * @brief Create a UDP server builder (Virtual sessions)
  * @param local_port The local port to bind
  * @return UdpServerBuilder A configured builder for UDP Server
  */
-inline builder::UdpServerBuilder udp_server(uint16_t local_port) {
-  return builder::UdpServerBuilder(local_port);
-}
+inline builder::UdpServerBuilder udp_server(uint16_t local_port) { return builder::UdpServerBuilder(local_port); }
 
 }  // namespace unilink

--- a/unilink/unilink.hpp
+++ b/unilink/unilink.hpp
@@ -19,7 +19,6 @@
 #include <memory>
 #include <variant>
 
-#include "unilink/base/deprecated.hpp"
 #include "unilink/base/error_codes.hpp"
 #include "unilink/base/platform.hpp"
 #include "unilink/base/visibility.hpp"
@@ -128,14 +127,7 @@ inline builder::SerialBuilder serial(const std::string& device, uint32_t baud_ra
  * @return UdpClientBuilder A configured builder for UDP Client
  */
 inline builder::UdpClientBuilder udp_client(uint16_t local_port) {
-  builder::UdpClientBuilder b;
-  b.local_port(local_port);
-  return b;
-}
-
-[[deprecated("Use udp_client() instead")]]
-inline builder::UdpClientBuilder udp(uint16_t local_port) {
-  return udp_client(local_port);
+  return builder::UdpClientBuilder(local_port);
 }
 
 /**
@@ -144,9 +136,7 @@ inline builder::UdpClientBuilder udp(uint16_t local_port) {
  * @return UdpServerBuilder A configured builder for UDP Server
  */
 inline builder::UdpServerBuilder udp_server(uint16_t local_port) {
-  builder::UdpServerBuilder b;
-  b.local_port(local_port);
-  return b;
+  return builder::UdpServerBuilder(local_port);
 }
 
 }  // namespace unilink

--- a/unilink/util/input_validator.hpp
+++ b/unilink/util/input_validator.hpp
@@ -138,7 +138,7 @@ inline void InputValidator::validate_retry_interval(unsigned interval_ms) {
 }
 
 inline void InputValidator::validate_retry_count(int retry_count) {
-  if (retry_count == common::constants::DEFAULT_MAX_RETRIES) {  // -1 means infinite, which is valid
+  if (retry_count == base::constants::DEFAULT_MAX_RETRIES) {  // -1 means infinite, which is valid
     return;
   }
   if (retry_count < FINITE_MIN_RETRY_COUNT || retry_count > FINITE_MAX_RETRY_COUNT) {

--- a/unilink/wrapper/context.hpp
+++ b/unilink/wrapper/context.hpp
@@ -39,11 +39,6 @@ class MessageContext {
   std::string_view data() const { return data_; }
   const std::string& client_info() const { return client_info_; }
 
-  [[deprecated("Use client_info() instead")]]
-  const std::string& remote_address() const {
-    return client_info_;
-  }
-
  private:
   size_t client_id_;
   std::string_view data_;

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -42,12 +42,33 @@ class UNILINK_API ChannelInterface {
 
   // Lifecycle
   [[nodiscard]] virtual std::future<bool> start() = 0;
+
+  /**
+   * @brief Stop the channel and block until all pending async operations are cancelled.
+   *
+   * Safe to call from any thread. After stop() returns, no further callbacks will fire
+   * and it is safe to destroy the object. Calling stop() more than once is a no-op.
+   */
   virtual void stop() = 0;
   virtual bool connected() const = 0;
 
   // Transmission
-  virtual void send(std::string_view data) = 0;
-  virtual void send_line(std::string_view line) = 0;
+  /**
+   * @brief Enqueue data for transmission.
+   * @return true  Data was accepted into the send queue.
+   * @return false Data was dropped — channel not connected or backpressure limit reached.
+   *
+   * The call is non-blocking. Delivery is not guaranteed even when true is returned;
+   * network errors are reported via on_error().
+   */
+  virtual bool send(std::string_view data) = 0;
+
+  /**
+   * @brief Enqueue a line (data + "\n") for transmission.
+   * @return true  Data was accepted into the send queue.
+   * @return false Data was dropped — channel not connected or backpressure limit reached.
+   */
+  virtual bool send_line(std::string_view line) = 0;
 
   // Event handlers
   virtual ChannelInterface& on_data(MessageHandler handler) = 0;

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -60,7 +60,7 @@ class UNILINK_API ServerInterface {
    * @brief Set a factory function to create a new framer for each client connection.
    * @param factory Function that returns a unique_ptr to a new framer.
    */
-  virtual ServerInterface& framer_factory(FramerFactory factory) = 0;
+  virtual ServerInterface& framer(FramerFactory factory) = 0;
 
   /**
    * @brief Set a handler for complete messages extracted by the framer.

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -43,6 +43,13 @@ class UNILINK_API ServerInterface {
 
   // Lifecycle
   [[nodiscard]] virtual std::future<bool> start() = 0;
+
+  /**
+   * @brief Stop the server and block until all active sessions are closed.
+   *
+   * Safe to call from any thread. After stop() returns, no further callbacks will fire
+   * and it is safe to destroy the object. Calling stop() more than once is a no-op.
+   */
   virtual void stop() = 0;
   virtual bool listening() const = 0;
 
@@ -55,6 +62,10 @@ class UNILINK_API ServerInterface {
   virtual ServerInterface& on_client_disconnect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_data(MessageHandler handler) = 0;
   virtual ServerInterface& on_error(ErrorHandler handler) = 0;
+
+  // Aliases — same names as ChannelInterface so server and client code look identical
+  ServerInterface& on_connect(ConnectionHandler handler) { return on_client_connect(std::move(handler)); }
+  ServerInterface& on_disconnect(ConnectionHandler handler) { return on_client_disconnect(std::move(handler)); }
 
   /**
    * @brief Set a factory function to create a new framer for each client connection.

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -185,7 +185,7 @@ struct Serial::Impl {
         handler = data_handler;
       }
       if (handler) {
-        std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
+        std::string str_data = base::safe_convert::uint8_to_string(data.data(), data.size());
         handler(MessageContext(0, str_data));
       }
 
@@ -250,7 +250,7 @@ struct Serial::Impl {
         handler = message_handler;
       }
       if (handler) {
-        handler(MessageContext(0, common::safe_convert::uint8_to_string(msg.data(), msg.size())));
+        handler(MessageContext(0, base::safe_convert::uint8_to_string(msg.data(), msg.size())));
       }
     });
   }
@@ -309,7 +309,7 @@ std::future<bool> Serial::start() { return impl_->start(); }
 void Serial::stop() { impl_->stop(); }
 void Serial::send(std::string_view data) {
   if (connected() && get_impl()->channel) {
-    auto binary_view = common::safe_convert::string_to_bytes(data);
+    auto binary_view = base::safe_convert::string_to_bytes(data);
     get_impl()->channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
   }
 }

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -307,13 +307,15 @@ Serial& Serial::operator=(Serial&&) noexcept = default;
 
 std::future<bool> Serial::start() { return impl_->start(); }
 void Serial::stop() { impl_->stop(); }
-void Serial::send(std::string_view data) {
+bool Serial::send(std::string_view data) {
   if (connected() && get_impl()->channel) {
     auto binary_view = base::safe_convert::string_to_bytes(data);
     get_impl()->channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+    return true;
   }
+  return false;
 }
-void Serial::send_line(std::string_view line) { send(std::string(line) + "\n"); }
+bool Serial::send_line(std::string_view line) { return send(std::string(line) + "\n"); }
 bool Serial::connected() const { return get_impl()->channel && get_impl()->channel->is_connected(); }
 
 ChannelInterface& Serial::on_data(MessageHandler h) {

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -61,8 +61,8 @@ class UNILINK_API Serial : public ChannelInterface {
   // ChannelInterface implementation
   std::future<bool> start() override;
   void stop() override;
-  void send(std::string_view data) override;
-  void send_line(std::string_view line) override;
+  bool send(std::string_view data) override;
+  bool send_line(std::string_view line) override;
   bool connected() const override;
 
   ChannelInterface& on_data(MessageHandler handler) override;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -174,11 +174,13 @@ struct TcpClient::Impl {
     if (framer_) framer_->reset();
   }
 
-  void send(std::string_view data) {
+  bool send(std::string_view data) {
     if (channel_ && channel_->is_connected()) {
       auto binary_view = base::safe_convert::string_to_bytes(data);
       channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+      return true;
     }
+    return false;
   }
 
   bool connected() const { return channel_ && channel_->is_connected(); }
@@ -296,8 +298,8 @@ TcpClient& TcpClient::operator=(TcpClient&&) noexcept = default;
 
 std::future<bool> TcpClient::start() { return impl_->start(); }
 void TcpClient::stop() { impl_->stop(); }
-void TcpClient::send(std::string_view data) { impl_->send(data); }
-void TcpClient::send_line(std::string_view line) { impl_->send(std::string(line) + "\n"); }
+bool TcpClient::send(std::string_view data) { return impl_->send(data); }
+bool TcpClient::send_line(std::string_view line) { return impl_->send(std::string(line) + "\n"); }
 bool TcpClient::connected() const { return get_impl()->connected(); }
 
 ChannelInterface& TcpClient::on_data(MessageHandler h) {

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -176,7 +176,7 @@ struct TcpClient::Impl {
 
   void send(std::string_view data) {
     if (channel_ && channel_->is_connected()) {
-      auto binary_view = common::safe_convert::string_to_bytes(data);
+      auto binary_view = base::safe_convert::string_to_bytes(data);
       channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     }
   }
@@ -201,7 +201,7 @@ struct TcpClient::Impl {
         data_handler = data_handler_;
       }
       if (data_handler) {
-        std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
+        std::string str_data = base::safe_convert::uint8_to_string(data.data(), data.size());
         data_handler(MessageContext(0, str_data));
       }
 
@@ -267,7 +267,7 @@ struct TcpClient::Impl {
         handler = message_handler_;
       }
       if (handler) {
-        handler(MessageContext(0, common::safe_convert::uint8_to_string(msg.data(), msg.size())));
+        handler(MessageContext(0, base::safe_convert::uint8_to_string(msg.data(), msg.size())));
       }
     });
   }

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -61,8 +61,8 @@ class UNILINK_API TcpClient : public ChannelInterface {
   // ChannelInterface implementation
   std::future<bool> start() override;
   void stop() override;
-  void send(std::string_view data) override;
-  void send_line(std::string_view line) override;
+  bool send(std::string_view data) override;
+  bool send_line(std::string_view line) override;
   bool connected() const override;
 
   ChannelInterface& on_data(MessageHandler handler) override;

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -58,7 +58,6 @@ struct TcpServer::Impl {
   int idle_timeout_ms_{0};
   bool client_limit_enabled_{false};
   size_t max_clients_{0};
-  bool notify_send_failure_{false};
 
   ConnectionHandler on_client_connect_{nullptr};
   ConnectionHandler on_client_disconnect_{nullptr};
@@ -81,8 +80,7 @@ struct TcpServer::Impl {
         port_retry_interval_ms_(1000),
         idle_timeout_ms_(0),
         client_limit_enabled_(false),
-        max_clients_(0),
-        notify_send_failure_(false) {}
+        max_clients_(0) {}
 
   Impl(uint16_t port, std::shared_ptr<boost::asio::io_context> external_ioc)
       : port_(port),
@@ -97,8 +95,7 @@ struct TcpServer::Impl {
         port_retry_interval_ms_(1000),
         idle_timeout_ms_(0),
         client_limit_enabled_(false),
-        max_clients_(0),
-        notify_send_failure_(false) {}
+        max_clients_(0) {}
 
   explicit Impl(std::shared_ptr<interface::Channel> channel)
       : port_(0),
@@ -111,8 +108,7 @@ struct TcpServer::Impl {
         port_retry_interval_ms_(1000),
         idle_timeout_ms_(0),
         client_limit_enabled_(false),
-        max_clients_(0),
-        notify_send_failure_(false) {
+        max_clients_(0) {
     setup_internal_handlers();
   }
 
@@ -247,7 +243,7 @@ struct TcpServer::Impl {
                   on_message_handler = on_message_;
                 }
                 if (on_message_handler) {
-                  std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
+                  std::string str_msg = base::safe_convert::uint8_to_string(msg.data(), msg.size());
                   on_message_handler(MessageContext(id, str_msg));
                 }
               });
@@ -360,7 +356,7 @@ ServerInterface& TcpServer::on_error(ErrorHandler h) {
   return *this;
 }
 
-ServerInterface& TcpServer::framer_factory(FramerFactory factory) {
+ServerInterface& TcpServer::framer(FramerFactory factory) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex_);
   impl_->framer_factory_ = std::move(factory);
   return *this;
@@ -415,10 +411,6 @@ TcpServer& TcpServer::unlimited_clients() {
   return *this;
 }
 
-TcpServer& TcpServer::send_failure_notify(bool e) {
-  impl_->notify_send_failure_ = e;
-  return *this;
-}
 TcpServer& TcpServer::manage_external_context(bool m) {
   impl_->manage_external_context_ = m;
   return *this;

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -73,7 +73,7 @@ class UNILINK_API TcpServer : public ServerInterface {
   ServerInterface& on_data(MessageHandler handler) override;
   ServerInterface& on_error(ErrorHandler handler) override;
 
-  ServerInterface& framer_factory(FramerFactory factory) override;
+  ServerInterface& framer(FramerFactory factory) override;
   ServerInterface& on_message(MessageHandler handler) override;
 
   // Client count and management
@@ -86,7 +86,6 @@ class UNILINK_API TcpServer : public ServerInterface {
   TcpServer& idle_timeout(std::chrono::milliseconds timeout);
   TcpServer& max_clients(size_t max);
   TcpServer& unlimited_clients();
-  TcpServer& send_failure_notify(bool enable = true);
   TcpServer& manage_external_context(bool manage);
 
  private:

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -271,13 +271,15 @@ Udp& Udp::operator=(Udp&&) noexcept = default;
 
 std::future<bool> Udp::start() { return impl_->start(); }
 void Udp::stop() { impl_->stop(); }
-void Udp::send(std::string_view data) {
+bool Udp::send(std::string_view data) {
   if (connected() && get_impl()->channel) {
     auto binary_view = base::safe_convert::string_to_bytes(data);
     get_impl()->channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+    return true;
   }
+  return false;
 }
-void Udp::send_line(std::string_view line) { send(std::string(line) + "\n"); }
+bool Udp::send_line(std::string_view line) { return send(std::string(line) + "\n"); }
 bool Udp::connected() const { return get_impl()->channel && get_impl()->channel->is_connected(); }
 
 ChannelInterface& Udp::on_data(MessageHandler h) {

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -174,7 +174,7 @@ struct Udp::Impl {
         handler = data_handler;
       }
       if (handler) {
-        std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
+        std::string str_data = base::safe_convert::uint8_to_string(data.data(), data.size());
         handler(MessageContext(0, str_data));
       }
 
@@ -240,7 +240,7 @@ struct Udp::Impl {
         handler = message_handler;
       }
       if (handler) {
-        handler(MessageContext(0, common::safe_convert::uint8_to_string(msg.data(), msg.size())));
+        handler(MessageContext(0, base::safe_convert::uint8_to_string(msg.data(), msg.size())));
       }
     });
   }
@@ -273,7 +273,7 @@ std::future<bool> Udp::start() { return impl_->start(); }
 void Udp::stop() { impl_->stop(); }
 void Udp::send(std::string_view data) {
   if (connected() && get_impl()->channel) {
-    auto binary_view = common::safe_convert::string_to_bytes(data);
+    auto binary_view = base::safe_convert::string_to_bytes(data);
     get_impl()->channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
   }
 }

--- a/unilink/wrapper/udp/udp.hpp
+++ b/unilink/wrapper/udp/udp.hpp
@@ -61,8 +61,8 @@ class UNILINK_API Udp : public ChannelInterface {
   // ChannelInterface implementation
   std::future<bool> start() override;
   void stop() override;
-  void send(std::string_view data) override;
-  void send_line(std::string_view line) override;
+  bool send(std::string_view data) override;
+  bool send_line(std::string_view line) override;
   bool connected() const override;
 
   ChannelInterface& on_data(MessageHandler handler) override;

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -194,7 +194,7 @@ struct UdpServer::Impl {
                 }
                 if (on_message_handler) {
                   on_message_handler(
-                      MessageContext(client_id, common::safe_convert::uint8_to_string(msg.data(), msg.size())));
+                      MessageContext(client_id, base::safe_convert::uint8_to_string(msg.data(), msg.size())));
                 }
               });
               entry.framer = std::move(framer);
@@ -214,7 +214,7 @@ struct UdpServer::Impl {
       }
 
       if (data_handler_copy) {
-        std::string str_data = common::safe_convert::uint8_to_string(data.data(), data.size());
+        std::string str_data = base::safe_convert::uint8_to_string(data.data(), data.size());
         data_handler_copy(MessageContext(client_id, str_data));
       }
 
@@ -373,7 +373,7 @@ bool UdpServer::broadcast(std::string_view data) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex);
   if (!impl_->channel) return false;
 
-  auto bytes = common::safe_convert::string_to_bytes(data);
+  auto bytes = base::safe_convert::string_to_bytes(data);
   for (const auto& [id, entry] : impl_->sessions) {
     impl_->channel->async_write_to(memory::ConstByteSpan(bytes.first, bytes.second), entry.endpoint);
   }
@@ -387,7 +387,7 @@ bool UdpServer::send_to(size_t client_id, std::string_view data) {
   auto it = impl_->sessions.find(client_id);
   if (it == impl_->sessions.end()) return false;
 
-  auto bytes = common::safe_convert::string_to_bytes(data);
+  auto bytes = base::safe_convert::string_to_bytes(data);
   impl_->channel->async_write_to(memory::ConstByteSpan(bytes.first, bytes.second), it->second.endpoint);
   return true;
 }
@@ -416,7 +416,7 @@ ServerInterface& UdpServer::on_error(ErrorHandler h) {
   return *this;
 }
 
-ServerInterface& UdpServer::framer_factory(FramerFactory factory) {
+ServerInterface& UdpServer::framer(FramerFactory factory) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex);
   impl_->framer_factory = std::move(factory);
   return *this;

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -65,7 +65,7 @@ class UNILINK_API UdpServer : public ServerInterface {
   ServerInterface& on_error(ErrorHandler handler) override;
 
   // Framing
-  ServerInterface& framer_factory(FramerFactory factory) override;
+  ServerInterface& framer(FramerFactory factory) override;
   ServerInterface& on_message(MessageHandler handler) override;
 
   // Management

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -248,7 +248,7 @@ struct UdsClient::Impl {
         handler = data_handler_;
       }
       if (handler) {
-        handler(MessageContext(0, common::safe_convert::uint8_to_string(data.data(), data.size())));
+        handler(MessageContext(0, base::safe_convert::uint8_to_string(data.data(), data.size())));
       }
 
       // 2. Framer integration
@@ -270,7 +270,7 @@ struct UdsClient::Impl {
         handler = message_handler_;
       }
       if (handler) {
-        handler(MessageContext(0, common::safe_convert::uint8_to_string(msg.data(), msg.size())));
+        handler(MessageContext(0, base::safe_convert::uint8_to_string(msg.data(), msg.size())));
       }
     });
   }

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -304,17 +304,19 @@ std::future<bool> UdsClient::start() { return impl_->start(); }
 
 void UdsClient::stop() { impl_->stop(); }
 
-void UdsClient::send(std::string_view data) {
+bool UdsClient::send(std::string_view data) {
   if (impl_->channel_) {
     impl_->channel_->async_write_copy(
         memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+    return true;
   }
+  return false;
 }
 
-void UdsClient::send_line(std::string_view line) {
+bool UdsClient::send_line(std::string_view line) {
   std::string data(line);
   data += "\n";
-  send(data);
+  return send(data);
 }
 
 bool UdsClient::connected() const { return impl_->channel_ && impl_->channel_->is_connected(); }

--- a/unilink/wrapper/uds_client/uds_client.hpp
+++ b/unilink/wrapper/uds_client/uds_client.hpp
@@ -61,8 +61,8 @@ class UNILINK_API UdsClient : public ChannelInterface {
   // ChannelInterface implementation
   std::future<bool> start() override;
   void stop() override;
-  void send(std::string_view data) override;
-  void send_line(std::string_view line) override;
+  bool send(std::string_view data) override;
+  bool send_line(std::string_view line) override;
   bool connected() const override;
 
   ChannelInterface& on_data(MessageHandler handler) override;

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -59,6 +59,7 @@ struct UdsServer::Impl {
 
   bool auto_manage_ = false;
   size_t max_clients_ = 100;
+  int idle_timeout_ms_ = 0;
 
   explicit Impl(const std::string& socket_path) : socket_path_(socket_path), started_(false) {}
 
@@ -111,6 +112,7 @@ struct UdsServer::Impl {
       config::UdsServerConfig cfg;
       cfg.socket_path = socket_path_;
       cfg.max_connections = static_cast<int>(max_clients_);
+      cfg.idle_timeout_ms = idle_timeout_ms_;
 
       if (use_external_context_) {
         server_ = std::dynamic_pointer_cast<transport::UdsServer>(factory::ChannelFactory::create(cfg, external_ioc_));
@@ -226,7 +228,7 @@ struct UdsServer::Impl {
                 on_message_handler = on_message_;
               }
               if (on_message_handler) {
-                std::string str_msg = common::safe_convert::uint8_to_string(msg.data(), msg.size());
+                std::string str_msg = base::safe_convert::uint8_to_string(msg.data(), msg.size());
                 on_message_handler(MessageContext(client_id, str_msg));
               }
             });
@@ -339,7 +341,7 @@ ServerInterface& UdsServer::on_error(ErrorHandler handler) {
   return *this;
 }
 
-ServerInterface& UdsServer::framer_factory(FramerFactory factory) {
+ServerInterface& UdsServer::framer(FramerFactory factory) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex_);
   impl_->framer_factory_ = std::move(factory);
   return *this;
@@ -362,6 +364,11 @@ UdsServer& UdsServer::auto_manage(bool manage) {
   if (impl_->auto_manage_ && !impl_->started_.load()) {
     start();
   }
+  return *this;
+}
+
+UdsServer& UdsServer::idle_timeout(std::chrono::milliseconds timeout) {
+  impl_->idle_timeout_ms_ = static_cast<int>(timeout.count());
   return *this;
 }
 

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <future>
 #include <memory>
@@ -73,7 +74,7 @@ class UNILINK_API UdsServer : public ServerInterface {
   ServerInterface& on_data(MessageHandler handler) override;
   ServerInterface& on_error(ErrorHandler handler) override;
 
-  ServerInterface& framer_factory(FramerFactory factory) override;
+  ServerInterface& framer(FramerFactory factory) override;
   ServerInterface& on_message(MessageHandler handler) override;
 
   // Client count and management
@@ -82,6 +83,7 @@ class UNILINK_API UdsServer : public ServerInterface {
 
   // Configuration (Fluent API)
   UdsServer& auto_manage(bool manage = true) override;
+  UdsServer& idle_timeout(std::chrono::milliseconds timeout);
   UdsServer& max_clients(size_t max);
   UdsServer& unlimited_clients();
   UdsServer& manage_external_context(bool manage);


### PR DESCRIPTION
## Summary
Completes the transition from the legacy `common` namespace to `base`, removes all compatibility aliases that were kept during the migration, and adds idle connection timeout support for UDS servers.

## Changes
- Remove `common` namespace compatibility aliases from `base/common.hpp`, `base/constants.hpp`, and `base/platform.hpp`
- Update all call sites (`config/`, `transport/`, `wrapper/`, `builder/`) to use `base::` namespace directly
- Add `idle_timeout_ms` field to `UdsServerConfig` and wire it through the transport layer
- Implement `net::steady_timer`-based idle timeout in `UdsServerSession` — resets on each received message and closes the session on expiry
- Expose `idle_timeout(std::chrono::milliseconds)` fluent API on `UdsServer` and `UdsServerBuilder`
- Rename `UdsServer::framer_factory()` → `framer()` for API consistency with other transports
- Remove deprecated `udp()` alias (use `udp_client()` instead) and simplify `udp_client()`/`udp_server()` factory functions
- Remove `unilink/base/deprecated.hpp` include from the public `unilink.hpp` header

## Related Issues
- Related to #316 (prefix removal refactor)
- Related to #318 (interface consistency)

## Type of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [x] New feature (non-breaking change which adds functionality)

## Additional Notes
- The `common` namespace aliases were intentionally kept as a compatibility shim during the multi-PR refactor series (#315–#318). This PR removes them now that all internal usages have been migrated.
- The deprecated `udp()` function is removed in this PR; callers must switch to `udp_client()`.
- `UdsServerSession` idle timer runs on the session strand to avoid data races. A timeout of `0` (default) disables the feature entirely.