### PR TITLE
refactor: improve API usability and consistency

### DIFF
--- a/bindings/python/module.cpp.in
+++ b/bindings/python/module.cpp.in
@@ -69,11 +69,12 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &TcpClient::start_sync)
       .def("stop", &TcpClient::stop)
       .def("send", &TcpClient::send)
       .def("send_line", &TcpClient::send_line)
       .def("connected", &TcpClient::connected)
-      .def("auto_manage", &TcpClient::auto_manage, py::arg("manage") = true)
+      .def("auto_start", &TcpClient::auto_start, py::arg("start") = true)
       .def("retry_interval", &TcpClient::retry_interval)
       .def("max_retries", &TcpClient::max_retries)
       .def("connection_timeout", &TcpClient::connection_timeout)
@@ -137,12 +138,14 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &TcpServer::start_sync)
       .def("stop", &TcpServer::stop)
       .def("broadcast", &TcpServer::broadcast)
       .def("send_to", &TcpServer::send_to)
       .def("client_count", &TcpServer::client_count)
       .def("connected_clients", &TcpServer::connected_clients)
       .def("listening", &TcpServer::listening)
+      .def("auto_start", &TcpServer::auto_start, py::arg("start") = true)
       .def(
           "use_line_framer",
           [](TcpServer& self, const std::string& d, bool i, size_t m) {
@@ -203,11 +206,12 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &Serial::start_sync)
       .def("stop", &Serial::stop)
       .def("send", &Serial::send)
       .def("send_line", &Serial::send_line)
       .def("connected", &Serial::connected)
-      .def("auto_manage", &Serial::auto_manage, py::arg("manage") = true)
+      .def("auto_start", &Serial::auto_start, py::arg("start") = true)
       .def("baud_rate", &Serial::baud_rate)
       .def("data_bits", &Serial::data_bits)
       .def("stop_bits", &Serial::stop_bits)
@@ -274,11 +278,12 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &UdsClient::start_sync)
       .def("stop", &UdsClient::stop)
       .def("send", &UdsClient::send)
       .def("send_line", &UdsClient::send_line)
       .def("connected", &UdsClient::connected)
-      .def("auto_manage", &UdsClient::auto_manage, py::arg("manage") = true)
+      .def("auto_start", &UdsClient::auto_start, py::arg("start") = true)
       .def("retry_interval", &UdsClient::retry_interval)
       .def("max_retries", &UdsClient::max_retries)
       .def("connection_timeout", &UdsClient::connection_timeout)
@@ -342,12 +347,14 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &UdsServer::start_sync)
       .def("stop", &UdsServer::stop)
       .def("broadcast", &UdsServer::broadcast)
       .def("send_to", &UdsServer::send_to)
       .def("client_count", &UdsServer::client_count)
       .def("connected_clients", &UdsServer::connected_clients)
       .def("listening", &UdsServer::listening)
+      .def("auto_start", &UdsServer::auto_start, py::arg("start") = true)
       .def(
           "use_line_framer",
           [](UdsServer& self, const std::string& d, bool i, size_t m) {
@@ -411,33 +418,34 @@ PYBIND11_MODULE(unilink_py, m) {
       .def_readwrite("enable_memory_pool", &config::UdpConfig::enable_memory_pool)
       .def_readwrite("stop_on_callback_exception", &config::UdpConfig::stop_on_callback_exception);
 
-  // Udp (Client role)
-  py::class_<Udp, std::shared_ptr<Udp>>(m, "Udp")
+  // UdpClient (Client role)
+  py::class_<UdpClient, std::shared_ptr<UdpClient>>(m, "UdpClient")
       .def(py::init<const config::UdpConfig&>())
       .def("start",
-           [](Udp& self) {
+           [](UdpClient& self) {
              py::gil_scoped_release release;
              return self.start().get();
            })
-      .def("stop", &Udp::stop)
-      .def("send", &Udp::send)
-      .def("send_line", &Udp::send_line)
-      .def("connected", &Udp::connected)
-      .def("auto_manage", &Udp::auto_manage, py::arg("manage") = true)
+      .def("start_sync", &UdpClient::start_sync)
+      .def("stop", &UdpClient::stop)
+      .def("send", &UdpClient::send)
+      .def("send_line", &UdpClient::send_line)
+      .def("connected", &UdpClient::connected)
+      .def("auto_start", &UdpClient::auto_start, py::arg("start") = true)
       .def(
           "use_line_framer",
-          [](Udp& self, const std::string& d, bool i, size_t m) {
+          [](UdpClient& self, const std::string& d, bool i, size_t m) {
             self.framer(std::make_unique<framer::LineFramer>(d, i, m));
             return &self;
           },
           py::arg("delimiter") = "\n", py::arg("include_delimiter") = false, py::arg("max_length") = 65536)
       .def("use_packet_framer",
-           [](Udp& self, const std::vector<uint8_t>& s, const std::vector<uint8_t>& e, size_t m) {
+           [](UdpClient& self, const std::vector<uint8_t>& s, const std::vector<uint8_t>& e, size_t m) {
              self.framer(std::make_unique<framer::PacketFramer>(s, e, m));
              return &self;
            })
       .def("on_message",
-           [](Udp& self, std::function<void(const MessageContext&)> h) {
+           [](UdpClient& self, std::function<void(const MessageContext&)> h) {
              self.on_message([h](const MessageContext& ctx) {
                py::gil_scoped_acquire gil;
                h(ctx);
@@ -445,7 +453,7 @@ PYBIND11_MODULE(unilink_py, m) {
              return &self;
            })
       .def("on_data",
-           [](Udp& self, std::function<void(const MessageContext&)> h) {
+           [](UdpClient& self, std::function<void(const MessageContext&)> h) {
              self.on_data([h](const MessageContext& ctx) {
                py::gil_scoped_acquire gil;
                h(ctx);
@@ -453,7 +461,7 @@ PYBIND11_MODULE(unilink_py, m) {
              return &self;
            })
       .def("on_connect",
-           [](Udp& self, std::function<void(const ConnectionContext&)> h) {
+           [](UdpClient& self, std::function<void(const ConnectionContext&)> h) {
              self.on_connect([h](const ConnectionContext& ctx) {
                py::gil_scoped_acquire gil;
                h(ctx);
@@ -461,14 +469,14 @@ PYBIND11_MODULE(unilink_py, m) {
              return &self;
            })
       .def("on_disconnect",
-           [](Udp& self, std::function<void(const ConnectionContext&)> h) {
+           [](UdpClient& self, std::function<void(const ConnectionContext&)> h) {
              self.on_disconnect([h](const ConnectionContext& ctx) {
                py::gil_scoped_acquire gil;
                h(ctx);
              });
              return &self;
            })
-      .def("on_error", [](Udp& self, std::function<void(const ErrorContext&)> h) {
+      .def("on_error", [](UdpClient& self, std::function<void(const ErrorContext&)> h) {
         self.on_error([h](const ErrorContext& ctx) {
           py::gil_scoped_acquire gil;
           h(ctx);
@@ -485,12 +493,14 @@ PYBIND11_MODULE(unilink_py, m) {
              py::gil_scoped_release release;
              return self.start().get();
            })
+      .def("start_sync", &UdpServer::start_sync)
       .def("stop", &UdpServer::stop)
       .def("broadcast", &UdpServer::broadcast)
       .def("send_to", &UdpServer::send_to)
       .def("client_count", &UdpServer::client_count)
       .def("connected_clients", &UdpServer::connected_clients)
       .def("listening", &UdpServer::listening)
+      .def("auto_start", &UdpServer::auto_start, py::arg("start") = true)
       .def("session_timeout", &UdpServer::session_timeout)
       .def(
           "use_line_framer",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -142,7 +142,7 @@ namespace unilink::wrapper {
 
     class TcpClient : public ChannelInterface;
     class Serial : public ChannelInterface;
-    class Udp : public ChannelInterface;
+    class UdpClient : public ChannelInterface;
     class UdsClient : public ChannelInterface;
     class TcpServer : public ServerInterface;
     class UdsServer : public ServerInterface;

--- a/docs/architecture/wrapper_contract.md
+++ b/docs/architecture/wrapper_contract.md
@@ -3,7 +3,7 @@
 > Public wrapper behavior note
 >
 > This document describes the intended application-facing behavior of the wrapper layer:
-> `TcpClient`, `TcpServer`, `Udp`, `UdpServer`, `Serial`, `UdsClient`, and `UdsServer`.
+> `TcpClient`, `TcpServer`, `UdpClient`, `UdpServer`, `Serial`, `UdsClient`, and `UdsServer`.
 > For lower-level transport guarantees, see `docs/architecture/channel_contract.md`.
 
 ## Scope
@@ -31,11 +31,11 @@ This document captures the behavioral contract currently enforced by the wrapper
 - `stop()` is intended to be idempotent from the caller's perspective.
 - Shutdown may clear pending startup futures with `false` when startup did not complete.
 
-### 3. `auto_manage(true)` follows the same startup contract
+### 3. `auto_start(true)` follows the same startup contract
 
-- Enabling `auto_manage(true)` triggers the same wrapper startup path used by explicit `start()`.
+- Enabling `auto_start(true)` triggers the same wrapper startup path used by explicit `start()`.
 - Auto-managed startup is not a separate fast path with weaker guarantees.
-- Callback registration should still happen before enabling `auto_manage(true)` or before calling `start()`.
+- Callback registration should still happen before enabling `auto_start(true)` or before calling `start()`.
 
 ## External `io_context` Contract
 

--- a/docs/guides/core/best_practices.md
+++ b/docs/guides/core/best_practices.md
@@ -111,7 +111,7 @@ auto client2 = tcp_client("server2.com", 8080).build();
 // GOOD - Automatic cleanup
 {
     auto client = unilink::tcp_client("server.com", 8080)
-        .auto_manage(true)  // Auto cleanup
+        .auto_start(true)  // Auto cleanup
         .build();
     
     // Use client...
@@ -156,7 +156,7 @@ class Application {
 };
 ```
 
-> Tip: Register all callbacks before calling `.auto_manage(true)` or manually invoking `start()`, because `auto_manage(true)` now starts the connection immediately.
+> Tip: Register all callbacks before calling `.auto_start(true)` or manually invoking `start()`, because `auto_start(true)` now starts the connection immediately.
 
 > Advanced: If you supply your own `boost::asio::io_context` to the wrappers, unilink will not run or stop it for you (unless you explicitly opt in with `manage_external_context(true)`). Make sure the context is running on a thread you control.
 

--- a/docs/guides/core/python_bindings.md
+++ b/docs/guides/core/python_bindings.md
@@ -125,14 +125,14 @@ serial = unilink.Serial("/dev/ttyUSB0", 115200)
 # Configure
 serial.baud_rate(9600)
 serial.retry_interval(datetime.timedelta(milliseconds=1000))
-serial.auto_manage(True) # Automatically starts
+serial.auto_start(True) # Automatically starts
 
 def on_data(ctx):
     print(f"Serial Data: {ctx.data}")
 
 serial.on_data(on_data)
 
-# If not using auto_manage, call start()
+# If not using auto_start, call start()
 # serial.start()
 
 serial.send("AT\r\n")
@@ -154,7 +154,7 @@ config.local_port = 8081
 config.remote_address = "127.0.0.1"
 config.remote_port = 8080
 
-udp = unilink.Udp(config)
+udp = unilink.UdpClient(config)
 
 def on_data(ctx):
     print(f"UDP Received: {ctx.data}")
@@ -245,7 +245,7 @@ The bindings are designed to be thread-safe. When C++ triggers a callback, it au
 ### Lifecycle Management
 - **`start()`**: Blocks until the initial start attempt completes and returns `True` or `False`.
 - **`stop()`**: Synchronously stops all I/O operations and joins internal threads.
-- **`auto_manage(True)`**: When enabled, the channel starts immediately and stops when the Python object is garbage collected.
+- **`auto_start(True)`**: When enabled, the channel starts immediately and stops when the Python object is garbage collected.
 
 ### Configuration
 - **`UdpConfig`**: A dedicated class for UDP settings (buffer sizes, memory pools, etc.).

--- a/docs/reference/api_guide.md
+++ b/docs/reference/api_guide.md
@@ -42,7 +42,7 @@ auto channel = unilink::{type}(params)
 | `.on_connect(callback)`          | Handle connection events (`const ConnectionContext&`)             | None     |
 | `.on_disconnect(callback)`       | Handle disconnection (`const ConnectionContext&`)                 | None     |
 | `.on_error(callback)`            | Handle errors (`const ErrorContext&`)                             | None     |
-| `.auto_manage(bool)`             | Auto-start/stop the wrapper (starts immediately when `true`)      | `false`  |
+| `.auto_start(bool)`             | Auto-start/stop the wrapper (starts immediately when `true`)      | `false`  |
 | `.independent_context(bool)`     | Create and run a dedicated `io_context` thread managed by unilink | `false`  |
 | `.use_line_framer(...)`          | Split incoming bytes into delimiter-based messages                | Disabled |
 | `.use_packet_framer(...)`        | Split incoming bytes into packet-based messages                   | Disabled |
@@ -77,10 +77,12 @@ Use `.on_message()` together with a framer when you want callback flow to operat
 **Lifecycle Methods:**
 | Method | Description |
 | ------------------------------------ | ---------------------------------------------------------------------- |
-| `->start()` | **Required**: Start the connection |
+| `->start()` | Start the connection (returns `std::future<bool>`) |
+| `->start_sync()` | Start the connection and block until established (returns `bool`) |
 | `->stop()` | Stop the connection |
-| `TcpClient` / `Serial` / `Udp` / `UdsClient`: `->send(data)` / `->send_line(text)` | Send data to the configured peer |
-| `TcpClient` / `Serial` / `Udp` / `UdsClient`: `->connected()` | Check channel state |
+| `TcpClient` / `Serial` / `UdpClient` / `UdsClient`: `->send(data)` / `->send_line(text)` | Send data to the configured peer |
+| `TcpClient` / `Serial` / `UdpClient` / `UdsClient`: `->connected()` | Check channel state |
+
 | `TcpServer` / `UdsServer`: `->broadcast(data)` / `->send_to(client_id, data)` | Send data to one or more connected clients |
 | `TcpServer` / `UdsServer`: `->listening()` | Check if the server socket is bound and listening |
 
@@ -99,7 +101,7 @@ tcp_server(port)
 
 - **Default**: Builders use the shared `IoContextManager` thread; unilink starts/stops it for you.
 - **`independent_context(true)`**: Builder creates its own `io_context` and runs it on an internal thread; cleanup is automatic.
-- **External `io_context`**: If you manually pass a custom `io_context` to wrapper constructors, unilink will _not_ run/stop it unless you call `manage_external_context(true)` on the wrapper. In that case, callbacks should be registered before enabling `auto_manage(true)` (it starts immediately).
+- **External `io_context`**: If you manually pass a custom `io_context` to wrapper constructors, unilink will _not_ run/stop it unless you call `manage_external_context(true)` on the wrapper. In that case, callbacks should be registered before enabling `auto_start(true)` (it starts immediately).
 
 ---
 
@@ -156,7 +158,7 @@ unilink::tcp_client(const std::string& host, uint16_t port)
 | `max_retries(count)`        | `int`      | Set maximum reconnect attempts (`-1` for unlimited)        |
 | `connection_timeout(ms)`    | `unsigned` | Set connection timeout in milliseconds                     |
 | `independent_context()`     | `bool`     | Use separate IO thread (for testing)                       |
-| `auto_manage()`             | `bool`     | Auto-start immediately and stop on destruction             |
+| `auto_start()`             | `bool`     | Auto-start immediately and stop on destruction             |
 
 #### Instance Methods
 
@@ -294,7 +296,7 @@ unilink::tcp_server(uint16_t port)
 | `unlimited_clients()`       | None                         | Accept unlimited clients                                             |
 | `port_retry()`       | `bool, retries, interval_ms` | Retry if port is in use                                              |
 | `independent_context()`     | `bool`                       | Run on a dedicated `io_context` thread managed by unilink            |
-| `auto_manage()`             | `bool`                       | Auto-start immediately and stop on destruction                       |
+| `auto_start()`             | `bool`                       | Auto-start immediately and stop on destruction                       |
 
 Multi-client callbacks use the standard `ConnectionContext` and `MessageContext` which contain `client_id()` and `client_info()` accessors.
 
@@ -410,7 +412,7 @@ unilink::serial(const std::string& device, uint32_t baud_rate)
 | `flow_control(mode)`        | `string`   | Set flow control before `build()`                         |
 | `retry_interval(ms)`        | `unsigned` | Set reconnection interval (default `3000`)                |
 | `independent_context()`     | `bool`     | Run on a dedicated `io_context` thread managed by unilink |
-| `auto_manage()`             | `bool`     | Auto-start immediately and stop on destruction            |
+| `auto_start()`             | `bool`     | Auto-start immediately and stop on destruction            |
 
 #### Instance Methods
 
@@ -540,7 +542,7 @@ unilink::udp_client(uint16_t local_port)
 | `local_port(port)`          | `uint16_t`         | Bind to a specific local port        |
 | `remote(ip, port)`          | `string, uint16_t` | Set default destination for `send()` |
 | `independent_context()`     | `bool`             | Run on dedicated IO thread           |
-| `auto_manage()`             | `bool`             | Auto-start/stop lifecycle            |
+| `auto_start()`             | `bool`             | Auto-start/stop lifecycle            |
 
 #### Instance Methods
 
@@ -626,7 +628,7 @@ unilink::uds_client(const std::string& socket_path)
 | `max_clients(max)`          | `size_t`   | Allow up to `max` concurrent clients |
 | `unlimited_clients()`       | None       | Allow unlimited clients              |
 | `independent_context()`     | `bool`     | Run on dedicated IO thread           |
-| `auto_manage()`             | `bool`     | Auto-start/stop lifecycle            |
+| `auto_start()`             | `bool`     | Auto-start/stop lifecycle            |
 
 #### Builder Methods (UDS Client)
 
@@ -636,7 +638,7 @@ unilink::uds_client(const std::string& socket_path)
 | `max_retries(count)`        | `int`      | Set maximum reconnect attempts             |
 | `connection_timeout(ms)`    | `unsigned` | Set connection timeout in milliseconds     |
 | `independent_context()`     | `bool`     | Run on a dedicated `io_context` thread     |
-| `auto_manage()`             | `bool`     | Auto-start/stop lifecycle                  |
+| `auto_start()`             | `bool`     | Auto-start/stop lifecycle                  |
 
 #### Instance Methods (UDS Client)
 

--- a/docs/tutorials/05_udp_communication.md
+++ b/docs/tutorials/05_udp_communication.md
@@ -35,7 +35,7 @@ int main() {
         })
         .build();
 
-    if (!receiver->start().get()) {
+    if (!receiver->start_sync()) {
         std::cerr << "Failed to start receiver" << std::endl;
         return 1;
     }

--- a/examples/tcp/multi-chat/multi_chat_tcp_client.cc
+++ b/examples/tcp/multi-chat/multi_chat_tcp_client.cc
@@ -35,7 +35,7 @@ class MultiChatClient {
 
   void run() {
     auto client = unilink::tcp_client(host_, port_)
-                      .auto_manage(true)
+                      .auto_start(true)
                       .on_connect([](const unilink::ConnectionContext&) {
                         std::cout << "\n*** Connected to Multi-Chat Server ***" << std::endl;
                       })

--- a/examples/tcp/single-echo/echo_tcp_server.cc
+++ b/examples/tcp/single-echo/echo_tcp_server.cc
@@ -69,7 +69,7 @@ class EchoServer {
     }
   }
 
-  void on_client_connect(const unilink::ConnectionContext& ctx) {
+  void on_connect(const unilink::ConnectionContext& ctx) {
     logger_.info("server", "connect", "Client " + std::to_string(ctx.client_id()) + " connected: " + ctx.client_info());
   }
 
@@ -98,7 +98,7 @@ class EchoServer {
     server_ = unilink::tcp_server(port_)
                   .single_client()
                   .port_retry(true, 3, 1000)
-                  .on_connect([this](const unilink::ConnectionContext& ctx) { on_client_connect(ctx); })
+                  .on_connect([this](const unilink::ConnectionContext& ctx) { on_connect(ctx); })
                   .on_disconnect([this](const unilink::ConnectionContext& ctx) { on_client_disconnect(ctx); })
                   .on_data([this](const unilink::MessageContext& ctx) { on_data(ctx); })
                   .on_error([this](const unilink::ErrorContext& ctx) { on_error(ctx); })

--- a/test/integration/core/test_safety_integrated.cc
+++ b/test/integration/core/test_safety_integrated.cc
@@ -49,7 +49,7 @@ TEST_F(SafetyIntegratedTest, NullCallbackSafety) {
 
   // These should not crash
   server->on_data(nullptr);
-  server->on_client_connect(nullptr);
+  server->on_connect(nullptr);
   server->on_client_disconnect(nullptr);
   server->on_error(nullptr);
 

--- a/test/integration/core/test_stable_integration.cc
+++ b/test/integration/core/test_stable_integration.cc
@@ -41,7 +41,7 @@ TEST_F(StableCoreIntegrationTest, ServerClientStability) {
 
   ASSERT_TRUE(server->start().get());
 
-  auto client = tcp_client("127.0.0.1", port_).auto_manage(true).build();
+  auto client = tcp_client("127.0.0.1", port_).auto_start(true).build();
 
   EXPECT_TRUE(TestUtils::waitForCondition([&]() { return client->connected(); }, 2000));
 

--- a/test/integration/tcp/test_integration.cc
+++ b/test/integration/tcp/test_integration.cc
@@ -60,7 +60,7 @@ TEST_F(TcpIntegrationTest, AutoInitialization) {
 TEST_F(TcpIntegrationTest, MethodChaining) {
   auto client =
       unilink::tcp_client("127.0.0.1", test_port_)
-          .auto_manage(false)
+          .auto_start(false)
           .on_connect([](const wrapper::ConnectionContext&) { std::cout << "Connected!" << std::endl; })
           .on_disconnect([](const wrapper::ConnectionContext&) { std::cout << "Disconnected!" << std::endl; })
           .on_data([](const wrapper::MessageContext& ctx) { std::cout << "Data: " << ctx.data() << std::endl; })
@@ -170,7 +170,7 @@ TEST_F(TcpIntegrationTest, MultipleClientConnections) {
 
   std::vector<std::unique_ptr<wrapper::TcpClient>> clients;
   for (int i = 0; i < 3; ++i) {
-    auto client = unilink::tcp_client("127.0.0.1", comm_port).auto_manage(true).build();
+    auto client = unilink::tcp_client("127.0.0.1", comm_port).auto_start(true).build();
     clients.push_back(std::move(client));
     TestUtils::waitFor(100);
   }
@@ -180,7 +180,7 @@ TEST_F(TcpIntegrationTest, MultipleClientConnections) {
 
 TEST_F(TcpIntegrationTest, ComprehensiveBuilderMethodChaining) {
   auto client = unilink::tcp_client("127.0.0.1", test_port_)
-                    .auto_manage(false)
+                    .auto_start(false)
                     .independent_context(true)
                     .on_connect([](const wrapper::ConnectionContext&) {})
                     .on_data([](const wrapper::MessageContext&) {})
@@ -190,7 +190,7 @@ TEST_F(TcpIntegrationTest, ComprehensiveBuilderMethodChaining) {
 
   auto server = unilink::tcp_server(test_port_)
                     .unlimited_clients()
-                    .auto_manage(false)
+                    .auto_start(false)
                     .on_connect([](const wrapper::ConnectionContext&) {})
                     .on_data([](const wrapper::MessageContext&) {})
                     .build();

--- a/test/integration/tcp/test_simple_server.cc
+++ b/test/integration/tcp/test_simple_server.cc
@@ -81,7 +81,7 @@ TEST_F(SimpleServerTest, AutoStartServer) {
   std::cout << "Testing auto-start server with port: " << test_port << std::endl;
 
   // Create server (auto-manage triggers start)
-  server_ = unilink::tcp_server(test_port).unlimited_clients().auto_manage(true).build();
+  server_ = unilink::tcp_server(test_port).unlimited_clients().auto_start(true).build();
 
   ASSERT_NE(server_, nullptr) << "Server creation failed";
   std::cout << "Server created with auto-start" << std::endl;

--- a/test/integration/tcp/test_tcp_flood.cc
+++ b/test/integration/tcp/test_tcp_flood.cc
@@ -53,7 +53,7 @@ TEST_F(TcpFloodTest, FloodServer) {
 
   for (int i = 0; i < num_clients; ++i) {
     clients.emplace_back([&]() {
-      auto client = tcp_client("127.0.0.1", test_port_).auto_manage(true).build();
+      auto client = tcp_client("127.0.0.1", test_port_).auto_start(true).build();
       bool connected = TestUtils::waitForCondition([&]() { return client->connected(); }, 5000);
       if (!connected) {
         client_connect_failed.store(true);

--- a/test/unit/builder/test_builder.cc
+++ b/test/unit/builder/test_builder.cc
@@ -45,7 +45,7 @@ class BuilderTest : public ::testing::Test {
 
   void setupConnectionHandler() {
     auto conn_cb = [this](const wrapper::ConnectionContext&) { connection_established_ = true; };
-    if (server_) server_->on_client_connect(conn_cb);
+    if (server_) server_->on_connect(conn_cb);
     if (client_) client_->on_connect(conn_cb);
     if (serial_) serial_->on_connect(conn_cb);
   }
@@ -72,7 +72,7 @@ class BuilderTest : public ::testing::Test {
   std::shared_ptr<wrapper::TcpServer> server_;
   std::shared_ptr<wrapper::TcpClient> client_;
   std::shared_ptr<wrapper::Serial> serial_;
-  std::shared_ptr<wrapper::Udp> udp_;
+  std::shared_ptr<wrapper::UdpClient> udp_;
 
   std::vector<std::string> data_received_;
   bool connection_established_;

--- a/test/unit/transport/test_tcp_rst.cpp
+++ b/test/unit/transport/test_tcp_rst.cpp
@@ -35,7 +35,7 @@ class TcpRstTest : public ::testing::Test {
   void SetUp() override {
     port_ = TestUtils::getAvailableTestPort();
     server_ = std::make_shared<wrapper::TcpServer>(port_);
-    server_->on_client_connect([this](const wrapper::ConnectionContext&) { connected_clients_++; });
+    server_->on_connect([this](const wrapper::ConnectionContext&) { connected_clients_++; });
     server_->on_client_disconnect([this](const wrapper::ConnectionContext&) { disconnected_clients_++; });
     auto f = server_->start();
     f.get();  // Ensure listening starts

--- a/test/unit/wrapper/test_serial_advanced.cc
+++ b/test/unit/wrapper/test_serial_advanced.cc
@@ -109,7 +109,7 @@ class SerialWrapperAdvancedTest : public ::testing::Test {
 };
 
 TEST_F(SerialWrapperAdvancedTest, AutoManageStartsAndStopsChannel) {
-  auto serial = unilink::serial(device_, 9600).auto_manage(true).build();
+  auto serial = unilink::serial(device_, 9600).auto_start(true).build();
 
   std::atomic<bool> connected{false};
   std::atomic<bool> disconnected{false};
@@ -150,7 +150,7 @@ TEST_F(SerialWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
   auto transport_serial = transport::Serial::create(cfg, std::make_unique<FakeSerialPort>(ioc), ioc);
   wrapper::Serial serial(std::static_pointer_cast<interface::Channel>(transport_serial));
 
-  serial.auto_manage(true);
+  serial.auto_start(true);
   ioc.run_for(50ms);
 
   EXPECT_TRUE(serial.connected());

--- a/test/unit/wrapper/test_tcp_client_advanced.cc
+++ b/test/unit/wrapper/test_tcp_client_advanced.cc
@@ -113,7 +113,7 @@ TEST_F(AdvancedTcpClientCoverageTest, ManagedExternalContextRestartsStoppedIoCon
 TEST_F(AdvancedTcpClientCoverageTest, AutoManageStartsClientAndInvokesCallback) {
   std::atomic<bool> connected{false};
   client_ = unilink::tcp_client("127.0.0.1", test_port_)
-                .auto_manage(true)
+                .auto_start(true)
                 .on_connect([&](const wrapper::ConnectionContext&) { connected = true; })
                 .build();
 

--- a/test/unit/wrapper/test_tcp_server_advanced.cc
+++ b/test/unit/wrapper/test_tcp_server_advanced.cc
@@ -117,7 +117,7 @@ TEST_F(AdvancedTcpServerCoverageTest, SendAndCountReflectLiveClientsAndReturnSta
   std::mutex ids_mutex;
 
   server_ = unilink::tcp_server(test_port_).build();
-  server_->on_client_connect([&](const wrapper::ConnectionContext& ctx) {
+  server_->on_connect([&](const wrapper::ConnectionContext& ctx) {
     std::lock_guard<std::mutex> lk(ids_mutex);
     ids.push_back(ctx.client_id());
   });
@@ -198,8 +198,8 @@ TEST_F(AdvancedTcpServerCoverageTest, ConcurrentStartStop) {
 TEST_F(AdvancedTcpServerCoverageTest, HandlerReplacement) {
   std::atomic<int> count{0};
   server_ = unilink::tcp_server(test_port_).build();
-  server_->on_client_connect([&](const wrapper::ConnectionContext&) { count = 1; });
-  server_->on_client_connect([&](const wrapper::ConnectionContext&) { count = 2; });
+  server_->on_connect([&](const wrapper::ConnectionContext&) { count = 1; });
+  server_->on_connect([&](const wrapper::ConnectionContext&) { count = 2; });
 
   server_->start();
   auto client = unilink::tcp_client("127.0.0.1", test_port_).build();

--- a/test/unit/wrapper/test_udp_failure.cc
+++ b/test/unit/wrapper/test_udp_failure.cc
@@ -31,7 +31,7 @@ using namespace unilink;
 TEST(UdpFailureTest, WrapperSendWithoutStart) {
   config::UdpConfig cfg;
   cfg.local_port = 0;  // Ephemeral
-  wrapper::Udp udp(cfg);
+  wrapper::UdpClient udp(cfg);
 
   // Not started
   EXPECT_FALSE(udp.connected());

--- a/test/unit/wrapper/test_udp_options.cc
+++ b/test/unit/wrapper/test_udp_options.cc
@@ -46,12 +46,12 @@ TEST_F(UdpOptionsTest, SetterCoverage) {
   UdpConfig config;
   config.local_port = 0;
 
-  Udp udp(config);
+  UdpClient udp(config);
 
-  // Test auto_manage setter
-  // It returns ChannelInterface& so we can chain it, but Udp wrapper implements it.
-  udp.auto_manage(true);
-  udp.auto_manage(false);
+  // Test auto_start setter
+  // It returns ChannelInterface& so we can chain it, but UdpClient wrapper implements it.
+  udp.auto_start(true);
+  udp.auto_start(false);
 
   // Test manage_external_context
   udp.manage_external_context(true);
@@ -63,10 +63,10 @@ TEST_F(UdpOptionsTest, ConstructorWithExternalContext) {
   config.local_port = 0;
 
   auto ioc = std::make_shared<boost::asio::io_context>();
-  Udp udp(config, ioc);
+  UdpClient udp(config, ioc);
 
   // Should not throw
-  udp.auto_manage(false);
+  udp.auto_start(false);
 }
 
 TEST_F(UdpOptionsTest, AutoManageStartsInjectedTransport) {
@@ -88,14 +88,14 @@ TEST_F(UdpOptionsTest, AutoManageStartsInjectedTransport) {
   auto sender_transport = unilink::transport::UdpChannel::create(sender_cfg, sender_ioc);
   auto receiver_transport = unilink::transport::UdpChannel::create(receiver_cfg, receiver_ioc);
 
-  Udp receiver(std::static_pointer_cast<unilink::interface::Channel>(receiver_transport));
+  UdpClient receiver(std::static_pointer_cast<unilink::interface::Channel>(receiver_transport));
   auto receiver_started = receiver.start();
   receiver_ioc.run_for(50ms);
   ASSERT_EQ(receiver_started.wait_for(100ms), std::future_status::ready);
   EXPECT_TRUE(receiver_started.get());
 
-  Udp sender(std::static_pointer_cast<unilink::interface::Channel>(sender_transport));
-  sender.auto_manage(true);
+  UdpClient sender(std::static_pointer_cast<unilink::interface::Channel>(sender_transport));
+  sender.auto_start(true);
   sender_ioc.run_for(50ms);
 
   EXPECT_TRUE(sender.connected());
@@ -116,7 +116,7 @@ TEST_F(UdpOptionsTest, StartFutureReflectsBindFailure) {
   cfg.local_address = "127.0.0.1";
   cfg.local_port = occupied_socket.local_endpoint().port();
 
-  Udp udp(cfg);
+  UdpClient udp(cfg);
   auto started = udp.start();
 
   ASSERT_EQ(started.wait_for(2s), std::future_status::ready);

--- a/test/unit/wrapper/test_udp_server_advanced.cc
+++ b/test/unit/wrapper/test_udp_server_advanced.cc
@@ -37,7 +37,7 @@ TEST(UdpServerWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
   auto transport_server = transport::UdpChannel::create(cfg, ioc);
   wrapper::UdpServer server(std::static_pointer_cast<interface::Channel>(transport_server));
 
-  server.auto_manage(true);
+  server.auto_start(true);
   ioc.run_for(50ms);
 
   EXPECT_TRUE(server.listening());
@@ -69,8 +69,8 @@ TEST(UdpServerWrapperContractTest, ConnectHandlerReplacementUsesLatestCallback) 
   std::atomic<int> connected{0};
   test::wrapper_support::UdpServerLoopbackHarness harness;
   auto server = harness.start_server();
-  server->on_client_connect([&](const wrapper::ConnectionContext&) { connected = 1; });
-  server->on_client_connect([&](const wrapper::ConnectionContext&) { connected = 2; });
+  server->on_connect([&](const wrapper::ConnectionContext&) { connected = 1; });
+  server->on_connect([&](const wrapper::ConnectionContext&) { connected = 2; });
 
   auto client = harness.start_sender();
   (void)client;

--- a/test/unit/wrapper/test_udp_state.cpp
+++ b/test/unit/wrapper/test_udp_state.cpp
@@ -45,7 +45,7 @@ TEST_F(UdpStateTest, BindConflict) {
   UdpConfig cfg2;
   cfg2.local_address = "127.0.0.1";
   cfg2.local_port = port;  // Same port already occupied by a live UDP socket
-  Udp udp2(cfg2);
+  UdpClient udp2(cfg2);
 
   auto udp2_started = udp2.start();
   ASSERT_EQ(udp2_started.wait_for(2s), std::future_status::ready);
@@ -60,7 +60,7 @@ TEST_F(UdpStateTest, BindConflict) {
 TEST_F(UdpStateTest, UninitializedUse) {
   UdpConfig cfg;
   cfg.local_port = 0;
-  Udp udp(cfg);
+  UdpClient udp(cfg);
 
   // Object created but not started (uninitialized state)
   EXPECT_FALSE(udp.connected());

--- a/test/unit/wrapper/test_udp_stop_perf.cc
+++ b/test/unit/wrapper/test_udp_stop_perf.cc
@@ -20,7 +20,7 @@ TEST(UdpWrapperTest, StopPerformance) {
   cfg.remote_address = "127.0.0.1";
   cfg.remote_port = 19001;
 
-  wrapper::Udp udp(cfg);
+  wrapper::UdpClient udp(cfg);
   udp.start();
 
   auto start = std::chrono::high_resolution_clock::now();
@@ -40,7 +40,7 @@ TEST(UdpWrapperTest, StopSafetyWithExternalIOC) {
   cfg.local_port = 0;
 
   {
-    wrapper::Udp udp(cfg, ioc);
+    wrapper::UdpClient udp(cfg, ioc);
     std::atomic<int> callbacks{0};
     udp.on_data([&](const wrapper::MessageContext&) { callbacks++; });
     udp.start();

--- a/test/unit/wrapper/test_uds_advanced.cc
+++ b/test/unit/wrapper/test_uds_advanced.cc
@@ -54,7 +54,7 @@ TEST(UdsClientWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
   EXPECT_CALL(*mock_socket, async_read_some(_, _)).WillRepeatedly(Invoke([](const auto&, auto) {}));
 
   UdsClient client(std::static_pointer_cast<interface::Channel>(transport_client));
-  client.auto_manage(true);
+  client.auto_start(true);
 
   ioc.restart();
   ioc.run_for(100ms);
@@ -136,7 +136,7 @@ TEST(UdsServerWrapperAdvancedTest, AutoManageStartsInjectedTransport) {
   EXPECT_CALL(*mock_acceptor, async_accept(_)).WillOnce(Invoke([](auto) {}));
 
   UdsServer server(std::static_pointer_cast<interface::Channel>(transport_server));
-  server.auto_manage(true);
+  server.auto_start(true);
 
   ioc.restart();
   ioc.poll();
@@ -270,8 +270,8 @@ TEST(UdsServerWrapperContractTest, ConnectHandlerReplacementUsesLatestCallback) 
 
   std::atomic<int> count{0};
   UdsServer server(std::static_pointer_cast<interface::Channel>(transport_server));
-  server.on_client_connect([&](const ConnectionContext&) { count = 1; });
-  server.on_client_connect([&](const ConnectionContext&) { count = 2; });
+  server.on_connect([&](const ConnectionContext&) { count = 1; });
+  server.on_connect([&](const ConnectionContext&) { count = 2; });
 
   auto started = server.start();
   ioc.restart();

--- a/test/unit/wrapper/wrapper_contract_test_utils.hpp
+++ b/test/unit/wrapper/wrapper_contract_test_utils.hpp
@@ -196,14 +196,14 @@ class UdpServerLoopbackHarness {
     return server_;
   }
 
-  std::shared_ptr<wrapper::Udp> start_sender() {
+  std::shared_ptr<wrapper::UdpClient> start_sender() {
     config::UdpConfig client_cfg;
     client_cfg.local_address = "127.0.0.1";
     client_cfg.local_port = 0;
     client_cfg.remote_address = std::string("127.0.0.1");
     client_cfg.remote_port = port_;
 
-    client_ = std::make_shared<wrapper::Udp>(client_cfg);
+    client_ = std::make_shared<wrapper::UdpClient>(client_cfg);
     auto started = client_->start();
     if (!started.get()) {
       throw std::runtime_error("Failed to start UDP test client");
@@ -239,7 +239,7 @@ class UdpServerLoopbackHarness {
  private:
   uint16_t port_;
   std::shared_ptr<wrapper::UdpServer> server_;
-  std::shared_ptr<wrapper::Udp> client_;
+  std::shared_ptr<wrapper::UdpClient> client_;
 };
 
 }  // namespace unilink::test::wrapper_support

--- a/unilink/builder/ibuilder.hpp
+++ b/unilink/builder/ibuilder.hpp
@@ -59,10 +59,10 @@ class BuilderInterface {
 
   /**
    * @brief Enable auto-manage functionality
-   * @param auto_manage Whether to automatically manage the wrapper lifecycle
+   * @param auto_start Whether to automatically manage the wrapper lifecycle
    * @return Derived& Reference to this builder for method chaining
    */
-  virtual Derived& auto_manage(bool auto_manage = true) = 0;
+  virtual Derived& auto_start(bool auto_start = true) = 0;
 
   /**
    * @brief Set data handler callback

--- a/unilink/builder/serial_builder.cc
+++ b/unilink/builder/serial_builder.cc
@@ -26,7 +26,7 @@ namespace builder {
 SerialBuilder::SerialBuilder(const std::string& device, uint32_t baud_rate)
     : device_(device),
       baud_rate_(baud_rate),
-      auto_manage_(false),
+      auto_start_(false),
       independent_context_(false),
       data_bits_(8),
       stop_bits_(1),
@@ -64,15 +64,15 @@ std::unique_ptr<wrapper::Serial> SerialBuilder::build() {
     serial->on_message(std::move(on_message_));
   }
 
-  if (auto_manage_) {
-    serial->auto_manage(true);
+  if (auto_start_) {
+    serial->auto_start(true);
   }
 
   return serial;
 }
 
-SerialBuilder& SerialBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+SerialBuilder& SerialBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 

--- a/unilink/builder/serial_builder.hpp
+++ b/unilink/builder/serial_builder.hpp
@@ -46,7 +46,7 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
 
   std::unique_ptr<wrapper::Serial> build() override;
 
-  SerialBuilder& auto_manage(bool auto_manage = true) override;
+  SerialBuilder& auto_start(bool auto_start = true) override;
 
   /**
    * @brief Set number of data bits
@@ -81,7 +81,7 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
  private:
   std::string device_;
   uint32_t baud_rate_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
 
   // Configuration

--- a/unilink/builder/tcp_client_builder.cc
+++ b/unilink/builder/tcp_client_builder.cc
@@ -27,7 +27,7 @@ namespace builder {
 TcpClientBuilder::TcpClientBuilder(const std::string& host, uint16_t port)
     : host_(host),
       port_(port),
-      auto_manage_(false),
+      auto_start_(false),
       independent_context_(false),
       retry_interval_(3000),
       max_retries_(-1),
@@ -64,15 +64,15 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder::build() {
     client->on_message(std::move(on_message_));
   }
 
-  if (auto_manage_) {
-    client->auto_manage(true);
+  if (auto_start_) {
+    client->auto_start(true);
   }
 
   return client;
 }
 
-TcpClientBuilder& TcpClientBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+TcpClientBuilder& TcpClientBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 

--- a/unilink/builder/tcp_client_builder.hpp
+++ b/unilink/builder/tcp_client_builder.hpp
@@ -46,7 +46,7 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
 
   std::unique_ptr<wrapper::TcpClient> build() override;
 
-  TcpClientBuilder& auto_manage(bool auto_manage = true) override;
+  TcpClientBuilder& auto_start(bool auto_start = true) override;
 
   /**
    * @brief Set connection retry interval
@@ -71,7 +71,7 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
  private:
   std::string host_;
   uint16_t port_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
 
   // Configuration

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -27,7 +27,7 @@ namespace builder {
 
 TcpServerBuilder::TcpServerBuilder(uint16_t port)
     : port_(port),
-      auto_manage_(false),
+      auto_start_(false),
       independent_context_(false),
       enable_port_retry_(false),
       max_port_retries_(3),
@@ -51,7 +51,7 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder::build() {
   }
 
   if (on_data_) server->on_data(on_data_);
-  if (on_connect_) server->on_client_connect(on_connect_);
+  if (on_connect_) server->on_connect(on_connect_);
   if (on_disconnect_) server->on_client_disconnect(on_disconnect_);
   if (on_error_) server->on_error(on_error_);
 
@@ -78,15 +78,15 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder::build() {
       server->max_clients(max_clients_);
   }
 
-  if (auto_manage_) {
-    server->auto_manage(true);
+  if (auto_start_) {
+    server->auto_start(true);
   }
 
   return server;
 }
 
-TcpServerBuilder& TcpServerBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+TcpServerBuilder& TcpServerBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 

--- a/unilink/builder/tcp_server_builder.hpp
+++ b/unilink/builder/tcp_server_builder.hpp
@@ -52,17 +52,10 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
 
   /**
    * @brief Enable auto-manage functionality
-   * @param auto_manage Whether to automatically manage the server lifecycle
+   * @param auto_start Whether to automatically manage the server lifecycle
    * @return TcpServerBuilder& Reference to this builder
    */
-  TcpServerBuilder& auto_manage(bool auto_manage = true) override;
-
-  /**
-   * @brief Helper for client connection events
-   */
-  TcpServerBuilder& on_client_connect(std::function<void(const wrapper::ConnectionContext&)> handler) {
-    return on_connect(std::move(handler));
-  }
+  TcpServerBuilder& auto_start(bool auto_start = true) override;
 
   /**
    * @brief Helper for client disconnection events
@@ -108,7 +101,7 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
 
  private:
   uint16_t port_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
 
   // Configuration

--- a/unilink/builder/udp_builder.cc
+++ b/unilink/builder/udp_builder.cc
@@ -26,17 +26,17 @@ namespace builder {
 
 // --- UdpClientBuilder Implementation ---
 
-UdpClientBuilder::UdpClientBuilder(uint16_t local_port) : auto_manage_(false), independent_context_(false) {
+UdpClientBuilder::UdpClientBuilder(uint16_t local_port) : auto_start_(false), independent_context_(false) {
   cfg_.local_port = local_port;
 }
 
-std::unique_ptr<wrapper::Udp> UdpClientBuilder::build() {
+std::unique_ptr<wrapper::UdpClient> UdpClientBuilder::build() {
   std::shared_ptr<boost::asio::io_context> ioc = nullptr;
   if (independent_context_) {
     ioc = std::make_shared<boost::asio::io_context>();
   }
 
-  auto udp = std::make_unique<wrapper::Udp>(cfg_, ioc);
+  auto udp = std::make_unique<wrapper::UdpClient>(cfg_, ioc);
   if (independent_context_) {
     udp->manage_external_context(true);
   }
@@ -53,15 +53,15 @@ std::unique_ptr<wrapper::Udp> UdpClientBuilder::build() {
     udp->on_message(std::move(on_message_));
   }
 
-  if (auto_manage_) {
-    udp->auto_manage(true);
+  if (auto_start_) {
+    udp->auto_start(true);
   }
 
   return udp;
 }
 
-UdpClientBuilder& UdpClientBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+UdpClientBuilder& UdpClientBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 
@@ -93,7 +93,7 @@ UdpClientBuilder& UdpClientBuilder::reuse_address(bool enable) {
 
 // --- UdpServerBuilder Implementation ---
 
-UdpServerBuilder::UdpServerBuilder(uint16_t local_port) : auto_manage_(false), independent_context_(false) {
+UdpServerBuilder::UdpServerBuilder(uint16_t local_port) : auto_start_(false), independent_context_(false) {
   cfg_.local_port = local_port;
 }
 
@@ -109,7 +109,7 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
   }
 
   if (on_data_) server->on_data(on_data_);
-  if (on_connect_) server->on_client_connect(on_connect_);
+  if (on_connect_) server->on_connect(on_connect_);
   if (on_disconnect_) server->on_client_disconnect(on_disconnect_);
   if (on_error_) server->on_error(on_error_);
 
@@ -121,15 +121,15 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
     server->on_message(on_message_);
   }
 
-  if (auto_manage_) {
+  if (auto_start_) {
     server->start();
   }
 
   return server;
 }
 
-UdpServerBuilder& UdpServerBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+UdpServerBuilder& UdpServerBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 

--- a/unilink/builder/udp_builder.hpp
+++ b/unilink/builder/udp_builder.hpp
@@ -38,13 +38,13 @@ namespace builder {
 #pragma warning(push)
 #pragma warning(disable : 4251)
 #endif
-class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::Udp, UdpClientBuilder> {
+class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClient, UdpClientBuilder> {
  public:
   explicit UdpClientBuilder(uint16_t local_port = 0);
 
-  std::unique_ptr<wrapper::Udp> build() override;
+  std::unique_ptr<wrapper::UdpClient> build() override;
 
-  UdpClientBuilder& auto_manage(bool auto_manage = true) override;
+  UdpClientBuilder& auto_start(bool auto_start = true) override;
 
   UdpClientBuilder& local_port(uint16_t port);
   UdpClientBuilder& remote(const std::string& address, uint16_t port);
@@ -54,7 +54,7 @@ class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::Udp, UdpCl
 
  private:
   config::UdpConfig cfg_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
 };
 #ifdef _MSC_VER
@@ -74,14 +74,7 @@ class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer,
 
   std::unique_ptr<wrapper::UdpServer> build() override;
 
-  UdpServerBuilder& auto_manage(bool auto_manage = true) override;
-
-  /**
-   * @brief Helper for client connection events
-   */
-  UdpServerBuilder& on_client_connect(std::function<void(const wrapper::ConnectionContext&)> handler) {
-    return on_connect(std::move(handler));
-  }
+  UdpServerBuilder& auto_start(bool auto_start = true) override;
 
   /**
    * @brief Helper for client disconnection events
@@ -97,7 +90,7 @@ class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer,
 
  private:
   config::UdpConfig cfg_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
 };
 #ifdef _MSC_VER

--- a/unilink/builder/uds_builder.cc
+++ b/unilink/builder/uds_builder.cc
@@ -26,7 +26,7 @@ namespace builder {
 
 UdsClientBuilder::UdsClientBuilder(const std::string& socket_path)
     : socket_path_(socket_path),
-      auto_manage_(false),
+      auto_start_(false),
       independent_context_(false),
       retry_interval_(3000),
       max_retries_(-1),
@@ -60,15 +60,15 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder::build() {
     client->on_message(std::move(on_message_));
   }
 
-  if (auto_manage_) {
-    client->auto_manage(true);
+  if (auto_start_) {
+    client->auto_start(true);
   }
 
   return client;
 }
 
-UdsClientBuilder& UdsClientBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+UdsClientBuilder& UdsClientBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 
@@ -95,7 +95,7 @@ UdsClientBuilder& UdsClientBuilder::independent_context(bool use_independent) {
 // UdsServerBuilder implementation
 
 UdsServerBuilder::UdsServerBuilder(const std::string& socket_path)
-    : socket_path_(socket_path), auto_manage_(false), independent_context_(false), max_clients_(100) {}
+    : socket_path_(socket_path), auto_start_(false), independent_context_(false), max_clients_(100) {}
 
 std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
   AutoInitializer::ensure_io_context_running();
@@ -110,7 +110,7 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
   }
 
   if (on_data_) server->on_data(on_data_);
-  if (on_connect_) server->on_client_connect(on_connect_);
+  if (on_connect_) server->on_connect(on_connect_);
   if (on_disconnect_) server->on_client_disconnect(on_disconnect_);
   if (on_error_) server->on_error(on_error_);
 
@@ -125,15 +125,15 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
   server->idle_timeout(idle_timeout_);
   server->max_clients(max_clients_);
 
-  if (auto_manage_) {
-    server->auto_manage(true);
+  if (auto_start_) {
+    server->auto_start(true);
   }
 
   return server;
 }
 
-UdsServerBuilder& UdsServerBuilder::auto_manage(bool auto_manage) {
-  auto_manage_ = auto_manage;
+UdsServerBuilder& UdsServerBuilder::auto_start(bool auto_start) {
+  auto_start_ = auto_start;
   return *this;
 }
 

--- a/unilink/builder/uds_builder.hpp
+++ b/unilink/builder/uds_builder.hpp
@@ -40,7 +40,7 @@ class UNILINK_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient,
   explicit UdsClientBuilder(const std::string& socket_path);
 
   std::unique_ptr<wrapper::UdsClient> build() override;
-  UdsClientBuilder& auto_manage(bool auto_manage = true) override;
+  UdsClientBuilder& auto_start(bool auto_start = true) override;
 
   UdsClientBuilder& retry_interval(std::chrono::milliseconds milliseconds);
   UdsClientBuilder& max_retries(int max_retries);
@@ -49,7 +49,7 @@ class UNILINK_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient,
 
  private:
   std::string socket_path_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
   std::chrono::milliseconds retry_interval_;
   int max_retries_;
@@ -71,14 +71,7 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
   explicit UdsServerBuilder(const std::string& socket_path);
 
   std::unique_ptr<wrapper::UdsServer> build() override;
-  UdsServerBuilder& auto_manage(bool auto_manage = true) override;
-
-  /**
-   * @brief Helper for client connection events
-   */
-  UdsServerBuilder& on_client_connect(std::function<void(const wrapper::ConnectionContext&)> handler) {
-    return on_connect(std::move(handler));
-  }
+  UdsServerBuilder& auto_start(bool auto_start = true) override;
 
   /**
    * @brief Helper for client disconnection events
@@ -94,7 +87,7 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
 
  private:
   std::string socket_path_;
-  bool auto_manage_;
+  bool auto_start_;
   bool independent_context_;
   std::chrono::milliseconds idle_timeout_{0};
   size_t max_clients_;

--- a/unilink/unilink.hpp
+++ b/unilink/unilink.hpp
@@ -64,7 +64,7 @@ namespace unilink {
 using TcpClient = wrapper::TcpClient;
 using TcpServer = wrapper::TcpServer;
 using Serial = wrapper::Serial;
-using Udp = wrapper::Udp;
+using UdpClient = wrapper::UdpClient;
 using UdpServer = wrapper::UdpServer;
 using UdsClient = wrapper::UdsClient;
 using UdsServer = wrapper::UdsServer;

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -44,6 +44,11 @@ class UNILINK_API ChannelInterface {
   [[nodiscard]] virtual std::future<bool> start() = 0;
 
   /**
+   * @brief Synchronously start the channel/server and wait for the result.
+   */
+  [[nodiscard]] virtual bool start_sync() { return start().get(); }
+
+  /**
    * @brief Stop the channel and block until all pending async operations are cancelled.
    *
    * Safe to call from any thread. After stop() returns, no further callbacks will fire
@@ -89,7 +94,7 @@ class UNILINK_API ChannelInterface {
   virtual ChannelInterface& on_message(MessageHandler handler) = 0;
 
   // Management
-  virtual ChannelInterface& auto_manage(bool manage = true) = 0;
+  virtual ChannelInterface& auto_start(bool manage = true) = 0;
 };
 
 }  // namespace wrapper

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -45,6 +45,11 @@ class UNILINK_API ServerInterface {
   [[nodiscard]] virtual std::future<bool> start() = 0;
 
   /**
+   * @brief Synchronously start the channel/server and wait for the result.
+   */
+  [[nodiscard]] virtual bool start_sync() { return start().get(); }
+
+  /**
    * @brief Stop the server and block until all active sessions are closed.
    *
    * Safe to call from any thread. After stop() returns, no further callbacks will fire
@@ -58,13 +63,12 @@ class UNILINK_API ServerInterface {
   virtual bool send_to(size_t client_id, std::string_view data) = 0;
 
   // Event handlers
-  virtual ServerInterface& on_client_connect(ConnectionHandler handler) = 0;
+  virtual ServerInterface& on_connect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_client_disconnect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_data(MessageHandler handler) = 0;
   virtual ServerInterface& on_error(ErrorHandler handler) = 0;
 
   // Aliases — same names as ChannelInterface so server and client code look identical
-  ServerInterface& on_connect(ConnectionHandler handler) { return on_client_connect(std::move(handler)); }
   ServerInterface& on_disconnect(ConnectionHandler handler) { return on_client_disconnect(std::move(handler)); }
 
   /**
@@ -80,7 +84,7 @@ class UNILINK_API ServerInterface {
   virtual ServerInterface& on_message(MessageHandler handler) = 0;
 
   // Management
-  virtual ServerInterface& auto_manage(bool manage = true) = 0;
+  virtual ServerInterface& auto_start(bool manage = true) = 0;
   virtual size_t client_count() const = 0;
   virtual std::vector<size_t> connected_clients() const = 0;
 };

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -65,7 +65,7 @@ struct Serial::Impl {
   std::unique_ptr<framer::IFramer> framer{nullptr};
 
   // Configuration
-  bool auto_manage = false;
+  bool auto_start = false;
   int data_bits = 8;
   int stop_bits = 1;
   std::string parity = "none";
@@ -344,9 +344,9 @@ ChannelInterface& Serial::on_message(MessageHandler h) {
   return *this;
 }
 
-ChannelInterface& Serial::auto_manage(bool m) {
-  impl_->auto_manage = m;
-  if (impl_->auto_manage && !impl_->started_.load()) start();
+ChannelInterface& Serial::auto_start(bool m) {
+  impl_->auto_start = m;
+  if (impl_->auto_start && !impl_->started_.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -73,7 +73,7 @@ class UNILINK_API Serial : public ChannelInterface {
   ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
   ChannelInterface& on_message(MessageHandler handler) override;
 
-  ChannelInterface& auto_manage(bool manage = true) override;
+  ChannelInterface& auto_start(bool manage = true) override;
 
   // Serial-specific methods
   Serial& baud_rate(uint32_t baud_rate);

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -57,7 +57,7 @@ struct TcpClient::Impl {
 
   std::unique_ptr<framer::IFramer> framer_{nullptr};
 
-  bool auto_manage_ = false;
+  bool auto_start_ = false;
   std::chrono::milliseconds retry_interval_{3000};
   int max_retries_ = -1;
   std::chrono::milliseconds connection_timeout_{5000};
@@ -332,9 +332,9 @@ ChannelInterface& TcpClient::on_message(MessageHandler h) {
   return *this;
 }
 
-ChannelInterface& TcpClient::auto_manage(bool m) {
-  impl_->auto_manage_ = m;
-  if (impl_->auto_manage_ && !impl_->started_.load()) start();
+ChannelInterface& TcpClient::auto_start(bool m) {
+  impl_->auto_start_ = m;
+  if (impl_->auto_start_ && !impl_->started_.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -73,7 +73,7 @@ class UNILINK_API TcpClient : public ChannelInterface {
   ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
   ChannelInterface& on_message(MessageHandler handler) override;
 
-  ChannelInterface& auto_manage(bool manage = true) override;
+  ChannelInterface& auto_start(bool manage = true) override;
 
   // Configuration
   TcpClient& retry_interval(std::chrono::milliseconds interval);

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -51,7 +51,7 @@ struct TcpServer::Impl {
   std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
   // Configuration
-  bool auto_manage_{false};
+  bool auto_start_{false};
   bool port_retry_enabled_{false};
   int max_port_retries_{3};
   int port_retry_interval_ms_{1000};
@@ -74,7 +74,7 @@ struct TcpServer::Impl {
       : port_(port),
         started_(false),
         is_listening_(false),
-        auto_manage_(false),
+        auto_start_(false),
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
@@ -89,7 +89,7 @@ struct TcpServer::Impl {
         manage_external_context_(false),
         started_(false),
         is_listening_(false),
-        auto_manage_(false),
+        auto_start_(false),
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
@@ -102,7 +102,7 @@ struct TcpServer::Impl {
         channel_(std::move(channel)),
         started_(false),
         is_listening_(false),
-        auto_manage_(false),
+        auto_start_(false),
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
@@ -335,7 +335,7 @@ bool TcpServer::send_to(size_t client_id, std::string_view data) {
   return ts ? ts->send_to_client(client_id, data) : false;
 }
 
-ServerInterface& TcpServer::on_client_connect(ConnectionHandler h) {
+ServerInterface& TcpServer::on_connect(ConnectionHandler h) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_client_connect_ = std::move(h);
   return *this;
@@ -378,9 +378,9 @@ std::vector<size_t> TcpServer::connected_clients() const {
   return ts ? ts->connected_clients() : std::vector<size_t>();
 }
 
-TcpServer& TcpServer::auto_manage(bool m) {
-  impl_->auto_manage_ = m;
-  if (impl_->auto_manage_ && !impl_->started_.load()) start();
+TcpServer& TcpServer::auto_start(bool m) {
+  impl_->auto_start_ = m;
+  if (impl_->auto_start_ && !impl_->started_.load()) start();
   return *this;
 }
 

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -68,7 +68,7 @@ class UNILINK_API TcpServer : public ServerInterface {
   bool send_to(size_t client_id, std::string_view data) override;
 
   // Event handlers
-  ServerInterface& on_client_connect(ConnectionHandler handler) override;
+  ServerInterface& on_connect(ConnectionHandler handler) override;
   ServerInterface& on_client_disconnect(ConnectionHandler handler) override;
   ServerInterface& on_data(MessageHandler handler) override;
   ServerInterface& on_error(ErrorHandler handler) override;
@@ -81,7 +81,7 @@ class UNILINK_API TcpServer : public ServerInterface {
   std::vector<size_t> connected_clients() const override;
 
   // Configuration (Fluent API)
-  TcpServer& auto_manage(bool manage = true) override;
+  TcpServer& auto_start(bool manage = true) override;
   TcpServer& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
   TcpServer& idle_timeout(std::chrono::milliseconds timeout);
   TcpServer& max_clients(size_t max);

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -36,7 +36,7 @@
 namespace unilink {
 namespace wrapper {
 
-struct Udp::Impl {
+struct UdpClient::Impl {
   mutable std::mutex mutex_;
   config::UdpConfig cfg;
   std::shared_ptr<interface::Channel> channel;
@@ -55,7 +55,7 @@ struct Udp::Impl {
 
   std::unique_ptr<framer::IFramer> framer{nullptr};
 
-  bool auto_manage{false};
+  bool auto_start{false};
   std::vector<std::promise<bool>> pending_promises;
   std::atomic<bool> started{false};
   std::shared_ptr<bool> alive_marker{std::make_shared<bool>(true)};
@@ -258,20 +258,20 @@ struct Udp::Impl {
   }
 };
 
-Udp::Udp(const config::UdpConfig& cfg) : impl_(std::make_unique<Impl>(cfg)) {}
-Udp::Udp(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> ioc)
+UdpClient::UdpClient(const config::UdpConfig& cfg) : impl_(std::make_unique<Impl>(cfg)) {}
+UdpClient::UdpClient(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> ioc)
     : impl_(std::make_unique<Impl>(cfg, ioc)) {}
-Udp::Udp(std::shared_ptr<interface::Channel> ch) : impl_(std::make_unique<Impl>(ch)) {
+UdpClient::UdpClient(std::shared_ptr<interface::Channel> ch) : impl_(std::make_unique<Impl>(ch)) {
   impl_->setup_internal_handlers();
 }
-Udp::~Udp() = default;
+UdpClient::~UdpClient() = default;
 
-Udp::Udp(Udp&&) noexcept = default;
-Udp& Udp::operator=(Udp&&) noexcept = default;
+UdpClient::UdpClient(UdpClient&&) noexcept = default;
+UdpClient& UdpClient::operator=(UdpClient&&) noexcept = default;
 
-std::future<bool> Udp::start() { return impl_->start(); }
-void Udp::stop() { impl_->stop(); }
-bool Udp::send(std::string_view data) {
+std::future<bool> UdpClient::start() { return impl_->start(); }
+void UdpClient::stop() { impl_->stop(); }
+bool UdpClient::send(std::string_view data) {
   if (connected() && get_impl()->channel) {
     auto binary_view = base::safe_convert::string_to_bytes(data);
     get_impl()->channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
@@ -279,42 +279,42 @@ bool Udp::send(std::string_view data) {
   }
   return false;
 }
-bool Udp::send_line(std::string_view line) { return send(std::string(line) + "\n"); }
-bool Udp::connected() const { return get_impl()->channel && get_impl()->channel->is_connected(); }
+bool UdpClient::send_line(std::string_view line) { return send(std::string(line) + "\n"); }
+bool UdpClient::connected() const { return get_impl()->channel && get_impl()->channel->is_connected(); }
 
-ChannelInterface& Udp::on_data(MessageHandler h) {
+ChannelInterface& UdpClient::on_data(MessageHandler h) {
   impl_->data_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Udp::on_connect(ConnectionHandler h) {
+ChannelInterface& UdpClient::on_connect(ConnectionHandler h) {
   impl_->connect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Udp::on_disconnect(ConnectionHandler h) {
+ChannelInterface& UdpClient::on_disconnect(ConnectionHandler h) {
   impl_->disconnect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Udp::on_error(ErrorHandler h) {
+ChannelInterface& UdpClient::on_error(ErrorHandler h) {
   impl_->error_handler = std::move(h);
   return *this;
 }
 
-ChannelInterface& Udp::framer(std::unique_ptr<framer::IFramer> f) {
+ChannelInterface& UdpClient::framer(std::unique_ptr<framer::IFramer> f) {
   impl_->set_framer(std::move(f));
   return *this;
 }
-ChannelInterface& Udp::on_message(MessageHandler h) {
+ChannelInterface& UdpClient::on_message(MessageHandler h) {
   impl_->on_message(std::move(h));
   return *this;
 }
 
-ChannelInterface& Udp::auto_manage(bool m) {
-  impl_->auto_manage = m;
-  if (impl_->auto_manage && !impl_->started.load()) start();
+ChannelInterface& UdpClient::auto_start(bool m) {
+  impl_->auto_start = m;
+  if (impl_->auto_start && !impl_->started.load()) start();
   return *this;
 }
 
-Udp& Udp::manage_external_context(bool manage) {
+UdpClient& UdpClient::manage_external_context(bool manage) {
   impl_->manage_external_context = manage;
   return *this;
 }

--- a/unilink/wrapper/udp/udp.hpp
+++ b/unilink/wrapper/udp/udp.hpp
@@ -43,20 +43,20 @@ namespace wrapper {
 /**
  * @brief Modernized UDP Wrapper
  */
-class UNILINK_API Udp : public ChannelInterface {
+class UNILINK_API UdpClient : public ChannelInterface {
  public:
-  explicit Udp(const config::UdpConfig& cfg);
-  Udp(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> external_ioc);
-  explicit Udp(std::shared_ptr<interface::Channel> channel);
-  ~Udp() override;
+  explicit UdpClient(const config::UdpConfig& cfg);
+  UdpClient(const config::UdpConfig& cfg, std::shared_ptr<boost::asio::io_context> external_ioc);
+  explicit UdpClient(std::shared_ptr<interface::Channel> channel);
+  ~UdpClient() override;
 
   // Move semantics
-  Udp(Udp&&) noexcept;
-  Udp& operator=(Udp&&) noexcept;
+  UdpClient(UdpClient&&) noexcept;
+  UdpClient& operator=(UdpClient&&) noexcept;
 
   // Disable copy
-  Udp(const Udp&) = delete;
-  Udp& operator=(const Udp&) = delete;
+  UdpClient(const UdpClient&) = delete;
+  UdpClient& operator=(const UdpClient&) = delete;
 
   // ChannelInterface implementation
   std::future<bool> start() override;
@@ -73,9 +73,9 @@ class UNILINK_API Udp : public ChannelInterface {
   ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
   ChannelInterface& on_message(MessageHandler handler) override;
 
-  ChannelInterface& auto_manage(bool manage = true) override;
+  ChannelInterface& auto_start(bool manage = true) override;
 
-  Udp& manage_external_context(bool manage);
+  UdpClient& manage_external_context(bool manage);
 
  private:
   struct Impl;

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -80,7 +80,7 @@ struct UdpServer::Impl {
   std::unordered_map<size_t, SessionEntry> sessions;
   std::chrono::milliseconds session_timeout{30000};  // Default 30s
   std::unique_ptr<boost::asio::steady_timer> reaper_timer;
-  bool auto_manage{false};
+  bool auto_start{false};
 
   ConnectionHandler on_connect{nullptr};
   ConnectionHandler on_disconnect{nullptr};
@@ -392,7 +392,7 @@ bool UdpServer::send_to(size_t client_id, std::string_view data) {
   return true;
 }
 
-ServerInterface& UdpServer::on_client_connect(ConnectionHandler h) {
+ServerInterface& UdpServer::on_connect(ConnectionHandler h) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex);
   impl_->on_connect = std::move(h);
   return *this;
@@ -443,9 +443,9 @@ std::vector<size_t> UdpServer::connected_clients() const {
   return ids;
 }
 
-UdpServer& UdpServer::auto_manage(bool m) {
-  impl_->auto_manage = m;
-  if (impl_->auto_manage && !impl_->started.load()) {
+UdpServer& UdpServer::auto_start(bool m) {
+  impl_->auto_start = m;
+  if (impl_->auto_start && !impl_->started.load()) {
     start();
   }
   return *this;

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -59,7 +59,7 @@ class UNILINK_API UdpServer : public ServerInterface {
   bool send_to(size_t client_id, std::string_view data) override;
 
   // Event handlers
-  ServerInterface& on_client_connect(ConnectionHandler handler) override;
+  ServerInterface& on_connect(ConnectionHandler handler) override;
   ServerInterface& on_client_disconnect(ConnectionHandler handler) override;
   ServerInterface& on_data(MessageHandler handler) override;
   ServerInterface& on_error(ErrorHandler handler) override;
@@ -73,7 +73,7 @@ class UNILINK_API UdpServer : public ServerInterface {
   std::vector<size_t> connected_clients() const override;
 
   // UDP specific
-  UdpServer& auto_manage(bool manage = true) override;
+  UdpServer& auto_start(bool manage = true) override;
   UdpServer& session_timeout(std::chrono::milliseconds timeout);
   UdpServer& manage_external_context(bool manage);
 

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -56,7 +56,7 @@ struct UdsClient::Impl {
 
   std::unique_ptr<framer::IFramer> framer_{nullptr};
 
-  bool auto_manage_ = false;
+  bool auto_start_ = false;
   std::chrono::milliseconds retry_interval_{3000};
   int max_retries_ = -1;
   std::chrono::milliseconds connection_timeout_{5000};
@@ -355,9 +355,9 @@ ChannelInterface& UdsClient::on_message(MessageHandler h) {
   return *this;
 }
 
-ChannelInterface& UdsClient::auto_manage(bool manage) {
-  impl_->auto_manage_ = manage;
-  if (impl_->auto_manage_ && !impl_->started_.load()) {
+ChannelInterface& UdsClient::auto_start(bool manage) {
+  impl_->auto_start_ = manage;
+  if (impl_->auto_start_ && !impl_->started_.load()) {
     start();
   }
   return *this;

--- a/unilink/wrapper/uds_client/uds_client.hpp
+++ b/unilink/wrapper/uds_client/uds_client.hpp
@@ -73,7 +73,7 @@ class UNILINK_API UdsClient : public ChannelInterface {
   ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
   ChannelInterface& on_message(MessageHandler handler) override;
 
-  ChannelInterface& auto_manage(bool manage = true) override;
+  ChannelInterface& auto_start(bool manage = true) override;
 
   // Configuration
   UdsClient& retry_interval(std::chrono::milliseconds interval);

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -57,7 +57,7 @@ struct UdsServer::Impl {
 
   std::unordered_map<size_t, std::unique_ptr<framer::IFramer>> framers_;
 
-  bool auto_manage_ = false;
+  bool auto_start_ = false;
   size_t max_clients_ = 100;
   int idle_timeout_ms_ = 0;
 
@@ -317,7 +317,7 @@ bool UdsServer::send_to(size_t client_id, std::string_view data) {
   return impl_->server_ ? impl_->server_->send_to_client(client_id, data) : false;
 }
 
-ServerInterface& UdsServer::on_client_connect(ConnectionHandler handler) {
+ServerInterface& UdsServer::on_connect(ConnectionHandler handler) {
   std::lock_guard<std::shared_mutex> lock(impl_->mutex_);
   impl_->client_connect_handler_ = std::move(handler);
   return *this;
@@ -359,9 +359,9 @@ std::vector<size_t> UdsServer::connected_clients() const {
   return impl_->server_ ? impl_->server_->connected_clients() : std::vector<size_t>();
 }
 
-UdsServer& UdsServer::auto_manage(bool manage) {
-  impl_->auto_manage_ = manage;
-  if (impl_->auto_manage_ && !impl_->started_.load()) {
+UdsServer& UdsServer::auto_start(bool manage) {
+  impl_->auto_start_ = manage;
+  if (impl_->auto_start_ && !impl_->started_.load()) {
     start();
   }
   return *this;

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -69,7 +69,7 @@ class UNILINK_API UdsServer : public ServerInterface {
   bool send_to(size_t client_id, std::string_view data) override;
 
   // Event handlers
-  ServerInterface& on_client_connect(ConnectionHandler handler) override;
+  ServerInterface& on_connect(ConnectionHandler handler) override;
   ServerInterface& on_client_disconnect(ConnectionHandler handler) override;
   ServerInterface& on_data(MessageHandler handler) override;
   ServerInterface& on_error(ErrorHandler handler) override;
@@ -82,7 +82,7 @@ class UNILINK_API UdsServer : public ServerInterface {
   std::vector<size_t> connected_clients() const override;
 
   // Configuration (Fluent API)
-  UdsServer& auto_manage(bool manage = true) override;
+  UdsServer& auto_start(bool manage = true) override;
   UdsServer& idle_timeout(std::chrono::milliseconds timeout);
   UdsServer& max_clients(size_t max);
   UdsServer& unlimited_clients();


### PR DESCRIPTION
## Summary

 This PR improves the usability and consistency of the public API by unifying naming conventions across different transport layers and adding convenient synchronization methods. Documentation has also been updated to reflect these changes.

## Changes

### Core API

- Renamed `Udp` class to `UdpClient` to align with `TcpClient` and `UdsClient` naming conventions.
- Renamed `auto_manage` parameter to `auto_start` in builders and interfaces for better semantic clarity.
- Unified callback naming by renaming `on_client_connect` to `on_connect` across all server interfaces (`TcpServer`, `UdsServer`, etc.).
- Added `start_sync()` method to `ChannelInterface` and `ServerInterface` to support convenient blocking initialization.

### Documentation

- Updated `docs/reference/api_guide.md` to reflect new naming and include `start_sync()`.
- Updated tutorials (e.g., `docs/tutorials/05_udp_communication.md`) to use `start_sync()` for cleaner examples.
- Updated core guides (`best_practices.md`, `python_bindings.md`, `wrapper_contract.md`) with the new API terminology.

## Related Issues

- Related to #320 (Aligning with simplified API policy)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Additional Notes

 These changes ensure a consistent developer experience across all supported protocols in Unilink. While these are breaking changes, they significantly improve API discoverability and align with the "Simple API" initiative.
