### PR TITLE
ci: run code formatting check only on PR and fix existing style issues

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,6 +21,7 @@ jobs:
     name: Code Formatting
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: github.event_name == 'pull_request'
 
     steps:
     - name: Checkout code

--- a/test/unit/common/test_error_mapping_exhaustive.cc
+++ b/test/unit/common/test_error_mapping_exhaustive.cc
@@ -1,28 +1,31 @@
 #include <gtest/gtest.h>
+
 #include <boost/asio.hpp>
-#include "unilink/diagnostics/error_types.hpp"
-#include <vector>
 #include <iostream>
+#include <vector>
+
+#include "unilink/diagnostics/error_types.hpp"
 
 using namespace unilink::diagnostics;
 
 TEST(ErrorMappingExhaustiveTest, ErrorInfoFormatting) {
   // Test basic construction and string conversion
   ErrorInfo info(ErrorLevel::ERROR, ErrorCategory::COMMUNICATION, "test_comp", "read", "test message");
-  
+
   EXPECT_EQ(info.level_string(), "ERROR");
   EXPECT_EQ(info.category_string(), "COMMUNICATION");
   EXPECT_NE(info.summary(), "");
   EXPECT_NE(info.timestamp_string(), "");
-  
+
   // Test with boost error
   boost::system::error_code ec = boost::asio::error::connection_reset;
   ErrorInfo info2(ErrorLevel::CRITICAL, ErrorCategory::CONNECTION, "tcp", "connect", "reset by peer", ec, true);
-  
+
   EXPECT_EQ(info2.level_string(), "CRITICAL");
   EXPECT_TRUE(info2.retryable);
   EXPECT_EQ(info2.boost_error, ec);
-  EXPECT_TRUE(info2.summary().find("connection_reset") != std::string::npos || info2.summary().find("reset") != std::string::npos);
+  EXPECT_TRUE(info2.summary().find("connection_reset") != std::string::npos ||
+              info2.summary().find("reset") != std::string::npos);
 }
 
 TEST(ErrorMappingExhaustiveTest, EnumCoverage) {
@@ -33,10 +36,9 @@ TEST(ErrorMappingExhaustiveTest, EnumCoverage) {
     EXPECT_FALSE(info.level_string().empty());
   }
 
-  std::vector<ErrorCategory> cats = {
-    ErrorCategory::CONNECTION, ErrorCategory::COMMUNICATION, ErrorCategory::CONFIGURATION,
-    ErrorCategory::MEMORY, ErrorCategory::SYSTEM, ErrorCategory::UNKNOWN
-  };
+  std::vector<ErrorCategory> cats = {ErrorCategory::CONNECTION,    ErrorCategory::COMMUNICATION,
+                                     ErrorCategory::CONFIGURATION, ErrorCategory::MEMORY,
+                                     ErrorCategory::SYSTEM,        ErrorCategory::UNKNOWN};
   for (auto c : cats) {
     ErrorInfo info(ErrorLevel::INFO, c, "c", "o", "m");
     EXPECT_FALSE(info.category_string().empty());
@@ -48,7 +50,7 @@ TEST(ErrorMappingExhaustiveTest, ErrorStatsTest) {
   stats.reset();
   EXPECT_EQ(stats.total_errors, 0);
   EXPECT_EQ(stats.error_rate(), 0.0);
-  
+
   stats.total_errors = 10;
   stats.first_error = std::chrono::system_clock::now() - std::chrono::minutes(5);
   stats.last_error = std::chrono::system_clock::now();

--- a/test/unit/common/test_input_validator_edge.cc
+++ b/test/unit/common/test_input_validator_edge.cc
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
-#include "unilink/util/input_validator.hpp"
+
 #include <string>
+
+#include "unilink/util/input_validator.hpp"
 
 using namespace unilink::util;
 
@@ -15,7 +17,7 @@ TEST(InputValidatorEdgeTest, IPv6Validation) {
 TEST(InputValidatorEdgeTest, UdsPathValidation) {
   EXPECT_TRUE(InputValidator::is_valid_uds_path("/tmp/test.sock"));
   EXPECT_FALSE(InputValidator::is_valid_uds_path(""));
-  
+
   // Test extremely long path
   std::string long_path(200, 'a');
   EXPECT_FALSE(InputValidator::is_valid_uds_path(long_path));
@@ -31,8 +33,9 @@ TEST(InputValidatorEdgeTest, HostValidation) {
 TEST(InputValidatorEdgeTest, StringValidationExceptions) {
   EXPECT_THROW(InputValidator::validate_non_empty_string("", "test_field"), unilink::diagnostics::ValidationException);
   EXPECT_NO_THROW(InputValidator::validate_non_empty_string("not empty", "test_field"));
-  
-  EXPECT_THROW(InputValidator::validate_string_length("too long", 5, "test_field"), unilink::diagnostics::ValidationException);
+
+  EXPECT_THROW(InputValidator::validate_string_length("too long", 5, "test_field"),
+               unilink::diagnostics::ValidationException);
   EXPECT_NO_THROW(InputValidator::validate_string_length("short", 10, "test_field"));
 }
 
@@ -41,12 +44,17 @@ TEST(InputValidatorEdgeTest, NumericValidationExceptions) {
   EXPECT_THROW(InputValidator::validate_positive_number(-1, "test_field"), unilink::diagnostics::ValidationException);
   EXPECT_NO_THROW(InputValidator::validate_positive_number(1, "test_field"));
 
-  EXPECT_THROW(InputValidator::validate_range(static_cast<int64_t>(5), static_cast<int64_t>(10), static_cast<int64_t>(20), "test_field"), unilink::diagnostics::ValidationException);
-  EXPECT_THROW(InputValidator::validate_range(static_cast<int64_t>(25), static_cast<int64_t>(10), static_cast<int64_t>(20), "test_field"), unilink::diagnostics::ValidationException);
-  EXPECT_NO_THROW(InputValidator::validate_range(static_cast<int64_t>(15), static_cast<int64_t>(10), static_cast<int64_t>(20), "test_field"));
+  EXPECT_THROW(InputValidator::validate_range(static_cast<int64_t>(5), static_cast<int64_t>(10),
+                                              static_cast<int64_t>(20), "test_field"),
+               unilink::diagnostics::ValidationException);
+  EXPECT_THROW(InputValidator::validate_range(static_cast<int64_t>(25), static_cast<int64_t>(10),
+                                              static_cast<int64_t>(20), "test_field"),
+               unilink::diagnostics::ValidationException);
+  EXPECT_NO_THROW(InputValidator::validate_range(static_cast<int64_t>(15), static_cast<int64_t>(10),
+                                                 static_cast<int64_t>(20), "test_field"));
 }
 TEST(InputValidatorEdgeTest, RetryValidation) {
-  EXPECT_NO_THROW(InputValidator::validate_retry_count(-1)); // infinite
+  EXPECT_NO_THROW(InputValidator::validate_retry_count(-1));  // infinite
   EXPECT_NO_THROW(InputValidator::validate_retry_count(0));
   EXPECT_NO_THROW(InputValidator::validate_retry_count(100));
   EXPECT_THROW(InputValidator::validate_retry_count(-2), unilink::diagnostics::ValidationException);

--- a/test/unit/common/test_memory_advanced.cc
+++ b/test/unit/common/test_memory_advanced.cc
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
+
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include "unilink/diagnostics/logger.hpp"
 #include "unilink/memory/memory_tracker.hpp"
 #include "unilink/memory/safe_data_buffer.hpp"
-#include "unilink/diagnostics/logger.hpp"
-#include <vector>
-#include <thread>
-#include <sstream>
 
 using namespace unilink::memory;
 
@@ -14,25 +16,23 @@ class MemoryAdvancedTest : public ::testing::Test {
     MemoryTracker::instance().clear_tracking_data();
     MemoryTracker::instance().enable_tracking(true);
   }
-  
-  void TearDown() override {
-    MemoryTracker::instance().clear_tracking_data();
-  }
+
+  void TearDown() override { MemoryTracker::instance().clear_tracking_data(); }
 };
 
 TEST_F(MemoryAdvancedTest, MemoryTrackerDetailedStats) {
   auto& tracker = MemoryTracker::instance();
   void* ptr1 = (void*)0x1234;
   void* ptr2 = (void*)0x5678;
-  
+
   tracker.track_allocation(ptr1, 100, __FILE__, __LINE__, __FUNCTION__);
   tracker.track_allocation(ptr2, 200, __FILE__, __LINE__, __FUNCTION__);
-  
+
   auto stats = tracker.stats();
   EXPECT_EQ(stats.total_allocations, 2);
   EXPECT_EQ(stats.current_bytes_allocated, 300);
   EXPECT_EQ(stats.peak_bytes_allocated, 300);
-  
+
   tracker.track_deallocation(ptr1);
   stats = tracker.stats();
   EXPECT_EQ(stats.total_deallocations, 1);
@@ -43,11 +43,11 @@ TEST_F(MemoryAdvancedTest, MemoryTrackerControl) {
   auto& tracker = MemoryTracker::instance();
   tracker.disable_tracking();
   EXPECT_FALSE(tracker.tracking_enabled());
-  
+
   void* ptr = (void*)0x9999;
   tracker.track_allocation(ptr, 500, __FILE__, __LINE__, __FUNCTION__);
   EXPECT_EQ(tracker.stats().total_allocations, 0);
-  
+
   tracker.enable_tracking();
   tracker.track_allocation(ptr, 500, __FILE__, __LINE__, __FUNCTION__);
   EXPECT_EQ(tracker.stats().total_allocations, 1);
@@ -56,7 +56,7 @@ TEST_F(MemoryAdvancedTest, MemoryTrackerControl) {
 TEST_F(MemoryAdvancedTest, ScopedTracker) {
   auto& tracker = MemoryTracker::instance();
   void* ptr = (void*)0xAAAA;
-  
+
   {
     ScopedMemoryTracker scoped(__FILE__, __LINE__, __FUNCTION__);
     scoped.track_allocation(ptr, 150);
@@ -69,7 +69,7 @@ TEST_F(MemoryAdvancedTest, ScopedTracker) {
 TEST_F(MemoryAdvancedTest, ReportingMethods) {
   auto& tracker = MemoryTracker::instance();
   tracker.track_allocation((void*)0x1, 10, nullptr, 0, nullptr);
-  
+
   // These print to stdout or log. Just ensuring they don't crash.
   EXPECT_NO_THROW(tracker.print_memory_report());
   EXPECT_NO_THROW(tracker.print_leak_report());
@@ -80,29 +80,29 @@ TEST_F(MemoryAdvancedTest, ReportingMethods) {
 TEST_F(MemoryAdvancedTest, SafeDataBufferComprehensive) {
   std::string original = "Unilink Safe Buffer Test";
   SafeDataBuffer buffer(original);
-  
+
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size(), original.size());
   EXPECT_EQ(buffer.as_string(), original);
-  
+
   // Access
   EXPECT_EQ(buffer[0], 'U');
   EXPECT_EQ(buffer.at(original.size() - 1), 't');
   EXPECT_THROW(buffer.at(original.size()), std::out_of_range);
   EXPECT_THROW(buffer[original.size()], std::out_of_range);
-  
+
   // Comparison
   SafeDataBuffer buffer2(original);
   EXPECT_EQ(buffer, buffer2);
-  
+
   SafeDataBuffer buffer3(std::string("Different"));
   EXPECT_NE(buffer, buffer3);
-  
+
   // Lifecycle
   buffer.clear();
   EXPECT_TRUE(buffer.empty());
   EXPECT_EQ(buffer.size(), 0);
-  
+
   buffer.reserve(100);
   buffer.resize(10);
   EXPECT_EQ(buffer.size(), 10);
@@ -112,12 +112,12 @@ TEST_F(MemoryAdvancedTest, SafeDataBufferErrorCases) {
   // Null pointer with size > 0
   EXPECT_THROW(SafeDataBuffer(static_cast<const uint8_t*>(nullptr), 10), std::invalid_argument);
   EXPECT_THROW(SafeDataBuffer(static_cast<const char*>(nullptr), 10), std::invalid_argument);
-  
+
   // Size limit (100MB)
   size_t too_large = 1024 * 1024 * 101;
   // Note: we don't actually allocate the memory, just pass the size to trigger validation
   EXPECT_THROW(SafeDataBuffer(reinterpret_cast<const uint8_t*>(0x1), too_large), std::invalid_argument);
-  
+
   // Validate method
   SafeDataBuffer buffer(std::vector<uint8_t>(10, 0));
   EXPECT_NO_THROW(buffer.validate());
@@ -126,11 +126,11 @@ TEST_F(MemoryAdvancedTest, SafeDataBufferErrorCases) {
 
 TEST_F(MemoryAdvancedTest, SafeDataBufferFactory) {
   using namespace safe_buffer_factory;
-  
+
   EXPECT_EQ(from_string("test").as_string(), "test");
   EXPECT_EQ(from_c_string("test").as_string(), "test");
   EXPECT_TRUE(from_c_string(nullptr).empty());
-  
+
   std::vector<uint8_t> vec = {1, 2, 3};
   EXPECT_EQ(from_vector(vec).size(), 3);
   EXPECT_EQ(from_raw_data(vec.data(), 3).size(), 3);
@@ -140,7 +140,7 @@ TEST_F(MemoryAdvancedTest, SafeDataBufferFactory) {
 TEST_F(MemoryAdvancedTest, MemoryTrackerLeakDetection) {
   auto& tracker = MemoryTracker::instance();
   tracker.track_allocation((void*)0xBBBB, 50, __FILE__, __LINE__, __FUNCTION__);
-  
+
   auto leaks = tracker.leaked_allocations();
   ASSERT_EQ(leaks.size(), 1);
   EXPECT_EQ(leaks[0].size, 50);
@@ -157,10 +157,10 @@ TEST(BaseUtilityTest, SafeMemcpy) {
   using namespace unilink::base::safe_memory;
   uint8_t src[] = {1, 2, 3, 4, 5};
   uint8_t dest[5];
-  
+
   EXPECT_NO_THROW(safe_memcpy(dest, src, 5));
   EXPECT_EQ(dest[0], 1);
-  
+
   EXPECT_THROW(safe_memcpy(nullptr, src, 5), std::invalid_argument);
   EXPECT_THROW(safe_memcpy(dest, nullptr, 5), std::invalid_argument);
   EXPECT_THROW(safe_memcpy(dest, src, 1024 * 1024 + 1), std::invalid_argument);
@@ -170,16 +170,15 @@ TEST(BaseUtilityTest, SafeMemcpy) {
 TEST(BaseUtilityTest, SafeConvert) {
   using namespace unilink::base::safe_convert;
   std::string s = "test";
-  
+
   auto vec = string_to_uint8(s);
   EXPECT_EQ(vec.size(), 4);
   EXPECT_EQ(vec[0], 't');
-  
+
   EXPECT_EQ(uint8_to_string(vec.data(), vec.size()), s);
   EXPECT_EQ(uint8_to_string(nullptr, 0), "");
-  
+
   auto bytes = string_to_bytes(s);
   EXPECT_EQ(bytes.second, 4);
   EXPECT_EQ(bytes.first[0], 't');
 }
-

--- a/test/unit/transport/transport_uds_error_test.cc
+++ b/test/unit/transport/transport_uds_error_test.cc
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
+
 #include <boost/asio.hpp>
 #include <filesystem>
-#include "unilink/transport/uds/uds_server.hpp"
-#include "unilink/transport/uds/uds_client.hpp"
+
 #include "test_utils.hpp"
+#include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/transport/uds/uds_server.hpp"
 
 using namespace unilink;
 using namespace unilink::transport;
@@ -15,11 +17,9 @@ class UdsErrorTest : public ::testing::Test {
     temp_sock_ = "/tmp/unilink_error_" + std::to_string(TestUtils::getAvailableTestPort()) + ".sock";
     TestUtils::removeFileIfExists(temp_sock_);
   }
-  
-  void TearDown() override {
-    TestUtils::removeFileIfExists(temp_sock_);
-  }
-  
+
+  void TearDown() override { TestUtils::removeFileIfExists(temp_sock_); }
+
   std::string temp_sock_;
 };
 
@@ -27,16 +27,16 @@ TEST_F(UdsErrorTest, InvalidSocketPath) {
   config::UdsServerConfig cfg;
   // Extremely long path that exceeds sun_path limit (usually 108 bytes)
   cfg.socket_path = "/tmp/very_long_path_" + std::string(200, 'a') + ".sock";
-  
+
   auto server = UdsServer::create(cfg);
   ASSERT_NE(server, nullptr);
-  
+
   // Start should not crash but may set state to Error
   server->start();
-  
+
   // Give some time for async operation if needed
-  TestUtils::waitForCondition([&]{ return server->get_state() == base::LinkState::Error; }, 500);
-  
+  TestUtils::waitForCondition([&] { return server->get_state() == base::LinkState::Error; }, 500);
+
   // In some implementations, it might stay in Idle if path validation fails immediately
   EXPECT_TRUE(server->get_state() == base::LinkState::Error || server->get_state() == base::LinkState::Idle);
 }
@@ -46,26 +46,28 @@ TEST_F(UdsErrorTest, PathPermissionDenied) {
   GTEST_SKIP() << "UDS file permissions are not consistent on Windows AF_UNIX";
 #else
   config::UdsServerConfig cfg;
-  
+
   // Create a temporary directory and remove all permissions
   std::string restricted_dir = "/tmp/unilink_restricted_" + std::to_string(TestUtils::getAvailableTestPort());
   std::filesystem::create_directory(restricted_dir);
   std::filesystem::permissions(restricted_dir, std::filesystem::perms::none);
-  
+
   cfg.socket_path = restricted_dir + "/test.sock";
-  
+
   auto server = UdsServer::create(cfg);
   ASSERT_NE(server, nullptr);
   server->start();
-  
+
   // Wait for potential async error transition (longer timeout)
-  bool error_state = TestUtils::waitForCondition([&]{ 
-    auto s = server->get_state();
-    return s == base::LinkState::Error || s == base::LinkState::Idle; 
-  }, 1000);
-  
+  bool error_state = TestUtils::waitForCondition(
+      [&] {
+        auto s = server->get_state();
+        return s == base::LinkState::Error || s == base::LinkState::Idle;
+      },
+      1000);
+
   EXPECT_TRUE(error_state);
-  
+
   // Cleanup: Restore permissions so directory can be deleted
   std::filesystem::permissions(restricted_dir, std::filesystem::perms::owner_all);
   std::filesystem::remove_all(restricted_dir);
@@ -77,7 +79,7 @@ TEST_F(UdsErrorTest, ClientConnectWithoutServer) {
   cfg.socket_path = "/tmp/non_existent_server.sock";
   cfg.max_retries = 1;
   cfg.retry_interval_ms = 10;
-  
+
   auto client = UdsClient::create(cfg);
   std::atomic<bool> error_state_seen{false};
   client->on_state([&](base::LinkState state) {
@@ -85,41 +87,43 @@ TEST_F(UdsErrorTest, ClientConnectWithoutServer) {
       error_state_seen = true;
     }
   });
-  
+
   client->start();
-  
+
   // Wait for retry attempt
-  EXPECT_TRUE(TestUtils::waitForCondition([&]{ return error_state_seen.load() || !client->is_connected(); }, 1000));
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return error_state_seen.load() || !client->is_connected(); }, 1000));
 }
 
 // This test is currently disabled due to intermittent timing issues with UDS session cleanup.
-// It consistently reaches 81%+ coverage even when disabled because the logic is exercised 
+// It consistently reaches 81%+ coverage even when disabled because the logic is exercised
 // by other tests, but this specific scenario is flaky in high-load environments.
 TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
   config::UdsServerConfig scfg;
   scfg.socket_path = temp_sock_;
   auto server = UdsServer::create(scfg);
   server->start();
-  
+
   // Wait for server to be ready
-  ASSERT_TRUE(TestUtils::waitForCondition([&]{ return server->get_state() == base::LinkState::Listening; }, 2000));
-  
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->get_state() == base::LinkState::Listening; }, 2000));
+
   config::UdsClientConfig ccfg;
   ccfg.socket_path = temp_sock_;
   auto client = UdsClient::create(ccfg);
   client->start();
-  
+
   // Wait for connection
-  ASSERT_TRUE(TestUtils::waitForCondition([&]{ return client->is_connected(); }, 2000));
-  
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return client->is_connected(); }, 2000));
+
   // Stop server while client is connected - this must not crash
   server->stop();
-  
+
   // Just verify server reached Idle or Error state
-  EXPECT_TRUE(TestUtils::waitForCondition([&]{ 
-    auto s = server->get_state();
-    return s == base::LinkState::Idle || s == base::LinkState::Error;
-  }, 3000));
+  EXPECT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        auto s = server->get_state();
+        return s == base::LinkState::Idle || s == base::LinkState::Error;
+      },
+      3000));
 
   client->stop();
 }

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -369,11 +369,11 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
       session->on_close([weak_self, client_id]() {
         auto s = weak_self.lock();
         if (!s || s->impl_->stopping_) return;
-        
+
         MultiClientDisconnectHandler disconnect_handler;
         {
           std::lock_guard<std::mutex> lock(s->impl_->sessions_mutex_);
-          if (s->impl_->stopping_) return; // Double check inside lock
+          if (s->impl_->stopping_) return;  // Double check inside lock
           s->impl_->sessions_.erase(client_id);
           disconnect_handler = s->impl_->on_multi_disconnect_;
         }


### PR DESCRIPTION
This PR modifies the CI workflow to run formatting checks only on PRs and fixes existing style violations.

Changes:
- Updated .github/workflows/code-quality.yml to restrict formatting checks to pull_request events.
- Applied clang-format and cmake-format to fix all existing style violations.