### PR TITLE
ci: update Doxygen installation to use Ubuntu 24.04 and specify version

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,16 +11,22 @@ permissions:
 jobs:
   deploy-docs:
     name: Build and Deploy Doxygen
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
 
     - name: Install Doxygen
+      env:
+        DOXYGEN_APT_VERSION: 1.9.8+ds-2build5
+        EXPECTED_DOXYGEN_VERSION: 1.9.8
       run: |
         sudo apt-get update
-        sudo apt-get install -y doxygen graphviz
+        sudo apt-get install -y "doxygen=${DOXYGEN_APT_VERSION}" graphviz
+        actual_version="$(doxygen --version)"
+        echo "Doxygen version: ${actual_version}"
+        test "${actual_version}" = "${EXPECTED_DOXYGEN_VERSION}"
 
     - name: Generate Documentation
       run: |


### PR DESCRIPTION
## Summary
Fix the GitHub Pages documentation deployment by ensuring CI builds Doxygen output with the same Doxygen version expected by the custom HTML header template.

## Changes
- Update the documentation deployment runner from `ubuntu-22.04` to `ubuntu-24.04`.
- Install the explicit Doxygen apt package version `1.9.8+ds-2build5`.
- Verify that the installed `doxygen --version` is `1.9.8` before generating and deploying documentation.

## Related Issues
- Fixes the broken Doxygen Pages rendering caused by CI using Doxygen 1.9.1 with a Doxygen 1.9.8 custom header template.
- Related to the GitHub Pages documentation deployment.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Additional Notes
The deployed HTML previously contained unexpanded Doxygen template markers such as `$darkmode` and sidebar condition blocks because CI installed Doxygen 1.9.1 from the Ubuntu 22.04 package repository. Pinning CI to Doxygen 1.9.8 keeps the generated HTML compatible with the checked-in custom Doxygen header.
