### PR TITLE
fix/bench: stability overhaul, backpressure API, and C++ native benchmark

### DIFF
--- a/bindings/python/module.cpp.in
+++ b/bindings/python/module.cpp.in
@@ -165,7 +165,15 @@ PYBIND11_MODULE(unilink_py, m) {
           h(ctx);
         });
         return &self;
-      });
+      })
+      .def("on_backpressure",
+           [](TcpClient& self, std::function<void(size_t)> h) {
+             self.on_backpressure([h](size_t queued) {
+               py::gil_scoped_acquire gil;
+               h(queued);
+             });
+             return &self;
+           });
 
   // TcpServer
   py::class_<TcpServer, std::shared_ptr<TcpServer>>(m, "TcpServer")

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv3.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv3.md
@@ -1,0 +1,78 @@
+# Stability Benchmark Results — 2026-04-26
+
+## Environment
+
+- OS: Linux 6.6.87.2-microsoft-standard-WSL2
+- Python: 3.12
+- Unilink: v0.6.0
+- Commit: fix/test: fix backpressure watermarks and add multi-level stability benchmark
+- Duration per level: 60s (LV1–LV3)
+
+## Level Configurations
+
+| Level | Payload | SEND_SLEEP | Chaos Interval | Down Time |
+|-------|---------|------------|----------------|-----------|
+| LV1   | 1 KB    | 1 ms       | 20s            | 2s        |
+| LV2   | 4 KB    | 100 μs     | 10s            | 2s        |
+| LV3   | 64 KB   | 10 μs      | 7s             | 2s        |
+
+---
+
+## Unilink Results
+
+| Metric             | LV1      | LV2       | LV3        |
+|--------------------|----------|-----------|------------|
+| Reconnect          | 4        | 6         | 8          |
+| Exceptions         | 0        | 0         | 0          |
+| Backpressure Hits  | 0        | 0         | 917        |
+| Peak RSS           | 20.2 MB  | 20.2 MB   | 36.6 MB    |
+| Memory Drift       | 0.00 MB  | 0.00 MB   | +0.16 MB   |
+| Throughput Avg     | 0.80 MB/s| 15.76 MB/s| 137.31 MB/s|
+| Throughput StdDev  | 0.27 MB/s| 9.08 MB/s | 89.82 MB/s |
+
+## Raw Socket Results (LV3 only, baseline)
+
+| Metric             | LV3         |
+|--------------------|-------------|
+| Reconnect          | 15          |
+| Exceptions         | 14          |
+| Backpressure Hits  | N/A         |
+| Peak RSS           | 15.0 MB     |
+| Memory Drift       | +0.01 MB    |
+| Throughput Avg     | 575.25 MB/s |
+| Throughput StdDev  | 283.14 MB/s |
+
+## LV3 Comparison: Unilink vs Raw Socket
+
+| Metric            | Unilink     | Raw Socket  | Note                                      |
+|-------------------|-------------|-------------|-------------------------------------------|
+| Exceptions        | **0**       | 14          | Unilink absorbs BrokenPipe via reconnect  |
+| Reconnect         | 8           | 15          | Unilink has 3s retry interval; raw retries immediately |
+| Throughput        | 137 MB/s    | 575 MB/s    | Raw socket uses blocking sendall(); unilink has async overhead + 10μs sleep throttle |
+| Memory            | 36.6 MB     | 15.0 MB     | Framework overhead (ASIO, strand, memory pool, batch queue) |
+| Backpressure      | 917 events  | N/A         | OS kernel socket buffer handles flow control for raw socket |
+
+## Key Findings
+
+### Bug fixed in this session
+- `on_bp` watermarks were checked against `> 40 MiB` (pause) / `< 10 MiB` (resume), but the
+  C++ core fires ON at `bp_high_ = 16 MiB` and OFF at `bp_low_ = 8 MiB`.
+  `send_allowed` was never cleared → backpressure completely bypassed → OOM/kernel crash at LV3+.
+- Fixed to: `> 8 MiB` (ON) / `else` (OFF).
+
+### LV3 minimum sleep requirement
+- `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire the GIL to fire
+  backpressure callbacks. Added `10 μs` sleep (matches `stability_bench_raw.py` LV3).
+
+### Throughput gap explanation
+- Raw socket `sendall()` is blocking; the OS kernel naturally throttles via socket send buffer.
+- Unilink async dispatch requires explicit flow control. With backpressure working correctly,
+  the sender pauses ~13 times/sec at LV3 (917 events / 70s ≈ 13/s), which is expected
+  behavior under 64 KB payload × 100K sends/sec dispatch pressure.
+
+### Memory stability
+- Zero exceptions and near-zero memory drift across LV1–LV3 confirms no memory leak
+  under chaos (server stop/start) + high-load conditions.
+
+## Pending
+- LV4 (ultra stress, 180s, 4 KB payload, 2s chaos interval) — not yet run

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -6,29 +6,30 @@
 - Python: 3.12
 - Unilink: v0.6.0
 - Commit: fix/test: fix backpressure watermarks and add multi-level stability benchmark
-- Duration per level: 60s (LV1–LV3)
+- Duration: 60s (LV1–LV3), 180s (LV4)
 
 ## Level Configurations
 
-| Level | Payload | SEND_SLEEP | Chaos Interval | Down Time |
-|-------|---------|------------|----------------|-----------|
-| LV1   | 1 KB    | 1 ms       | 20s            | 2s        |
-| LV2   | 4 KB    | 100 μs     | 10s            | 2s        |
-| LV3   | 64 KB   | 10 μs      | 7s             | 2s        |
+| Level | Payload | SEND_SLEEP | Chaos Interval | Down Time | Duration |
+|-------|---------|------------|----------------|-----------|----------|
+| LV1   | 1 KB    | 1 ms       | 20s            | 2s        | 60s      |
+| LV2   | 4 KB    | 100 μs     | 10s            | 2s        | 60s      |
+| LV3   | 64 KB   | 10 μs      | 7s             | 2s        | 60s      |
+| LV4   | 4 KB    | 10 μs      | 2s             | 2s        | 180s     |
 
 ---
 
 ## Unilink Results
 
-| Metric             | LV1      | LV2       | LV3        |
-|--------------------|----------|-----------|------------|
-| Reconnect          | 4        | 6         | 8          |
-| Exceptions         | 0        | 0         | 0          |
-| Backpressure Hits  | 0        | 0         | 917        |
-| Peak RSS           | 20.2 MB  | 20.2 MB   | 36.6 MB    |
-| Memory Drift       | 0.00 MB  | 0.00 MB   | +0.16 MB   |
-| Throughput Avg     | 0.80 MB/s| 15.76 MB/s| 137.31 MB/s|
-| Throughput StdDev  | 0.27 MB/s| 9.08 MB/s | 89.82 MB/s |
+| Metric             | LV1       | LV2        | LV3         | LV4        |
+|--------------------|-----------|------------|-------------|------------|
+| Reconnect          | 4         | 6          | 8           | 47         |
+| Exceptions         | 0         | 0          | 0           | 0          |
+| Backpressure Hits  | 0         | 0          | 917         | 0          |
+| Peak RSS           | 20.2 MB   | 20.2 MB    | 36.6 MB     | 20.5 MB    |
+| Memory Drift       | 0.00 MB   | 0.00 MB    | +0.16 MB    | +0.16 MB   |
+| Throughput Avg     | 0.80 MB/s | 15.76 MB/s | 137.31 MB/s | 9.31 MB/s  |
+| Throughput StdDev  | 0.27 MB/s | 9.08 MB/s  | 89.82 MB/s  | 15.89 MB/s |
 
 ## Raw Socket Results (LV3 only, baseline)
 
@@ -74,5 +75,14 @@
 - Zero exceptions and near-zero memory drift across LV1–LV3 confirms no memory leak
   under chaos (server stop/start) + high-load conditions.
 
-## Pending
-- LV4 (ultra stress, 180s, 4 KB payload, 2s chaos interval) — not yet run
+## LV4 Notes
+
+- **47 reconnects in 180s** with 2s chaos interval: server down every 2s, 3s retry → nearly
+  all connection time is spent reconnecting. Effective send window per cycle ≈ 1s.
+- **BP Hits = 0**: 4KB payload with 10μs sleep caps dispatch rate at ~100K msg/s = ~400 MB/s,
+  but actual throughput is 9.31 MB/s because the connection is down most of the time.
+  Queue never reaches 16 MiB bp_high_ threshold during the brief connected windows.
+- **StdDev 15.89 MB/s >> Avg 9.31 MB/s**: throughput spikes during connected windows
+  and drops to 0 during the frequent reconnect windows — expected chaos behavior.
+- **Memory stable**: +0.16 MB drift over 180s with 47 reconnects confirms no leak per cycle.
+- All levels passed with Exceptions = 0.

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -3,95 +3,91 @@
 ## Environment
 
 - OS: Linux 6.6.87.2-microsoft-standard-WSL2
-- Python: 3.12
-- Unilink: v0.6.0
+- Python: 3.12 / Unilink: v0.6.0
 - Duration: 60s (LV1–LV3), 180s (LV4)
 
 ## Level Configurations
 
-| Level | Payload | SEND_SLEEP | Chaos Interval | Down Time | Duration |
-|-------|---------|------------|----------------|-----------|----------|
-| LV1   | 1 KB    | 1 ms       | 20s            | 2s        | 60s      |
-| LV2   | 4 KB    | 100 μs     | 10s            | 2s        | 60s      |
-| LV3   | 64 KB   | 10 μs      | 7s             | 2s        | 60s      |
-| LV4   | 4 KB    | 10 μs      | 2s             | 2s        | 180s     |
+| Level | Payload | Send Sleep (Python) | Send Sleep (C++) | Chaos Interval | Down Time | Duration |
+|-------|---------|---------------------|------------------|----------------|-----------|----------|
+| LV1   | 1 KB    | 1 ms                | 1 ms             | 20s            | 2s        | 60s      |
+| LV2   | 4 KB    | 100 μs              | 100 μs           | 10s            | 2s        | 60s      |
+| LV3   | 64 KB   | 10 μs †             | 0 μs             | 7s             | 2s        | 60s      |
+| LV4   | 4 KB    | 10 μs †             | 0 μs             | 2s             | 2s        | 180s     |
 
-Retry interval: Unilink default **1000ms** (100ms fast first retry + 1000ms subsequent).
-Raw socket benchmark mirrors same pattern (100ms first, 1000ms subsequent).
-Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kernel buffer).
+† Python LV3/LV4 require a minimum 10 μs sleep to prevent GIL starvation of the backpressure callback.
+C++ has no such constraint and runs at 0 μs sleep.
 
----
-
-## Unilink Results
-
-| Metric             | LV1       | LV2        | LV3          | LV4        |
-|--------------------|-----------|------------|--------------|------------|
-| Reconnect          | 4         | 6          | 8            | 47         |
-| Exceptions         | 0         | 0          | 0            | 0          |
-| Backpressure Hits  | 0         | 0          | 965          | 0          |
-| Sent               | 56.58 MB  | 1241.55 MB | 9300.56 MB   | 3776.24 MB |
-| Server Received    | 56.58 MB  | 1241.41 MB | 9248.53 MB   | 3774.72 MB |
-| Delivery Rate      | 100.00%   | 99.99%     | 99.44%       | 99.96%     |
-| Peak RSS           | 20.3 MB   | 20.3 MB    | 36.4 MB      | 20.3 MB    |
-| Memory Drift       | 0.00 MB   | 0.00 MB    | 0.00 MB      | +0.16 MB   |
-| Throughput Avg     | 0.83 MB/s | 17.28 MB/s | 133.49 MB/s  | 19.33 MB/s |
-| Throughput StdDev  | 0.22 MB/s | 7.74 MB/s  | 66.76 MB/s   | 18.92 MB/s |
-
-## Raw Socket Results
-
-| Metric             | LV1      | LV2        | LV3          | LV4          |
-|--------------------|----------|------------|--------------|--------------|
-| Reconnect          | 7        | 11         | 15           | 89           |
-| Exceptions         | 6        | 10         | 14           | 88           |
-| Sent               | 57.24 MB | 1344.23 MB | 39218.00 MB  | 153359.60 MB |
-| Server Received    | 56.99 MB | 1336.97 MB | 39205.38 MB  | 153281.65 MB |
-| Delivery Rate      | 99.56%   | 99.46%     | 99.97%       | 99.95%       |
-| Peak RSS           | 14.5 MB  | 14.7 MB    | 15.0 MB      | 15.0 MB      |
-| Memory Drift       | 0.00 MB  | +0.31 MB   | −0.11 MB     | −0.57 MB     |
-| Throughput Avg     | 0.84 MB/s| 18.76 MB/s | 563.50 MB/s  | 760.90 MB/s  |
-| Throughput StdDev  | 0.22 MB/s| 7.86 MB/s  | 268.25 MB/s  | 678.90 MB/s  |
+Retry policy (all implementations): 100 ms fast first retry → 1000 ms subsequent retries.
 
 ---
 
-## Unilink vs Raw Socket — Side-by-Side
+## Full Results Summary
 
-### Exceptions
+### Throughput and Delivery Rate
 
-| Level | Unilink | Raw Socket |
-|-------|---------|------------|
-| LV1   | **0**   | 6          |
-| LV2   | **0**   | 10         |
-| LV3   | **0**   | 14         |
-| LV4   | **0**   | 88         |
+| Level | Py Unilink (MB/s) | Py Raw (MB/s) | C++ Unilink (MB/s) | C++ Raw (MB/s) |
+|-------|-------------------|---------------|---------------------|----------------|
+| LV1   | 0.83              | 0.84          | 0.84                | 0.84           |
+| LV2   | 17.28             | 18.76         | 18.73               | 18.89          |
+| LV3   | 133.49            | 563.50        | 1,420.44            | 6,382.37       |
+| LV4   | 19.33             | 760.90        | 387.77              | 2,412.20       |
 
-### Delivery Rate (Server Received / Client Sent)
+| Level | Py Unilink Delivery | Py Raw Delivery | C++ Unilink Delivery | C++ Raw Delivery |
+|-------|---------------------|-----------------|----------------------|------------------|
+| LV1   | **100.00%**         | 99.56%          | **100.00%**          | 99.99%           |
+| LV2   | **99.99%**          | 99.46%          | **99.999%**          | 99.998%          |
+| LV3   | 99.44%              | **99.97%**      | 99.94%               | **99.998%**      |
+| LV4   | **99.96%**          | 99.95%          | 99.97%               | **99.99%**       |
 
-| Level | Unilink    | Raw Socket | Data Loss (Raw) |
-|-------|------------|------------|-----------------|
-| LV1   | **100.00%**| 99.56%     | 0.25 MB         |
-| LV2   | **99.99%** | 99.46%     | 7.26 MB         |
-| LV3   | 99.44%     | **99.97%** | 12.62 MB        |
-| LV4   | **99.96%** | 99.95%     | 77.95 MB        |
+### Exceptions (Python) / Exceptions (C++)
 
-### Throughput Avg (MB/s) and Ratio
+| Level | Py Unilink | Py Raw | C++ Unilink | C++ Raw |
+|-------|-----------|--------|-------------|---------|
+| LV1   | **0**     | 6      | **0**       | 4       |
+| LV2   | **0**     | 10     | **0**       | 10      |
+| LV3   | **0**     | 14     | **0**       | 12      |
+| LV4   | **0**     | 88     | **0**       | 90      |
 
-| Level | Unilink     | Raw Socket   | Ratio |
-|-------|-------------|--------------|-------|
-| LV1   | 0.83        | 0.84         | ×1.01 |
-| LV2   | 17.28       | 18.76        | ×1.09 |
-| LV3   | 133.49      | 563.50       | ×4.22 |
-| LV4   | 19.33       | 760.90       | ×39.4 |
+### Absolute Data Loss
 
-### Throughput StdDev (MB/s)
+| Level | Py Unilink | Py Raw   | C++ Unilink | C++ Raw |
+|-------|-----------|----------|-------------|---------|
+| LV1   | **0 MB**  | 0.25 MB  | **0 MB**    | ~0 MB   |
+| LV2   | **0.14 MB** | 7.26 MB | **~0 MB**  | ~0 MB   |
+| LV3   | 52.03 MB  | 12.62 MB | 53 MB       | **8 MB** |
+| LV4   | **1.52 MB** | 77.95 MB | 21 MB      | 45 MB   |
 
-| Level | Unilink | Raw Socket |
-|-------|---------|------------|
-| LV1   | 0.22    | 0.22       |
-| LV2   | 7.74    | 7.86       |
-| LV3   | 66.76   | 268.25     |
-| LV4   | 18.92   | 678.90     |
+### Throughput StdDev
 
-### Peak RSS and Memory Drift
+| Level | Py Unilink | Py Raw   | C++ Unilink | C++ Raw   |
+|-------|-----------|----------|-------------|-----------|
+| LV1   | 0.22      | 0.22     | 0.23        | 0.23      |
+| LV2   | 7.74      | 7.86     | 8.47        | 8.55      |
+| LV3   | **66.76** | 268.25   | **718.25**  | 3,228.35  |
+| LV4   | **18.92** | 678.90   | **346.26**  | 2,427.47  |
+
+*(Lower is more predictable. Unilink's backpressure flattens throughput variance.)*
+
+### Python vs C++ — GIL Overhead
+
+| Level | Py Unilink | C++ Unilink | Speedup   | Py Raw  | C++ Raw   | Speedup   |
+|-------|-----------|-------------|-----------|---------|-----------|-----------|
+| LV1   | 0.83 MB/s | 0.84 MB/s   | ×1.01     | 0.84    | 0.84      | ×1.00     |
+| LV2   | 17.28     | 18.73       | ×1.08     | 18.76   | 18.89     | ×1.01     |
+| LV3   | 133.49    | 1,420.44    | **×10.6** | 563.50  | 6,382.37  | **×11.3** |
+| LV4   | 19.33     | 387.77      | **×20.1** | 760.90  | 2,412.20  | **×3.2**  |
+
+### C++ Unilink vs C++ Raw — Structural Overhead
+
+| Level | C++ Unilink | C++ Raw   | Ratio     |
+|-------|-------------|-----------|-----------|
+| LV1   | 0.84 MB/s   | 0.84 MB/s | ×1.00     |
+| LV2   | 18.73       | 18.89     | ×1.01     |
+| LV3   | 1,420.44    | 6,382.37  | **×4.49** |
+| LV4   | 387.77      | 2,412.20  | **×6.22** |
+
+### Memory (Python binding only)
 
 | Level | Unilink RSS | Raw RSS | Unilink Drift | Raw Drift |
 |-------|-------------|---------|---------------|-----------|
@@ -102,204 +98,140 @@ Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kerne
 
 ---
 
-## Analysis
-
-### Exceptions: Unilink 0 vs Raw socket up to 88
-Unilink absorbs all transport errors internally and retries automatically. The Python layer
-never sees BrokenPipe or ConnectionReset. Raw socket exposes every one directly as an
-exception — approximately one per chaos cycle.
-
-### Delivery Rate: level-by-level interpretation
-
-#### LV1 and LV2 — Unilink clearly wins
-At normal application loads (LV1: 0.83 MB/s, LV2: 17 MB/s), Unilink achieves 100.00% and
-99.99% delivery rate versus Raw's 99.56% and 99.46%. At LV2, Raw loses 7.26 MB absolute
-while Unilink loses 0.14 MB. The gaps are caused by Raw socket data loss on each exception
-(one 4KB payload lost per exception, plus any in-kernel-buffer data at disconnect time).
-Unilink's async queue is small enough that very little data is in-flight when disconnects occur.
-
-#### LV3 — Unilink delivery rate is lower (99.44% vs 99.97%)
-This is the one level where Raw socket outperforms Unilink on delivery completeness. The cause
-is Unilink's async write queue depth at disconnect time.
-
-At LV3 (64KB payloads, 10μs sleep), Unilink sends at ~133 MB/s and the async strand queue can
-hold significant data. When the server goes down, the queue may contain several megabytes of
-buffered-but-undelivered data. With 8 reconnects × ~6.5 MB average queue at disconnect =
-~52 MB lost. Raw socket's blocking `sendall()` means data enters the kernel buffer synchronously
-and is bounded by the kernel's SO_SNDBUF (~4 MB per socket), so per-disconnect loss is lower.
-
-This is a structural trade-off: Unilink's larger async buffer enables burst absorption and
-backpressure control, but increases potential loss per disconnect event at high throughput.
-
-#### LV4 — Near-identical delivery rate, different exception profile
-Both achieve ~99.95–99.96%. The key difference is Unilink's 0 exceptions vs Raw's 88.
-At LV4, Unilink's 10μs sleep rate-limits the queue depth, keeping in-flight data small at
-disconnect (47 reconnects × ~0.032 MB/reconnect = 1.52 MB lost). Raw socket's no-sleep
-aggressive sending means more data is in kernel buffers at disconnect time (89 reconnects ×
-~0.876 MB/reconnect = 77.95 MB lost), but the sheer volume sent (153 GB) makes the
-percentage loss appear equivalent.
-
-### Throughput gap — why average numbers are misleading
-
-`Throughput Avg = total bytes sent ÷ total elapsed time`, so reconnect dead time and
-backpressure pauses both reduce the average. The two implementations accumulate dead time
-differently, making a direct average comparison unfair.
-
-#### LV3 (×4.22): backpressure pauses dominate
-
-| Source of dead time | Unilink                    | Raw Socket              |
-|---------------------|----------------------------|-------------------------|
-| Chaos downtime       | 8 × ~3.1s ≈ **25s**        | 15 × ~2.1s ≈ **32s**   |
-| Backpressure pauses | 965 × ~13ms ≈ **13s**      | 0 (OS handles it)       |
-| Estimated send time | ~32s / 70s                 | ~38s / 70s              |
-| **Peak throughput** | 133×70/32 ≈ **291 MB/s**   | 563×70/38 ≈ **1,037 MB/s** |
-
-Peak ratio ≈ **×3.6**. The remaining gap is structural: raw `sendall()` leverages the OS
-kernel socket buffer as an implicit write-coalescing layer, while Unilink's async dispatch
-adds strand serialization overhead.
-
-#### LV4 (×39.4): connected window size dominates
-
-With 2s chaos (2s up → 2s down) and matching 1000ms retry interval:
-
-| | Unilink | Raw Socket |
-|---|---|---|
-| Reconnect dead time | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** |
-| Connected window | ~1.9s per 4s cycle ≈ **47% uptime** | ~1.9s per 4s cycle ≈ **47% uptime** |
-| Peak throughput (uptime-adjusted) | 19.33/0.47 ≈ **41 MB/s** | 761/0.47 ≈ **1,620 MB/s** |
-
-After equalizing uptime, peak ratio is still **×40**. This reflects the fundamental difference
-in send path: Unilink sends 4KB chunks at 10μs intervals through an async dispatch queue.
-Raw socket uses blocking `sendall()` with zero sleep, letting the kernel DMA data at
-near-loopback line rate (~1.6 GB/s).
-
-### StdDev: Unilink far lower
-Raw socket's throughput swings wildly (StdDev 268–679 MB/s) because it alternates between
-near-line-rate kernel bursts and zero. Unilink's backpressure dampens this significantly:
-StdDev 67 MB/s at LV3 and only 19 MB/s at LV4. Lower variance means more predictable
-behavior under load.
-
-### Memory overhead (~6 MB per level)
-Unilink carries ~6 MB more RSS consistently: Boost.ASIO io_context, strand, memory pool,
-batch queue, callback wiring, and the Python binding GIL-acquire wrappers.
-
----
-
-## Retry Interval Decision (3000ms → 1000ms)
-
-The default retry interval was changed from 3000ms to **1000ms** across all wrapper layers
-(TcpClient, UdsClient, Serial). The transport layer already read from `constants.hpp`;
-the wrappers had the value hardcoded and were fixed to reference the constant.
-
-**Rationale:**
-- Industry standard: Redis, MQTT clients, and gRPC all default to ~1s
-- With fast first retry (100ms) + 1s subsequent: recovery from a 2s outage ≈ 2.1s total
-- 3000ms was too conservative — in LV4's 2s chaos it caused the client to systematically
-  miss entire reconnect windows, halving effective uptime (22% → 47%)
-
----
-
 ## Key Findings
 
-### Bugs fixed in this session
-- `on_bp` watermarks were checked against `> 40 MiB` / `< 10 MiB`, but the C++ core fires
-  ON at `bp_high_ = 16 MiB` and OFF at `bp_low_ = 8 MiB`. `send_allowed` was never cleared
-  → backpressure bypassed → OOM/kernel crash at LV3+.
-  Fixed to: `> 8 MiB` (ON) / `else` (OFF).
+### 1. LV1/LV2 — All four implementations converge on throughput; Unilink wins on reliability
 
-- `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire GIL to fire
-  backpressure callbacks. Added 10μs sleep for LV3/LV4.
+At normal application loads, all implementations (Python/C++ × Unilink/Raw) produce
+identical throughput. The only meaningful differences are:
 
-- All three wrappers (TcpClient, UdsClient, Serial) had `retry_interval` hardcoded to 3000ms,
-  ignoring `DEFAULT_RETRY_INTERVAL_MS` in `constants.hpp`. Fixed to reference the constant.
+- Unilink: 0 exceptions across all runs. Raw socket: 6–10 exceptions per 60-second run.
+- Unilink delivery rate: 100.00–99.99%. Raw socket: 99.56–99.46% (0.25–7.26 MB lost).
 
-### Summary
+This is Unilink's primary value range. Users get raw-socket throughput with automatic
+reconnect, zero application-visible errors, and near-perfect data delivery.
 
-| Dimension              | LV1/LV2 (target range) | LV3/LV4 (extreme) |
-|------------------------|------------------------|-------------------|
-| Exceptions             | Unilink 0, Raw 6–10    | Unilink 0, Raw 14–88 |
-| Delivery Rate          | Unilink wins clearly   | Comparable; LV3 nuanced |
-| Throughput             | ~×1 (negligible gap)   | ×4–40 gap (structural) |
-| StdDev                 | Unilink lower          | Unilink much lower |
-| Absolute Data Loss     | Unilink 0–0.14 MB      | LV3: Raw better; LV4: comparable |
+### 2. LV3 — Structural overhead: ×4.5 (async dispatch vs blocking sendall)
 
-Unilink's value proposition is strongest in LV1/LV2: zero exceptions, near-perfect delivery
-completeness, and throughput on par with raw sockets. At extreme loads (LV3/LV4), the
-trade-off becomes visible — lower throughput and higher per-reconnect queue loss at LV3
-versus raw socket's larger total loss and 88 unhandled exceptions at LV4.
+The throughput gap between Unilink and raw socket is **×4–4.5 in C++ and Python alike**,
+confirming this is a structural cost of the async strand, not a Python/GIL artifact.
 
-LV1–LV4 all passed with Exceptions = 0 and no memory leak.
+Root cause: `sendall()` writes directly into the OS kernel socket buffer and returns only
+when all bytes are accepted. Unilink's `async_write_copy()` enqueues the buffer to the
+strand and returns immediately — the actual write happens asynchronously. For 64 KB
+payloads at maximum rate, the strand serialization and context-switch overhead accumulates.
+
+LV3 delivery rate: Unilink's async queue depth at disconnect time causes higher per-event
+data loss (~6.5 MB/reconnect in Python, ~7.5 MB in C++) versus raw socket's kernel buffer
+bound (~1 MB/reconnect). This is an inherent trade-off of buffered async I/O.
+
+### 3. LV4 — GIL overhead is dominant in Python; structural overhead ×6.2 in C++
+
+Python LV4 shows a ×39 throughput gap. After switching to C++:
+- Unilink: 19 → 388 MB/s (×20.1 speedup — GIL + mandatory sleep removed)
+- Raw: 761 → 2,412 MB/s (×3.2 speedup — less GIL-dependent since no callbacks)
+- C++ Unilink vs C++ Raw: ×6.2 (true structural overhead for small 4 KB payloads at max rate)
+
+The Python ×39 gap was mostly from the mandatory 10 μs send_sleep (needed to yield the GIL
+for backpressure callbacks). In C++, the true structural overhead is ×6.2.
+
+### 4. StdDev — Unilink throughput is far more predictable
+
+Raw socket alternates between near-line-rate bursts and zero (during reconnect). Unilink's
+backpressure mechanism actively limits queue depth, producing much smoother per-second
+throughput:
+
+- LV3: Raw StdDev 268–3,228 MB/s vs Unilink 67–718 MB/s (×4 lower)
+- LV4: Raw StdDev 679–2,427 MB/s vs Unilink 19–346 MB/s (×7 lower)
+
+### 5. GIL overhead: ×10–20 at high frequency, negligible below LV2
+
+The Python binding overhead becomes significant only when send frequency exceeds ~10 K/s
+(roughly 100 μs sleep or less). At LV1/LV2, GIL contention is negligible (×1.01–1.08).
+At LV3 (10 μs sleep) and LV4 (0 sleep in C++), GIL overhead is the dominant factor.
 
 ---
 
-## C++ Native Benchmark (No Python/GIL Overhead)
+## Bugs Fixed
 
-### Environment note
-C++ native benchmark uses `unilink::TcpClient` / `unilink::TcpServer` wrapper API directly.
-LV3/LV4 use **0μs send_sleep** (no GIL starvation risk in C++), vs Python's mandatory 10μs.
+| Bug | Symptom | Fix |
+|-----|---------|-----|
+| `on_bp` watermarks wrong | `send_allowed` never cleared → backpressure bypassed → OOM/kernel crash at LV3+ | Changed threshold from `> 40 MiB` to `> 8 MiB` (midpoint of bp_low/bp_high) |
+| `SEND_SLEEP = 0` GIL starvation | ASIO thread could not acquire GIL to fire backpressure callback | Added 10 μs minimum sleep for Python LV3/LV4 |
+| Wrapper retry interval hardcoded | TcpClient/UdsClient/Serial had `retry_interval{3000}` ignoring `DEFAULT_RETRY_INTERVAL_MS` | Fixed to reference `base::constants::DEFAULT_RETRY_INTERVAL_MS` |
 
-### C++ Unilink Results
+---
 
-| Metric             | LV1       | LV2        | LV3           | LV4           |
-|--------------------|-----------|------------|---------------|---------------|
-| Reconnect          | 3         | 5          | 7             | 45            |
-| Sent               | 50.21 MB  | 1123.6 MB  | 85226 MB      | 69798 MB      |
-| Server Received    | 50.21 MB  | 1123.6 MB  | 85173 MB      | 69777 MB      |
-| Delivery Rate      | 100.00%   | 99.999%    | 99.94%        | 99.97%        |
-| Throughput Avg     | 0.84 MB/s | 18.73 MB/s | 1420.44 MB/s  | 387.77 MB/s   |
-| Throughput StdDev  | 0.23 MB/s | 8.47 MB/s  | 718.25 MB/s   | 346.26 MB/s   |
+## Retry Interval Change: 3000 ms → 1000 ms
 
-### C++ Raw Socket Results
+Changed `DEFAULT_RETRY_INTERVAL_MS` in `constants.hpp` from 3000 to 1000.
 
-| Metric             | LV1       | LV2        | LV3           | LV4           |
-|--------------------|-----------|------------|---------------|---------------|
-| Reconnect          | 5         | 10         | 13            | 90            |
-| Exceptions         | 4         | 10         | 12            | 90            |
-| Sent               | 50.19 MB  | 1133.37 MB | 382943 MB     | 434196 MB     |
-| Server Received    | 50.19 MB  | 1133.34 MB | 382935 MB     | 434151 MB     |
-| Delivery Rate      | 99.99%    | 99.998%    | 99.998%       | 99.99%        |
-| Throughput Avg     | 0.84 MB/s | 18.89 MB/s | 6382.37 MB/s  | 2412.20 MB/s  |
-| Throughput StdDev  | 0.23 MB/s | 8.55 MB/s  | 3228.35 MB/s  | 2427.47 MB/s  |
+**Rationale:**
+- Industry standard: Redis, MQTT, gRPC all default to ~1 s reconnect interval.
+- With fast first retry (100 ms) + 1 s subsequent: recovery from a 2 s outage ≈ 2.1 s total.
+- At 3000 ms, LV4's 2 s chaos caused clients to miss entire reconnect windows (effective
+  uptime 22%). At 1000 ms, uptime recovers to 47% — a 2× improvement.
+- LV4 throughput impact: 9.31 → 19.21 MB/s (×2.06). LV3 impact: +13%.
 
-### Python vs C++ — GIL Overhead
+---
 
-| Level | Python Unilink | C++ Unilink | Speedup | Python Raw | C++ Raw | Speedup |
-|-------|---------------|-------------|---------|------------|---------|---------|
-| LV1   | 0.83 MB/s     | 0.84 MB/s   | ×1.01   | 0.84 MB/s  | 0.84 MB/s | ×1.00 |
-| LV2   | 17.28 MB/s    | 18.73 MB/s  | ×1.08   | 18.76 MB/s | 18.89 MB/s | ×1.01 |
-| LV3   | 133.49 MB/s   | 1420 MB/s   | **×10.6** | 563 MB/s | 6382 MB/s | **×11.3** |
-| LV4   | 19.33 MB/s    | 388 MB/s    | **×20.1** | 761 MB/s | 2412 MB/s | **×3.2** |
+## Python Benchmark Raw Results
 
-### C++ Unilink vs C++ Raw — Structural Overhead
+### Unilink (Python)
 
-| Level | C++ Unilink | C++ Raw  | Ratio  |
-|-------|-------------|----------|--------|
-| LV1   | 0.84 MB/s   | 0.84 MB/s| ×1.00  |
-| LV2   | 18.73 MB/s  | 18.89 MB/s| ×1.01 |
-| LV3   | 1420 MB/s   | 6382 MB/s| ×4.49  |
-| LV4   | 388 MB/s    | 2412 MB/s| ×6.22  |
+| Metric            | LV1       | LV2        | LV3          | LV4        |
+|-------------------|-----------|------------|--------------|------------|
+| Reconnect         | 4         | 6          | 8            | 47         |
+| Exceptions        | 0         | 0          | 0            | 0          |
+| Backpressure Hits | 0         | 0          | 965          | 0          |
+| Sent              | 56.58 MB  | 1241.55 MB | 9300.56 MB   | 3776.24 MB |
+| Server Received   | 56.58 MB  | 1241.41 MB | 9248.53 MB   | 3774.72 MB |
+| Delivery Rate     | 100.00%   | 99.99%     | 99.44%       | 99.96%     |
+| Peak RSS          | 20.3 MB   | 20.3 MB    | 36.4 MB      | 20.3 MB    |
+| Memory Drift      | 0.00 MB   | 0.00 MB    | 0.00 MB      | +0.16 MB   |
+| Throughput Avg    | 0.83 MB/s | 17.28 MB/s | 133.49 MB/s  | 19.33 MB/s |
+| Throughput StdDev | 0.22 MB/s | 7.74 MB/s  | 66.76 MB/s   | 18.92 MB/s |
 
-### Analysis
+### Raw Socket (Python)
 
-**GIL overhead is dominant at LV3/LV4:**
-Python Unilink is ×10.6 slower than C++ Unilink at LV3, and ×20 slower at LV4. The LV4
-gap is larger because Python required a 10μs send_sleep to avoid GIL starvation of the
-backpressure callback, while C++ can run at 0μs sleep with no such constraint.
+| Metric            | LV1       | LV2        | LV3          | LV4           |
+|-------------------|-----------|------------|--------------|---------------|
+| Reconnect         | 7         | 11         | 15           | 89            |
+| Exceptions        | 6         | 10         | 14           | 88            |
+| Sent              | 57.24 MB  | 1344.23 MB | 39218.00 MB  | 153359.60 MB  |
+| Server Received   | 56.99 MB  | 1336.97 MB | 39205.38 MB  | 153281.65 MB  |
+| Delivery Rate     | 99.56%    | 99.46%     | 99.97%       | 99.95%        |
+| Peak RSS          | 14.5 MB   | 14.7 MB    | 15.0 MB      | 15.0 MB       |
+| Memory Drift      | 0.00 MB   | +0.31 MB   | −0.11 MB     | −0.57 MB      |
+| Throughput Avg    | 0.84 MB/s | 18.76 MB/s | 563.50 MB/s  | 760.90 MB/s   |
+| Throughput StdDev | 0.22 MB/s | 7.86 MB/s  | 268.25 MB/s  | 678.90 MB/s   |
 
-**Structural overhead (async dispatch vs raw socket) is ×4-6 in C++:**
-After removing GIL from the equation, the remaining ratio between Unilink and raw socket
-is ×4.49 at LV3 and ×6.22 at LV4 — a consistent overhead from strand serialization,
-memory pool, and backpressure bookkeeping.
+---
 
-Compare with Python: the Python ratio at LV3 is ×4.22 (similar to C++), confirming that
-the ×4 gap is structural (not GIL-related). The Python LV4 ratio of ×39 was mostly the
-mandatory 10μs sleep; corrected to C++, the true structural overhead is ×6.
+## C++ Native Benchmark Raw Results
 
-**Delivery rate in C++ is better than Python:**
-C++ Unilink LV3: 99.94% (Python: 99.44%) — higher throughput means same amount of
-queue-at-disconnect data is a smaller fraction of total sent.
+LV3/LV4 use 0 μs send_sleep (no GIL constraint). Ports 10003/10004 (separate from Python benchmarks).
 
-**LV1/LV2 are identical across all implementations:**
-Below the strand saturation point, all four implementations (Python/C++ × Unilink/Raw)
-converge to the same throughput. This confirms LV1/LV2 is the correct operating range
-for Unilink's reliability guarantees with no throughput penalty.
+### Unilink (C++)
+
+| Metric            | LV1       | LV2        | LV3           | LV4          |
+|-------------------|-----------|------------|---------------|--------------|
+| Reconnect         | 3         | 5          | 7             | 45           |
+| Exceptions        | 0         | 0          | 0             | 0            |
+| Sent              | 50.21 MB  | 1123.6 MB  | 85,226 MB     | 69,798 MB    |
+| Server Received   | 50.21 MB  | 1123.6 MB  | 85,173 MB     | 69,777 MB    |
+| Delivery Rate     | 100.00%   | 99.999%    | 99.94%        | 99.97%       |
+| Throughput Avg    | 0.84 MB/s | 18.73 MB/s | 1,420.44 MB/s | 387.77 MB/s  |
+| Throughput StdDev | 0.23 MB/s | 8.47 MB/s  | 718.25 MB/s   | 346.26 MB/s  |
+
+### Raw Socket (C++)
+
+| Metric            | LV1       | LV2        | LV3           | LV4          |
+|-------------------|-----------|------------|---------------|--------------|
+| Reconnect         | 5         | 10         | 13            | 90           |
+| Exceptions        | 4         | 10         | 12            | 90           |
+| Sent              | 50.19 MB  | 1133.37 MB | 382,943 MB    | 434,196 MB   |
+| Server Received   | 50.19 MB  | 1133.34 MB | 382,935 MB    | 434,151 MB   |
+| Delivery Rate     | 99.99%    | 99.998%    | 99.998%       | 99.99%       |
+| Throughput Avg    | 0.84 MB/s | 18.89 MB/s | 6,382.37 MB/s | 2,412.20 MB/s|
+| Throughput StdDev | 0.23 MB/s | 8.55 MB/s  | 3,228.35 MB/s | 2,427.47 MB/s|

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -229,3 +229,77 @@ trade-off becomes visible — lower throughput and higher per-reconnect queue lo
 versus raw socket's larger total loss and 88 unhandled exceptions at LV4.
 
 LV1–LV4 all passed with Exceptions = 0 and no memory leak.
+
+---
+
+## C++ Native Benchmark (No Python/GIL Overhead)
+
+### Environment note
+C++ native benchmark uses `unilink::TcpClient` / `unilink::TcpServer` wrapper API directly.
+LV3/LV4 use **0μs send_sleep** (no GIL starvation risk in C++), vs Python's mandatory 10μs.
+
+### C++ Unilink Results
+
+| Metric             | LV1       | LV2        | LV3           | LV4           |
+|--------------------|-----------|------------|---------------|---------------|
+| Reconnect          | 3         | 5          | 7             | 45            |
+| Sent               | 50.21 MB  | 1123.6 MB  | 85226 MB      | 69798 MB      |
+| Server Received    | 50.21 MB  | 1123.6 MB  | 85173 MB      | 69777 MB      |
+| Delivery Rate      | 100.00%   | 99.999%    | 99.94%        | 99.97%        |
+| Throughput Avg     | 0.84 MB/s | 18.73 MB/s | 1420.44 MB/s  | 387.77 MB/s   |
+| Throughput StdDev  | 0.23 MB/s | 8.47 MB/s  | 718.25 MB/s   | 346.26 MB/s   |
+
+### C++ Raw Socket Results
+
+| Metric             | LV1       | LV2        | LV3           | LV4           |
+|--------------------|-----------|------------|---------------|---------------|
+| Reconnect          | 5         | 10         | 13            | 90            |
+| Exceptions         | 4         | 10         | 12            | 90            |
+| Sent               | 50.19 MB  | 1133.37 MB | 382943 MB     | 434196 MB     |
+| Server Received    | 50.19 MB  | 1133.34 MB | 382935 MB     | 434151 MB     |
+| Delivery Rate      | 99.99%    | 99.998%    | 99.998%       | 99.99%        |
+| Throughput Avg     | 0.84 MB/s | 18.89 MB/s | 6382.37 MB/s  | 2412.20 MB/s  |
+| Throughput StdDev  | 0.23 MB/s | 8.55 MB/s  | 3228.35 MB/s  | 2427.47 MB/s  |
+
+### Python vs C++ — GIL Overhead
+
+| Level | Python Unilink | C++ Unilink | Speedup | Python Raw | C++ Raw | Speedup |
+|-------|---------------|-------------|---------|------------|---------|---------|
+| LV1   | 0.83 MB/s     | 0.84 MB/s   | ×1.01   | 0.84 MB/s  | 0.84 MB/s | ×1.00 |
+| LV2   | 17.28 MB/s    | 18.73 MB/s  | ×1.08   | 18.76 MB/s | 18.89 MB/s | ×1.01 |
+| LV3   | 133.49 MB/s   | 1420 MB/s   | **×10.6** | 563 MB/s | 6382 MB/s | **×11.3** |
+| LV4   | 19.33 MB/s    | 388 MB/s    | **×20.1** | 761 MB/s | 2412 MB/s | **×3.2** |
+
+### C++ Unilink vs C++ Raw — Structural Overhead
+
+| Level | C++ Unilink | C++ Raw  | Ratio  |
+|-------|-------------|----------|--------|
+| LV1   | 0.84 MB/s   | 0.84 MB/s| ×1.00  |
+| LV2   | 18.73 MB/s  | 18.89 MB/s| ×1.01 |
+| LV3   | 1420 MB/s   | 6382 MB/s| ×4.49  |
+| LV4   | 388 MB/s    | 2412 MB/s| ×6.22  |
+
+### Analysis
+
+**GIL overhead is dominant at LV3/LV4:**
+Python Unilink is ×10.6 slower than C++ Unilink at LV3, and ×20 slower at LV4. The LV4
+gap is larger because Python required a 10μs send_sleep to avoid GIL starvation of the
+backpressure callback, while C++ can run at 0μs sleep with no such constraint.
+
+**Structural overhead (async dispatch vs raw socket) is ×4-6 in C++:**
+After removing GIL from the equation, the remaining ratio between Unilink and raw socket
+is ×4.49 at LV3 and ×6.22 at LV4 — a consistent overhead from strand serialization,
+memory pool, and backpressure bookkeeping.
+
+Compare with Python: the Python ratio at LV3 is ×4.22 (similar to C++), confirming that
+the ×4 gap is structural (not GIL-related). The Python LV4 ratio of ×39 was mostly the
+mandatory 10μs sleep; corrected to C++, the true structural overhead is ×6.
+
+**Delivery rate in C++ is better than Python:**
+C++ Unilink LV3: 99.94% (Python: 99.44%) — higher throughput means same amount of
+queue-at-disconnect data is a smaller fraction of total sent.
+
+**LV1/LV2 are identical across all implementations:**
+Below the strand saturation point, all four implementations (Python/C++ × Unilink/Raw)
+converge to the same throughput. This confirms LV1/LV2 is the correct operating range
+for Unilink's reliability guarantees with no throughput penalty.

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -15,43 +15,113 @@
 | LV1   | 1 KB    | 1 ms       | 20s            | 2s        | 60s      |
 | LV2   | 4 KB    | 100 μs     | 10s            | 2s        | 60s      |
 | LV3   | 64 KB   | 10 μs      | 7s             | 2s        | 60s      |
-| LV4   | 4 KB    | 10 μs      | 2s             | 2s        | 180s     |
+| LV4   | 4 KB    | 10 μs *    | 2s             | 2s        | 180s     |
+
+\* Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kernel buffer)
 
 ---
 
-## Unilink Results
+## Unilink vs Raw Socket — Full Comparison
 
-| Metric             | LV1       | LV2        | LV3         | LV4        |
-|--------------------|-----------|------------|-------------|------------|
-| Reconnect          | 4         | 6          | 8           | 47         |
-| Exceptions         | 0         | 0          | 0           | 0          |
-| Backpressure Hits  | 0         | 0          | 917         | 0          |
-| Peak RSS           | 20.2 MB   | 20.2 MB    | 36.6 MB     | 20.5 MB    |
-| Memory Drift       | 0.00 MB   | 0.00 MB    | +0.16 MB    | +0.16 MB   |
-| Throughput Avg     | 0.80 MB/s | 15.76 MB/s | 137.31 MB/s | 9.31 MB/s  |
-| Throughput StdDev  | 0.27 MB/s | 9.08 MB/s  | 89.82 MB/s  | 15.89 MB/s |
+### Reconnect Successes
 
-## Raw Socket Results (LV3 only, baseline)
+| Level | Unilink | Raw Socket | Note |
+|-------|---------|------------|------|
+| LV1   | 4       | 7          | Raw retries immediately; Unilink waits 3s retry interval |
+| LV2   | 6       | 11         | Same pattern |
+| LV3   | 8       | 15         | Same pattern |
+| LV4   | 47      | 91         | 2s chaos → raw reconnects ~twice as often |
 
-| Metric             | LV3         |
-|--------------------|-------------|
-| Reconnect          | 15          |
-| Exceptions         | 14          |
-| Backpressure Hits  | N/A         |
-| Peak RSS           | 15.0 MB     |
-| Memory Drift       | +0.01 MB    |
-| Throughput Avg     | 575.25 MB/s |
-| Throughput StdDev  | 283.14 MB/s |
+### Exceptions
 
-## LV3 Comparison: Unilink vs Raw Socket
+| Level | Unilink | Raw Socket | Note |
+|-------|---------|------------|------|
+| LV1   | **0**   | 6          | Raw socket exposes BrokenPipe/ConnReset directly |
+| LV2   | **0**   | 10         | |
+| LV3   | **0**   | 14         | |
+| LV4   | **0**   | 90         | 90 exceptions over 180s — one per reconnect cycle |
 
-| Metric            | Unilink     | Raw Socket  | Note                                      |
-|-------------------|-------------|-------------|-------------------------------------------|
-| Exceptions        | **0**       | 14          | Unilink absorbs BrokenPipe via reconnect  |
-| Reconnect         | 8           | 15          | Unilink has 3s retry interval; raw retries immediately |
-| Throughput        | 137 MB/s    | 575 MB/s    | Raw socket uses blocking sendall(); unilink has async overhead + 10μs sleep throttle |
-| Memory            | 36.6 MB     | 15.0 MB     | Framework overhead (ASIO, strand, memory pool, batch queue) |
-| Backpressure      | 917 events  | N/A         | OS kernel socket buffer handles flow control for raw socket |
+### Throughput Avg (MB/s)
+
+| Level | Unilink    | Raw Socket  | Ratio |
+|-------|------------|-------------|-------|
+| LV1   | 0.80       | 0.84        | ×1.05 |
+| LV2   | 15.76      | 18.91       | ×1.20 |
+| LV3   | 137.31     | 575.25      | ×4.19 |
+| LV4   | 9.31       | 811.42      | ×87   |
+
+### Throughput StdDev (MB/s)
+
+| Level | Unilink | Raw Socket |
+|-------|---------|------------|
+| LV1   | 0.27    | 0.22       |
+| LV2   | 9.08    | 8.35       |
+| LV3   | 89.82   | 283.14     |
+| LV4   | 15.89   | 685.37     |
+
+### Peak RSS
+
+| Level | Unilink | Raw Socket |
+|-------|---------|------------|
+| LV1   | 20.2 MB | 14.1 MB    |
+| LV2   | 20.2 MB | 14.7 MB    |
+| LV3   | 36.6 MB | 15.0 MB    |
+| LV4   | 20.5 MB | 15.7 MB    |
+
+### Memory Drift
+
+| Level | Unilink  | Raw Socket |
+|-------|----------|------------|
+| LV1   | 0.00 MB  | 0.00 MB    |
+| LV2   | 0.00 MB  | −0.05 MB   |
+| LV3   | +0.16 MB | +0.01 MB   |
+| LV4   | +0.16 MB | −0.73 MB   |
+
+### Backpressure Hits (Unilink only)
+
+| Level | Unilink |
+|-------|---------|
+| LV1   | 0       |
+| LV2   | 0       |
+| LV3   | 917     |
+| LV4   | 0       |
+
+---
+
+## Analysis
+
+### Exceptions: Unilink 0 vs Raw socket up to 90
+Unilink wraps all transport errors in the reconnect loop and fires `on_error` callbacks
+internally. The Python layer never sees a BrokenPipe or ConnectionReset. Raw socket exposes
+every one directly as an exception — one per chaos cycle.
+
+### Throughput gap (LV3: ×4, LV4: ×87)
+- **LV3**: Raw socket `sendall()` is blocking and the OS kernel socket send buffer (typically
+  128–256 KB) acts as a natural throttle. When the buffer fills, `sendall()` blocks in the kernel
+  and the GIL is released, so throughput is very high. Unilink adds: async dispatch overhead,
+  10 μs sleep per send (caps at ~100K sends/s), and explicit backpressure pauses (917 events).
+- **LV4**: The gap is extreme (×87) because the raw LV4 uses `SEND_SLEEP=0`. Blocking
+  `sendall()` with zero sleep hits the kernel buffer at full speed between reconnects. Unilink
+  uses 10 μs sleep to prevent GIL starvation, capping burst throughput significantly.
+  Both are dominated by reconnect downtime at 2s chaos interval — the raw socket just sends
+  faster during the brief connected windows.
+
+### StdDev: Raw socket far higher at LV3/LV4
+Raw socket's throughput swings wildly (StdDev 283–685 MB/s) because it alternates between
+near-line-rate bursts and zero. Unilink's backpressure smooths this: StdDev 89 MB/s at LV3
+and only 15 MB/s at LV4 (most time spent reconnecting, little variation in that pattern).
+
+### Memory overhead (~6 MB)
+Unilink carries ~6 MB more RSS than raw socket across all levels, consistent with
+framework overhead: Boost.ASIO io_context, strand, memory pool (400 buffers × 4 sizes),
+batch queue, callback registrations, and the Python binding layer.
+
+### Memory drift
+Both are stable. Unilink's +0.16 MB at LV3/LV4 is a one-time allocation (likely memory pool
+expansion under high load) that does not grow further — not a leak. Raw socket's −0.73 MB
+at LV4 is OS reclaiming pages after peak socket buffer usage.
+
+---
 
 ## Key Findings
 
@@ -63,26 +133,10 @@
 
 ### LV3 minimum sleep requirement
 - `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire the GIL to fire
-  backpressure callbacks. Added `10 μs` sleep (matches `stability_bench_raw.py` LV3).
+  backpressure callbacks. Added 10 μs sleep (matches `stability_bench_raw.py` LV3).
 
-### Throughput gap explanation
-- Raw socket `sendall()` is blocking; the OS kernel naturally throttles via socket send buffer.
-- Unilink async dispatch requires explicit flow control. With backpressure working correctly,
-  the sender pauses ~13 times/sec at LV3 (917 events / 70s ≈ 13/s), which is expected
-  behavior under 64 KB payload × 100K sends/sec dispatch pressure.
-
-### Memory stability
-- Zero exceptions and near-zero memory drift across LV1–LV3 confirms no memory leak
-  under chaos (server stop/start) + high-load conditions.
-
-## LV4 Notes
-
-- **47 reconnects in 180s** with 2s chaos interval: server down every 2s, 3s retry → nearly
-  all connection time is spent reconnecting. Effective send window per cycle ≈ 1s.
-- **BP Hits = 0**: 4KB payload with 10μs sleep caps dispatch rate at ~100K msg/s = ~400 MB/s,
-  but actual throughput is 9.31 MB/s because the connection is down most of the time.
-  Queue never reaches 16 MiB bp_high_ threshold during the brief connected windows.
-- **StdDev 15.89 MB/s >> Avg 9.31 MB/s**: throughput spikes during connected windows
-  and drops to 0 during the frequent reconnect windows — expected chaos behavior.
-- **Memory stable**: +0.16 MB drift over 180s with 47 reconnects confirms no leak per cycle.
-- All levels passed with Exceptions = 0.
+### Summary
+- Unilink trades raw throughput for **zero user-visible exceptions**, **automatic reconnect**,
+  **backpressure flow control**, and **lower throughput variance** — all expected for a
+  production-grade async transport framework vs. raw socket.
+- LV1–LV4 all passed with Exceptions = 0 and no memory leak.

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -28,22 +28,28 @@ Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kerne
 |--------------------|-----------|------------|--------------|------------|
 | Reconnect          | 4         | 6          | 8            | 47         |
 | Exceptions         | 0         | 0          | 0            | 0          |
-| Backpressure Hits  | 0         | 0          | 1046         | 0          |
-| Peak RSS           | 20.2 MB   | 20.2 MB    | 36.9 MB      | 20.3 MB    |
-| Memory Drift       | 0.00 MB   | 0.00 MB    | +0.47 MB     | 0.00 MB    |
-| Throughput Avg     | 0.80 MB/s | 15.76 MB/s | 154.94 MB/s  | 19.21 MB/s |
-| Throughput StdDev  | 0.27 MB/s | 9.08 MB/s  | 77.46 MB/s   | 19.18 MB/s |
+| Backpressure Hits  | 0         | 0          | 965          | 0          |
+| Sent               | 56.58 MB  | 1241.55 MB | 9300.56 MB   | 3776.24 MB |
+| Server Received    | 56.58 MB  | 1241.41 MB | 9248.53 MB   | 3774.72 MB |
+| Delivery Rate      | 100.00%   | 99.99%     | 99.44%       | 99.96%     |
+| Peak RSS           | 20.3 MB   | 20.3 MB    | 36.4 MB      | 20.3 MB    |
+| Memory Drift       | 0.00 MB   | 0.00 MB    | 0.00 MB      | +0.16 MB   |
+| Throughput Avg     | 0.83 MB/s | 17.28 MB/s | 133.49 MB/s  | 19.33 MB/s |
+| Throughput StdDev  | 0.22 MB/s | 7.74 MB/s  | 66.76 MB/s   | 18.92 MB/s |
 
 ## Raw Socket Results
 
-| Metric             | LV1      | LV2        | LV3          | LV4         |
-|--------------------|----------|------------|--------------|-------------|
-| Reconnect          | 7        | 11         | 15           | 89          |
-| Exceptions         | 6        | 10         | 14           | 88          |
-| Peak RSS           | 14.1 MB  | 14.7 MB    | 14.8 MB      | 15.4 MB     |
-| Memory Drift       | 0.00 MB  | −0.05 MB   | −0.23 MB     | −0.25 MB    |
-| Throughput Avg     | 0.84 MB/s| 18.91 MB/s | 564.34 MB/s  | 779.13 MB/s |
-| Throughput StdDev  | 0.22 MB/s| 8.35 MB/s  | 269.31 MB/s  | 690.95 MB/s |
+| Metric             | LV1      | LV2        | LV3          | LV4          |
+|--------------------|----------|------------|--------------|--------------|
+| Reconnect          | 7        | 11         | 15           | 89           |
+| Exceptions         | 6        | 10         | 14           | 88           |
+| Sent               | 57.24 MB | 1344.23 MB | 39218.00 MB  | 153359.60 MB |
+| Server Received    | 56.99 MB | 1336.97 MB | 39205.38 MB  | 153281.65 MB |
+| Delivery Rate      | 99.56%   | 99.46%     | 99.97%       | 99.95%       |
+| Peak RSS           | 14.5 MB  | 14.7 MB    | 15.0 MB      | 15.0 MB      |
+| Memory Drift       | 0.00 MB  | +0.31 MB   | −0.11 MB     | −0.57 MB     |
+| Throughput Avg     | 0.84 MB/s| 18.76 MB/s | 563.50 MB/s  | 760.90 MB/s  |
+| Throughput StdDev  | 0.22 MB/s| 7.86 MB/s  | 268.25 MB/s  | 678.90 MB/s  |
 
 ---
 
@@ -58,32 +64,41 @@ Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kerne
 | LV3   | **0**   | 14         |
 | LV4   | **0**   | 88         |
 
+### Delivery Rate (Server Received / Client Sent)
+
+| Level | Unilink    | Raw Socket | Data Loss (Raw) |
+|-------|------------|------------|-----------------|
+| LV1   | **100.00%**| 99.56%     | 0.25 MB         |
+| LV2   | **99.99%** | 99.46%     | 7.26 MB         |
+| LV3   | 99.44%     | **99.97%** | 12.62 MB        |
+| LV4   | **99.96%** | 99.95%     | 77.95 MB        |
+
 ### Throughput Avg (MB/s) and Ratio
 
 | Level | Unilink     | Raw Socket   | Ratio |
 |-------|-------------|--------------|-------|
-| LV1   | 0.80        | 0.84         | ×1.05 |
-| LV2   | 15.76       | 18.91        | ×1.20 |
-| LV3   | 154.94      | 564.34       | ×3.64 |
-| LV4   | 19.21       | 779.13       | ×40.6 |
+| LV1   | 0.83        | 0.84         | ×1.01 |
+| LV2   | 17.28       | 18.76        | ×1.09 |
+| LV3   | 133.49      | 563.50       | ×4.22 |
+| LV4   | 19.33       | 760.90       | ×39.4 |
 
 ### Throughput StdDev (MB/s)
 
 | Level | Unilink | Raw Socket |
 |-------|---------|------------|
-| LV1   | 0.27    | 0.22       |
-| LV2   | 9.08    | 8.35       |
-| LV3   | 77.46   | 269.31     |
-| LV4   | 19.18   | 690.95     |
+| LV1   | 0.22    | 0.22       |
+| LV2   | 7.74    | 7.86       |
+| LV3   | 66.76   | 268.25     |
+| LV4   | 18.92   | 678.90     |
 
 ### Peak RSS and Memory Drift
 
 | Level | Unilink RSS | Raw RSS | Unilink Drift | Raw Drift |
 |-------|-------------|---------|---------------|-----------|
-| LV1   | 20.2 MB     | 14.1 MB | 0.00 MB       | 0.00 MB   |
-| LV2   | 20.2 MB     | 14.7 MB | 0.00 MB       | −0.05 MB  |
-| LV3   | 36.9 MB     | 14.8 MB | +0.47 MB      | −0.23 MB  |
-| LV4   | 20.3 MB     | 15.4 MB | 0.00 MB       | −0.25 MB  |
+| LV1   | 20.3 MB     | 14.5 MB | 0.00 MB       | 0.00 MB   |
+| LV2   | 20.3 MB     | 14.7 MB | 0.00 MB       | +0.31 MB  |
+| LV3   | 36.4 MB     | 15.0 MB | 0.00 MB       | −0.11 MB  |
+| LV4   | 20.3 MB     | 15.0 MB | +0.16 MB      | −0.57 MB  |
 
 ---
 
@@ -94,27 +109,56 @@ Unilink absorbs all transport errors internally and retries automatically. The P
 never sees BrokenPipe or ConnectionReset. Raw socket exposes every one directly as an
 exception — approximately one per chaos cycle.
 
+### Delivery Rate: level-by-level interpretation
+
+#### LV1 and LV2 — Unilink clearly wins
+At normal application loads (LV1: 0.83 MB/s, LV2: 17 MB/s), Unilink achieves 100.00% and
+99.99% delivery rate versus Raw's 99.56% and 99.46%. At LV2, Raw loses 7.26 MB absolute
+while Unilink loses 0.14 MB. The gaps are caused by Raw socket data loss on each exception
+(one 4KB payload lost per exception, plus any in-kernel-buffer data at disconnect time).
+Unilink's async queue is small enough that very little data is in-flight when disconnects occur.
+
+#### LV3 — Unilink delivery rate is lower (99.44% vs 99.97%)
+This is the one level where Raw socket outperforms Unilink on delivery completeness. The cause
+is Unilink's async write queue depth at disconnect time.
+
+At LV3 (64KB payloads, 10μs sleep), Unilink sends at ~133 MB/s and the async strand queue can
+hold significant data. When the server goes down, the queue may contain several megabytes of
+buffered-but-undelivered data. With 8 reconnects × ~6.5 MB average queue at disconnect =
+~52 MB lost. Raw socket's blocking `sendall()` means data enters the kernel buffer synchronously
+and is bounded by the kernel's SO_SNDBUF (~4 MB per socket), so per-disconnect loss is lower.
+
+This is a structural trade-off: Unilink's larger async buffer enables burst absorption and
+backpressure control, but increases potential loss per disconnect event at high throughput.
+
+#### LV4 — Near-identical delivery rate, different exception profile
+Both achieve ~99.95–99.96%. The key difference is Unilink's 0 exceptions vs Raw's 88.
+At LV4, Unilink's 10μs sleep rate-limits the queue depth, keeping in-flight data small at
+disconnect (47 reconnects × ~0.032 MB/reconnect = 1.52 MB lost). Raw socket's no-sleep
+aggressive sending means more data is in kernel buffers at disconnect time (89 reconnects ×
+~0.876 MB/reconnect = 77.95 MB lost), but the sheer volume sent (153 GB) makes the
+percentage loss appear equivalent.
+
 ### Throughput gap — why average numbers are misleading
 
 `Throughput Avg = total bytes sent ÷ total elapsed time`, so reconnect dead time and
 backpressure pauses both reduce the average. The two implementations accumulate dead time
 differently, making a direct average comparison unfair.
 
-#### LV3 (×3.64): backpressure pauses dominate
+#### LV3 (×4.22): backpressure pauses dominate
 
 | Source of dead time | Unilink                    | Raw Socket              |
 |---------------------|----------------------------|-------------------------|
 | Chaos downtime       | 8 × ~3.1s ≈ **25s**        | 15 × ~2.1s ≈ **32s**   |
-| Backpressure pauses | 1046 × ~13ms ≈ **14s**     | 0 (OS handles it)       |
-| Estimated send time | ~31s / 70s                 | ~38s / 70s              |
-| **Peak throughput** | 154.94×70/31 ≈ **350 MB/s**| 564×70/38 ≈ **1,040 MB/s** |
+| Backpressure pauses | 965 × ~13ms ≈ **13s**      | 0 (OS handles it)       |
+| Estimated send time | ~32s / 70s                 | ~38s / 70s              |
+| **Peak throughput** | 133×70/32 ≈ **291 MB/s**   | 563×70/38 ≈ **1,037 MB/s** |
 
-Peak ratio ≈ **×3.0** (not ×3.64). The backpressure pauses account for ~20% of the gap.
-The remaining ×2 gap is structural: raw `sendall()` leverages the OS kernel socket buffer
-as an implicit write-coalescing layer, while Unilink's async dispatch adds a strand
-serialization overhead.
+Peak ratio ≈ **×3.6**. The remaining gap is structural: raw `sendall()` leverages the OS
+kernel socket buffer as an implicit write-coalescing layer, while Unilink's async dispatch
+adds strand serialization overhead.
 
-#### LV4 (×40.6): connected window size dominates
+#### LV4 (×39.4): connected window size dominates
 
 With 2s chaos (2s up → 2s down) and matching 1000ms retry interval:
 
@@ -122,20 +166,17 @@ With 2s chaos (2s up → 2s down) and matching 1000ms retry interval:
 |---|---|---|
 | Reconnect dead time | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** |
 | Connected window | ~1.9s per 4s cycle ≈ **47% uptime** | ~1.9s per 4s cycle ≈ **47% uptime** |
-| Peak throughput (uptime-adjusted) | 19.21/0.47 ≈ **41 MB/s** | 779/0.47 ≈ **1,657 MB/s** |
+| Peak throughput (uptime-adjusted) | 19.33/0.47 ≈ **41 MB/s** | 761/0.47 ≈ **1,620 MB/s** |
 
 After equalizing uptime, peak ratio is still **×40**. This reflects the fundamental difference
-in send path: Unilink sends 4KB chunks at 10μs intervals (capped at ~100K/s = ~400 MB/s
-theoretical) through an async dispatch queue. Raw socket uses blocking `sendall()` with zero
-sleep, letting the kernel DMA data at near-loopback line rate (~1.6 GB/s).
-
-The ×40 in "peak" throughput is therefore the honest architectural cost of async dispatch
-vs blocking I/O for small 4KB payloads at very high frequency with no sleep.
+in send path: Unilink sends 4KB chunks at 10μs intervals through an async dispatch queue.
+Raw socket uses blocking `sendall()` with zero sleep, letting the kernel DMA data at
+near-loopback line rate (~1.6 GB/s).
 
 ### StdDev: Unilink far lower
-Raw socket's throughput swings wildly (StdDev 269–691 MB/s) because it alternates between
+Raw socket's throughput swings wildly (StdDev 268–679 MB/s) because it alternates between
 near-line-rate kernel bursts and zero. Unilink's backpressure dampens this significantly:
-StdDev 77 MB/s at LV3 and only 19 MB/s at LV4. Lower variance means more predictable
+StdDev 67 MB/s at LV3 and only 19 MB/s at LV4. Lower variance means more predictable
 behavior under load.
 
 ### Memory overhead (~6 MB per level)
@@ -155,33 +196,36 @@ the wrappers had the value hardcoded and were fixed to reference the constant.
 - With fast first retry (100ms) + 1s subsequent: recovery from a 2s outage ≈ 2.1s total
 - 3000ms was too conservative — in LV4's 2s chaos it caused the client to systematically
   miss entire reconnect windows, halving effective uptime (22% → 47%)
-- LV4 throughput impact: **9.31 → 19.21 MB/s** (×2.06) — uptime-normalized peak unchanged
-
-**LV3 throughput impact:** 137.31 → 154.94 MB/s (+13%) — shorter reconnect dead time
-per chaos cycle with 1s retry vs 3s retry.
 
 ---
 
 ## Key Findings
 
-### Bug fixed in this session
+### Bugs fixed in this session
 - `on_bp` watermarks were checked against `> 40 MiB` / `< 10 MiB`, but the C++ core fires
   ON at `bp_high_ = 16 MiB` and OFF at `bp_low_ = 8 MiB`. `send_allowed` was never cleared
   → backpressure bypassed → OOM/kernel crash at LV3+.
   Fixed to: `> 8 MiB` (ON) / `else` (OFF).
 
-### LV3 minimum sleep requirement
 - `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire GIL to fire
-  backpressure callbacks. Added 10μs sleep (matches raw benchmark LV3).
+  backpressure callbacks. Added 10μs sleep for LV3/LV4.
 
-### Wrapper retry interval inconsistency fixed
 - All three wrappers (TcpClient, UdsClient, Serial) had `retry_interval` hardcoded to 3000ms,
   ignoring `DEFAULT_RETRY_INTERVAL_MS` in `constants.hpp`. Fixed to reference the constant.
 
 ### Summary
-Unilink's lower average throughput is explained by:
-1. Explicit backpressure pauses (LV3: 1046 events) — OS handles this transparently for raw socket
-2. Async dispatch overhead vs blocking sendall() for small payloads at very high rate
-3. (Previously) longer reconnect dead time due to 3s retry interval — now fixed to 1s
+
+| Dimension              | LV1/LV2 (target range) | LV3/LV4 (extreme) |
+|------------------------|------------------------|-------------------|
+| Exceptions             | Unilink 0, Raw 6–10    | Unilink 0, Raw 14–88 |
+| Delivery Rate          | Unilink wins clearly   | Comparable; LV3 nuanced |
+| Throughput             | ~×1 (negligible gap)   | ×4–40 gap (structural) |
+| StdDev                 | Unilink lower          | Unilink much lower |
+| Absolute Data Loss     | Unilink 0–0.14 MB      | LV3: Raw better; LV4: comparable |
+
+Unilink's value proposition is strongest in LV1/LV2: zero exceptions, near-perfect delivery
+completeness, and throughput on par with raw sockets. At extreme loads (LV3/LV4), the
+trade-off becomes visible — lower throughput and higher per-reconnect queue loss at LV3
+versus raw socket's larger total loss and 88 unhandled exceptions at LV4.
 
 LV1–LV4 all passed with Exceptions = 0 and no memory leak.

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -95,16 +95,48 @@ Unilink wraps all transport errors in the reconnect loop and fires `on_error` ca
 internally. The Python layer never sees a BrokenPipe or ConnectionReset. Raw socket exposes
 every one directly as an exception — one per chaos cycle.
 
-### Throughput gap (LV3: ×4, LV4: ×87)
-- **LV3**: Raw socket `sendall()` is blocking and the OS kernel socket send buffer (typically
-  128–256 KB) acts as a natural throttle. When the buffer fills, `sendall()` blocks in the kernel
-  and the GIL is released, so throughput is very high. Unilink adds: async dispatch overhead,
-  10 μs sleep per send (caps at ~100K sends/s), and explicit backpressure pauses (917 events).
-- **LV4**: The gap is extreme (×87) because the raw LV4 uses `SEND_SLEEP=0`. Blocking
-  `sendall()` with zero sleep hits the kernel buffer at full speed between reconnects. Unilink
-  uses 10 μs sleep to prevent GIL starvation, capping burst throughput significantly.
-  Both are dominated by reconnect downtime at 2s chaos interval — the raw socket just sends
-  faster during the brief connected windows.
+### Throughput gap (LV3: ×4, LV4: ×87) — 평균값의 함정
+
+`Throughput Avg = 총 전송량 ÷ 전체 실행 시간`이므로 연결이 끊겨 있는 시간(재연결 대기 +
+백프레셔 정지)이 분모에 포함된다. Unilink와 raw socket은 이 "dead time"의 구조가 다르다.
+
+#### LV3 (×4.19) — 백프레셔 정지 시간이 주원인
+
+| 원인 | Unilink | Raw Socket |
+|------|---------|------------|
+| chaos downtime | 8회 × ~5s = **40s** | 15회 × ~2s = **30s** |
+| 백프레셔 정지 | 917회 × ~13ms ≈ **12s** | 없음 (OS 커널이 투명하게 처리) |
+| 실제 전송 구간 (추정) | ~18s / 70s | ~40s / 70s |
+| **전송 구간만의 피크 처리량** | 137×70/18 ≈ **532 MB/s** | 575×70/40 ≈ **1,006 MB/s** |
+
+피크 기준으로는 ×4가 아닌 ×1.9 수준이다. Raw socket의 `sendall()`도 OS 커널 소켓 버퍼가
+꽉 차면 블로킹으로 멈추지만 그 시간은 측정에 포함되지 않는다. Unilink는 백프레셔 정지를
+명시적으로 구현하므로 dead time으로 측정된다. 917회 백프레셔는 고장이 아니라 **64KB ×
+최대속도 전송이 16 MiB 큐 한도에 부딪혀 OOM을 막기 위해 의도적으로 제동을 건 것**이다.
+
+#### LV4 (×87) — 재연결 대기 시간이 압도적 주원인
+
+| 원인 | Unilink | Raw Socket |
+|------|---------|------------|
+| 재연결 전략 | 3s retry interval (기본값) | 즉시 재시도 |
+| 2s chaos 사이클당 dead time | 2s down + 3s wait = **5s** | 2s down + 즉시 ≈ **2s** |
+| 유효 업타임 (추정) | ~17% | ~50% |
+| **연결 구간만의 처리량** | 9.31/0.17 ≈ **55 MB/s** | 811/0.50 ≈ **1,622 MB/s** |
+
+ub타임 차이를 보정해도 연결 구간 처리량 자체도 raw가 더 높은데, 이는 raw LV4의
+`SEND_SLEEP=0` vs Unilink의 10μs 조건 차이이기도 하다. ×87 격차의 가장 큰 요인은
+**3s retry interval이 2s chaos 간격보다 길어서 대기 시간이 연결 시간을 초과**하는 구조다.
+retry_interval을 500ms로 줄이면 업타임이 ~50%로 올라가 격차가 ×10 미만으로 좁혀진다.
+
+#### 결론
+
+LV3·LV4의 낮은 평균 처리량은 **Unilink 자체의 전송 성능 문제가 아니다**.
+
+- LV3: 백프레셔가 정상 작동한 결과 (dead time 포함)
+- LV4: retry interval 기본값(3s)이 극단적 chaos 간격(2s)에 맞지 않아 발생하는 구조적 차이
+- 실사용 기준: raw socket의 높은 수치는 14~90개 예외를 감수한 것; Unilink는 0 예외 + 자동
+  reconnect + backpressure를 모두 보장하면서 나온 수치
+- StdDev가 Unilink에서 훨씬 낮다(LV3: 89 vs 283 MB/s)는 점이 안정성의 실질적 지표다
 
 ### StdDev: Raw socket far higher at LV3/LV4
 Raw socket's throughput swings wildly (StdDev 283–685 MB/s) because it alternates between
@@ -140,3 +172,9 @@ at LV4 is OS reclaiming pages after peak socket buffer usage.
   **backpressure flow control**, and **lower throughput variance** — all expected for a
   production-grade async transport framework vs. raw socket.
 - LV1–LV4 all passed with Exceptions = 0 and no memory leak.
+- **평균 처리량의 낮은 수치는 설계상 차이(retry interval, 명시적 백프레셔)에서 오는 것이며
+  전송 성능 자체의 결함이 아니다.** 공정 비교를 위해서는 연결 구간만의 처리량 또는
+  동일한 retry interval 조건에서 측정해야 한다.
+
+## Pending
+- 동일 retry interval 조건(예: 100ms)에서의 Unilink vs Raw 재비교

--- a/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
+++ b/tools/benchmark/stability/results/2026-04-26_lv1-lv4.md
@@ -5,7 +5,6 @@
 - OS: Linux 6.6.87.2-microsoft-standard-WSL2
 - Python: 3.12
 - Unilink: v0.6.0
-- Commit: fix/test: fix backpressure watermarks and add multi-level stability benchmark
 - Duration: 60s (LV1–LV3), 180s (LV4)
 
 ## Level Configurations
@@ -15,40 +14,58 @@
 | LV1   | 1 KB    | 1 ms       | 20s            | 2s        | 60s      |
 | LV2   | 4 KB    | 100 μs     | 10s            | 2s        | 60s      |
 | LV3   | 64 KB   | 10 μs      | 7s             | 2s        | 60s      |
-| LV4   | 4 KB    | 10 μs *    | 2s             | 2s        | 180s     |
+| LV4   | 4 KB    | 10 μs      | 2s             | 2s        | 180s     |
 
-\* Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kernel buffer)
+Retry interval: Unilink default **1000ms** (100ms fast first retry + 1000ms subsequent).
+Raw socket benchmark mirrors same pattern (100ms first, 1000ms subsequent).
+Raw socket LV4 uses SEND_SLEEP=0 (blocking sendall throttles naturally via kernel buffer).
 
 ---
 
-## Unilink vs Raw Socket — Full Comparison
+## Unilink Results
 
-### Reconnect Successes
+| Metric             | LV1       | LV2        | LV3          | LV4        |
+|--------------------|-----------|------------|--------------|------------|
+| Reconnect          | 4         | 6          | 8            | 47         |
+| Exceptions         | 0         | 0          | 0            | 0          |
+| Backpressure Hits  | 0         | 0          | 1046         | 0          |
+| Peak RSS           | 20.2 MB   | 20.2 MB    | 36.9 MB      | 20.3 MB    |
+| Memory Drift       | 0.00 MB   | 0.00 MB    | +0.47 MB     | 0.00 MB    |
+| Throughput Avg     | 0.80 MB/s | 15.76 MB/s | 154.94 MB/s  | 19.21 MB/s |
+| Throughput StdDev  | 0.27 MB/s | 9.08 MB/s  | 77.46 MB/s   | 19.18 MB/s |
 
-| Level | Unilink | Raw Socket | Note |
-|-------|---------|------------|------|
-| LV1   | 4       | 7          | Raw retries immediately; Unilink waits 3s retry interval |
-| LV2   | 6       | 11         | Same pattern |
-| LV3   | 8       | 15         | Same pattern |
-| LV4   | 47      | 91         | 2s chaos → raw reconnects ~twice as often |
+## Raw Socket Results
+
+| Metric             | LV1      | LV2        | LV3          | LV4         |
+|--------------------|----------|------------|--------------|-------------|
+| Reconnect          | 7        | 11         | 15           | 89          |
+| Exceptions         | 6        | 10         | 14           | 88          |
+| Peak RSS           | 14.1 MB  | 14.7 MB    | 14.8 MB      | 15.4 MB     |
+| Memory Drift       | 0.00 MB  | −0.05 MB   | −0.23 MB     | −0.25 MB    |
+| Throughput Avg     | 0.84 MB/s| 18.91 MB/s | 564.34 MB/s  | 779.13 MB/s |
+| Throughput StdDev  | 0.22 MB/s| 8.35 MB/s  | 269.31 MB/s  | 690.95 MB/s |
+
+---
+
+## Unilink vs Raw Socket — Side-by-Side
 
 ### Exceptions
 
-| Level | Unilink | Raw Socket | Note |
-|-------|---------|------------|------|
-| LV1   | **0**   | 6          | Raw socket exposes BrokenPipe/ConnReset directly |
-| LV2   | **0**   | 10         | |
-| LV3   | **0**   | 14         | |
-| LV4   | **0**   | 90         | 90 exceptions over 180s — one per reconnect cycle |
+| Level | Unilink | Raw Socket |
+|-------|---------|------------|
+| LV1   | **0**   | 6          |
+| LV2   | **0**   | 10         |
+| LV3   | **0**   | 14         |
+| LV4   | **0**   | 88         |
 
-### Throughput Avg (MB/s)
+### Throughput Avg (MB/s) and Ratio
 
-| Level | Unilink    | Raw Socket  | Ratio |
-|-------|------------|-------------|-------|
-| LV1   | 0.80       | 0.84        | ×1.05 |
-| LV2   | 15.76      | 18.91       | ×1.20 |
-| LV3   | 137.31     | 575.25      | ×4.19 |
-| LV4   | 9.31       | 811.42      | ×87   |
+| Level | Unilink     | Raw Socket   | Ratio |
+|-------|-------------|--------------|-------|
+| LV1   | 0.80        | 0.84         | ×1.05 |
+| LV2   | 15.76       | 18.91        | ×1.20 |
+| LV3   | 154.94      | 564.34       | ×3.64 |
+| LV4   | 19.21       | 779.13       | ×40.6 |
 
 ### Throughput StdDev (MB/s)
 
@@ -56,125 +73,115 @@
 |-------|---------|------------|
 | LV1   | 0.27    | 0.22       |
 | LV2   | 9.08    | 8.35       |
-| LV3   | 89.82   | 283.14     |
-| LV4   | 15.89   | 685.37     |
+| LV3   | 77.46   | 269.31     |
+| LV4   | 19.18   | 690.95     |
 
-### Peak RSS
+### Peak RSS and Memory Drift
 
-| Level | Unilink | Raw Socket |
-|-------|---------|------------|
-| LV1   | 20.2 MB | 14.1 MB    |
-| LV2   | 20.2 MB | 14.7 MB    |
-| LV3   | 36.6 MB | 15.0 MB    |
-| LV4   | 20.5 MB | 15.7 MB    |
-
-### Memory Drift
-
-| Level | Unilink  | Raw Socket |
-|-------|----------|------------|
-| LV1   | 0.00 MB  | 0.00 MB    |
-| LV2   | 0.00 MB  | −0.05 MB   |
-| LV3   | +0.16 MB | +0.01 MB   |
-| LV4   | +0.16 MB | −0.73 MB   |
-
-### Backpressure Hits (Unilink only)
-
-| Level | Unilink |
-|-------|---------|
-| LV1   | 0       |
-| LV2   | 0       |
-| LV3   | 917     |
-| LV4   | 0       |
+| Level | Unilink RSS | Raw RSS | Unilink Drift | Raw Drift |
+|-------|-------------|---------|---------------|-----------|
+| LV1   | 20.2 MB     | 14.1 MB | 0.00 MB       | 0.00 MB   |
+| LV2   | 20.2 MB     | 14.7 MB | 0.00 MB       | −0.05 MB  |
+| LV3   | 36.9 MB     | 14.8 MB | +0.47 MB      | −0.23 MB  |
+| LV4   | 20.3 MB     | 15.4 MB | 0.00 MB       | −0.25 MB  |
 
 ---
 
 ## Analysis
 
-### Exceptions: Unilink 0 vs Raw socket up to 90
-Unilink wraps all transport errors in the reconnect loop and fires `on_error` callbacks
-internally. The Python layer never sees a BrokenPipe or ConnectionReset. Raw socket exposes
-every one directly as an exception — one per chaos cycle.
+### Exceptions: Unilink 0 vs Raw socket up to 88
+Unilink absorbs all transport errors internally and retries automatically. The Python layer
+never sees BrokenPipe or ConnectionReset. Raw socket exposes every one directly as an
+exception — approximately one per chaos cycle.
 
-### Throughput gap (LV3: ×4, LV4: ×87) — 평균값의 함정
+### Throughput gap — why average numbers are misleading
 
-`Throughput Avg = 총 전송량 ÷ 전체 실행 시간`이므로 연결이 끊겨 있는 시간(재연결 대기 +
-백프레셔 정지)이 분모에 포함된다. Unilink와 raw socket은 이 "dead time"의 구조가 다르다.
+`Throughput Avg = total bytes sent ÷ total elapsed time`, so reconnect dead time and
+backpressure pauses both reduce the average. The two implementations accumulate dead time
+differently, making a direct average comparison unfair.
 
-#### LV3 (×4.19) — 백프레셔 정지 시간이 주원인
+#### LV3 (×3.64): backpressure pauses dominate
 
-| 원인 | Unilink | Raw Socket |
-|------|---------|------------|
-| chaos downtime | 8회 × ~5s = **40s** | 15회 × ~2s = **30s** |
-| 백프레셔 정지 | 917회 × ~13ms ≈ **12s** | 없음 (OS 커널이 투명하게 처리) |
-| 실제 전송 구간 (추정) | ~18s / 70s | ~40s / 70s |
-| **전송 구간만의 피크 처리량** | 137×70/18 ≈ **532 MB/s** | 575×70/40 ≈ **1,006 MB/s** |
+| Source of dead time | Unilink                    | Raw Socket              |
+|---------------------|----------------------------|-------------------------|
+| Chaos downtime       | 8 × ~3.1s ≈ **25s**        | 15 × ~2.1s ≈ **32s**   |
+| Backpressure pauses | 1046 × ~13ms ≈ **14s**     | 0 (OS handles it)       |
+| Estimated send time | ~31s / 70s                 | ~38s / 70s              |
+| **Peak throughput** | 154.94×70/31 ≈ **350 MB/s**| 564×70/38 ≈ **1,040 MB/s** |
 
-피크 기준으로는 ×4가 아닌 ×1.9 수준이다. Raw socket의 `sendall()`도 OS 커널 소켓 버퍼가
-꽉 차면 블로킹으로 멈추지만 그 시간은 측정에 포함되지 않는다. Unilink는 백프레셔 정지를
-명시적으로 구현하므로 dead time으로 측정된다. 917회 백프레셔는 고장이 아니라 **64KB ×
-최대속도 전송이 16 MiB 큐 한도에 부딪혀 OOM을 막기 위해 의도적으로 제동을 건 것**이다.
+Peak ratio ≈ **×3.0** (not ×3.64). The backpressure pauses account for ~20% of the gap.
+The remaining ×2 gap is structural: raw `sendall()` leverages the OS kernel socket buffer
+as an implicit write-coalescing layer, while Unilink's async dispatch adds a strand
+serialization overhead.
 
-#### LV4 (×87) — 재연결 대기 시간이 압도적 주원인
+#### LV4 (×40.6): connected window size dominates
 
-| 원인 | Unilink | Raw Socket |
-|------|---------|------------|
-| 재연결 전략 | 3s retry interval (기본값) | 즉시 재시도 |
-| 2s chaos 사이클당 dead time | 2s down + 3s wait = **5s** | 2s down + 즉시 ≈ **2s** |
-| 유효 업타임 (추정) | ~17% | ~50% |
-| **연결 구간만의 처리량** | 9.31/0.17 ≈ **55 MB/s** | 811/0.50 ≈ **1,622 MB/s** |
+With 2s chaos (2s up → 2s down) and matching 1000ms retry interval:
 
-ub타임 차이를 보정해도 연결 구간 처리량 자체도 raw가 더 높은데, 이는 raw LV4의
-`SEND_SLEEP=0` vs Unilink의 10μs 조건 차이이기도 하다. ×87 격차의 가장 큰 요인은
-**3s retry interval이 2s chaos 간격보다 길어서 대기 시간이 연결 시간을 초과**하는 구조다.
-retry_interval을 500ms로 줄이면 업타임이 ~50%로 올라가 격차가 ×10 미만으로 좁혀진다.
+| | Unilink | Raw Socket |
+|---|---|---|
+| Reconnect dead time | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** | 0.1s fail + 1.0s fail + 1.0s success = **2.1s** |
+| Connected window | ~1.9s per 4s cycle ≈ **47% uptime** | ~1.9s per 4s cycle ≈ **47% uptime** |
+| Peak throughput (uptime-adjusted) | 19.21/0.47 ≈ **41 MB/s** | 779/0.47 ≈ **1,657 MB/s** |
 
-#### 결론
+After equalizing uptime, peak ratio is still **×40**. This reflects the fundamental difference
+in send path: Unilink sends 4KB chunks at 10μs intervals (capped at ~100K/s = ~400 MB/s
+theoretical) through an async dispatch queue. Raw socket uses blocking `sendall()` with zero
+sleep, letting the kernel DMA data at near-loopback line rate (~1.6 GB/s).
 
-LV3·LV4의 낮은 평균 처리량은 **Unilink 자체의 전송 성능 문제가 아니다**.
+The ×40 in "peak" throughput is therefore the honest architectural cost of async dispatch
+vs blocking I/O for small 4KB payloads at very high frequency with no sleep.
 
-- LV3: 백프레셔가 정상 작동한 결과 (dead time 포함)
-- LV4: retry interval 기본값(3s)이 극단적 chaos 간격(2s)에 맞지 않아 발생하는 구조적 차이
-- 실사용 기준: raw socket의 높은 수치는 14~90개 예외를 감수한 것; Unilink는 0 예외 + 자동
-  reconnect + backpressure를 모두 보장하면서 나온 수치
-- StdDev가 Unilink에서 훨씬 낮다(LV3: 89 vs 283 MB/s)는 점이 안정성의 실질적 지표다
+### StdDev: Unilink far lower
+Raw socket's throughput swings wildly (StdDev 269–691 MB/s) because it alternates between
+near-line-rate kernel bursts and zero. Unilink's backpressure dampens this significantly:
+StdDev 77 MB/s at LV3 and only 19 MB/s at LV4. Lower variance means more predictable
+behavior under load.
 
-### StdDev: Raw socket far higher at LV3/LV4
-Raw socket's throughput swings wildly (StdDev 283–685 MB/s) because it alternates between
-near-line-rate bursts and zero. Unilink's backpressure smooths this: StdDev 89 MB/s at LV3
-and only 15 MB/s at LV4 (most time spent reconnecting, little variation in that pattern).
+### Memory overhead (~6 MB per level)
+Unilink carries ~6 MB more RSS consistently: Boost.ASIO io_context, strand, memory pool,
+batch queue, callback wiring, and the Python binding GIL-acquire wrappers.
 
-### Memory overhead (~6 MB)
-Unilink carries ~6 MB more RSS than raw socket across all levels, consistent with
-framework overhead: Boost.ASIO io_context, strand, memory pool (400 buffers × 4 sizes),
-batch queue, callback registrations, and the Python binding layer.
+---
 
-### Memory drift
-Both are stable. Unilink's +0.16 MB at LV3/LV4 is a one-time allocation (likely memory pool
-expansion under high load) that does not grow further — not a leak. Raw socket's −0.73 MB
-at LV4 is OS reclaiming pages after peak socket buffer usage.
+## Retry Interval Decision (3000ms → 1000ms)
+
+The default retry interval was changed from 3000ms to **1000ms** across all wrapper layers
+(TcpClient, UdsClient, Serial). The transport layer already read from `constants.hpp`;
+the wrappers had the value hardcoded and were fixed to reference the constant.
+
+**Rationale:**
+- Industry standard: Redis, MQTT clients, and gRPC all default to ~1s
+- With fast first retry (100ms) + 1s subsequent: recovery from a 2s outage ≈ 2.1s total
+- 3000ms was too conservative — in LV4's 2s chaos it caused the client to systematically
+  miss entire reconnect windows, halving effective uptime (22% → 47%)
+- LV4 throughput impact: **9.31 → 19.21 MB/s** (×2.06) — uptime-normalized peak unchanged
+
+**LV3 throughput impact:** 137.31 → 154.94 MB/s (+13%) — shorter reconnect dead time
+per chaos cycle with 1s retry vs 3s retry.
 
 ---
 
 ## Key Findings
 
 ### Bug fixed in this session
-- `on_bp` watermarks were checked against `> 40 MiB` (pause) / `< 10 MiB` (resume), but the
-  C++ core fires ON at `bp_high_ = 16 MiB` and OFF at `bp_low_ = 8 MiB`.
-  `send_allowed` was never cleared → backpressure completely bypassed → OOM/kernel crash at LV3+.
-- Fixed to: `> 8 MiB` (ON) / `else` (OFF).
+- `on_bp` watermarks were checked against `> 40 MiB` / `< 10 MiB`, but the C++ core fires
+  ON at `bp_high_ = 16 MiB` and OFF at `bp_low_ = 8 MiB`. `send_allowed` was never cleared
+  → backpressure bypassed → OOM/kernel crash at LV3+.
+  Fixed to: `> 8 MiB` (ON) / `else` (OFF).
 
 ### LV3 minimum sleep requirement
-- `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire the GIL to fire
-  backpressure callbacks. Added 10 μs sleep (matches `stability_bench_raw.py` LV3).
+- `SEND_SLEEP = 0` caused GIL starvation: the ASIO thread couldn't acquire GIL to fire
+  backpressure callbacks. Added 10μs sleep (matches raw benchmark LV3).
+
+### Wrapper retry interval inconsistency fixed
+- All three wrappers (TcpClient, UdsClient, Serial) had `retry_interval` hardcoded to 3000ms,
+  ignoring `DEFAULT_RETRY_INTERVAL_MS` in `constants.hpp`. Fixed to reference the constant.
 
 ### Summary
-- Unilink trades raw throughput for **zero user-visible exceptions**, **automatic reconnect**,
-  **backpressure flow control**, and **lower throughput variance** — all expected for a
-  production-grade async transport framework vs. raw socket.
-- LV1–LV4 all passed with Exceptions = 0 and no memory leak.
-- **평균 처리량의 낮은 수치는 설계상 차이(retry interval, 명시적 백프레셔)에서 오는 것이며
-  전송 성능 자체의 결함이 아니다.** 공정 비교를 위해서는 연결 구간만의 처리량 또는
-  동일한 retry interval 조건에서 측정해야 한다.
+Unilink's lower average throughput is explained by:
+1. Explicit backpressure pauses (LV3: 1046 events) — OS handles this transparently for raw socket
+2. Async dispatch overhead vs blocking sendall() for small payloads at very high rate
+3. (Previously) longer reconnect dead time due to 3s retry interval — now fixed to 1s
 
-## Pending
-- 동일 retry interval 조건(예: 100ms)에서의 Unilink vs Raw 재비교
+LV1–LV4 all passed with Exceptions = 0 and no memory leak.

--- a/tools/benchmark/stability/run_comparison.sh
+++ b/tools/benchmark/stability/run_comparison.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Usage: ./run_comparison.sh [LOAD_LEVEL]
+# LOAD_LEVEL: 1=light, 2=medium, 3=heavy, 4=ultra (default: 1)
+
+LOAD_LEVEL=${1:-1}
+
+export PYTHONPATH=$(pwd)/bindings/python:$(pwd)/build/lib
+export LOAD_LEVEL
+
+echo "Starting Stability Benchmark Comparison (Level ${LOAD_LEVEL}, 60s each)..."
+echo "----------------------------------------------------"
+
+# Run Unilink Benchmark
+python3 tools/benchmark/stability/stability_bench.py
+
+echo ""
+
+# Run Raw Socket Benchmark
+python3 tools/benchmark/stability/stability_bench_raw.py
+
+echo ""
+echo "Benchmark Comparison Complete."

--- a/tools/benchmark/stability/stability_bench.py
+++ b/tools/benchmark/stability/stability_bench.py
@@ -1,139 +1,187 @@
+import os
 import time
 import threading
+import statistics
 import unilink
-import os
+import psutil
 import sys
 
-# Constants
-TEST_DURATION = 60  # Duration in seconds for a quick stability run
-PAYLOAD_SIZE = 4096 # 4KB chunks
-HOST = "127.0.0.1"
-PORT = 9990
+# Configuration levels
+LOAD_LEVEL = int(os.getenv("LOAD_LEVEL", "1"))
 
-class StabilityMonitor:
+if LOAD_LEVEL == 1:
+    PAYLOAD_SIZE = 1024
+    SEND_SLEEP = 0.001
+    CHAOS_INTERVAL = 20
+    DURATION = 60
+elif LOAD_LEVEL == 2:
+    PAYLOAD_SIZE = 4096
+    SEND_SLEEP = 0.0001
+    CHAOS_INTERVAL = 10
+    DURATION = 60
+elif LOAD_LEVEL == 3:
+    PAYLOAD_SIZE = 65536
+    SEND_SLEEP = 0.00001  # 10μs - prevent strand queue starvation under max load
+    CHAOS_INTERVAL = 7
+    DURATION = 60
+else:
+    PAYLOAD_SIZE = 4096
+    SEND_SLEEP = 0.00001  # minimum throttle even for ultra stress
+    CHAOS_INTERVAL = 2
+    DURATION = 180
+
+PORT = 10001
+CHAOS_DOWN_TIME = 2
+
+class UnilinkStabilityBench:
     def __init__(self):
-        self.start_memory = self.get_memory_usage()
-        self.max_memory = self.start_memory
+        self.server = None
+        self.client = None
+        self.running = False
+        self.sent_bytes = 0
         self.reconnect_count = 0
-        self.error_count = 0
-        self.total_bytes = 0
-        self.is_running = True
+        self.exceptions = 0
+        self.bp_events_triggered = 0
+        self.snapshots = []
+        self.process = psutil.Process(os.getpid())
+        self.send_allowed = threading.Event()
+        self.send_allowed.set()
 
-    def get_memory_usage(self):
-        # Returns RSS memory in MB
+    def start_server(self):
         try:
-            import psutil
-            process = psutil.Process(os.getpid())
-            return process.memory_info().rss / 1024 / 1024
-        except ImportError:
-            # Fallback for Linux if psutil is not available
+            self.server = unilink.TcpServer(PORT)
+            self.server.on_data(lambda ctx: None) # Sink
+            self.server.start_sync()
+        except Exception as e:
+            self.exceptions += 1
+
+    def stop_server(self):
+        if self.server:
             try:
-                with open('/proc/self/status', 'r') as f:
-                    for line in f:
-                        if line.startswith('VmRSS:'):
-                            return int(line.split()[1]) / 1024
-            except:
-                return 0
-        return 0
+                self.server.stop()
+                self.server = None
+            except Exception:
+                pass
 
-    def monitor_loop(self):
-        while self.is_running:
-            current_mem = self.get_memory_usage()
-            self.max_memory = max(self.max_memory, current_mem)
+    def on_bp(self, queued_bytes):
+        # C++ fires ON  when queued_bytes >= bp_high_ (default 16 MiB)
+        # C++ fires OFF when queued_bytes <= bp_low_  (default  8 MiB = bp_high_/2)
+        # Distinguish ON from OFF by comparing against the midpoint (bp_low_).
+        if queued_bytes > 8 * 1024 * 1024:  # ON event: value >= 16 MiB
+            self.send_allowed.clear()
+            self.bp_events_triggered += 1
+        else:                                # OFF event: value <= 8 MiB
+            self.send_allowed.set()
+
+    def monitor(self):
+        start_time = time.time()
+        while self.running and (time.time() - start_time < DURATION):
+            prev_sent = self.sent_bytes
             time.sleep(1)
+            curr_sent = self.sent_bytes
+            throughput = (curr_sent - prev_sent) / (1024 * 1024) # MB/s
+            rss = self.process.memory_info().rss / (1024 * 1024) # MB
+            self.snapshots.append((throughput, rss))
+            
+    def sender(self):
+        payload = b"A" * PAYLOAD_SIZE
+        while self.running:
+            try:
+                # Flow control
+                self.send_allowed.wait(timeout=0.1)
+                if not self.send_allowed.is_set():
+                    continue
 
-    def print_report(self, duration):
-        end_memory = self.get_memory_usage()
-        print("\n" + "="*50)
-        print("🛡️ UNILINK STABILITY REPORT")
-        print("="*50)
-        print(f"Test Duration:      {duration:.1f} seconds")
-        print(f"Total Data Xfer:    {self.total_bytes / 1024 / 1024:.2f} MB")
-        print(f"Average Throughput: {self.total_bytes / 1024 / 1024 / duration:.2f} MB/s")
-        print("-"*50)
-        print(f"Start Memory (RSS): {self.start_memory:.2f} MB")
-        print(f"Peak Memory (RSS):  {self.max_memory:.2f} MB")
-        print(f"End Memory (RSS):   {end_memory:.2f} MB")
-        print(f"Memory Drift:       {end_memory - self.start_memory:+.4f} MB")
-        print("-"*50)
-        print(f"Successful Reconnects: {self.reconnect_count}")
-        print(f"Total Errors:          {self.error_count}")
+                if self.client and self.client.connected():
+                    if self.client.send(payload):
+                        self.sent_bytes += PAYLOAD_SIZE
+                    else:
+                        # Send failed (backpressure hard limit or disconnected)
+                        time.sleep(0.001) 
+                    
+                    if SEND_SLEEP > 0:
+                        time.sleep(SEND_SLEEP)
+                else:
+                    self.send_allowed.set() # Reset if disconnected
+                    time.sleep(0.01) 
+            except Exception:
+                self.exceptions += 1
+
+    def chaos(self):
+        start_time = time.time()
+        while self.running and (time.time() - start_time < DURATION):
+            time.sleep(CHAOS_INTERVAL)
+            if not self.running: break
+            self.stop_server()
+            time.sleep(CHAOS_DOWN_TIME)
+            if not self.running: break
+            self.start_server()
+
+    def run(self):
+        print(f"--- Starting Unilink Stability Bench (Level {LOAD_LEVEL}) ---")
+        print(f"Payload: {PAYLOAD_SIZE} bytes, Flow Control: ON, Chaos: {CHAOS_INTERVAL}s")
         
-        if (end_memory - self.start_memory) < 1.0 and self.error_count == 0:
-            print("\n✅ STATUS: ROCK SOLID (Perfect memory flatness & zero errors)")
-        elif self.error_count > 0:
-            print("\n⚠️ STATUS: UNSTABLE (Errors detected)")
-        else:
-            print("\nℹ️ STATUS: OBSERVATION NEEDED (Minor memory drift)")
-        print("="*50)
-
-def run_stability_test():
-    monitor = StabilityMonitor()
-    monitor_thread = threading.Thread(target=monitor.monitor_loop)
-    monitor_thread.start()
-
-    server = unilink.TcpServer(PORT)
-    client = unilink.TcpClient(HOST, PORT)
-
-    # Use Batching to stress GIL and memory pool
-    def on_server_batch(batch):
-        monitor.total_bytes += sum(len(ctx.data) for ctx in batch)
-
-    def on_client_error(ctx):
-        monitor.error_count += 1
-        # print(f"Client error: {ctx.message}")
-
-    def on_client_connect(ctx):
-        monitor.reconnect_count += 1
-
-    server.on_data_batch(on_server_batch)
-    client.on_error(on_client_error)
-    client.on_connect(on_client_connect)
-
-    server.start()
-    client.start()
-    
-    # We expect one initial connect
-    time.sleep(1)
-    monitor.reconnect_count = 0 
-
-    start_time = time.time()
-    payload = b"S" * PAYLOAD_SIZE
-
-    print(f"🚀 Starting high-load stability test for {TEST_DURATION}s...")
-    
-    # Chaos Simulation: periodically stop and start the server
-    def chaos_loop():
-        while time.time() - start_time < TEST_DURATION - 5:
-            time.sleep(10)
-            # print("🔥 Chaos: Restarting Server...")
-            server.stop()
-            time.sleep(2)
-            server.start()
-
-    chaos_thread = threading.Thread(target=chaos_loop, daemon=True)
-    chaos_thread.start()
-
-    # Data Flood Loop
-    while time.time() - start_time < TEST_DURATION:
+        self.running = True
+        self.start_server()
+        
+        self.client = unilink.TcpClient("127.0.0.1", PORT)
+        self.client.on_connect(lambda ctx: setattr(self, 'reconnect_count', self.reconnect_count + 1))
+        self.client.on_backpressure(self.on_bp)
+        
+        # Optimize
+        self.client.batch_size(200)
+        from datetime import timedelta
+        self.client.batch_latency(timedelta(milliseconds=1))
+        
         try:
-            if client.connected():
-                if not client.send(payload):
-                    # Backpressure hit
-                    time.sleep(0.01)
-            else:
-                time.sleep(0.1)
-        except:
-            monitor.error_count += 1
+            self.client.start_sync()
+        except Exception:
+            self.running = False
+            return
 
-    actual_duration = time.time() - start_time
-    monitor.is_running = False
-    monitor_thread.join()
-    
-    client.stop()
-    server.stop()
-    
-    monitor.print_report(actual_duration)
+        threads = [
+            threading.Thread(target=self.sender, name="Sender"),
+            threading.Thread(target=self.chaos, name="Chaos"),
+            threading.Thread(target=self.monitor, name="Monitor")
+        ]
+
+        for t in threads: t.start()
+        
+        try:
+            start_run = time.time()
+            while self.running and (time.time() - start_run < DURATION):
+                time.sleep(10)
+                print(f"[Heartbeat] {int(time.time() - start_run)}s elapsed... BP count: {self.bp_events_triggered}")
+        except KeyboardInterrupt:
+            print("\nBenchmark interrupted")
+        finally:
+            self.running = False
+            self.send_allowed.set() # Release sender
+            for t in threads: t.join(timeout=2.0)
+            self.stop_server()
+            if self.client: self.client.stop()
+        
+        self.report()
+
+    def report(self):
+        all_throughputs = [s[0] for s in self.snapshots]
+        rss_values = [s[1] for s in self.snapshots]
+        
+        avg_tp = statistics.mean(all_throughputs) if all_throughputs else 0
+        std_tp = statistics.stdev(all_throughputs) if len(all_throughputs) > 1 else 0
+        mem_drift = rss_values[-1] - rss_values[0] if rss_values else 0
+        peak_rss = max(rss_values) if rss_values else 0
+        
+        print(f"\n--- Unilink Stability Results (Level {LOAD_LEVEL}) ---")
+        print(f"Reconnect Successes: {self.reconnect_count}")
+        print(f"Exceptions:          {self.exceptions}")
+        print(f"Backpressure Hits:   {self.bp_events_triggered}")
+        print(f"Peak Memory (RSS):   {peak_rss:.2f} MB")
+        print(f"Memory Drift:        {mem_drift:.2f} MB")
+        print(f"Throughput Avg:      {avg_tp:.2f} MB/s")
+        print(f"Throughput StdDev:   {std_tp:.2f} MB/s")
+        print(f"--------------------------------------------------")
 
 if __name__ == "__main__":
-    run_stability_test()
+    bench = UnilinkStabilityBench()
+    bench.run()

--- a/tools/benchmark/stability/stability_bench.py
+++ b/tools/benchmark/stability/stability_bench.py
@@ -39,6 +39,7 @@ class UnilinkStabilityBench:
         self.client = None
         self.running = False
         self.sent_bytes = 0
+        self.server_received_bytes = 0
         self.reconnect_count = 0
         self.exceptions = 0
         self.bp_events_triggered = 0
@@ -50,10 +51,13 @@ class UnilinkStabilityBench:
     def start_server(self):
         try:
             self.server = unilink.TcpServer(PORT)
-            self.server.on_data(lambda ctx: None) # Sink
+            self.server.on_data(lambda ctx: self._count_server_recv(len(ctx.data)))
             self.server.start_sync()
         except Exception as e:
             self.exceptions += 1
+
+    def _count_server_recv(self, n):
+        self.server_received_bytes += n
 
     def stop_server(self):
         if self.server:
@@ -172,10 +176,17 @@ class UnilinkStabilityBench:
         mem_drift = rss_values[-1] - rss_values[0] if rss_values else 0
         peak_rss = max(rss_values) if rss_values else 0
         
+        sent_mb = self.sent_bytes / (1024 * 1024)
+        recv_mb = self.server_received_bytes / (1024 * 1024)
+        delivery_rate = recv_mb / sent_mb * 100 if sent_mb > 0 else 0
+
         print(f"\n--- Unilink Stability Results (Level {LOAD_LEVEL}) ---")
         print(f"Reconnect Successes: {self.reconnect_count}")
         print(f"Exceptions:          {self.exceptions}")
         print(f"Backpressure Hits:   {self.bp_events_triggered}")
+        print(f"Sent:                {sent_mb:.2f} MB")
+        print(f"Server Received:     {recv_mb:.2f} MB")
+        print(f"Delivery Rate:       {delivery_rate:.2f}%")
         print(f"Peak Memory (RSS):   {peak_rss:.2f} MB")
         print(f"Memory Drift:        {mem_drift:.2f} MB")
         print(f"Throughput Avg:      {avg_tp:.2f} MB/s")

--- a/tools/benchmark/stability/stability_bench_cpp.cc
+++ b/tools/benchmark/stability/stability_bench_cpp.cc
@@ -1,0 +1,391 @@
+/*
+ * C++ native stability benchmark — Unilink wrapper API (no Python/GIL overhead)
+ * Mirrors tools/benchmark/stability/stability_bench.py in structure.
+ *
+ * Usage:  LOAD_LEVEL=1 ./stability_bench_cpp
+ */
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "unilink/unilink.hpp"
+
+using namespace std::chrono;
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+struct Config {
+    size_t      payload_size;
+    microseconds send_sleep;    // 0 = no sleep (safe in C++ without GIL issue)
+    seconds     chaos_interval;
+    seconds     duration;
+};
+
+Config get_config(int level) {
+    switch (level) {
+        case 1:  return {1024,   microseconds(1000), seconds(20), seconds(60)};
+        case 2:  return {4096,   microseconds(100),  seconds(10), seconds(60)};
+        case 3:  return {65536,  microseconds(0),    seconds(7),  seconds(60)};
+        default: return {4096,   microseconds(0),    seconds(2),  seconds(180)};
+    }
+}
+
+static constexpr uint16_t UNILINK_PORT = 10003;
+static constexpr int      CHAOS_DOWN_S = 2;
+
+// ─── Stats helper ─────────────────────────────────────────────────────────────
+
+static void print_stats(const std::string& label, int level,
+                        int reconnects,
+                        uint64_t sent, uint64_t recv,
+                        const std::vector<double>& snaps) {
+    double avg = 0, sd = 0;
+    if (!snaps.empty()) {
+        avg = std::accumulate(snaps.begin(), snaps.end(), 0.0) / snaps.size();
+        if (snaps.size() > 1) {
+            double sq = 0;
+            for (double v : snaps) sq += (v - avg) * (v - avg);
+            sd = std::sqrt(sq / (snaps.size() - 1));
+        }
+    }
+    double sent_mb = sent / (1024.0 * 1024.0);
+    double recv_mb = recv / (1024.0 * 1024.0);
+    double delivery = sent > 0 ? 100.0 * recv_mb / sent_mb : 0.0;
+
+    std::cout << "\n--- " << label << " Results (Level " << level << ") ---\n"
+              << "Reconnect:         " << reconnects    << "\n"
+              << "Sent:              " << sent_mb       << " MB\n"
+              << "Server Received:   " << recv_mb       << " MB\n"
+              << "Delivery Rate:     " << delivery      << "%\n"
+              << "Throughput Avg:    " << avg           << " MB/s\n"
+              << "Throughput StdDev: " << sd            << " MB/s\n"
+              << "--------------------------------------------\n";
+}
+
+// ─── Unilink C++ Benchmark ────────────────────────────────────────────────────
+
+void run_unilink(int level, const Config& cfg) {
+    std::cout << "--- Unilink C++ Stability Bench (Level " << level << ") ---\n"
+              << "Payload: " << cfg.payload_size << " bytes"
+              << "  send_sleep: " << cfg.send_sleep.count() << " us"
+              << "  chaos: " << cfg.chaos_interval.count() << "s\n";
+
+    std::atomic<uint64_t> sent_bytes{0};
+    std::atomic<uint64_t> recv_bytes{0};
+    std::atomic<int>      reconnects{0};
+    std::atomic<bool>     send_allowed{true};
+    std::atomic<bool>     running{true};
+
+    std::mutex             snap_mu;
+    std::vector<double>    snaps;
+
+    // Server factory — recreated on each start
+    std::mutex                         srv_mu;
+    std::unique_ptr<unilink::TcpServer> server;
+
+    auto start_server = [&] {
+        std::lock_guard<std::mutex> lk(srv_mu);
+        server = std::make_unique<unilink::TcpServer>(UNILINK_PORT);
+        server->on_data([&](const unilink::MessageContext& ctx) {
+            recv_bytes.fetch_add(ctx.data().size(), std::memory_order_relaxed);
+        });
+        server->start_sync();
+    };
+
+    auto stop_server = [&] {
+        std::lock_guard<std::mutex> lk(srv_mu);
+        if (server) { server->stop(); server.reset(); }
+    };
+
+    start_server();
+
+    unilink::TcpClient client("127.0.0.1", UNILINK_PORT);
+    client.on_connect([&](const unilink::ConnectionContext&) {
+        reconnects.fetch_add(1, std::memory_order_relaxed);
+    });
+    client.on_backpressure([&](size_t queued) {
+        // Mirror Python on_bp: ON when >= bp_high_ (16 MiB), OFF when <= bp_low_ (8 MiB)
+        if (queued > 8u * 1024u * 1024u)
+            send_allowed.store(false, std::memory_order_relaxed);
+        else
+            send_allowed.store(true,  std::memory_order_relaxed);
+    });
+    if (!client.start_sync()) {
+        std::cerr << "Failed to connect\n";
+        return;
+    }
+
+    // Sender thread
+    std::thread sender([&] {
+        std::string payload(cfg.payload_size, 'A');
+        while (running.load(std::memory_order_relaxed)) {
+            if (!send_allowed.load(std::memory_order_relaxed)) {
+                std::this_thread::sleep_for(microseconds(100));
+                continue;
+            }
+            if (client.connected()) {
+                if (client.send(payload))
+                    sent_bytes.fetch_add(cfg.payload_size, std::memory_order_relaxed);
+                if (cfg.send_sleep.count() > 0)
+                    std::this_thread::sleep_for(cfg.send_sleep);
+            } else {
+                send_allowed.store(true, std::memory_order_relaxed);
+                std::this_thread::sleep_for(milliseconds(10));
+            }
+        }
+    });
+
+    // Chaos thread
+    std::thread chaos([&] {
+        auto deadline = steady_clock::now() + cfg.duration;
+        while (running.load() && steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(cfg.chaos_interval);
+            if (!running.load()) break;
+            stop_server();
+            std::this_thread::sleep_for(seconds(CHAOS_DOWN_S));
+            if (!running.load()) break;
+            start_server();
+        }
+    });
+
+    // Monitor thread
+    std::thread monitor([&] {
+        auto deadline = steady_clock::now() + cfg.duration;
+        while (running.load() && steady_clock::now() < deadline) {
+            uint64_t prev = sent_bytes.load();
+            std::this_thread::sleep_for(seconds(1));
+            uint64_t curr = sent_bytes.load();
+            double tp = (curr - prev) / (1024.0 * 1024.0);
+            std::lock_guard<std::mutex> lk(snap_mu);
+            snaps.push_back(tp);
+        }
+    });
+
+    // Main wait loop
+    auto deadline = steady_clock::now() + cfg.duration;
+    int elapsed = 0;
+    while (steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(seconds(10));
+        elapsed += 10;
+        std::cout << "[Heartbeat] " << elapsed << "s elapsed\n";
+    }
+
+    running.store(false);
+    send_allowed.store(true);  // unblock sender
+    sender.join();
+    chaos.join();
+    monitor.join();
+
+    stop_server();
+    client.stop();
+
+    print_stats("Unilink C++", level,
+                reconnects.load(), sent_bytes.load(), recv_bytes.load(), snaps);
+}
+
+// ─── Raw Socket C++ Benchmark ─────────────────────────────────────────────────
+
+static constexpr uint16_t RAW_PORT = 10004;
+// Mirror Unilink retry: 100ms fast first, 1000ms subsequent
+static constexpr int RETRY_FIRST_MS    = 100;
+static constexpr int RETRY_INTERVAL_MS = 1000;
+
+void run_raw(int level, const Config& cfg) {
+    std::cout << "--- Raw Socket C++ Stability Bench (Level " << level << ") ---\n"
+              << "Payload: " << cfg.payload_size << " bytes"
+              << "  send_sleep: " << cfg.send_sleep.count() << " us"
+              << "  chaos: " << cfg.chaos_interval.count() << "s\n";
+
+    signal(SIGPIPE, SIG_IGN);  // avoid crash on broken pipe
+
+    std::atomic<uint64_t> sent_bytes{0};
+    std::atomic<uint64_t> recv_bytes{0};
+    std::atomic<int>      reconnects{0};
+    std::atomic<int>      exceptions{0};
+    std::atomic<bool>     server_active{false};
+    std::atomic<bool>     running{true};
+
+    std::vector<double>   snaps;
+    std::mutex            snap_mu;
+
+    // ── Server ──
+    std::atomic<int> server_fd{-1};
+
+    auto start_server = [&] {
+        int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        int opt = 1;
+        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = INADDR_ANY;
+        addr.sin_port = htons(RAW_PORT);
+        ::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        ::listen(fd, 128);
+        server_fd.store(fd);
+        server_active.store(true);
+    };
+
+    auto stop_server = [&] {
+        server_active.store(false);
+        int fd = server_fd.exchange(-1);
+        if (fd >= 0) ::close(fd);
+    };
+
+    // Server accept + drain loop
+    std::thread server_t([&] {
+        while (running.load()) {
+            int lfd = server_fd.load();
+            if (lfd < 0 || !server_active.load()) {
+                std::this_thread::sleep_for(milliseconds(10));
+                continue;
+            }
+            struct timeval tv{0, 100000};
+            setsockopt(lfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+            sockaddr_in cli{};
+            socklen_t len = sizeof(cli);
+            int cfd = ::accept(lfd, reinterpret_cast<sockaddr*>(&cli), &len);
+            if (cfd < 0) continue;
+
+            std::thread([&, cfd] {
+                std::vector<char> buf(65536);
+                while (server_active.load()) {
+                    ssize_t n = ::recv(cfd, buf.data(), buf.size(), 0);
+                    if (n <= 0) break;
+                    recv_bytes.fetch_add(static_cast<uint64_t>(n), std::memory_order_relaxed);
+                }
+                ::close(cfd);
+            }).detach();
+        }
+    });
+
+    start_server();
+
+    // Chaos thread
+    std::thread chaos([&] {
+        auto deadline = steady_clock::now() + cfg.duration;
+        while (running.load() && steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(cfg.chaos_interval);
+            if (!running.load()) break;
+            stop_server();
+            std::this_thread::sleep_for(seconds(CHAOS_DOWN_S));
+            if (!running.load()) break;
+            start_server();
+        }
+    });
+
+    // Monitor thread
+    std::thread monitor([&] {
+        auto deadline = steady_clock::now() + cfg.duration;
+        while (running.load() && steady_clock::now() < deadline) {
+            uint64_t prev = sent_bytes.load();
+            std::this_thread::sleep_for(seconds(1));
+            uint64_t curr = sent_bytes.load();
+            double tp = (curr - prev) / (1024.0 * 1024.0);
+            std::lock_guard<std::mutex> lk(snap_mu);
+            snaps.push_back(tp);
+        }
+    });
+
+    // Sender thread
+    std::thread sender([&] {
+        std::string payload(cfg.payload_size, 'A');
+        int retry_attempt = 0;
+        int sock = -1;
+
+        while (running.load()) {
+            if (sock < 0) {
+                // Reconnect with fast-first retry
+                sock = ::socket(AF_INET, SOCK_STREAM, 0);
+                struct timeval tv{1, 0};
+                setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+                setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+                sockaddr_in addr{};
+                addr.sin_family = AF_INET;
+                ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+                addr.sin_port = htons(RAW_PORT);
+                if (::connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+                    reconnects.fetch_add(1, std::memory_order_relaxed);
+                    retry_attempt = 0;
+                } else {
+                    ::close(sock);
+                    sock = -1;
+                    int wait_ms = (retry_attempt == 0) ? RETRY_FIRST_MS : RETRY_INTERVAL_MS;
+                    retry_attempt++;
+                    std::this_thread::sleep_for(milliseconds(wait_ms));
+                    continue;
+                }
+            }
+
+            ssize_t n = ::send(sock, payload.data(), payload.size(), MSG_NOSIGNAL);
+            if (n > 0) {
+                sent_bytes.fetch_add(static_cast<uint64_t>(n), std::memory_order_relaxed);
+                if (cfg.send_sleep.count() > 0)
+                    std::this_thread::sleep_for(cfg.send_sleep);
+            } else {
+                exceptions.fetch_add(1, std::memory_order_relaxed);
+                ::close(sock);
+                sock = -1;
+                retry_attempt = 0;
+            }
+        }
+        if (sock >= 0) ::close(sock);
+    });
+
+    // Main wait
+    auto deadline = steady_clock::now() + cfg.duration;
+    int elapsed = 0;
+    while (steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(seconds(10));
+        elapsed += 10;
+        std::cout << "[Heartbeat] " << elapsed << "s elapsed\n";
+    }
+
+    running.store(false);
+    stop_server();
+    sender.join();
+    chaos.join();
+    monitor.join();
+    server_t.join();
+
+    std::cout << "Exceptions: " << exceptions.load() << "\n";
+    print_stats("Raw Socket C++", level,
+                reconnects.load(), sent_bytes.load(), recv_bytes.load(), snaps);
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+    int level = 1;
+    const char* mode = "unilink";
+
+    const char* env_level = std::getenv("LOAD_LEVEL");
+    const char* env_mode  = std::getenv("MODE");
+    if (env_level) level = std::atoi(env_level);
+    if (env_mode)  mode  = env_mode;
+    if (argc > 1) level = std::atoi(argv[1]);
+    if (argc > 2) mode  = argv[2];
+
+    Config cfg = get_config(level);
+
+    if (std::string(mode) == "raw")
+        run_raw(level, cfg);
+    else
+        run_unilink(level, cfg);
+
+    return 0;
+}

--- a/tools/benchmark/stability/stability_bench_raw.py
+++ b/tools/benchmark/stability/stability_bench_raw.py
@@ -1,0 +1,204 @@
+import os
+import time
+import socket
+import threading
+import statistics
+import psutil
+import sys
+
+# Configuration levels
+LOAD_LEVEL = int(os.getenv("LOAD_LEVEL", "1"))
+
+if LOAD_LEVEL == 1:
+    PAYLOAD_SIZE = 1024
+    SEND_SLEEP = 0.001
+    CHAOS_INTERVAL = 20
+    DURATION = 60
+elif LOAD_LEVEL == 2:
+    PAYLOAD_SIZE = 4096
+    SEND_SLEEP = 0.0001
+    CHAOS_INTERVAL = 10
+    DURATION = 60
+elif LOAD_LEVEL == 3:
+    PAYLOAD_SIZE = 65536
+    SEND_SLEEP = 0.00001 # 10us delay to prevent kernel lockup
+    CHAOS_INTERVAL = 7   # Slightly increased from 5
+    DURATION = 60
+else:
+    PAYLOAD_SIZE = 4096
+    SEND_SLEEP = 0
+    CHAOS_INTERVAL = 2
+    DURATION = 180
+
+PORT = 10002
+CHAOS_DOWN_TIME = 2
+
+class RawSocketStabilityBench:
+    def __init__(self):
+        self.server_sock = None
+        self.client_sock = None
+        self.running = False
+        self.server_active = False
+        self.sent_bytes = 0
+        self.reconnect_count = 0
+        self.exceptions = 0
+        self.snapshots = []
+        self.process = psutil.Process(os.getpid())
+        self.server_thread = None
+        self.connections = []
+
+    def server_loop(self):
+        try:
+            self.server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.server_sock.bind(("127.0.0.1", PORT))
+            self.server_sock.listen(128) # Increased backlog
+            self.server_sock.settimeout(0.5)
+            
+            while self.server_active:
+                try:
+                    conn, addr = self.server_sock.accept()
+                    conn.settimeout(0.5)
+                    self.connections.append(conn)
+                    t = threading.Thread(target=self.handle_client, args=(conn,))
+                    t.daemon = True
+                    t.start()
+                except socket.timeout:
+                    continue
+                except Exception:
+                    break
+        finally:
+            if self.server_sock:
+                self.server_sock.close()
+                self.server_sock = None
+
+    def handle_client(self, conn):
+        try:
+            while self.server_active:
+                data = conn.recv(65536)
+                if not data: break
+        except Exception:
+            pass
+        finally:
+            try: conn.close()
+            except: pass
+            if conn in self.connections:
+                self.connections.remove(conn)
+
+    def start_server(self):
+        self.server_active = True
+        self.server_thread = threading.Thread(target=self.server_loop)
+        self.server_thread.start()
+
+    def stop_server(self):
+        self.server_active = False
+        for c in self.connections[:]:
+            try: c.close()
+            except: pass
+        if self.server_sock:
+            try: self.server_sock.close()
+            except: pass
+        if self.server_thread:
+            self.server_thread.join(timeout=1.0)
+
+    def monitor(self):
+        start_time = time.time()
+        while self.running and (time.time() - start_time < DURATION):
+            prev_sent = self.sent_bytes
+            time.sleep(1)
+            curr_sent = self.sent_bytes
+            throughput = (curr_sent - prev_sent) / (1024 * 1024) # MB/s
+            rss = self.process.memory_info().rss / (1024 * 1024) # MB
+            self.snapshots.append((throughput, rss))
+            
+    def sender(self):
+        payload = b"A" * PAYLOAD_SIZE
+        while self.running:
+            try:
+                if not self.client_sock:
+                    try:
+                        self.client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                        self.client_sock.settimeout(1.0)
+                        self.client_sock.connect(("127.0.0.1", PORT))
+                        self.reconnect_count += 1
+                    except Exception:
+                        self.client_sock = None
+                        time.sleep(0.1)
+                        continue
+                
+                self.client_sock.sendall(payload)
+                self.sent_bytes += PAYLOAD_SIZE
+                if SEND_SLEEP > 0:
+                    time.sleep(SEND_SLEEP)
+            except (socket.error, BrokenPipeError, ConnectionResetError):
+                self.exceptions += 1
+                if self.client_sock:
+                    try: self.client_sock.close()
+                    except: pass
+                self.client_sock = None
+            except Exception as e:
+                self.exceptions += 1
+                self.client_sock = None
+
+    def chaos(self):
+        start_time = time.time()
+        while self.running and (time.time() - start_time < DURATION):
+            time.sleep(CHAOS_INTERVAL)
+            if not self.running: break
+            self.stop_server()
+            time.sleep(CHAOS_DOWN_TIME)
+            if not self.running: break
+            self.start_server()
+
+    def run(self):
+        print(f"--- Starting Raw Socket Stability Bench (Level {LOAD_LEVEL}) ---")
+        print(f"Payload: {PAYLOAD_SIZE} bytes, Delay: {SEND_SLEEP}s, Chaos: {CHAOS_INTERVAL}s")
+        
+        self.running = True
+        self.start_server()
+        
+        threads = [
+            threading.Thread(target=self.sender, name="Sender"),
+            threading.Thread(target=self.chaos, name="Chaos"),
+            threading.Thread(target=self.monitor, name="Monitor")
+        ]
+
+        for t in threads: t.start()
+        
+        try:
+            start_run = time.time()
+            while self.running and (time.time() - start_run < DURATION):
+                time.sleep(10); print(f"[Heartbeat] {int(time.time() - start_run)}s elapsed...")
+        except KeyboardInterrupt:
+            print("\nBenchmark interrupted by user")
+        finally:
+            self.running = False
+            for t in threads: t.join(timeout=2.0)
+            self.stop_server()
+            if self.client_sock: 
+                try: self.client_sock.close()
+                except: pass
+        
+        self.report()
+
+    def report(self):
+        all_throughputs = [s[0] for s in self.snapshots]
+        rss_values = [s[1] for s in self.snapshots]
+        
+        avg_tp = statistics.mean(all_throughputs) if all_throughputs else 0
+        std_tp = statistics.stdev(all_throughputs) if len(all_throughputs) > 1 else 0
+        mem_drift = rss_values[-1] - rss_values[0] if rss_values else 0
+        peak_rss = max(rss_values) if rss_values else 0
+        
+        print(f"\n--- Raw Socket Stability Results (Level {LOAD_LEVEL}) ---")
+        print(f"Reconnect Successes: {self.reconnect_count}")
+        print(f"Exceptions:          {self.exceptions}")
+        print(f"Peak Memory (RSS):   {peak_rss:.2f} MB")
+        print(f"Memory Drift:        {mem_drift:.2f} MB")
+        print(f"Throughput Avg:      {avg_tp:.2f} MB/s")
+        print(f"Throughput StdDev:   {std_tp:.2f} MB/s")
+        print(f"----------------------------------------------------")
+
+if __name__ == "__main__":
+    bench = RawSocketStabilityBench()
+    bench.run()

--- a/tools/benchmark/stability/stability_bench_raw.py
+++ b/tools/benchmark/stability/stability_bench_raw.py
@@ -33,6 +33,10 @@ else:
 PORT = 10002
 CHAOS_DOWN_TIME = 2
 
+# Match Unilink's reconnect behavior: fast first retry then fixed interval
+RETRY_FIRST_MS = 0.1   # 100ms — same as Unilink's first_retry_interval_ms_
+RETRY_INTERVAL = 1.0   # 1s   — same as Unilink's DEFAULT_RETRY_INTERVAL_MS
+
 class RawSocketStabilityBench:
     def __init__(self):
         self.server_sock = None
@@ -113,6 +117,7 @@ class RawSocketStabilityBench:
             
     def sender(self):
         payload = b"A" * PAYLOAD_SIZE
+        retry_attempt = 0
         while self.running:
             try:
                 if not self.client_sock:
@@ -121,9 +126,13 @@ class RawSocketStabilityBench:
                         self.client_sock.settimeout(1.0)
                         self.client_sock.connect(("127.0.0.1", PORT))
                         self.reconnect_count += 1
+                        retry_attempt = 0
                     except Exception:
                         self.client_sock = None
-                        time.sleep(0.1)
+                        # Mirror Unilink: fast first retry, then fixed interval
+                        sleep_time = RETRY_FIRST_MS if retry_attempt == 0 else RETRY_INTERVAL
+                        retry_attempt += 1
+                        time.sleep(sleep_time)
                         continue
                 
                 self.client_sock.sendall(payload)
@@ -136,9 +145,11 @@ class RawSocketStabilityBench:
                     try: self.client_sock.close()
                     except: pass
                 self.client_sock = None
+                retry_attempt = 0
             except Exception as e:
                 self.exceptions += 1
                 self.client_sock = None
+                retry_attempt = 0
 
     def chaos(self):
         start_time = time.time()

--- a/tools/benchmark/stability/stability_bench_raw.py
+++ b/tools/benchmark/stability/stability_bench_raw.py
@@ -44,6 +44,7 @@ class RawSocketStabilityBench:
         self.running = False
         self.server_active = False
         self.sent_bytes = 0
+        self.server_received_bytes = 0
         self.reconnect_count = 0
         self.exceptions = 0
         self.snapshots = []
@@ -81,6 +82,7 @@ class RawSocketStabilityBench:
             while self.server_active:
                 data = conn.recv(65536)
                 if not data: break
+                self.server_received_bytes += len(data)
         except Exception:
             pass
         finally:
@@ -201,9 +203,16 @@ class RawSocketStabilityBench:
         mem_drift = rss_values[-1] - rss_values[0] if rss_values else 0
         peak_rss = max(rss_values) if rss_values else 0
         
+        sent_mb = self.sent_bytes / (1024 * 1024)
+        recv_mb = self.server_received_bytes / (1024 * 1024)
+        delivery_rate = recv_mb / sent_mb * 100 if sent_mb > 0 else 0
+
         print(f"\n--- Raw Socket Stability Results (Level {LOAD_LEVEL}) ---")
         print(f"Reconnect Successes: {self.reconnect_count}")
         print(f"Exceptions:          {self.exceptions}")
+        print(f"Sent:                {sent_mb:.2f} MB")
+        print(f"Server Received:     {recv_mb:.2f} MB")
+        print(f"Delivery Rate:       {delivery_rate:.2f}%")
         print(f"Peak Memory (RSS):   {peak_rss:.2f} MB")
         print(f"Memory Drift:        {mem_drift:.2f} MB")
         print(f"Throughput Avg:      {avg_tp:.2f} MB/s")

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -32,7 +32,7 @@ constexpr size_t MAX_BACKPRESSURE_THRESHOLD = 100 << 20;             // 100 MiB 
 constexpr size_t DEFAULT_READ_BUFFER_SIZE = 4096;                    // 4 KiB
 
 // Retry and timeout constants
-constexpr unsigned DEFAULT_RETRY_INTERVAL_MS = 3000;      // 3 seconds
+constexpr unsigned DEFAULT_RETRY_INTERVAL_MS = 1000;      // 1 second
 constexpr unsigned MIN_RETRY_INTERVAL_MS = 100;           // 100ms minimum
 constexpr unsigned MAX_RETRY_INTERVAL_MS = 300000;        // 5 minutes maximum
 constexpr unsigned DEFAULT_CONNECTION_TIMEOUT_MS = 5000;  // 5 seconds

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -88,6 +88,15 @@ class UNILINK_API ChannelInterface {
   virtual ChannelInterface& on_error(ErrorHandler handler) = 0;
 
   /**
+   * @brief Register a callback to be notified when send queue congestion changes.
+   * @param handler Callback receiving the current number of queued bytes.
+   */
+  virtual ChannelInterface& on_backpressure(std::function<void(size_t)> handler) {
+    (void)handler;
+    return *this;
+  }
+
+  /**
    * @brief Set a message framer for this channel.
    * @param framer The framer instance to use.
    */

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "unilink/base/common.hpp"
+#include "unilink/base/constants.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/serial/serial.hpp"
 
@@ -82,7 +83,7 @@ struct Serial::Impl {
   int stop_bits = 1;
   std::string parity = "none";
   std::string flow_control = "none";
-  std::chrono::milliseconds retry_interval{3000};
+  std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
 
   Impl(const std::string& dev, uint32_t baud) : device(dev), baud_rate(baud) {}
   Impl(const std::string& dev, uint32_t baud, std::shared_ptr<boost::asio::io_context> ioc)

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -57,6 +57,7 @@ struct TcpClient::Impl {
   ConnectionHandler connect_handler_{nullptr};
   ConnectionHandler disconnect_handler_{nullptr};
   ErrorHandler error_handler_{nullptr};
+  std::function<void(size_t)> bp_handler_{nullptr};
   MessageHandler message_handler_{nullptr};
   BatchMessageHandler message_batch_handler_{nullptr};
 
@@ -331,6 +332,17 @@ struct TcpClient::Impl {
         }
       }
     });
+
+    channel_->on_backpressure([this, weak_alive](size_t queued) {
+      auto alive = weak_alive.lock();
+      if (!alive) return;
+      std::function<void(size_t)> handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        handler = bp_handler_;
+      }
+      if (handler) handler(queued);
+    });
   }
 
   void attach_framer_callback() {
@@ -418,6 +430,12 @@ ChannelInterface& TcpClient::on_disconnect(ConnectionHandler h) {
 ChannelInterface& TcpClient::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler_ = std::move(h);
+  return *this;
+}
+
+ChannelInterface& TcpClient::on_backpressure(std::function<void(size_t)> h) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->bp_handler_ = std::move(h);
   return *this;
 }
 

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "unilink/base/common.hpp"
+#include "unilink/base/constants.hpp"
 #include "unilink/config/tcp_client_config.hpp"
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
@@ -71,7 +72,7 @@ struct TcpClient::Impl {
   std::chrono::milliseconds max_batch_latency_{1};
 
   std::atomic<bool> auto_start_ = false;
-  std::chrono::milliseconds retry_interval_{3000};
+  std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   int max_retries_ = -1;
   std::chrono::milliseconds connection_timeout_{5000};
 

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -70,6 +70,7 @@ class UNILINK_API TcpClient : public ChannelInterface {
   ChannelInterface& on_connect(ConnectionHandler handler) override;
   ChannelInterface& on_disconnect(ConnectionHandler handler) override;
   ChannelInterface& on_error(ErrorHandler handler) override;
+  ChannelInterface& on_backpressure(std::function<void(size_t)> handler) override;
 
   ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
   ChannelInterface& on_message(MessageHandler handler) override;

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "unilink/base/common.hpp"
+#include "unilink/base/constants.hpp"
 #include "unilink/config/uds_config.hpp"
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
@@ -69,7 +70,7 @@ struct UdsClient::Impl {
   std::chrono::milliseconds max_batch_latency_{1};
 
   std::atomic<bool> auto_start_ = false;
-  std::chrono::milliseconds retry_interval_{3000};
+  std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   int max_retries_ = -1;
   std::chrono::milliseconds connection_timeout_{5000};
 


### PR DESCRIPTION
## Description

This PR addresses three stability bugs discovered during LV3/LV4 stress testing, exposes the backpressure callback as a first-class API, and adds a comprehensive benchmark suite covering Python, C++ native, and raw socket baselines. Full results are documented in `tools/benchmark/stability/results/2026-04-26_lv1-lv4.md`.

## Key Changes

**Bug Fixes**
- `on_backpressure` watermark was comparing against the wrong threshold (> 40 MiB instead of the bp_low midpoint of 8 MiB), causing `send_allowed` to never clear and leading to OOM/kernel crash at LV3+
- `TcpClient::Impl::retry_interval_` was hardcoded to `3000ms` instead of referencing `DEFAULT_RETRY_INTERVAL_MS`, silently ignoring the constant
- Same hardcoded retry found in `UdsClient` and `Serial` wrappers — all fixed to reference `DEFAULT_RETRY_INTERVAL_MS`
- `DEFAULT_RETRY_INTERVAL_MS` reduced from 3000 ms to 1000 ms (aligns with Redis/MQTT/gRPC defaults; improves LV4 uptime from 22% → 47%)

**New API**
- `TcpClient::on_backpressure(std::function<void(size_t)>)` — propagates the channel-layer backpressure signal to user code
- `ChannelInterface::on_backpressure()` — default no-op virtual method so existing subclasses compile without change
- Python binding: `TcpClient.on_backpressure(handler)` with `gil_scoped_acquire` to safely invoke Python callbacks from the ASIO thread

**Benchmark Suite**
- `stability_bench_raw.py` — raw POSIX socket Python baseline with matching retry logic (100 ms fast-first + 1 s subsequent)
- `stability_bench_cpp.cc` — C++ native benchmark for both Unilink wrapper and raw socket (no GIL overhead, 0 μs sleep)
- Server-side received byte counting and delivery rate metric added to all benchmarks
- `run_comparison.sh` — single script to run all four variants sequentially

## Related Issues

- N/A (discovered during internal stability benchmarking)

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Benchmark Summary (2026-04-26)

| Level | Py Unilink | Py Raw | C++ Unilink | C++ Raw | Py Uni Delivery | Py Raw Delivery |
|-------|-----------|--------|-------------|---------|-----------------|-----------------|
| LV1   | 0.83 MB/s | 0.84   | 0.84        | 0.84    | **100.00%**     | 99.56%          |
| LV2   | 17.3 MB/s | 18.8   | 18.7        | 18.9    | **99.99%**      | 99.46%          |
| LV3   | 133 MB/s  | 564    | 1,420       | 6,382   | 99.44%          | 99.97%          |
| LV4   | 19.3 MB/s | 761    | 388         | 2,412   | **99.96%**      | 99.95%          |

Key findings: LV1/LV2 throughput converges; Unilink delivers 0 exceptions vs 6–10 for raw socket. GIL overhead is ×10–20 at high frequency; structural async dispatch cost vs blocking `sendall` is ×4.5–6.2.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

The mandatory 10 μs Python send sleep (LV3/LV4) is a GIL constraint: without it, the ASIO thread cannot acquire the GIL to fire the backpressure callback, causing unbounded queue growth. C++ benchmarks have no such constraint and run at 0 μs sleep, which is why C++ LV4 Unilink is ×20 faster than Python LV4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)