### PR TITLE
test: enhance test stability and concurrency coverage

### DIFF
--- a/test/e2e/stress/test_stress.cc
+++ b/test/e2e/stress/test_stress.cc
@@ -92,6 +92,75 @@ TEST_F(StressTest, RealNetworkHighThroughput) {
   server->stop();
 }
 
+TEST_F(StressTest, RapidStartStop) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+  const int iterations = 20;
+
+  for (int i = 0; i < iterations; ++i) {
+    auto server = tcp_server(port).unlimited_clients().build();
+    ASSERT_NE(server, nullptr);
+
+    auto start_future = server->start();
+    // Don't even wait for get() in some cases, or stop immediately
+    if (i % 2 == 0) {
+      start_future.get();
+    }
+    server->stop();
+  }
+}
+
+TEST_F(StressTest, ConcurrentClientConnections) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+  const int num_clients = 20;
+  std::atomic<int> connected_count{0};
+  std::atomic<int> received_count{0};
+
+  auto server = tcp_server(port)
+                    .unlimited_clients()
+                    .on_connect([&](const wrapper::ConnectionContext&) { connected_count++; })
+                    .on_data([&](const wrapper::MessageContext&) { received_count++; })
+                    .build();
+
+  server->start();
+  TestUtils::waitForCondition([&]() { return server->listening(); }, 1000);
+
+  std::vector<std::shared_ptr<wrapper::TcpClient>> clients;
+  for (int i = 0; i < num_clients; ++i) {
+    auto client = tcp_client("127.0.0.1", port).build();
+    clients.push_back(std::move(client));
+    clients.back()->start();
+  }
+
+  // Wait for all to connect
+  TestUtils::waitForCondition([&]() { return connected_count.load() == num_clients; }, 5000);
+  EXPECT_EQ(connected_count.load(), num_clients);
+
+  // Small delay to ensure all connections are fully established in the OS
+  std::this_thread::sleep_for(200ms);
+
+  // Send messages concurrently
+  std::vector<std::thread> senders;
+  for (auto& client : clients) {
+    senders.emplace_back([client]() {
+      for (int i = 0; i < 50; ++i) {
+        if (client->send("stress_test_data")) {
+          // Successfully queued
+        }
+        std::this_thread::sleep_for(5ms);  // Increased delay
+      }
+    });
+  }
+
+  for (auto& t : senders) t.join();
+
+  // Wait for all data
+  TestUtils::waitForCondition([&]() { return received_count.load() == num_clients * 50; }, 5000);
+  EXPECT_EQ(received_count.load(), num_clients * 50);
+
+  for (auto& client : clients) client->stop();
+  server->stop();
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/tcp/test_client_limit_integration.cc
+++ b/test/integration/tcp/test_client_limit_integration.cc
@@ -34,13 +34,14 @@ using namespace std::chrono_literals;
 
 class ClientLimitIntegrationTest : public ::testing::Test {
  protected:
-  void SetUp() override { std::this_thread::sleep_for(std::chrono::milliseconds(100)); }
+  void SetUp() override {
+    // Reset logger or other states if needed
+  }
 
   void TearDown() override {
     if (server_) {
       server_->stop();
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
   uint16_t getTestPort() { return TestUtils::getAvailableTestPort(); }

--- a/test/integration/tcp/test_dos_protection.cc
+++ b/test/integration/tcp/test_dos_protection.cc
@@ -73,28 +73,24 @@ TEST_F(DoSProtectionTest, TightLoopPrevention) {
 
   ASSERT_NE(server_, nullptr) << "Server creation failed";
   server_->start();
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  TestUtils::waitForCondition([&]() { return server_->listening(); }, 1000);
 
   // 1. Connect first client (Success)
   auto s1 = unilink::tcp_client("127.0.0.1", test_port).build();
   s1->start();
 
   // Wait for connection
-  int retries = 0;
-  while (!s1->connected() && retries++ < 20) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
+  bool s1_connected = TestUtils::waitForCondition([&]() { return s1->connected(); }, 2000);
 
-  if (!s1->connected()) {
+  if (!s1_connected) {
     FAIL() << "Client 1 failed to connect";
   }
   std::cout << "Client 1 connected" << std::endl;
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
   // Verify s1 is holding the slot
-  if (server_->client_count() != 1) {
-    FAIL() << "Client 1 is not connected. Client count: " << server_->client_count();
+  bool server_saw_client = TestUtils::waitForCondition([&]() { return server_->client_count() == 1; }, 1000);
+  if (!server_saw_client) {
+    FAIL() << "Server failed to detect Client 1 connection. Client count: " << server_->client_count();
   }
 
   // 2. Flood server with attempts
@@ -152,19 +148,18 @@ TEST_F(DoSProtectionTest, TightLoopPrevention) {
   // Verify we can resume accepting after client disconnects
   s1->stop();
   std::cout << "Client 1 disconnected, waiting for resume..." << std::endl;
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));  // Wait for on_close and resume
+
+  // Wait for server to detect disconnection and resume
+  TestUtils::waitForCondition([&]() { return server_->client_count() == 0; }, 2000);
 
   // Try to connect again
   auto s3 = unilink::tcp_client("127.0.0.1", test_port).build();
   s3->start();
 
   // Wait for connection
-  retries = 0;
-  while (!s3->connected() && retries++ < 20) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
+  bool s3_connected = TestUtils::waitForCondition([&]() { return s3->connected(); }, 2000);
 
-  if (!s3->connected()) {
+  if (!s3_connected) {
     FAIL() << "Failed to connect after resume";
   }
   std::cout << "Client 3 connected (Resume success)" << std::endl;

--- a/test/integration/tcp/test_simple_server.cc
+++ b/test/integration/tcp/test_simple_server.cc
@@ -86,12 +86,12 @@ TEST_F(SimpleServerTest, AutoStartServer) {
   ASSERT_NE(server_, nullptr) << "Server creation failed";
   std::cout << "Server created with auto-start" << std::endl;
 
-  // Brief wait for auto-manage to kick in
-  std::this_thread::sleep_for(test::constants::kMediumTimeout);
+  // Wait for auto-manage to kick in
+  bool is_listening = test::TestUtils::waitForCondition([&]() { return server_->listening(); }, 1000);
 
   std::cout << "Server state: " << (server_->listening() ? "listening" : "not listening") << std::endl;
 
-  EXPECT_TRUE(server_->listening());
+  EXPECT_TRUE(is_listening);
 }
 
 /**

--- a/test/unit/transport/transport_tcp_client.cc
+++ b/test/unit/transport/transport_tcp_client.cc
@@ -107,7 +107,7 @@ TEST_F(TransportTcpClientTest, StopPreventsReconnectAfterManualStop) {
   boost::asio::io_context ioc;
   config::TcpClientConfig cfg;
   cfg.host = "256.256.256.256";  // force resolve failure quickly
-  cfg.port = 12345;
+  cfg.port = TestUtils::getAvailableTestPort();
   cfg.retry_interval_ms = 30;
 
   client_ = TcpClient::create(cfg, ioc);
@@ -181,8 +181,8 @@ TEST_F(TransportTcpClientTest, QueueLimitMovesClientToError) {
   net::io_context ioc;
   config::TcpClientConfig cfg;
   cfg.host = "127.0.0.1";
-  cfg.port = 1;                       // no real server needed
-  cfg.backpressure_threshold = 1024;  // limit becomes 1MB
+  cfg.port = TestUtils::getAvailableTestPort();  // no real server needed
+  cfg.backpressure_threshold = 1024;             // limit becomes 1MB
 
   client_ = TcpClient::create(cfg, ioc);
 
@@ -250,8 +250,8 @@ TEST_F(TransportTcpClientTest, MoveWriteRespectsQueueLimit) {
   net::io_context ioc;
   config::TcpClientConfig cfg;
   cfg.host = "127.0.0.1";
-  cfg.port = 1;                       // no real server needed
-  cfg.backpressure_threshold = 1024;  // limit becomes 1MB
+  cfg.port = TestUtils::getAvailableTestPort();  // no real server needed
+  cfg.backpressure_threshold = 1024;             // limit becomes 1MB
 
   client_ = TcpClient::create(cfg, ioc);
 
@@ -275,8 +275,8 @@ TEST_F(TransportTcpClientTest, SharedWriteRespectsQueueLimit) {
   net::io_context ioc;
   config::TcpClientConfig cfg;
   cfg.host = "127.0.0.1";
-  cfg.port = 1;                       // no real server needed
-  cfg.backpressure_threshold = 1024;  // limit becomes 1MB
+  cfg.port = TestUtils::getAvailableTestPort();  // no real server needed
+  cfg.backpressure_threshold = 1024;             // limit becomes 1MB
 
   client_ = TcpClient::create(cfg, ioc);
 

--- a/test/unit/transport/transport_udp_extended.cc
+++ b/test/unit/transport/transport_udp_extended.cc
@@ -190,8 +190,9 @@ TEST(TransportUdpExtendedTest, BackpressureReporting) {
 
   // Now run IO to drain. The strand ensures the writes are processed
   // before the send completion handler reduces the queue, triggering the BP callback.
-  pump_io(ioc, 50ms);
+  bool success = wait_for_condition(ioc, [&]() { return bp_triggered.load() && bp_cleared.load(); }, 2000ms);
 
+  EXPECT_TRUE(success);
   EXPECT_TRUE(bp_triggered);
   EXPECT_TRUE(bp_cleared);
 
@@ -215,9 +216,10 @@ TEST(TransportUdpExtendedTest, CallbackExceptionSafety) {
   channel->start();
 
   // Trigger state change
-  pump_io(ioc, 10ms);
+  bool ok = wait_for_condition(ioc, [&]() { return calls.load() > 0; }, 1000ms);
 
   // Should still be running/usable
+  EXPECT_TRUE(ok);
   EXPECT_GT(calls, 0);
   EXPECT_NO_THROW(channel->stop());
 }

--- a/test/unit/wrapper/test_serial_fail.cc
+++ b/test/unit/wrapper/test_serial_fail.cc
@@ -40,7 +40,7 @@ TEST(WrapperSerialFailTest, OpenInvalidPort) {
   serial.on_error([&](const wrapper::ErrorContext& err) { error_called = true; });
 
   // Try to start - should trigger error or at least not be connected
-  serial.start();
+  auto f = serial.start();
 
   // Wait a bit for async operations
   std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/test/unit/wrapper/test_tcp_client_advanced.cc
+++ b/test/unit/wrapper/test_tcp_client_advanced.cc
@@ -177,7 +177,7 @@ TEST(TcpClientWrapperContractTest, StopSuppressesLateCallbacks) {
   client.on_error([&](const wrapper::ErrorContext&) { callbacks++; });
   client.on_disconnect([&](const wrapper::ConnectionContext&) { callbacks++; });
 
-  client.start();
+  auto f = client.start();
   client.stop();
 
   fake_channel->emit_state(base::LinkState::Connected);

--- a/test/unit/wrapper/test_tcp_client_error_mapping.cc
+++ b/test/unit/wrapper/test_tcp_client_error_mapping.cc
@@ -43,7 +43,7 @@ TEST(TcpClientErrorMappingTest, ConnectionRefused) {
   });
 
   client.max_retries(0);  // Fail fast
-  client.start();
+  auto f = client.start();
 
   // Wait for error
   std::future_status status = error_future.wait_for(std::chrono::seconds(5));
@@ -80,7 +80,7 @@ TEST(TcpClientErrorMappingTest, Timeout) {
     }
   });
 
-  client.start();
+  auto f = client.start();
 
   std::future_status status = error_future.wait_for(std::chrono::seconds(2));
 

--- a/test/unit/wrapper/test_tcp_server_advanced.cc
+++ b/test/unit/wrapper/test_tcp_server_advanced.cc
@@ -69,7 +69,7 @@ TEST_F(AdvancedTcpServerCoverageTest, ExternalContextNotStoppedWhenNotManaged) {
   auto work = boost::asio::make_work_guard(*ioc);
 
   server_ = std::make_shared<wrapper::TcpServer>(test_port_, ioc);
-  server_->start();
+  auto f = server_->start();
 
   std::thread t([&]() { ioc->run(); });
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -88,7 +88,7 @@ TEST_F(AdvancedTcpServerCoverageTest, ExternalContextManagedRunsAndStops) {
   auto ioc = std::make_shared<boost::asio::io_context>();
   server_ = std::make_shared<wrapper::TcpServer>(test_port_, ioc);
   server_->manage_external_context(true);
-  server_->start();
+  auto f = server_->start();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
   EXPECT_TRUE(server_->listening());
@@ -185,7 +185,7 @@ TEST_F(AdvancedTcpServerCoverageTest, ConcurrentStartStop) {
   for (int i = 0; i < 2; ++i) {  // Reduced count for stability
     threads.emplace_back([this]() {
       for (int j = 0; j < 5; ++j) {
-        server_->start();
+        auto f = server_->start();
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
         server_->stop();
       }
@@ -201,7 +201,7 @@ TEST_F(AdvancedTcpServerCoverageTest, HandlerReplacement) {
   server_->on_connect([&](const wrapper::ConnectionContext&) { count = 1; });
   server_->on_connect([&](const wrapper::ConnectionContext&) { count = 2; });
 
-  server_->start();
+  auto f = server_->start();
   auto client = unilink::tcp_client("127.0.0.1", test_port_).build();
   client->start();
 

--- a/test/unit/wrapper/test_udp_stop_perf.cc
+++ b/test/unit/wrapper/test_udp_stop_perf.cc
@@ -21,7 +21,7 @@ TEST(UdpWrapperTest, StopPerformance) {
   cfg.remote_port = 19001;
 
   wrapper::UdpClient udp(cfg);
-  udp.start();
+  auto f = udp.start();
 
   auto start = std::chrono::high_resolution_clock::now();
   udp.stop();
@@ -43,7 +43,7 @@ TEST(UdpWrapperTest, StopSafetyWithExternalIOC) {
     wrapper::UdpClient udp(cfg, ioc);
     std::atomic<int> callbacks{0};
     udp.on_data([&](const wrapper::MessageContext&) { callbacks++; });
-    udp.start();
+    auto f = udp.start();
 
     // Stop and destroy immediately
     udp.stop();

--- a/test/unit/wrapper/test_uds_advanced.cc
+++ b/test/unit/wrapper/test_uds_advanced.cc
@@ -232,9 +232,9 @@ TEST(UdsClientWrapperContractTest, StopSuppressesLateCallbacks) {
   client.on_connect([&](const ConnectionContext&) { callbacks++; });
   client.on_data([&](const MessageContext&) { callbacks++; });
   client.on_error([&](const ErrorContext&) { callbacks++; });
-  client.on_disconnect([&](const ConnectionContext&) { callbacks++; });
+  client.on_disconnect([&](const wrapper::ConnectionContext&) { callbacks++; });
 
-  client.start();
+  auto f = client.start();
   client.stop();
 
   fake_channel->emit_state(base::LinkState::Connected);

--- a/test/utils/test_utils.hpp
+++ b/test/utils/test_utils.hpp
@@ -368,8 +368,8 @@ class IntegrationTest : public NetworkTest {
 
   void TearDown() override {
     // Clean up integration test resources
-    // Increased wait time to ensure complete cleanup and avoid port conflicts
-    TestUtils::waitFor(1000);
+    // Removed fixed 1-second sleep to improve test performance.
+    // Individual tests should ensure their servers/clients are stopped properly.
     NetworkTest::TearDown();
   }
 };


### PR DESCRIPTION
## Description
This PR focuses on improving the stability of the test suite and expanding coverage for concurrent scenarios. It addresses flaky test failures often encountered during parallel execution by replacing timing-dependent code with robust conditional synchronization.

## Key Changes
- **Flakiness Fix**: Replaced numerous occurrences of `std::this_thread::sleep_for` and `pump_io` with `TestUtils::waitForCondition`. This ensures tests wait exactly as long as needed for asynchronous operations to complete.
- **Parallel Safety**: Replaced hardcoded port numbers (e.g., 12345, 1) with dynamic port allocation using `TestUtils::getAvailableTestPort()` to prevent `Address already in use` errors during concurrent `ctest` runs.
- **Stress Testing**: Added new test cases to `test/e2e/stress/test_stress.cc`:
    - `RapidStartStop`: Verifies resource cleanup and stability during high-frequency lifecycle changes.
    - `ConcurrentClientConnections`: Validates the server's ability to handle multiple clients sending data simultaneously.
- **Warning Resolution**: Captured return values of `start()` methods in tests to resolve `[[nodiscard]]` compiler warnings.
- **Performance**: Optimized `IntegrationTest::TearDown` by removing the mandatory 1-second sleep, significantly reducing total test suite duration.

## Related Issues
- Identified during stability audit of the CI/CD pipeline.

## Type of Change
- [ ] **Bug Fix**: (N/A)
- [ ] **New Feature**: (N/A)
- [ ] **Breaking Change**: (N/A)
- [ ] **Documentation**: (N/A)
- [ ] **Refactor**: (N/A)
- [ ] **Performance**: (N/A)
- [x] **Testing**: Major improvements to test reliability and coverage.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.