### PR TITLE
Add Ubuntu ARM64 support path and Orin Nano validation docs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,6 +39,24 @@ jobs:
             build_type: Release
             build_python: OFF
             vcpkg_features: ""
+          - name: C++ (Linux ARM64, GCC, Ubuntu 22.04)
+            os: ubuntu-22.04-arm
+            triplet: arm64-linux
+            cc: gcc
+            cxx: g++
+            generator: Ninja
+            build_type: Release
+            build_python: OFF
+            vcpkg_features: ""
+          - name: C++ (Linux ARM64, GCC, Ubuntu 24.04)
+            os: ubuntu-24.04-arm
+            triplet: arm64-linux
+            cc: gcc
+            cxx: g++
+            generator: Ninja
+            build_type: Release
+            build_python: OFF
+            vcpkg_features: ""
           - name: C++ (Windows, MSVC)
             os: windows-2022
             triplet: x64-windows
@@ -62,6 +80,24 @@ jobs:
           - name: Python3 (Linux, GCC)
             os: ubuntu-24.04
             triplet: x64-linux
+            cc: gcc
+            cxx: g++
+            generator: Ninja
+            build_type: Release
+            build_python: ON
+            vcpkg_features: "python"
+          - name: Python3 (Linux ARM64, GCC, Ubuntu 22.04)
+            os: ubuntu-22.04-arm
+            triplet: arm64-linux
+            cc: gcc
+            cxx: g++
+            generator: Ninja
+            build_type: Release
+            build_python: ON
+            vcpkg_features: "python"
+          - name: Python3 (Linux ARM64, GCC, Ubuntu 24.04)
+            os: ubuntu-24.04-arm
+            triplet: arm64-linux
             cc: gcc
             cxx: g++
             generator: Ninja

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,13 @@ jobs:
             release_files: |
               build/package/unilink-*.tar.gz
 
+          - os: ubuntu-22.04-arm
+            label: Linux ARM64 (Ubuntu 22.04)
+            cmake_generator: "Ninja"
+            cpack_generator: "TGZ"
+            release_files: |
+              build/package/unilink-*.tar.gz
+
           - os: macos-14
             label: macOS 14
             cmake_generator: "Ninja"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,11 @@ jobs:
             cc: clang-14
             cxx: clang++-14
             boost_version: "1.74"
+          - os: ubuntu-22.04-arm
+            compiler: gcc
+            cc: gcc
+            cxx: g++
+            boost_version: "1.74"
           # Ubuntu 24.04: GCC 13 and Clang 15
           - os: ubuntu-24.04
             compiler: gcc
@@ -51,6 +56,11 @@ jobs:
             compiler: clang
             cc: clang-15
             cxx: clang++-15
+            boost_version: "1.83"
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            cc: gcc
+            cxx: g++
             boost_version: "1.83"
           # macOS: Clang
           - os: macos-14
@@ -255,6 +265,64 @@ jobs:
       with:
         name: integration-test-results
         path: build-integration/Testing/
+        retention-days: 7
+        overwrite: true
+
+  integration-tests-arm64:
+    name: Integration Tests (ubuntu-22.04-arm, gcc)
+    runs-on: ubuntu-22.04-arm
+    timeout-minutes: 45
+    needs: []
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Cache ccache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ runner.os }}-integration-arm64-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          ccache-${{ runner.os }}-integration-arm64-
+
+    - name: Install dependencies
+      uses: ./.github/actions/apt-install
+      with:
+        packages: "build-essential cmake ccache libboost1.74-dev libboost-system1.74-dev socat"
+
+    - name: Configure CMake
+      run: |
+        cmake -S . -B build-integration-arm64 \
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+          -DCMAKE_CXX_STANDARD=${{ env.CXX_STANDARD }} \
+          -DUNILINK_ENABLE_CONFIG=ON \
+          -DUNILINK_BUILD_EXAMPLES=OFF \
+          -DUNILINK_BUILD_DOCS=OFF \
+          -DUNILINK_BUILD_TESTS=ON \
+          -DUNILINK_ENABLE_PERFORMANCE_TESTS=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build integration tests
+      run: cmake --build build-integration-arm64 -j $(nproc)
+
+    - name: Run integration tests
+      run: |
+        cd build-integration-arm64
+        ctest --output-on-failure --parallel 2 \
+          --label-regex "integration|mock|stable" \
+          --label-exclude "slow" || \
+        ctest --rerun-failed --output-on-failure --parallel 2 \
+          --label-regex "integration|mock|stable" \
+          --label-exclude "slow"
+
+    - name: Upload integration test results
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: integration-test-results-ubuntu-22.04-arm-gcc
+        path: build-integration-arm64/Testing/
         retention-days: 7
         overwrite: true
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Documentation is split by audience. Visit our **[Online Documentation](https://j
 
 * [Build Guide](docs/contributor/build_guide.md) – Build configurations, CMake flags, sanitizers
 * [Testing Guide](docs/contributor/testing.md) – Running tests and CI integration
+* [Orin Nano Validation](docs/contributor/orin_nano_validation.md) – Ubuntu 22.04 ARM64 bring-up and test runbook
 * [Implementation Status](docs/contributor/implementation_status.md) – Verified scope and known gaps
 * [Architecture Overview](docs/contributor/architecture/README.md) – High-level structure and layer responsibilities
 * [Runtime Behavior](docs/contributor/architecture/runtime_behavior.md) – Threading model, reconnection, backpressure

--- a/cmake/UnilinkConfig.cmake.in
+++ b/cmake/UnilinkConfig.cmake.in
@@ -1,5 +1,10 @@
 @PACKAGE_INIT@
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.31" AND POLICY CMP0167)
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0167 OLD)
+endif()
+
 include(CMakeFindDependencyMacro)
 
 # Find required dependencies.
@@ -25,4 +30,18 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/unilinkTargets.cmake")
 
+if(NOT TARGET unilink::unilink)
+  if(TARGET unilink::unilink_shared)
+    add_library(unilink::unilink INTERFACE IMPORTED)
+    target_link_libraries(unilink::unilink INTERFACE unilink::unilink_shared)
+  elseif(TARGET unilink::unilink_static)
+    add_library(unilink::unilink INTERFACE IMPORTED)
+    target_link_libraries(unilink::unilink INTERFACE unilink::unilink_static)
+  endif()
+endif()
+
 check_required_components(unilink)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.31" AND POLICY CMP0167)
+  cmake_policy(POP)
+endif()

--- a/cmake/UnilinkDependencies.cmake
+++ b/cmake/UnilinkDependencies.cmake
@@ -96,13 +96,33 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   if(NOT Boost_FOUND)
     # Manual fallback if the packaged Boost variants don't match expectations
     # (e.g., debug runtime mismatch)
+    set(_boost_fallback_library_hints /usr/lib /usr/local/lib /lib)
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      list(
+        APPEND
+        _boost_fallback_library_hints
+        "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+        "/usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+        "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+      )
+    endif()
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+      list(APPEND _boost_fallback_library_hints /usr/lib/x86_64-linux-gnu
+           /usr/local/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+      )
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+      list(APPEND _boost_fallback_library_hints /usr/lib/aarch64-linux-gnu
+           /usr/local/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu
+      )
+    endif()
+    list(REMOVE_DUPLICATES _boost_fallback_library_hints)
     find_path(BOOST_FALLBACK_INCLUDE_DIR boost/version.hpp
               HINTS /usr/include /usr/local/include
     )
     find_library(
       BOOST_FALLBACK_SYSTEM_LIB
       NAMES boost_system
-      HINTS /usr/lib /usr/lib/x86_64-linux-gnu /usr/local/lib
+      HINTS ${_boost_fallback_library_hints}
     )
     if(BOOST_FALLBACK_INCLUDE_DIR
        AND BOOST_FALLBACK_SYSTEM_LIB

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ docs/
 │   ├── index.md       # Contributor guide entry point
 │   ├── build_guide.md
 │   ├── testing.md
+│   ├── orin_nano_validation.md
 │   ├── implementation_status.md
 │   ├── test_structure.md
 │   └── architecture/  # Internal design and transport contracts

--- a/docs/contributor/implementation_status.md
+++ b/docs/contributor/implementation_status.md
@@ -61,6 +61,8 @@ Latest explicitly reported ARM64 validation:
 
 - Jetson Orin Nano on Ubuntu 22.04 `aarch64`
 - Full C++ `ctest` sweep passed: 481 passed, 0 failed
+- Python import smoke and Python API tests passed, including loopback-enabled TCP validation
+- ARM64 installed-package consumer smoke passed with `find_package(unilink)` and `unilink::unilink`
 - One disabled test was listed as not run: `UdsErrorTest.ServerStopWithActiveSessions`
 - See [Orin Nano Validation](orin_nano_validation.md) for the reproducible runbook and scope boundaries
 

--- a/docs/contributor/implementation_status.md
+++ b/docs/contributor/implementation_status.md
@@ -57,6 +57,13 @@ Dynamic test registration and current pass/fail state should be read from:
 - [Test Structure](test_structure.md)
 - `ctest` output from the active build directory
 
+Latest explicitly reported ARM64 validation:
+
+- Jetson Orin Nano on Ubuntu 22.04 `aarch64`
+- Full C++ `ctest` sweep passed: 481 passed, 0 failed
+- One disabled test was listed as not run: `UdsErrorTest.ServerStopWithActiveSessions`
+- See [Orin Nano Validation](orin_nano_validation.md) for the reproducible runbook and scope boundaries
+
 This document intentionally does not repeat exact version numbers, build-cache values, or test counts, because those change more often than the implementation scope itself.
 
 ## Recommended Reading Order

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -8,6 +8,7 @@ Documentation for developers building, extending, or contributing to unilink its
 
 - [Build Guide](build_guide.md) — CMake options, build profiles, sanitizers, platform-specific notes
 - [Testing](testing.md) — Running the test suite, CI integration, writing tests
+- [Orin Nano Validation](orin_nano_validation.md) — Ubuntu 22.04 ARM64 bring-up and test runbook
 - [Implementation Status](implementation_status.md) — Verified scope, known gaps, and codebase snapshot
 - [Test Structure](test_structure.md) — Test organization and coverage breakdown
 

--- a/docs/contributor/orin_nano_validation.md
+++ b/docs/contributor/orin_nano_validation.md
@@ -26,13 +26,17 @@ Most recent reported Jetson Orin Nano result:
 - Platform: Ubuntu 22.04 on `aarch64`
 - Result: `100% tests passed, 0 tests failed out of 481`
 - Real elapsed test time: `25.52 sec`
+- Python import smoke passed
+- Python API tests passed, including TCP loopback-enabled mode
+- ARM64 release artifact package generation passed
+- Installed-package consumer smoke passed with `find_package(unilink)` and `unilink::unilink`
 - Serial integration labels passed as part of the full sweep
 - One test was listed as not run because it is disabled by design:
   `UdsErrorTest.ServerStopWithActiveSessions`
 
 Interpretation:
 
-- This is strong evidence for Ubuntu 22.04 ARM64 support on Orin Nano
+- This is strong evidence for Ubuntu 22.04 ARM64 support on Orin Nano across C++, Python, and installed-package consumption paths
 - It does not by itself prove every other Linux ARM64 distribution or userspace combination
 
 ---
@@ -221,7 +225,11 @@ For a practical “supported on Orin Nano” claim, use this minimum bar:
 3. Unit and integration `ctest` commands pass.
 4. `bindings/python/test_import.py` passes when Python bindings are enabled.
 
-The current Orin Nano report satisfies the C++ test portion of that bar.
+The current Orin Nano report satisfies that bar and also includes:
+
+1. Python API tests with loopback enabled.
+2. ARM64 `TGZ` package generation.
+3. Installed-package consumer smoke using the canonical `unilink::unilink` target.
 
 For a stronger “generic Ubuntu ARM64” claim, add:
 

--- a/docs/contributor/orin_nano_validation.md
+++ b/docs/contributor/orin_nano_validation.md
@@ -1,0 +1,272 @@
+# Orin Nano Validation {#contrib_orin_nano_validation}
+
+Step-by-step validation runbook for `unilink` on NVIDIA Jetson Orin Nano and similar Ubuntu `aarch64` systems.
+
+---
+
+## Scope
+
+Use this guide when you want to answer one of these questions:
+
+- Does the library build from source on Ubuntu ARM64?
+- Do the unit and integration tests pass on Jetson Orin Nano?
+- Do the Python bindings import correctly on ARM64?
+- Do Linux serial integration tests work with `socat` or loopback hardware?
+
+This guide assumes:
+
+- Ubuntu 22.04 ARM64 is the primary validation baseline
+- Ubuntu 24.04 ARM64 is a secondary validation target
+- You are building from a local checkout of this repository
+
+---
+
+## Prerequisites
+
+Install the baseline packages:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential \
+  cmake \
+  ccache \
+  pkg-config \
+  libboost-dev \
+  libboost-system-dev \
+  python3 \
+  python3-dev \
+  python3-pip \
+  python3-venv \
+  socat
+```
+
+Install Python-side build and test helpers:
+
+```bash
+python3 -m pip install --user pybind11 pytest
+```
+
+Check the expected environment:
+
+```bash
+uname -m
+lsb_release -ds
+cmake --version
+python3 --version
+```
+
+Expected baseline:
+
+- `uname -m` prints `aarch64`
+- Ubuntu 22.04 is preferred on Orin Nano
+
+---
+
+## Configure And Build
+
+From the repository root:
+
+```bash
+cmake -S . -B build-orin \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DUNILINK_BUILD_EXAMPLES=OFF \
+  -DUNILINK_BUILD_DOCS=OFF \
+  -DUNILINK_BUILD_TESTS=ON \
+  -DUNILINK_ENABLE_PERFORMANCE_TESTS=OFF \
+  -DBUILD_PYTHON_BINDINGS=ON \
+  -DPython3_EXECUTABLE="$(python3 -c 'import sys; print(sys.executable)')"
+```
+
+```bash
+cmake --build build-orin -j"$(nproc)"
+```
+
+If you only want a C++ validation pass and do not need Python bindings:
+
+```bash
+cmake -S . -B build-orin \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DUNILINK_BUILD_EXAMPLES=OFF \
+  -DUNILINK_BUILD_DOCS=OFF \
+  -DUNILINK_BUILD_TESTS=ON \
+  -DUNILINK_ENABLE_PERFORMANCE_TESTS=OFF \
+  -DBUILD_PYTHON_BINDINGS=OFF
+```
+
+---
+
+## Run C++ Tests
+
+Run the fast unit-style suite first:
+
+```bash
+ctest --test-dir build-orin \
+  --output-on-failure \
+  --parallel "$(nproc)" \
+  --label-regex "unit|core|memory|config"
+```
+
+Run the integration suite next:
+
+```bash
+ctest --test-dir build-orin \
+  --output-on-failure \
+  --parallel 2 \
+  --label-regex "integration|mock|stable" \
+  --label-exclude "slow"
+```
+
+Run the end-to-end suite if you want broader confidence:
+
+```bash
+ctest --test-dir build-orin \
+  --output-on-failure \
+  --parallel 2 \
+  -L e2e
+```
+
+Run everything except performance benchmarks:
+
+```bash
+ctest --test-dir build-orin \
+  --output-on-failure \
+  --parallel 2 \
+  -LE "performance|docs_snippets"
+```
+
+---
+
+## Run Python Validation
+
+Use the in-tree package plus the built extension:
+
+```bash
+export PYTHONPATH="$(pwd)/bindings/python:$(pwd)/build-orin/lib:${PYTHONPATH}"
+python3 bindings/python/test_import.py
+```
+
+Run the Python API tests:
+
+```bash
+python3 -m pytest bindings/python/tests/test_bindings_api.py -q
+```
+
+By default, the real transport loopback tests in `test_bindings_api.py` are skipped. To enable them:
+
+```bash
+UNILINK_PYTHON_RUN_LOOPBACK_TESTS=1 \
+python3 -m pytest bindings/python/tests/test_bindings_api.py -q
+```
+
+Use that loopback mode only when local socket creation is allowed in the environment.
+
+---
+
+## Serial Validation
+
+### Automated Integration Coverage
+
+The ARM64 integration command above already includes serial integration tests.
+
+`test_serial_timeout.cc` creates a virtual serial pair with `socat` when it is available, so `socat` should be installed before running the integration suite.
+
+### Manual Virtual Serial Pair
+
+If you want to do manual bring-up without hardware:
+
+```bash
+socat -d -d pty,raw,echo=0,link=/tmp/ttyA pty,raw,echo=0,link=/tmp/ttyB
+```
+
+That creates two connected serial endpoints:
+
+- `/tmp/ttyA`
+- `/tmp/ttyB`
+
+You can then use the serial example or your own local smoke test against those endpoints.
+
+### Physical Loopback
+
+If your Orin Nano testbed includes UART hardware, you can validate a real loopback path:
+
+1. Connect TX/RX appropriately for your adapter or board header.
+2. Confirm the device node, for example `/dev/ttyTHS0`, `/dev/ttyUSB0`, or `/dev/ttyACM0`.
+3. Run your smoke test or serial example with that path.
+
+---
+
+## Pass Criteria
+
+For a practical “supported on Orin Nano” claim, use this minimum bar:
+
+1. `cmake` configure succeeds on Ubuntu 22.04 ARM64.
+2. `cmake --build` succeeds with tests enabled.
+3. Unit and integration `ctest` commands pass.
+4. `bindings/python/test_import.py` passes when Python bindings are enabled.
+
+For a stronger “generic Ubuntu ARM64” claim, add:
+
+1. The same validation on Ubuntu 24.04 ARM64.
+2. Python API tests with loopback enabled.
+3. At least one serial validation path, either `socat` or physical loopback.
+
+---
+
+## Troubleshooting
+
+### Boost Not Found
+
+Check that the ARM64 Boost packages are installed:
+
+```bash
+dpkg -l | grep libboost
+```
+
+If CMake still fails, clear the build directory and reconfigure:
+
+```bash
+rm -rf build-orin
+cmake -S . -B build-orin ...
+```
+
+### Python Import Fails
+
+Confirm the extension exists:
+
+```bash
+find build-orin/lib -maxdepth 1 -name 'unilink_py*'
+```
+
+Then confirm `PYTHONPATH` includes both:
+
+- `bindings/python`
+- `build-orin/lib`
+
+### Serial Tests Skip
+
+If the serial integration tests skip on ARM64:
+
+- confirm `socat` is installed
+- confirm `/tmp` is writable
+- check that no stale `socat` process is holding the test symlinks
+
+### Port-Binding Failures
+
+If TCP or UDS tests fail intermittently:
+
+- rerun the failed tests once
+- make sure no unrelated local services are occupying ephemeral ports
+- reduce test parallelism from `2` to `1`
+
+---
+
+## Related Docs
+
+- [Testing](testing.md)
+- [Build Guide](build_guide.md)
+- [Requirements](../user/requirements.md)
+- [Serial Communication Tutorial](../user/tutorials/04_serial_communication.md)
+- [Python Bindings Guide](../user/python_bindings.md)
+
+[← Contributor Guide](index.md)

--- a/docs/contributor/orin_nano_validation.md
+++ b/docs/contributor/orin_nano_validation.md
@@ -19,6 +19,22 @@ This guide assumes:
 - Ubuntu 24.04 ARM64 is a secondary validation target
 - You are building from a local checkout of this repository
 
+## Latest Validation Snapshot
+
+Most recent reported Jetson Orin Nano result:
+
+- Platform: Ubuntu 22.04 on `aarch64`
+- Result: `100% tests passed, 0 tests failed out of 481`
+- Real elapsed test time: `25.52 sec`
+- Serial integration labels passed as part of the full sweep
+- One test was listed as not run because it is disabled by design:
+  `UdsErrorTest.ServerStopWithActiveSessions`
+
+Interpretation:
+
+- This is strong evidence for Ubuntu 22.04 ARM64 support on Orin Nano
+- It does not by itself prove every other Linux ARM64 distribution or userspace combination
+
 ---
 
 ## Prerequisites
@@ -204,6 +220,8 @@ For a practical “supported on Orin Nano” claim, use this minimum bar:
 2. `cmake --build` succeeds with tests enabled.
 3. Unit and integration `ctest` commands pass.
 4. `bindings/python/test_import.py` passes when Python bindings are enabled.
+
+The current Orin Nano report satisfies the C++ test portion of that bar.
 
 For a stronger “generic Ubuntu ARM64” claim, add:
 

--- a/docs/contributor/testing.md
+++ b/docs/contributor/testing.md
@@ -17,6 +17,10 @@ Complete guide for testing `unilink`, including running tests, CI/CD integration
 
 ## Quick Start
 
+For Jetson / Ubuntu ARM64 validation, use the dedicated runbook:
+
+- [Orin Nano Validation](orin_nano_validation.md)
+
 ### Build and Run All Tests
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ You are developing or extending unilink itself.
 |----------|----------------|
 | [Build Guide](contributor/build_guide.md) | CMake options, build profiles, sanitizers |
 | [Testing](contributor/testing.md) | Running tests, CI integration |
+| [Orin Nano Validation](contributor/orin_nano_validation.md) | Ubuntu 22.04 ARM64 build and test runbook |
 | [Implementation Status](contributor/implementation_status.md) | Verified scope and known gaps |
 | [Test Structure](contributor/test_structure.md) | Test organization and coverage |
 | [Architecture Overview](contributor/architecture/README.md) | Layers, responsibilities, design patterns |

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -74,17 +74,27 @@ Pre-built binary packages are available from GitHub Releases.
 
 Choose the archive matching your OS and architecture. Replace `${VERSION}` with the current version number (found in the root `CMakeLists.txt`).
 
-- **Linux**: `.tar.gz` (e.g. `unilink-${VERSION}-Linux-x86_64.tar.gz`)
+- **Linux**: `.tar.gz` (e.g. `unilink-${VERSION}-Linux-x86_64.tar.gz` or `unilink-${VERSION}-Linux-aarch64.tar.gz`)
 - **macOS**: `.tar.gz`, `.dmg`
 - **Windows**: `.zip`
 
 ```bash
-# Example for Linux (replace ${VERSION} with the actual version, e.g., 0.4.3)
+# Example for Linux x86_64 (replace ${VERSION} with the actual version, e.g., 0.4.3)
 export UNILINK_VERSION="0.4.3"
 wget https://github.com/jwsung91/unilink/releases/latest/download/unilink-${UNILINK_VERSION}-Linux-x86_64.tar.gz
 tar -xzf unilink-${UNILINK_VERSION}-Linux-x86_64.tar.gz
 cd unilink-${UNILINK_VERSION}-Linux-x86_64
 ```
+
+```bash
+# Example for Linux ARM64 / aarch64
+export UNILINK_VERSION="0.4.3"
+wget https://github.com/jwsung91/unilink/releases/latest/download/unilink-${UNILINK_VERSION}-Linux-aarch64.tar.gz
+tar -xzf unilink-${UNILINK_VERSION}-Linux-aarch64.tar.gz
+cd unilink-${UNILINK_VERSION}-Linux-aarch64
+```
+
+ARM64 release artifacts are intended to be produced from an Ubuntu 22.04 baseline so Jetson/Orin systems can consume the same package without relying on Ubuntu 24.04 userspace.
 
 #### Step 2: Install
 

--- a/docs/user/requirements.md
+++ b/docs/user/requirements.md
@@ -99,6 +99,8 @@ sudo apt install -y libboost-system-dev
 - Validated on Jetson Orin Nano with Ubuntu 22.04 on `aarch64`
 - Current secondary validation target: Ubuntu 24.04 on `aarch64`
 - Full C++ test sweep passed on the Orin Nano testbed: 481 tests passed, 0 failed
+- Python bindings validation passed, including import smoke, API tests, and loopback-enabled TCP checks
+- ARM64 release packaging validation passed, including installed-package consumer smoke via `find_package(unilink)` and `unilink::unilink`
 - One test remains intentionally disabled in that run: `UdsErrorTest.ServerStopWithActiveSessions`
 - Serial integration tests require `socat` or physical loopback hardware
 

--- a/docs/user/requirements.md
+++ b/docs/user/requirements.md
@@ -14,15 +14,16 @@ This guide describes the system requirements and dependencies needed to build an
 
 ### Supported Platforms
 
-| Platform         | Status              | Notes                                 |
-| ---------------- | ------------------- | ------------------------------------- |
-| Ubuntu 22.04 LTS | ✅ Fully Supported  | Recommended for production            |
-| Ubuntu 24.04 LTS | ✅ Fully Supported  | Latest features and optimizations     |
-| Ubuntu ARM64     | 🔄 Validation Path  | Ubuntu 22.04 baseline, 24.04 also checked |
-| Ubuntu 20.04 LTS | ⚠️ Local Build Only | GCC 11+ required manually             |
-| Other Linux      | 🔄 Should Work      | Not officially tested                 |
-| macOS            | ✅ Fully Supported  | Tested in CI (macOS 14, Clang)        |
-| Windows          | ✅ Fully Supported  | Tested in CI (Windows 2022, MSVC)     |
+| Platform                   | Status             | Notes                                                  |
+| -------------------------- | ------------------ | ------------------------------------------------------ |
+| Ubuntu 22.04 LTS           | ✅ Fully Supported | Recommended for production                             |
+| Ubuntu 24.04 LTS           | ✅ Fully Supported | Latest features and optimizations                      |
+| Ubuntu 22.04 ARM64 (Orin)  | ✅ Validated       | Jetson Orin Nano testbed passed full C++ test sweep    |
+| Ubuntu 24.04 ARM64         | 🔄 Validation Path | Secondary ARM64 target in CI/build matrix              |
+| Ubuntu 20.04 LTS           | ⚠️ Local Build Only| GCC 11+ required manually                              |
+| Other Linux                | 🔄 Should Work     | Not officially tested across all distros/architectures |
+| macOS                      | ✅ Fully Supported | Tested in CI (macOS 14, Clang)                         |
+| Windows                    | ✅ Fully Supported | Tested in CI (Windows 2022, MSVC)                      |
 
 ---
 
@@ -95,9 +96,10 @@ sudo apt install -y libboost-system-dev
 ### Ubuntu ARM64 / Jetson Orin Nano
 
 - Source builds use the same Linux/POSIX code path as x86_64
-- Recommended baseline: Ubuntu 22.04 on `aarch64`
-- Secondary validation target: Ubuntu 24.04 on `aarch64`
-- Validate with unit tests, integration tests, and Python import smoke tests
+- Validated on Jetson Orin Nano with Ubuntu 22.04 on `aarch64`
+- Current secondary validation target: Ubuntu 24.04 on `aarch64`
+- Full C++ test sweep passed on the Orin Nano testbed: 481 tests passed, 0 failed
+- One test remains intentionally disabled in that run: `UdsErrorTest.ServerStopWithActiveSessions`
 - Serial integration tests require `socat` or physical loopback hardware
 
 ### Ubuntu 20.04 LTS

--- a/docs/user/requirements.md
+++ b/docs/user/requirements.md
@@ -18,6 +18,7 @@ This guide describes the system requirements and dependencies needed to build an
 | ---------------- | ------------------- | ------------------------------------- |
 | Ubuntu 22.04 LTS | ✅ Fully Supported  | Recommended for production            |
 | Ubuntu 24.04 LTS | ✅ Fully Supported  | Latest features and optimizations     |
+| Ubuntu ARM64     | 🔄 Validation Path  | Ubuntu 22.04 baseline, 24.04 also checked |
 | Ubuntu 20.04 LTS | ⚠️ Local Build Only | GCC 11+ required manually             |
 | Other Linux      | 🔄 Should Work      | Not officially tested                 |
 | macOS            | ✅ Fully Supported  | Tested in CI (macOS 14, Clang)        |
@@ -90,6 +91,14 @@ sudo apt install -y libboost-system-dev
 - Default GCC 11.4 meets all requirements
 - All features fully supported
 - Recommended platform for production use
+
+### Ubuntu ARM64 / Jetson Orin Nano
+
+- Source builds use the same Linux/POSIX code path as x86_64
+- Recommended baseline: Ubuntu 22.04 on `aarch64`
+- Secondary validation target: Ubuntu 24.04 on `aarch64`
+- Validate with unit tests, integration tests, and Python import smoke tests
+- Serial integration tests require `socat` or physical loopback hardware
 
 ### Ubuntu 20.04 LTS
 


### PR DESCRIPTION
## Description
Add the missing Linux ARM64 support path in the build and packaging flow, extend CI/release coverage for Ubuntu ARM64, fix the installed CMake package alias target, and document a reproducible Jetson Orin Nano validation runbook. This PR also records the reported Orin Nano validation results so the supported scope is explicit.

## Key Changes
- Add Linux ARM64-aware Boost fallback search paths in CMake so `aarch64` source builds do not depend on x86_64-specific library hints.
- Extend GitHub Actions build, test, and release workflows with Ubuntu ARM64 jobs, using Ubuntu 22.04 ARM64 as the primary baseline and Ubuntu 24.04 ARM64 as a secondary validation target.
- Fix the installed CMake package so downstream consumers can use the canonical `unilink::unilink` target after `find_package(unilink CONFIG REQUIRED)`.
- Update user and contributor documentation for ARM64 artifacts, supported-platform scope, and an Orin Nano validation runbook.
- Record the reported Jetson Orin Nano Ubuntu 22.04 ARM64 validation results across C++, Python, and installed-package consumption paths.

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
- Local validation in this branch included a clean configure/build check and an installed-package consumer smoke test using `unilink::unilink`.
- Reported Jetson Orin Nano validation result on Ubuntu 22.04 ARM64: `100% tests passed, 0 tests failed out of 481` in `25.52 sec` real time.
- Python validation on Orin Nano passed for import smoke, API tests, and loopback-enabled TCP tests.
- ARM64 release artifact validation on Orin Nano passed for `TGZ` package generation and downstream `find_package(unilink)` consumption.
- The Orin run reported one disabled test as not run: `UdsErrorTest.ServerStopWithActiveSessions`.