### PR TITLE
refactor: fix bugs, unify wrapper interfaces, and improve C++20 usability

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,6 +13,14 @@ on:
       - 'LICENSE'
       - 'NOTICE'
       - '.gitignore'
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'NOTICE'
+      - '.gitignore'
   workflow_call:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -529,4 +529,3 @@ jobs:
         echo "| Performance Tests | ${{ needs.performance-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| Memory Safety Tests | ${{ needs.memory-safety-tests.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
         echo "| E2E Tests | ${{ needs.e2e-tests.result == 'success' && '✅ Passed' || needs.e2e-tests.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-P_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
         fi
 
         # Install other tools. Boost and spdlog are supplied by vcpkg.
-        sudo apt-get install -y ninja-build
+        sudo apt-get install -y ninja-build ccache
 
     - name: Install tools (macOS)
       if: runner.os == 'macOS'

--- a/bindings/python/module.cpp.in
+++ b/bindings/python/module.cpp.in
@@ -809,7 +809,7 @@ PYBIND11_MODULE(unilink_py, m) {
       .def("connected_clients", &UdpServer::connected_clients)
       .def("listening", &UdpServer::listening)
       .def("auto_start", &UdpServer::auto_start, py::arg("start") = true)
-      .def("session_timeout", &UdpServer::session_timeout)
+      .def("idle_timeout", &UdpServer::idle_timeout)
       .def(
           "use_line_framer",
           [](UdpServer& self, const std::string& d, bool i, size_t m) {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,6 +18,41 @@ job_count() {
 
 JOBS="$(job_count)"
 
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SKIP_FORMAT=0
+SKIP_DOCS=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --tests-only|-t)
+      SKIP_FORMAT=1
+      SKIP_DOCS=1
+      ;;
+    --skip-format)
+      SKIP_FORMAT=1
+      ;;
+    --skip-docs)
+      SKIP_DOCS=1
+      ;;
+    --help|-h)
+      echo "Usage: $0 [options]"
+      echo ""
+      echo "Options:"
+      echo "  --tests-only, -t   Skip formatting and doc snippets; run build + tests only"
+      echo "  --skip-format      Skip clang-format / cmake-format step"
+      echo "  --skip-docs        Skip documentation snippet compilation"
+      echo "  --help, -h         Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [[ -z "${UNILINK_VERIFY_PRESET:-}" ]]; then
   # Detect host platform and suggest a preset
   OS="$(uname -s)"
@@ -41,9 +76,13 @@ fi
 # ---------------------------------------------------------------------------
 # Step 1: Format
 # ---------------------------------------------------------------------------
-section "Step 1: Formatting code"
-./scripts/apply_clang_format.sh
-./scripts/apply_cmake_format.sh
+if [[ "${SKIP_FORMAT}" -eq 0 ]]; then
+  section "Step 1: Formatting code"
+  ./scripts/apply_clang_format.sh
+  ./scripts/apply_cmake_format.sh
+else
+  section "Step 1: Formatting code [SKIPPED]"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 2: Build library + examples
@@ -70,8 +109,12 @@ cmake --build "${UNILINK_VERIFY_BUILD_DIR}" -j"${JOBS}"
 # ---------------------------------------------------------------------------
 # Step 3: Compile documentation snippets
 # ---------------------------------------------------------------------------
-section "Step 3: Compiling documentation snippets"
-cmake --build "${UNILINK_VERIFY_BUILD_DIR}" -j"${JOBS}" --target doc_snippets_smoke
+if [[ "${SKIP_DOCS}" -eq 0 ]]; then
+  section "Step 3: Compiling documentation snippets"
+  cmake --build "${UNILINK_VERIFY_BUILD_DIR}" -j"${JOBS}" --target doc_snippets_smoke
+else
+  section "Step 3: Compiling documentation snippets [SKIPPED]"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 4: Unit tests

--- a/test/unit/wrapper/test_udp_server_coverage.cc
+++ b/test/unit/wrapper/test_udp_server_coverage.cc
@@ -57,7 +57,7 @@ TEST(UdpServerCoverageTest, SessionReaping) {
   cfg.local_port = 0;
 
   wrapper::UdpServer server(cfg);
-  server.session_timeout(100ms);
+  server.idle_timeout(100ms);
 
   std::atomic<int> disconnects{0};
   server.on_disconnect([&](const wrapper::ConnectionContext&) { disconnects++; });

--- a/unilink/diagnostics/error_handler.cc
+++ b/unilink/diagnostics/error_handler.cc
@@ -30,12 +30,12 @@ namespace diagnostics {
 ErrorHandler::ErrorHandler() = default;
 ErrorHandler::~ErrorHandler() = default;
 
-ErrorHandler& ErrorHandler::default_handler() {
-  static ErrorHandler instance;
-  return instance;
+ErrorHandler& ErrorHandler::instance() {
+  static ErrorHandler inst;
+  return inst;
 }
 
-ErrorHandler& ErrorHandler::instance() { return default_handler(); }
+ErrorHandler& ErrorHandler::default_handler() { return instance(); }
 
 void ErrorHandler::report_error(const ErrorInfo& error) {
   if (!enabled_.load()) {

--- a/unilink/diagnostics/error_handler.hpp
+++ b/unilink/diagnostics/error_handler.hpp
@@ -44,6 +44,7 @@ class UNILINK_API ErrorHandler {
    * @brief Get singleton instance
    */
   static ErrorHandler& instance();
+  [[deprecated("Use ErrorHandler::instance() instead")]]
   static ErrorHandler& default_handler();
 
   ErrorHandler();

--- a/unilink/diagnostics/error_mapping.hpp
+++ b/unilink/diagnostics/error_mapping.hpp
@@ -87,8 +87,7 @@ inline bool is_retryable_tcp_connect_error(const boost::system::error_code& ec) 
   // Aborted usually means stopped by user, not retryable automatically
   if (ec == boost::asio::error::operation_aborted) return false;
 
-  // Default to true for unknown errors in network context to be resilient?
-  // Or false? The requirement says "PR2는 보수적으로 true로 둬도 됨" (conservative to keep retrying)
+  // Unknown network errors are treated as transient to err on the side of resilience.
   return true;
 }
 

--- a/unilink/diagnostics/logger.cc
+++ b/unilink/diagnostics/logger.cc
@@ -243,12 +243,12 @@ Logger::~Logger() = default;
 Logger::Logger(Logger&&) noexcept = default;
 Logger& Logger::operator=(Logger&&) noexcept = default;
 
-Logger& Logger::default_logger() {
-  static Logger* instance = new Logger();
-  return *instance;
+Logger& Logger::instance() {
+  static Logger* inst = new Logger();
+  return *inst;
 }
 
-Logger& Logger::instance() { return default_logger(); }
+Logger& Logger::default_logger() { return instance(); }
 
 void Logger::set_level(LogLevel level) {
   impl_->current_level_.store(level);

--- a/unilink/diagnostics/logger.hpp
+++ b/unilink/diagnostics/logger.hpp
@@ -105,6 +105,7 @@ class UNILINK_API Logger {
    * @brief Get singleton instance
    */
   static Logger& instance();
+  [[deprecated("Use Logger::instance() instead")]]
   static Logger& default_logger();
 
   Logger();
@@ -256,24 +257,11 @@ class UNILINK_API Logger {
   } while (0)
 
 /**
- * @brief Conditional logging macros (only evaluate message if level is enabled)
- */
-#define UNILINK_LOG_DEBUG_IF(component, operation, message)                                          \
-  do {                                                                                               \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) { \
-      UNILINK_LOG_DEBUG(component, operation, message);                                              \
-    }                                                                                                \
-  } while (0)
-
-#define UNILINK_LOG_INFO_IF(component, operation, message)                                          \
-  do {                                                                                              \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::INFO) { \
-      UNILINK_LOG_INFO(component, operation, message);                                              \
-    }                                                                                               \
-  } while (0)
-
-/**
- * @brief Performance logging macros for expensive operations
+ * @brief Performance logging macros for expensive operations.
+ *
+ * Usage: UNILINK_LOG_PERF_START and UNILINK_LOG_PERF_END must use the same
+ * `component` and `operation` tokens, and each `operation` token must be
+ * unique within its enclosing scope (the token becomes part of a variable name).
  */
 #define UNILINK_LOG_PERF_START(component, operation)                                              \
   auto _perf_start_##operation =                                                                  \

--- a/unilink/wrapper/context.hpp
+++ b/unilink/wrapper/context.hpp
@@ -41,7 +41,10 @@ class MessageContext {
   ClientId client_id() const { return client_id_; }
 
   /**
-   * @brief Get the received data as a view
+   * @brief Get the received data as a view.
+   *
+   * The returned view is only valid for the lifetime of this MessageContext.
+   * Do not store it past the callback's return — use data_as_string() instead.
    */
   std::string_view data() const { return std::string_view(reinterpret_cast<const char*>(data_.data()), data_.size()); }
 

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -140,6 +140,10 @@ class UNILINK_API ChannelInterface {
   /**
    * @brief Register a callback to be notified when send queue congestion changes.
    * @param handler Callback receiving the current number of queued bytes.
+   *
+   * Default implementation is a no-op. Concrete implementations that support
+   * backpressure reporting must override this method; otherwise the handler
+   * is silently discarded.
    */
   virtual ChannelInterface& on_backpressure(std::function<void(size_t)> handler) {
     (void)handler;

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -115,6 +115,26 @@ class UNILINK_API ServerInterface {
    */
   virtual bool try_broadcast(std::string_view data) = 0;
 
+  /**
+   * @brief Send a line (data + "\n") to all clients, honouring the backpressure strategy.
+   */
+  virtual bool broadcast_line(std::string_view line) = 0;
+
+  /**
+   * @brief Send a line (data + "\n") to a specific client, honouring the backpressure strategy.
+   */
+  virtual bool send_to_line(ClientId client_id, std::string_view line) = 0;
+
+  /**
+   * @brief Non-blocking broadcast_line that always drops on a full queue, ignoring strategy.
+   */
+  virtual bool try_broadcast_line(std::string_view line) = 0;
+
+  /**
+   * @brief Non-blocking send_to_line that always drops on a full queue, ignoring strategy.
+   */
+  virtual bool try_send_to_line(ClientId client_id, std::string_view line) = 0;
+
   // Event handlers
   virtual ServerInterface& on_connect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_disconnect(ConnectionHandler handler) = 0;
@@ -128,6 +148,10 @@ class UNILINK_API ServerInterface {
   /**
    * @brief Register a callback to be notified when send queue congestion changes.
    * @param handler Callback receiving the current number of queued bytes.
+   *
+   * Default implementation is a no-op. Concrete implementations that support
+   * backpressure reporting must override this method; otherwise the handler
+   * is silently discarded.
    */
   virtual ServerInterface& on_backpressure(std::function<void(size_t)> handler) {
     (void)handler;

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -459,52 +459,52 @@ bool Serial::connected() const {
   return impl_->channel && impl_->channel->is_connected();
 }
 
-ChannelInterface& Serial::on_data(MessageHandler h) {
+Serial& Serial::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Serial::on_data_batch(BatchMessageHandler h) {
+Serial& Serial::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& Serial::on_connect(ConnectionHandler h) {
+Serial& Serial::on_connect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->connect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Serial::on_disconnect(ConnectionHandler h) {
+Serial& Serial::on_disconnect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->disconnect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& Serial::on_error(ErrorHandler h) {
+Serial& Serial::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler = std::move(h);
   return *this;
 }
 
-ChannelInterface& Serial::on_backpressure(std::function<void(size_t)> h) {
+Serial& Serial::on_backpressure(std::function<void(size_t)> h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->bp_handler = std::move(h);
   return *this;
 }
 
-ChannelInterface& Serial::framer(std::unique_ptr<framer::IFramer> f) {
+Serial& Serial::framer(std::unique_ptr<framer::IFramer> f) {
   impl_->set_framer(std::move(f));
   return *this;
 }
-ChannelInterface& Serial::on_message(MessageHandler h) {
+Serial& Serial::on_message(MessageHandler h) {
   impl_->on_message(std::move(h));
   return *this;
 }
-ChannelInterface& Serial::on_message_batch(BatchMessageHandler h) {
+Serial& Serial::on_message_batch(BatchMessageHandler h) {
   impl_->on_message_batch(std::move(h));
   return *this;
 }
 
-ChannelInterface& Serial::auto_start(bool m) {
+Serial& Serial::auto_start(bool m) {
   impl_->auto_start_.store(m);
   if (impl_->auto_start_.load() && !impl_->started_.load()) start();
   return *this;

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -70,18 +70,18 @@ class UNILINK_API Serial : public ChannelInterface {
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
 
-  ChannelInterface& on_data(MessageHandler handler) override;
-  ChannelInterface& on_data_batch(BatchMessageHandler handler) override;
-  ChannelInterface& on_connect(ConnectionHandler handler) override;
-  ChannelInterface& on_disconnect(ConnectionHandler handler) override;
-  ChannelInterface& on_error(ErrorHandler handler) override;
-  ChannelInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  Serial& on_data(MessageHandler handler) override;
+  Serial& on_data_batch(BatchMessageHandler handler) override;
+  Serial& on_connect(ConnectionHandler handler) override;
+  Serial& on_disconnect(ConnectionHandler handler) override;
+  Serial& on_error(ErrorHandler handler) override;
+  Serial& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
-  ChannelInterface& on_message(MessageHandler handler) override;
-  ChannelInterface& on_message_batch(BatchMessageHandler handler) override;
+  Serial& framer(std::unique_ptr<framer::IFramer> framer) override;
+  Serial& on_message(MessageHandler handler) override;
+  Serial& on_message_batch(BatchMessageHandler handler) override;
 
-  ChannelInterface& auto_start(bool manage = true) override;
+  Serial& auto_start(bool manage = true) override;
 
   // Serial-specific methods
   Serial& baud_rate(uint32_t baud_rate);

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -463,52 +463,52 @@ bool TcpClient::send_blocking(std::string_view data) { return impl_->send_blocki
 bool TcpClient::send_line_blocking(std::string_view line) { return impl_->send_line_blocking(line); }
 bool TcpClient::connected() const { return get_impl()->connected(); }
 
-ChannelInterface& TcpClient::on_data(MessageHandler h) {
+TcpClient& TcpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& TcpClient::on_data_batch(BatchMessageHandler h) {
+TcpClient& TcpClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& TcpClient::on_connect(ConnectionHandler h) {
+TcpClient& TcpClient::on_connect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->connect_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& TcpClient::on_disconnect(ConnectionHandler h) {
+TcpClient& TcpClient::on_disconnect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->disconnect_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& TcpClient::on_error(ErrorHandler h) {
+TcpClient& TcpClient::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& TcpClient::on_backpressure(std::function<void(size_t)> h) {
+TcpClient& TcpClient::on_backpressure(std::function<void(size_t)> h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->bp_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& TcpClient::framer(std::unique_ptr<framer::IFramer> f) {
+TcpClient& TcpClient::framer(std::unique_ptr<framer::IFramer> f) {
   impl_->set_framer(std::move(f));
   return *this;
 }
-ChannelInterface& TcpClient::on_message(MessageHandler h) {
+TcpClient& TcpClient::on_message(MessageHandler h) {
   impl_->on_message(std::move(h));
   return *this;
 }
-ChannelInterface& TcpClient::on_message_batch(BatchMessageHandler h) {
+TcpClient& TcpClient::on_message_batch(BatchMessageHandler h) {
   impl_->on_message_batch(std::move(h));
   return *this;
 }
 
-ChannelInterface& TcpClient::auto_start(bool m) {
+TcpClient& TcpClient::auto_start(bool m) {
   impl_->auto_start_.store(m);
   if (impl_->auto_start_.load() && !impl_->started_.load()) start();
   return *this;

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -70,18 +70,18 @@ class UNILINK_API TcpClient : public ChannelInterface {
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
 
-  ChannelInterface& on_data(MessageHandler handler) override;
-  ChannelInterface& on_data_batch(BatchMessageHandler handler) override;
-  ChannelInterface& on_connect(ConnectionHandler handler) override;
-  ChannelInterface& on_disconnect(ConnectionHandler handler) override;
-  ChannelInterface& on_error(ErrorHandler handler) override;
-  ChannelInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  TcpClient& on_data(MessageHandler handler) override;
+  TcpClient& on_data_batch(BatchMessageHandler handler) override;
+  TcpClient& on_connect(ConnectionHandler handler) override;
+  TcpClient& on_disconnect(ConnectionHandler handler) override;
+  TcpClient& on_error(ErrorHandler handler) override;
+  TcpClient& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
-  ChannelInterface& on_message(MessageHandler handler) override;
-  ChannelInterface& on_message_batch(BatchMessageHandler handler) override;
+  TcpClient& framer(std::unique_ptr<framer::IFramer> framer) override;
+  TcpClient& on_message(MessageHandler handler) override;
+  TcpClient& on_message_batch(BatchMessageHandler handler) override;
 
-  ChannelInterface& auto_start(bool manage = true) override;
+  TcpClient& auto_start(bool manage = true) override;
 
   // Configuration
   TcpClient& batch_size(size_t size);

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -484,15 +484,11 @@ bool TcpServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-bool TcpServer::broadcast_line(std::string_view line) {
-  return broadcast(std::string(line) + "\n");
-}
+bool TcpServer::broadcast_line(std::string_view line) { return broadcast(std::string(line) + "\n"); }
 bool TcpServer::send_to_line(ClientId client_id, std::string_view line) {
   return send_to(client_id, std::string(line) + "\n");
 }
-bool TcpServer::try_broadcast_line(std::string_view line) {
-  return try_broadcast(std::string(line) + "\n");
-}
+bool TcpServer::try_broadcast_line(std::string_view line) { return try_broadcast(std::string(line) + "\n"); }
 bool TcpServer::try_send_to_line(ClientId client_id, std::string_view line) {
   return try_send_to(client_id, std::string(line) + "\n");
 }

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -484,51 +484,64 @@ bool TcpServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-ServerInterface& TcpServer::on_connect(ConnectionHandler h) {
+bool TcpServer::broadcast_line(std::string_view line) {
+  return broadcast(std::string(line) + "\n");
+}
+bool TcpServer::send_to_line(ClientId client_id, std::string_view line) {
+  return send_to(client_id, std::string(line) + "\n");
+}
+bool TcpServer::try_broadcast_line(std::string_view line) {
+  return try_broadcast(std::string(line) + "\n");
+}
+bool TcpServer::try_send_to_line(ClientId client_id, std::string_view line) {
+  return try_send_to(client_id, std::string(line) + "\n");
+}
+
+TcpServer& TcpServer::on_connect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_client_connect_ = std::move(h);
   return *this;
 }
-ServerInterface& TcpServer::on_disconnect(ConnectionHandler h) {
+TcpServer& TcpServer::on_disconnect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_disconnect_ = std::move(h);
   return *this;
 }
-ServerInterface& TcpServer::on_data(MessageHandler h) {
+TcpServer& TcpServer::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_data_ = std::move(h);
   return *this;
 }
-ServerInterface& TcpServer::on_data_batch(BatchMessageHandler h) {
+TcpServer& TcpServer::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(h);
   return *this;
 }
-ServerInterface& TcpServer::on_error(ErrorHandler h) {
+TcpServer& TcpServer::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_error_ = std::move(h);
   return *this;
 }
 
-ServerInterface& TcpServer::on_backpressure(std::function<void(size_t)> h) {
+TcpServer& TcpServer::on_backpressure(std::function<void(size_t)> h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_backpressure_ = std::move(h);
   return *this;
 }
 
-ServerInterface& TcpServer::framer(FramerFactory factory) {
+TcpServer& TcpServer::framer(FramerFactory factory) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->framer_factory_ = std::move(factory);
   return *this;
 }
 
-ServerInterface& TcpServer::on_message(MessageHandler handler) {
+TcpServer& TcpServer::on_message(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_message_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& TcpServer::on_message_batch(BatchMessageHandler h) {
+TcpServer& TcpServer::on_message_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->message_batch_handler_ = std::move(h);
   return *this;

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -70,18 +70,22 @@ class UNILINK_API TcpServer : public ServerInterface {
   bool send_to_blocking(ClientId client_id, std::string_view data) override;
   bool try_send_to(ClientId client_id, std::string_view data) override;
   bool try_broadcast(std::string_view data) override;
+  bool broadcast_line(std::string_view line) override;
+  bool send_to_line(ClientId client_id, std::string_view line) override;
+  bool try_broadcast_line(std::string_view line) override;
+  bool try_send_to_line(ClientId client_id, std::string_view line) override;
 
   // Event handlers
-  ServerInterface& on_connect(ConnectionHandler handler) override;
-  ServerInterface& on_disconnect(ConnectionHandler handler) override;
-  ServerInterface& on_data(MessageHandler handler) override;
-  ServerInterface& on_data_batch(BatchMessageHandler handler) override;
-  ServerInterface& on_error(ErrorHandler handler) override;
-  ServerInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  TcpServer& on_connect(ConnectionHandler handler) override;
+  TcpServer& on_disconnect(ConnectionHandler handler) override;
+  TcpServer& on_data(MessageHandler handler) override;
+  TcpServer& on_data_batch(BatchMessageHandler handler) override;
+  TcpServer& on_error(ErrorHandler handler) override;
+  TcpServer& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ServerInterface& framer(FramerFactory factory) override;
-  ServerInterface& on_message(MessageHandler handler) override;
-  ServerInterface& on_message_batch(BatchMessageHandler handler) override;
+  TcpServer& framer(FramerFactory factory) override;
+  TcpServer& on_message(MessageHandler handler) override;
+  TcpServer& on_message_batch(BatchMessageHandler handler) override;
 
   // Client count and management
   size_t client_count() const override;

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -416,53 +416,53 @@ bool UdpClient::connected() const {
   return impl_->channel && impl_->channel->is_connected();
 }
 
-ChannelInterface& UdpClient::on_data(MessageHandler h) {
+UdpClient& UdpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_handler = std::move(h);
   return *this;
 }
-ChannelInterface& UdpClient::on_data_batch(BatchMessageHandler h) {
+UdpClient& UdpClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(h);
   return *this;
 }
-ChannelInterface& UdpClient::on_connect(ConnectionHandler h) {
+UdpClient& UdpClient::on_connect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->connect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& UdpClient::on_disconnect(ConnectionHandler h) {
+UdpClient& UdpClient::on_disconnect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->disconnect_handler = std::move(h);
   return *this;
 }
-ChannelInterface& UdpClient::on_error(ErrorHandler h) {
+UdpClient& UdpClient::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdpClient::on_backpressure(std::function<void(size_t)> h) {
+UdpClient& UdpClient::on_backpressure(std::function<void(size_t)> h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->bp_handler = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdpClient::framer(std::unique_ptr<framer::IFramer> f) {
+UdpClient& UdpClient::framer(std::unique_ptr<framer::IFramer> f) {
   impl_->set_framer(std::move(f));
   return *this;
 }
-ChannelInterface& UdpClient::on_message(MessageHandler h) {
+UdpClient& UdpClient::on_message(MessageHandler h) {
   impl_->on_message(std::move(h));
   return *this;
 }
-ChannelInterface& UdpClient::on_message_batch(BatchMessageHandler h) {
+UdpClient& UdpClient::on_message_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->message_batch_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdpClient::auto_start(bool m) {
+UdpClient& UdpClient::auto_start(bool m) {
   impl_->auto_start_.store(m);
   if (impl_->auto_start_.load() && !impl_->started_.load()) start();
   return *this;

--- a/unilink/wrapper/udp/udp.hpp
+++ b/unilink/wrapper/udp/udp.hpp
@@ -70,18 +70,18 @@ class UNILINK_API UdpClient : public ChannelInterface {
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
 
-  ChannelInterface& on_data(MessageHandler handler) override;
-  ChannelInterface& on_data_batch(BatchMessageHandler handler) override;
-  ChannelInterface& on_connect(ConnectionHandler handler) override;
-  ChannelInterface& on_disconnect(ConnectionHandler handler) override;
-  ChannelInterface& on_error(ErrorHandler handler) override;
-  ChannelInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  UdpClient& on_data(MessageHandler handler) override;
+  UdpClient& on_data_batch(BatchMessageHandler handler) override;
+  UdpClient& on_connect(ConnectionHandler handler) override;
+  UdpClient& on_disconnect(ConnectionHandler handler) override;
+  UdpClient& on_error(ErrorHandler handler) override;
+  UdpClient& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
-  ChannelInterface& on_message(MessageHandler handler) override;
-  ChannelInterface& on_message_batch(BatchMessageHandler handler) override;
+  UdpClient& framer(std::unique_ptr<framer::IFramer> framer) override;
+  UdpClient& on_message(MessageHandler handler) override;
+  UdpClient& on_message_batch(BatchMessageHandler handler) override;
 
-  ChannelInterface& auto_start(bool manage = true) override;
+  UdpClient& auto_start(bool manage = true) override;
 
   UdpClient& backpressure_threshold(size_t threshold);
   UdpClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -85,6 +85,8 @@ struct UdpServer::Impl {
   std::chrono::milliseconds session_timeout{30000};  // Default 30s
   std::unique_ptr<boost::asio::steady_timer> reaper_timer;
   std::atomic<bool> auto_start{false};
+  std::atomic<bool> client_limit_enabled{false};
+  std::atomic<size_t> max_clients_limit{0};
 
   ConnectionHandler on_connect{nullptr};
   ConnectionHandler on_disconnect{nullptr};
@@ -233,6 +235,9 @@ struct UdpServer::Impl {
         std::unique_lock<std::shared_mutex> lock(mutex);
         auto it = endpoint_to_id.find(ep);
         if (it == endpoint_to_id.end()) {
+          if (client_limit_enabled.load() && sessions.size() >= max_clients_limit.load()) {
+            return;
+          }
           client_id = next_client_id++;
           endpoint_to_id[ep] = client_id;
           SessionEntry entry;
@@ -531,49 +536,62 @@ bool UdpServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-ServerInterface& UdpServer::on_connect(ConnectionHandler h) {
+bool UdpServer::broadcast_line(std::string_view line) {
+  return broadcast(std::string(line) + "\n");
+}
+bool UdpServer::send_to_line(ClientId client_id, std::string_view line) {
+  return send_to(client_id, std::string(line) + "\n");
+}
+bool UdpServer::try_broadcast_line(std::string_view line) {
+  return try_broadcast(std::string(line) + "\n");
+}
+bool UdpServer::try_send_to_line(ClientId client_id, std::string_view line) {
+  return try_send_to(client_id, std::string(line) + "\n");
+}
+
+UdpServer& UdpServer::on_connect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_connect = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::on_disconnect(ConnectionHandler h) {
+UdpServer& UdpServer::on_disconnect(ConnectionHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_disconnect = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::on_data(MessageHandler h) {
+UdpServer& UdpServer::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_data = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::on_data_batch(BatchMessageHandler h) {
+UdpServer& UdpServer::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_data_batch_ = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::on_error(ErrorHandler h) {
+UdpServer& UdpServer::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_error = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::framer(FramerFactory factory) {
+UdpServer& UdpServer::framer(FramerFactory factory) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->framer_factory = std::move(factory);
   return *this;
 }
 
-ServerInterface& UdpServer::on_message(MessageHandler h) {
+UdpServer& UdpServer::on_message(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_message = std::move(h);
   return *this;
 }
 
-ServerInterface& UdpServer::on_message_batch(BatchMessageHandler h) {
+UdpServer& UdpServer::on_message_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->on_message_batch_ = std::move(h);
   return *this;
@@ -602,7 +620,7 @@ UdpServer& UdpServer::auto_start(bool m) {
   return *this;
 }
 
-UdpServer& UdpServer::session_timeout(std::chrono::milliseconds timeout) {
+UdpServer& UdpServer::idle_timeout(std::chrono::milliseconds timeout) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->session_timeout = timeout;
   return *this;
@@ -611,6 +629,17 @@ UdpServer& UdpServer::session_timeout(std::chrono::milliseconds timeout) {
 UdpServer& UdpServer::on_backpressure(std::function<void(size_t)> handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->bp_handler = std::move(handler);
+  return *this;
+}
+
+UdpServer& UdpServer::max_clients(size_t max) {
+  impl_->client_limit_enabled.store(true);
+  impl_->max_clients_limit.store(max);
+  return *this;
+}
+
+UdpServer& UdpServer::unlimited_clients() {
+  impl_->client_limit_enabled.store(false);
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -536,15 +536,11 @@ bool UdpServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-bool UdpServer::broadcast_line(std::string_view line) {
-  return broadcast(std::string(line) + "\n");
-}
+bool UdpServer::broadcast_line(std::string_view line) { return broadcast(std::string(line) + "\n"); }
 bool UdpServer::send_to_line(ClientId client_id, std::string_view line) {
   return send_to(client_id, std::string(line) + "\n");
 }
-bool UdpServer::try_broadcast_line(std::string_view line) {
-  return try_broadcast(std::string(line) + "\n");
-}
+bool UdpServer::try_broadcast_line(std::string_view line) { return try_broadcast(std::string(line) + "\n"); }
 bool UdpServer::try_send_to_line(ClientId client_id, std::string_view line) {
   return try_send_to(client_id, std::string(line) + "\n");
 }

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -62,26 +62,32 @@ class UNILINK_API UdpServer : public ServerInterface {
   bool send_to_blocking(ClientId client_id, std::string_view data) override;
   bool try_send_to(ClientId client_id, std::string_view data) override;
   bool try_broadcast(std::string_view data) override;
+  bool broadcast_line(std::string_view line) override;
+  bool send_to_line(ClientId client_id, std::string_view line) override;
+  bool try_broadcast_line(std::string_view line) override;
+  bool try_send_to_line(ClientId client_id, std::string_view line) override;
 
   // Event handlers
-  ServerInterface& on_connect(ConnectionHandler handler) override;
-  ServerInterface& on_disconnect(ConnectionHandler handler) override;
-  ServerInterface& on_data(MessageHandler handler) override;
-  ServerInterface& on_data_batch(BatchMessageHandler handler) override;
-  ServerInterface& on_error(ErrorHandler handler) override;
+  UdpServer& on_connect(ConnectionHandler handler) override;
+  UdpServer& on_disconnect(ConnectionHandler handler) override;
+  UdpServer& on_data(MessageHandler handler) override;
+  UdpServer& on_data_batch(BatchMessageHandler handler) override;
+  UdpServer& on_error(ErrorHandler handler) override;
+  UdpServer& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ServerInterface& framer(FramerFactory factory) override;
-  ServerInterface& on_message(MessageHandler handler) override;
-  ServerInterface& on_message_batch(BatchMessageHandler handler) override;
+  UdpServer& framer(FramerFactory factory) override;
+  UdpServer& on_message(MessageHandler handler) override;
+  UdpServer& on_message_batch(BatchMessageHandler handler) override;
 
   // Client count and management
   size_t client_count() const override;
   std::vector<ClientId> connected_clients() const override;
 
-  // UDP specific
+  // Configuration (Fluent API)
   UdpServer& auto_start(bool manage = true) override;
-  UdpServer& session_timeout(std::chrono::milliseconds timeout);
-  UdpServer& on_backpressure(std::function<void(size_t)> handler);
+  UdpServer& idle_timeout(std::chrono::milliseconds timeout);
+  UdpServer& max_clients(size_t max);
+  UdpServer& unlimited_clients();
   UdpServer& backpressure_threshold(size_t threshold);
   UdpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdpServer& manage_external_context(bool manage);

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -457,58 +457,58 @@ bool UdsClient::connected() const {
   return impl_->channel_ && impl_->channel_->is_connected();
 }
 
-ChannelInterface& UdsClient::on_data(MessageHandler handler) {
+UdsClient& UdsClient::on_data(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_handler_ = std::move(handler);
   return *this;
 }
 
-ChannelInterface& UdsClient::on_data_batch(BatchMessageHandler h) {
+UdsClient& UdsClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdsClient::on_connect(ConnectionHandler handler) {
+UdsClient& UdsClient::on_connect(ConnectionHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->connect_handler_ = std::move(handler);
   return *this;
 }
 
-ChannelInterface& UdsClient::on_disconnect(ConnectionHandler handler) {
+UdsClient& UdsClient::on_disconnect(ConnectionHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->disconnect_handler_ = std::move(handler);
   return *this;
 }
 
-ChannelInterface& UdsClient::on_error(ErrorHandler h) {
+UdsClient& UdsClient::on_error(ErrorHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdsClient::on_backpressure(std::function<void(size_t)> h) {
+UdsClient& UdsClient::on_backpressure(std::function<void(size_t)> h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->bp_handler_ = std::move(h);
   return *this;
 }
 
-ChannelInterface& UdsClient::framer(std::unique_ptr<framer::IFramer> f) {
+UdsClient& UdsClient::framer(std::unique_ptr<framer::IFramer> f) {
   impl_->set_framer(std::move(f));
   return *this;
 }
 
-ChannelInterface& UdsClient::on_message(MessageHandler h) {
+UdsClient& UdsClient::on_message(MessageHandler h) {
   impl_->on_message(std::move(h));
   return *this;
 }
 
-ChannelInterface& UdsClient::on_message_batch(BatchMessageHandler h) {
+UdsClient& UdsClient::on_message_batch(BatchMessageHandler h) {
   impl_->on_message_batch(std::move(h));
   return *this;
 }
 
-ChannelInterface& UdsClient::auto_start(bool manage) {
+UdsClient& UdsClient::auto_start(bool manage) {
   impl_->auto_start_.store(manage);
   if (impl_->auto_start_.load() && !impl_->started_.load()) {
     start();

--- a/unilink/wrapper/uds_client/uds_client.hpp
+++ b/unilink/wrapper/uds_client/uds_client.hpp
@@ -70,18 +70,18 @@ class UNILINK_API UdsClient : public ChannelInterface {
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
 
-  ChannelInterface& on_data(MessageHandler handler) override;
-  ChannelInterface& on_data_batch(BatchMessageHandler handler) override;
-  ChannelInterface& on_connect(ConnectionHandler handler) override;
-  ChannelInterface& on_disconnect(ConnectionHandler handler) override;
-  ChannelInterface& on_error(ErrorHandler handler) override;
-  ChannelInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  UdsClient& on_data(MessageHandler handler) override;
+  UdsClient& on_data_batch(BatchMessageHandler handler) override;
+  UdsClient& on_connect(ConnectionHandler handler) override;
+  UdsClient& on_disconnect(ConnectionHandler handler) override;
+  UdsClient& on_error(ErrorHandler handler) override;
+  UdsClient& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ChannelInterface& framer(std::unique_ptr<framer::IFramer> framer) override;
-  ChannelInterface& on_message(MessageHandler handler) override;
-  ChannelInterface& on_message_batch(BatchMessageHandler handler) override;
+  UdsClient& framer(std::unique_ptr<framer::IFramer> framer) override;
+  UdsClient& on_message(MessageHandler handler) override;
+  UdsClient& on_message_batch(BatchMessageHandler handler) override;
 
-  ChannelInterface& auto_start(bool manage = true) override;
+  UdsClient& auto_start(bool manage = true) override;
 
   // Configuration
   UdsClient& retry_interval(std::chrono::milliseconds interval);

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -424,15 +424,11 @@ bool UdsServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-bool UdsServer::broadcast_line(std::string_view line) {
-  return broadcast(std::string(line) + "\n");
-}
+bool UdsServer::broadcast_line(std::string_view line) { return broadcast(std::string(line) + "\n"); }
 bool UdsServer::send_to_line(ClientId client_id, std::string_view line) {
   return send_to(client_id, std::string(line) + "\n");
 }
-bool UdsServer::try_broadcast_line(std::string_view line) {
-  return try_broadcast(std::string(line) + "\n");
-}
+bool UdsServer::try_broadcast_line(std::string_view line) { return try_broadcast(std::string(line) + "\n"); }
 bool UdsServer::try_send_to_line(ClientId client_id, std::string_view line) {
   return try_send_to(client_id, std::string(line) + "\n");
 }

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -424,55 +424,68 @@ bool UdsServer::send_to_blocking(ClientId client_id, std::string_view data) {
   return impl_->send_to_blocking(client_id, data);
 }
 
-ServerInterface& UdsServer::on_connect(ConnectionHandler handler) {
+bool UdsServer::broadcast_line(std::string_view line) {
+  return broadcast(std::string(line) + "\n");
+}
+bool UdsServer::send_to_line(ClientId client_id, std::string_view line) {
+  return send_to(client_id, std::string(line) + "\n");
+}
+bool UdsServer::try_broadcast_line(std::string_view line) {
+  return try_broadcast(std::string(line) + "\n");
+}
+bool UdsServer::try_send_to_line(ClientId client_id, std::string_view line) {
+  return try_send_to(client_id, std::string(line) + "\n");
+}
+
+UdsServer& UdsServer::on_connect(ConnectionHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->client_connect_handler_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_disconnect(ConnectionHandler handler) {
+UdsServer& UdsServer::on_disconnect(ConnectionHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->client_disconnect_handler_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_data(MessageHandler handler) {
+UdsServer& UdsServer::on_data(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_handler_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_data_batch(BatchMessageHandler handler) {
+UdsServer& UdsServer::on_data_batch(BatchMessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->data_batch_handler_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_error(ErrorHandler handler) {
+UdsServer& UdsServer::on_error(ErrorHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->error_handler_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_backpressure(std::function<void(size_t)> handler) {
+UdsServer& UdsServer::on_backpressure(std::function<void(size_t)> handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_backpressure_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::framer(FramerFactory factory) {
+UdsServer& UdsServer::framer(FramerFactory factory) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->framer_factory_ = std::move(factory);
   return *this;
 }
 
-ServerInterface& UdsServer::on_message(MessageHandler handler) {
+UdsServer& UdsServer::on_message(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_message_ = std::move(handler);
   return *this;
 }
 
-ServerInterface& UdsServer::on_message_batch(BatchMessageHandler handler) {
+UdsServer& UdsServer::on_message_batch(BatchMessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->on_message_batch_ = std::move(handler);
   return *this;

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -71,18 +71,22 @@ class UNILINK_API UdsServer : public ServerInterface {
   bool send_to_blocking(ClientId client_id, std::string_view data) override;
   bool try_send_to(ClientId client_id, std::string_view data) override;
   bool try_broadcast(std::string_view data) override;
+  bool broadcast_line(std::string_view line) override;
+  bool send_to_line(ClientId client_id, std::string_view line) override;
+  bool try_broadcast_line(std::string_view line) override;
+  bool try_send_to_line(ClientId client_id, std::string_view line) override;
 
   // Event handlers
-  ServerInterface& on_connect(ConnectionHandler handler) override;
-  ServerInterface& on_disconnect(ConnectionHandler handler) override;
-  ServerInterface& on_data(MessageHandler handler) override;
-  ServerInterface& on_data_batch(BatchMessageHandler handler) override;
-  ServerInterface& on_error(ErrorHandler handler) override;
-  ServerInterface& on_backpressure(std::function<void(size_t)> handler) override;
+  UdsServer& on_connect(ConnectionHandler handler) override;
+  UdsServer& on_disconnect(ConnectionHandler handler) override;
+  UdsServer& on_data(MessageHandler handler) override;
+  UdsServer& on_data_batch(BatchMessageHandler handler) override;
+  UdsServer& on_error(ErrorHandler handler) override;
+  UdsServer& on_backpressure(std::function<void(size_t)> handler) override;
 
-  ServerInterface& framer(FramerFactory factory) override;
-  ServerInterface& on_message(MessageHandler handler) override;
-  ServerInterface& on_message_batch(BatchMessageHandler handler) override;
+  UdsServer& framer(FramerFactory factory) override;
+  UdsServer& on_message(MessageHandler handler) override;
+  UdsServer& on_message_batch(BatchMessageHandler handler) override;
 
   // Client count and management
   size_t client_count() const override;


### PR DESCRIPTION
## Description

This PR addresses bugs found during a C++20 migration review, improves API usability, and enforces consistency across all wrapper interfaces (`TcpClient`, `UdpClient`, `UdsClient`, `Serial`, `TcpServer`, `UdsServer`, `UdpServer`). It also fixes a CI pipeline issue that was silently skipping all jobs.

## Key Changes

**Bug Fixes**
- `UdpServer::on_backpressure` was missing `override`, causing polymorphic calls via `ServerInterface*` to silently discard the registered handler
- `test.yml`: remove stray `P_SUMMARY` token that caused a YAML parse error, making all CI jobs silently skipped

**Usability & Documentation**
- `MessageContext::data()` now documents that the returned `string_view` is only valid for the duration of the callback — callers must use `data_as_string()` to retain the value
- `on_backpressure()` default no-op in `ChannelInterface` and `ServerInterface` now explicitly documents that un-overridden handlers are silently discarded
- `Logger::default_logger()` and `ErrorHandler::default_handler()` marked `[[deprecated]]`; `instance()` is now the canonical singleton entry point (delegation inverted to avoid self-referential deprecation warnings at build time)
- `UNILINK_LOG_DEBUG_IF` / `UNILINK_LOG_INFO_IF` removed — unused and behaviorally identical to their non-`_IF` counterparts
- `UNILINK_LOG_PERF_START` documents the unique-per-scope token constraint
- `error_mapping.hpp`: remove internal Korean-language requirement comment from public header

**Interface Consistency**
- All `on_*()`/`framer()`/`auto_start()` overrides now return the concrete type (covariant return), enabling unbroken fluent chains: `client.on_data(h).retry_interval(1s)`
- `UdpServer::session_timeout()` renamed to `idle_timeout()` to match `TcpServer` and `UdsServer`
- `ServerInterface` gains `broadcast_line()`, `send_to_line()`, `try_broadcast_line()`, `try_send_to_line()` — symmetric with `ChannelInterface::send_line()` / `try_send_line()`
- `UdpServer` gains `max_clients()` and `unlimited_clients()` — symmetric with `TcpServer` and `UdsServer`

**CI**
- `code-quality.yml`: add `pull_request` trigger so formatting and static analysis run before merge, not only after

**Developer Experience**
- `verify.sh`: add `--tests-only` / `-t` flag to skip the slow formatting step during local iteration; also adds `--skip-format` and `--skip-docs` for finer control

## Related Issues

- N/A

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

All covariant return changes are backward-compatible: code using `ChannelInterface*` or `ServerInterface*` polymorphically is unaffected. The change only benefits callers that hold the concrete type and want to chain configuration calls with event-handler registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line-oriented send/broadcast helpers added to servers/clients; non-blocking variants included.
  * UDP server: optional client limits and idle-timeout configuration.

* **API Improvements**
  * Fluent config methods now return concrete types for nicer chaining.
  * Timeout API renamed to idle_timeout.
  * Clarified docs on data lifetime and backpressure behavior.

* **CI / Tests**
  * Quality checks run on pull requests; test-summary includes perf/memory/E2E rows and tool install updates.

* **Chores**
  * Verify script gains CLI flags to skip formatting/docs or run tests-only.

* **Deprecations**
  * Legacy logger and error-handler accessors marked deprecated.

* **Removals**
  * Conditional debug/info logging macros removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->