### PR TITLE
refactor: unify client limit handling and improve wrapper thread-safety

### DIFF
--- a/bindings/python/module.cpp.in
+++ b/bindings/python/module.cpp.in
@@ -235,6 +235,11 @@ PYBIND11_MODULE(unilink_py, m) {
       .def("connected_clients", &TcpServer::connected_clients)
       .def("listening", &TcpServer::listening)
       .def("auto_start", &TcpServer::auto_start, py::arg("start") = true)
+      .def("bind_address", &TcpServer::bind_address)
+      .def("port_retry", &TcpServer::port_retry, py::arg("enable") = true, py::arg("max_retries") = 3,
+           py::arg("retry_interval_ms") = 1000)
+      .def("idle_timeout", &TcpServer::idle_timeout)
+      .def("max_clients", &TcpServer::max_clients)
       .def(
           "use_line_framer",
           [](TcpServer& self, const std::string& d, bool i, size_t m) {
@@ -570,6 +575,8 @@ PYBIND11_MODULE(unilink_py, m) {
       .def("connected_clients", &UdsServer::connected_clients)
       .def("listening", &UdsServer::listening)
       .def("auto_start", &UdsServer::auto_start, py::arg("start") = true)
+      .def("idle_timeout", &UdsServer::idle_timeout)
+      .def("max_clients", &UdsServer::max_clients)
       .def(
           "use_line_framer",
           [](UdsServer& self, const std::string& d, bool i, size_t m) {
@@ -810,6 +817,7 @@ PYBIND11_MODULE(unilink_py, m) {
       .def("listening", &UdpServer::listening)
       .def("auto_start", &UdpServer::auto_start, py::arg("start") = true)
       .def("idle_timeout", &UdpServer::idle_timeout)
+      .def("max_clients", &UdpServer::max_clients)
       .def(
           "use_line_framer",
           [](UdpServer& self, const std::string& d, bool i, size_t m) {

--- a/docs/contributor/testing.md
+++ b/docs/contributor/testing.md
@@ -519,7 +519,6 @@ TEST(CustomTest, ClientServerCommunication) {
     
     // Create server
     auto server = unilink::tcp_server(8080)
-        .unlimited_clients()
         .on_connect([](const unilink::ConnectionContext& ctx) {
             std::cout << "Client connected: " << ctx.client_id() << std::endl;
         })

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -78,7 +78,7 @@ To take ownership of the data, use:
 
 - `TcpClientBuilder` / `SerialBuilder`: `.retry_interval(ms)` (default `3000ms`)
 - `TcpServerBuilder`: `.port_retry(enable, max_retries, retry_interval_ms)`
-- `TcpServerBuilder`: `.single_client()`, `.multi_client(max>=2)`, `.unlimited_clients()` (Defaults to `unlimited_clients()` if not specified)
+- `TcpServerBuilder`: `.single_client()`, `.multi_client(max>=2)`, or `.max_clients(n)` (defaults to a bounded connection limit)
 - TCP server callbacks use the same Context-based signatures. Use `ctx.client_id()` and `ctx.client_info()` to distinguish clients.
 
 ### Framed Message Handling
@@ -266,7 +266,6 @@ Accept multiple client connections with thread-safe operations.
 #include "unilink/unilink.hpp"
 
 auto server = unilink::tcp_server(8080)
-    .unlimited_clients()
     .on_connect([](const unilink::ConnectionContext& ctx) {
         std::cout << "Client " << ctx.client_id() << " connected from " << ctx.client_info() << std::endl;
     })
@@ -300,7 +299,7 @@ if (listening && server->listening()) {
 server->stop();
 ```
 
-**Note:** If none of `.single_client()`, `.multi_client(max)`, or `.unlimited_clients()` is called before `build()`, the server defaults to unlimited clients.
+**Note:** If no client limit method is called before `build()`, the server uses the library default bounded limit.
 
 ### API Reference
 
@@ -316,7 +315,6 @@ unilink::tcp_server(uint16_t port)
 | --------------------------- | ---------------------------- | -------------------------------------------------------------------- |
 | `single_client()`           | None                         | Accept only one client (required to choose a limit before `build()`) |
 | `multi_client(max)`         | `size_t (>=2)`               | Accept up to `max` clients                                           |
-| `unlimited_clients()`       | None                         | Accept unlimited clients                                             |
 | `port_retry()`       | `bool, retries, interval_ms` | Retry if port is in use                                              |
 | `independent_context()`     | `bool`                       | Run on a dedicated `io_context` thread managed by unilink            |
 | `auto_start()`             | `bool`                       | Auto-start immediately and stop on destruction                       |
@@ -368,7 +366,6 @@ auto server = unilink::tcp_server(8080)
 
 ```cpp
 auto server = unilink::tcp_server(8080)
-    .unlimited_clients()
     .build();
 
 server->on_data([&server](const unilink::MessageContext& ctx) {
@@ -629,7 +626,6 @@ High-performance local inter-process communication (IPC) using Unix Domain Socke
 #include "unilink/unilink.hpp"
 
 auto server = unilink::uds_server("/tmp/my_service.sock")
-    .unlimited_clients()
     .on_connect([](const unilink::ConnectionContext& ctx) {
         std::cout << "Client connected!" << std::endl;
     })
@@ -675,7 +671,6 @@ unilink::uds_client(const std::string& socket_path)
 | Method                      | Parameters | Description                          |
 | --------------------------- | ---------- | ------------------------------------ |
 | `max_clients(max)`          | `size_t`   | Allow up to `max` concurrent clients |
-| `unlimited_clients()`       | None       | Allow unlimited clients              |
 | `independent_context()`     | `bool`     | Run on dedicated IO thread           |
 | `auto_start()`             | `bool`     | Auto-start/stop lifecycle            |
 
@@ -1101,4 +1096,3 @@ auto server = unilink::tcp_server(8080)
     .multi_client(100)  // max 100 clients
     .build();
 ```
-

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -76,7 +76,7 @@ g++ -std=c++17 my_client.cc -lunilink -lboost_system -pthread -o my_client
 #include "unilink/unilink.hpp"
 
 int main() {
-    // Create a TCP server (defaults to unlimited clients)
+    // Create a TCP server (uses the default bounded client limit)
     auto server = unilink::tcp_server(8080)
         .on_connect([](const unilink::ConnectionContext& ctx) {
             std::cout << "Client " << ctx.client_id() << " connected from " << ctx.client_info() << std::endl;
@@ -177,9 +177,8 @@ auto server = unilink::tcp_server(8080)
     .multi_client(8)  // allow up to 8 clients
     .build();
 
-// Unlimited clients (default)
+// Default bounded client limit
 auto server = unilink::tcp_server(8080)
-    .unlimited_clients()
     .build();
 ```
 
@@ -207,7 +206,6 @@ unilink::diagnostics::Logger::instance().set_console_output(true);
 
 ```cpp
 auto server = unilink::tcp_server(8080)
-    .unlimited_clients()
     .port_retry(true, 5, 1000)  // Try 5 times
     .build();
 ```

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -169,7 +169,6 @@ kill -9 <PID>
 
 ```cpp
 auto server = tcp_server(8081)  // Try different port
-    .unlimited_clients()
     .build();
 ```
 
@@ -177,7 +176,6 @@ auto server = tcp_server(8081)  // Try different port
 
 ```cpp
 auto server = tcp_server(8080)
-    .unlimited_clients()
     .port_retry(true, 5, 1000)  // Retry 5 times
     .build();
 ```

--- a/docs/user/tutorials/02_tcp_server.md
+++ b/docs/user/tutorials/02_tcp_server.md
@@ -33,7 +33,6 @@ class EchoServerApp {
 public:
     void start(uint16_t port) {
         server_ = unilink::tcp_server(port)
-            .unlimited_clients()
             .port_retry(true)
             .on_connect([this](const unilink::ConnectionContext& ctx) {
                 std::cout << "[Connect] client=" << ctx.client_id()
@@ -130,10 +129,10 @@ Choose a client-limit mode before `build()`:
 ```cpp
 unilink::tcp_server(8080).single_client();
 unilink::tcp_server(8080).multi_client(8);
-unilink::tcp_server(8080).unlimited_clients();
+unilink::tcp_server(8080);
 ```
 
-For tutorial simplicity, the example above uses `unlimited_clients()`.
+For tutorial simplicity, the example above uses the default bounded client limit.
 
 ---
 

--- a/docs/user/tutorials/03_uds_communication.md
+++ b/docs/user/tutorials/03_uds_communication.md
@@ -31,7 +31,6 @@ int main() {
 
     std::unique_ptr<unilink::UdsServer> server;
     server = unilink::uds_server(socket_path)
-        .unlimited_clients()
         .on_connect([](const unilink::ConnectionContext& ctx) {
             std::cout << "Client connected: " << ctx.client_id()
                       << " info=" << ctx.client_info() << std::endl;

--- a/examples/tcp/README.md
+++ b/examples/tcp/README.md
@@ -30,7 +30,6 @@ Type messages in any client terminal. `/quit` disconnects.
 
 ## API Patterns
 
-- `unlimited_clients()` — allow any number of concurrent connections
 - `send_to(client_id, data)` — reply to a specific client (echo server)
 - `broadcast(data)` — send to all connected clients (broadcast server)
 - `start_sync()` — block until the server is listening or failed

--- a/examples/tcp/async/echo_server.cc
+++ b/examples/tcp/async/echo_server.cc
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<unilink::wrapper::TcpServer> server;
 
   auto builder = unilink::tcp_server(port);
-  builder.unlimited_clients()
+  builder
       .on_connect([](const unilink::ConnectionContext& ctx) {
         std::cout << "[Server] Client connected: ID=" << ctx.client_id() << "\n";
       })

--- a/examples/tcp/sync/broadcast_server.cc
+++ b/examples/tcp/sync/broadcast_server.cc
@@ -28,7 +28,6 @@ class BroadcastServer {
 
   bool start() {
     server_ = unilink::tcp_server(port_)
-                  .unlimited_clients()
                   .on_connect([this](const unilink::ConnectionContext& ctx) {
                     std::string msg = "client " + std::to_string(ctx.client_id()) + " joined";
                     std::cout << "[connect] " << msg << " from " << ctx.client_info() << "\n";

--- a/examples/tcp/sync/echo_server.cc
+++ b/examples/tcp/sync/echo_server.cc
@@ -29,7 +29,6 @@ class EchoServer {
   bool start() {
     server_ =
         unilink::tcp_server(port_)
-            .unlimited_clients()
             .on_connect([](const unilink::ConnectionContext& ctx) {
               std::cout << "[connect] client " << ctx.client_id() << " from " << ctx.client_info() << "\n";
             })

--- a/examples/uds/async/echo_server.cc
+++ b/examples/uds/async/echo_server.cc
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<unilink::wrapper::UdsServer> server;
 
   auto builder = unilink::uds_server(path);
-  builder.unlimited_clients()
+  builder
       .on_connect([](const unilink::ConnectionContext& ctx) {
         std::cout << "[Server] Client connected: ID=" << ctx.client_id() << "\n";
       })

--- a/examples/uds/sync/echo_server.cc
+++ b/examples/uds/sync/echo_server.cc
@@ -27,7 +27,6 @@ class UdsEchoServer {
   bool start() {
     server_ =
         unilink::uds_server(path_)
-            .unlimited_clients()
             .on_connect([](const unilink::ConnectionContext& ctx) {
               std::cout << "[connect] client " << ctx.client_id() << "\n";
             })

--- a/test/e2e/scenarios/test_architecture.cc
+++ b/test/e2e/scenarios/test_architecture.cc
@@ -84,7 +84,7 @@ TEST_F(ImprovedArchitectureTest, CurrentResourceSharingIssue) {
   uint16_t test_port = TestUtils::getAvailableTestPort();
 
   // Create server
-  server_ = unilink::tcp_server(test_port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr);
   std::cout << "Server created successfully" << std::endl;
@@ -134,7 +134,7 @@ TEST_F(ImprovedArchitectureTest, UpperAPIAutoInitialization) {
   }
 
   // IoContextManager starts automatically when using builder
-  server_ = unilink::tcp_server(test_port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr);
 

--- a/test/e2e/stress/test_stress.cc
+++ b/test/e2e/stress/test_stress.cc
@@ -60,7 +60,6 @@ TEST_F(StressTest, RealNetworkHighThroughput) {
   std::atomic<size_t> server_received_bytes{0};
 
   auto server = tcp_server(port)
-                    .unlimited_clients()
                     .on_data([&](const wrapper::MessageContext& ctx) { server_received_bytes += ctx.data().size(); })
                     .on_error([](auto&&) {})
                     .build();
@@ -100,7 +99,7 @@ TEST_F(StressTest, RapidStartStop) {
   const int iterations = 20;
 
   for (int i = 0; i < iterations; ++i) {
-    auto server = tcp_server(port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+    auto server = tcp_server(port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
     ASSERT_NE(server, nullptr);
 
     auto start_future = server->start();
@@ -122,7 +121,6 @@ TEST_F(StressTest, ConcurrentClientConnections) {
   std::atomic<int> send_success_count{0};
 
   auto server = tcp_server(port)
-                    .unlimited_clients()
                     .use_line_framer()
                     .on_connect([&](const wrapper::ConnectionContext&) { connected_count++; })
                     .on_message([&](const wrapper::MessageContext& ctx) {

--- a/test/integration/builder/test_builder_integration.cc
+++ b/test/integration/builder/test_builder_integration.cc
@@ -40,7 +40,6 @@ TEST_F(UnifiedBuilderIntegrationTest, RealCommunicationBetweenBuilderObjects) {
   std::string received_msg;
 
   auto server = builder::UnifiedBuilder::tcp_server(port_)
-                    .unlimited_clients()
                     .on_data([&](const wrapper::MessageContext& ctx) {
                       received_msg = std::string(ctx.data());
                       data_received = true;

--- a/test/integration/tcp/test_client_limit_integration.cc
+++ b/test/integration/tcp/test_client_limit_integration.cc
@@ -117,9 +117,9 @@ TEST_F(ClientLimitIntegrationTest, MultiClientLimitTest) {
   for (auto& f : client_futures) f.wait();
 }
 
-TEST_F(ClientLimitIntegrationTest, UnlimitedClientsTest) {
+TEST_F(ClientLimitIntegrationTest, DefaultClientLimitAllowsTypicalLoad) {
   uint16_t test_port = getTestPort();
-  server_ = unilink::tcp_server(test_port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
   ASSERT_NE(server_, nullptr);
   ASSERT_TRUE(server_->start().get());
 

--- a/test/integration/tcp/test_integration.cc
+++ b/test/integration/tcp/test_integration.cc
@@ -44,8 +44,7 @@ class TcpIntegrationTest : public ::testing::Test {
 // ============================================================================
 
 TEST_F(TcpIntegrationTest, BuilderPatternIntegration) {
-  auto server =
-      unilink::tcp_server(test_port_).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto server = unilink::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
   EXPECT_NE(server, nullptr);
 
   auto client = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
@@ -79,12 +78,8 @@ TEST_F(TcpIntegrationTest, IndependentContext) {
                     .build();
   EXPECT_NE(client, nullptr);
 
-  auto server = unilink::tcp_server(test_port_)
-                    .unlimited_clients()
-                    .independent_context(false)
-                    .on_data([](auto&&) {})
-                    .on_error([](auto&&) {})
-                    .build();
+  auto server =
+      unilink::tcp_server(test_port_).independent_context(false).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
   EXPECT_NE(server, nullptr);
 }
 
@@ -101,7 +96,6 @@ TEST_F(TcpIntegrationTest, BasicCommunication) {
   std::string received_data;
 
   auto server = unilink::tcp_server(comm_port)
-                    .unlimited_clients()
                     .on_connect([&server_connected](const wrapper::ConnectionContext&) { server_connected = true; })
                     .on_data([&data_received, &received_data](const wrapper::MessageContext& ctx) {
                       received_data = std::string(ctx.data());
@@ -178,7 +172,6 @@ TEST_F(TcpIntegrationTest, MultipleClientConnections) {
   std::atomic<int> connection_count{0};
 
   auto server = unilink::tcp_server(comm_port)
-                    .unlimited_clients()
                     .on_connect([&connection_count](const wrapper::ConnectionContext&) { connection_count++; })
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})
@@ -214,7 +207,6 @@ TEST_F(TcpIntegrationTest, ComprehensiveBuilderMethodChaining) {
   EXPECT_NE(client, nullptr);
 
   auto server = unilink::tcp_server(test_port_)
-                    .unlimited_clients()
                     .auto_start(false)
                     .on_connect([](const wrapper::ConnectionContext&) {})
                     .on_data([](const wrapper::MessageContext&) {})

--- a/test/integration/tcp/test_simple_server.cc
+++ b/test/integration/tcp/test_simple_server.cc
@@ -57,7 +57,7 @@ TEST_F(SimpleServerTest, BasicServerCreation) {
 
   // Create server
   server_ = unilink::tcp_server(test_port)
-                .unlimited_clients()  // No client limit
+                // No client limit
                 .on_data([](auto&&) {})
                 .on_error([](auto&&) {})
                 .build();
@@ -83,12 +83,7 @@ TEST_F(SimpleServerTest, AutoStartServer) {
   std::cout << "Testing auto-start server with port: " << test_port << std::endl;
 
   // Create server (auto-manage triggers start)
-  server_ = unilink::tcp_server(test_port)
-                .unlimited_clients()
-                .auto_start(true)
-                .on_data([](auto&&) {})
-                .on_error([](auto&&) {})
-                .build();
+  server_ = unilink::tcp_server(test_port).auto_start(true).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr) << "Server creation failed";
   std::cout << "Server created with auto-start" << std::endl;
@@ -114,7 +109,6 @@ TEST_F(SimpleServerTest, ServerWithCallbacks) {
 
   // Create server
   server_ = unilink::tcp_server(test_port)
-                .unlimited_clients()
                 .on_connect([connect_called](const wrapper::ConnectionContext& ctx) {
                   std::cout << "Connect callback called for client: " << ctx.client_id() << std::endl;
                   connect_called->store(true);
@@ -141,7 +135,7 @@ TEST_F(SimpleServerTest, ServerStateCheck) {
   uint16_t test_port = getTestPort();
   std::cout << "Testing server state check, port: " << test_port << std::endl;
 
-  server_ = unilink::tcp_server(test_port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr);
 
@@ -180,11 +174,11 @@ TEST_F(SimpleServerTest, ClientLimitMultiClient) {
 }
 
 /**
- * @brief Client Limit Feature Test - Unlimited Clients
+ * @brief Client Limit Feature Test - Default Limit
  */
-TEST_F(SimpleServerTest, ClientLimitUnlimitedClients) {
+TEST_F(SimpleServerTest, ClientLimitDefaultAllowsServerCreation) {
   uint16_t test_port = getTestPort();
-  server_ = unilink::tcp_server(test_port).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr);
   EXPECT_TRUE(server_->start().get());

--- a/test/integration/tcp/test_stop_contract.cc
+++ b/test/integration/tcp/test_stop_contract.cc
@@ -65,7 +65,6 @@ TEST_F(StopContractTest, NoBackpressureCallbackAfterServerStop) {
 
   config::TcpServerConfig cfg;
   cfg.port = port;
-  cfg.max_connections = 0;
   // Lower threshold to ensure backpressure triggers easily when client doesn't read
   cfg.backpressure_threshold = 4096;
 
@@ -132,7 +131,6 @@ TEST_F(StopContractTest, NoDataCallbackAfterServerStop) {
   std::atomic<int> data_calls{0};
 
   auto server = tcp_server(port)
-                    .unlimited_clients()
                     .on_data([&](const wrapper::MessageContext& ctx) {
                       if (stop_called.load()) {
                         ADD_FAILURE() << "Data callback received AFTER stop! Size: " << ctx.data().size();

--- a/test/integration/tcp/test_tcp_flood.cc
+++ b/test/integration/tcp/test_tcp_flood.cc
@@ -39,7 +39,6 @@ class TcpFloodTest : public ::testing::Test {
 TEST_F(TcpFloodTest, FloodServer) {
   std::atomic<size_t> received_bytes{0};
   auto server = tcp_server(test_port_)
-                    .unlimited_clients()
                     .on_data([&](const wrapper::MessageContext& ctx) { received_bytes += ctx.data().size(); })
                     .on_error([](auto&&) {})
                     .build();

--- a/test/integration/tcp/test_tcp_server_chaos.cc
+++ b/test/integration/tcp/test_tcp_server_chaos.cc
@@ -46,7 +46,6 @@ class TcpServerChaosTest : public ::testing::Test {
 TEST_F(TcpServerChaosTest, GhostClient) {
   std::atomic<int> connect_count{0};
   auto server = tcp_server(test_port_)
-                    .unlimited_clients()
                     .on_connect([&](const wrapper::ConnectionContext&) { connect_count++; })
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})

--- a/test/integration/uds/test_uds_integration.cc
+++ b/test/integration/uds/test_uds_integration.cc
@@ -47,8 +47,7 @@ class UdsIntegrationTest : public ::testing::Test {
 };
 
 TEST_F(UdsIntegrationTest, BuilderPatternIntegration) {
-  auto server =
-      unilink::uds_server(socket_path_).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto server = unilink::uds_server(socket_path_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
   EXPECT_NE(server, nullptr);
 
   auto client = unilink::uds_client(socket_path_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
@@ -116,7 +115,6 @@ TEST_F(UdsIntegrationTest, MultiClientCommunication) {
   std::condition_variable cv;
 
   auto server = unilink::uds_server(socket_path_)
-                    .unlimited_clients()
                     .independent_context(true)
                     .on_connect([&connections](const wrapper::ConnectionContext&) { connections++; })
                     .on_data([&](const wrapper::MessageContext& ctx) { messages_received++; })

--- a/test/performance/benchmark/test_platform.cc
+++ b/test/performance/benchmark/test_platform.cc
@@ -250,7 +250,7 @@ TEST_F(PlatformTest, NetworkFunctionalityPlatformSpecific) {
 
   // Test TCP server creation
   auto server = UnifiedBuilder::tcp_server(test_port_)
-                    .unlimited_clients()  // No client limit
+                    // No client limit
 
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})
@@ -297,7 +297,7 @@ TEST_F(PlatformTest, NetworkPortHandlingPlatformSpecific) {
     std::cout << "Testing port: " << port << std::endl;
 
     auto server = UnifiedBuilder::tcp_server(port)
-                      .unlimited_clients()  // No client limit
+                      // No client limit
 
                       .on_data([](auto&&) {})
                       .on_error([](auto&&) {})
@@ -485,7 +485,7 @@ TEST_F(PlatformTest, CrossPlatformCompatibility) {
 
   // Test that basic functionality works across platforms
   auto server = UnifiedBuilder::tcp_server(test_port_)
-                    .unlimited_clients()  // No client limit
+                    // No client limit
 
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})

--- a/test/unit/builder/test_builder.cc
+++ b/test/unit/builder/test_builder.cc
@@ -131,7 +131,6 @@ TEST_F(BuilderTest, UdpBuilderBasic) {
 TEST_F(BuilderTest, BuilderChaining) {
   server_ =
       tcp_server(test_port_)
-          .unlimited_clients()
           .port_retry(true, 5, 500)
           .on_data([this](const wrapper::MessageContext& ctx) { data_received_.push_back(std::string(ctx.data())); })
           .on_data([](auto&&) {})
@@ -179,8 +178,7 @@ TEST_F(BuilderTest, CallbackRegistration) {
 TEST_F(BuilderTest, BuilderReuse) {
   builder::TcpServerBuilder builder(test_port_);
 
-  auto server1 =
-      builder.unlimited_clients().on_data([](const wrapper::MessageContext& ctx) {}).on_error([](auto&&) {}).build();
+  auto server1 = builder.on_data([](const wrapper::MessageContext& ctx) {}).on_error([](auto&&) {}).build();
   ASSERT_NE(server1, nullptr);
 
   auto server2 = builder.on_connect([](const wrapper::ConnectionContext& ctx) {})

--- a/test/unit/builder/test_uds_builder_coverage.cc
+++ b/test/unit/builder/test_uds_builder_coverage.cc
@@ -53,7 +53,6 @@ TEST(UdsBuilderCoverageTest, UdsServerBuilderSetters) {
                     .independent_context(true)
                     .idle_timeout(5000ms)
                     .max_clients(50)
-                    .unlimited_clients()
                     .on_data([](const wrapper::MessageContext&) {})
                     .on_connect([](const wrapper::ConnectionContext&) {})
                     .on_disconnect([](const wrapper::ConnectionContext&) {})

--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -188,7 +188,7 @@ TEST_F(ConfigTest, ConfigValidationBoundaryValues) {
 
   // Test TCP server configuration validation
   auto server = UnifiedBuilder::tcp_server(test_port_)
-                    .unlimited_clients()  // No client limit
+                    // No client limit
 
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})

--- a/test/unit/wrapper/test_tcp_server_advanced.cc
+++ b/test/unit/wrapper/test_tcp_server_advanced.cc
@@ -53,7 +53,7 @@ class AdvancedTcpServerCoverageTest : public ::testing::Test {
 };
 
 TEST_F(AdvancedTcpServerCoverageTest, ServerStartStopMultipleTimes) {
-  server_ = unilink::tcp_server(test_port_).unlimited_clients().on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_ = unilink::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
   for (int i = 0; i < 3; ++i) {
     auto f = server_->start();
     EXPECT_TRUE(f.get());

--- a/test/unit/wrapper/test_udp_client_coverage.cc
+++ b/test/unit/wrapper/test_udp_client_coverage.cc
@@ -16,10 +16,12 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <boost/asio.hpp>
 
 #include "unilink/framer/line_framer.hpp"
 #include "unilink/wrapper/udp/udp.hpp"
+#include "wrapper_contract_test_utils.hpp"
 
 using namespace unilink;
 
@@ -62,6 +64,24 @@ TEST(UdpClientCoverageTest, FramerIntegration) {
   wrapper::UdpClient client(cfg);
   client.framer(std::make_unique<framer::LineFramer>());
   client.on_message([](const wrapper::MessageContext&) {});
+}
+
+TEST(UdpClientCoverageTest, MessageBatchHandlerAttachesAfterFramer) {
+  auto fake_channel = std::make_shared<wrapper_support::FakeChannel>();
+  wrapper::UdpClient client(fake_channel);
+  std::atomic<int> batches{0};
+
+  client.framer(std::make_unique<framer::LineFramer>());
+  client.on_message_batch(
+      [&](const std::vector<wrapper::MessageContext>& messages) { batches += static_cast<int>(messages.size()); });
+
+  std::string payload;
+  for (int i = 0; i < 100; ++i) {
+    payload += "payload\n";
+  }
+  fake_channel->emit_bytes(payload);
+
+  EXPECT_EQ(batches.load(), 100);
 }
 
 TEST(UdpClientCoverageTest, StopWithoutStart) {

--- a/test/unit/wrapper/test_uds_advanced.cc
+++ b/test/unit/wrapper/test_uds_advanced.cc
@@ -25,6 +25,7 @@
 #include "test/mocks/mock_uds_acceptor.hpp"
 #include "test/mocks/mock_uds_socket.hpp"
 #include "test_utils.hpp"
+#include "unilink/framer/line_framer.hpp"
 #include "unilink/transport/uds/uds_client.hpp"
 #include "unilink/transport/uds/uds_server.hpp"
 #include "unilink/wrapper/uds_client/uds_client.hpp"
@@ -196,6 +197,21 @@ TEST(UdsServerWrapperAdvancedTest, ManagedExternalContextStopsOnShutdown) {
   server.stop();
   EXPECT_TRUE(ioc->stopped());
   test::TestUtils::removeFileIfExists(socket_path);
+}
+
+TEST(UdsServerWrapperAdvancedTest, FramedMessageDoesNotDeadlock) {
+  test::wrapper_support::UdsServerLoopbackHarness harness("uws-framer");
+  auto server = harness.start_server();
+  std::atomic<int> messages{0};
+
+  server->framer([]() { return std::make_unique<framer::LineFramer>(); });
+  server->on_message([&](const MessageContext&) { messages++; });
+
+  auto client = harness.connect_client();
+  ASSERT_TRUE(harness.wait_for_client_count(1));
+  ASSERT_TRUE(client->send_line("hello"));
+
+  EXPECT_TRUE(unilink::test::TestUtils::waitForCondition([&]() { return messages.load() == 1; }, 5000));
 }
 
 TEST(UdsClientWrapperContractTest, HandlerReplacementUsesLatestCallback) {

--- a/unilink/builder/ibuilder.hpp
+++ b/unilink/builder/ibuilder.hpp
@@ -42,6 +42,9 @@ template <typename T>
 concept DataHandler = std::invocable<T, const wrapper::MessageContext&>;
 
 template <typename T>
+concept BatchDataHandler = std::invocable<T, const std::vector<wrapper::MessageContext>&>;
+
+template <typename T>
 concept ErrorHandler = std::invocable<T, const wrapper::ErrorContext&>;
 
 template <typename T>
@@ -81,6 +84,15 @@ class BuilderInterface {
   template <DataHandler F>
   auto on_data(F&& handler) {
     on_data_ = std::forward<F>(handler);
+    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+  }
+
+  /**
+   * @brief Set batched data handler callback
+   */
+  template <BatchDataHandler F>
+  auto on_data_batch(F&& handler) {
+    on_data_batch_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
   }
 
@@ -186,6 +198,23 @@ class BuilderInterface {
   }
 
   /**
+   * @brief Set batched framed-message handler callback
+   */
+  template <BatchDataHandler F>
+  auto on_message_batch(F&& handler) {
+    on_message_batch_ = std::forward<F>(handler);
+    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+  }
+
+  /**
+   * @brief Set backpressure notification callback
+   */
+  Derived& on_backpressure(std::function<void(size_t)> handler) {
+    on_backpressure_ = std::move(handler);
+    return static_cast<Derived&>(*this);
+  }
+
+  /**
    * @brief Set message handler callback using member function pointer
    */
   template <typename U, typename F>
@@ -228,6 +257,9 @@ class BuilderInterface {
   std::function<void(const wrapper::ConnectionContext&)> on_disconnect_;
   std::function<void(const wrapper::ErrorContext&)> on_error_;
   std::function<void(const wrapper::MessageContext&)> on_message_;
+  std::function<void(const std::vector<wrapper::MessageContext>&)> on_data_batch_;
+  std::function<void(const std::vector<wrapper::MessageContext>&)> on_message_batch_;
+  std::function<void(size_t)> on_backpressure_;
 
   base::constants::BackpressureStrategy bp_strategy_{base::constants::BackpressureStrategy::Reliable};
   size_t bp_threshold_{0};

--- a/unilink/builder/serial_builder.cc
+++ b/unilink/builder/serial_builder.cc
@@ -61,9 +61,11 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   }
 
   if (this->on_data_) serial->on_data(this->on_data_);
+  if (this->on_data_batch_) serial->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) serial->on_connect(this->on_connect_);
   if (this->on_disconnect_) serial->on_disconnect(this->on_disconnect_);
   if (this->on_error_) serial->on_error(this->on_error_);
+  if (this->on_backpressure_) serial->on_backpressure(this->on_backpressure_);
 
   // Note: wrapper::Serial setters use strings for enum types
   std::string p_str = "none";
@@ -90,6 +92,9 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   }
   if (this->on_message_) {
     serial->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    serial->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {

--- a/unilink/builder/serial_builder.hpp
+++ b/unilink/builder/serial_builder.hpp
@@ -61,6 +61,9 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;

--- a/unilink/builder/tcp_client_builder.cc
+++ b/unilink/builder/tcp_client_builder.cc
@@ -58,9 +58,11 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   }
 
   if (this->on_data_) client->on_data(this->on_data_);
+  if (this->on_data_batch_) client->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) client->on_connect(this->on_connect_);
   if (this->on_disconnect_) client->on_disconnect(this->on_disconnect_);
   if (this->on_error_) client->on_error(this->on_error_);
+  if (this->on_backpressure_) client->on_backpressure(this->on_backpressure_);
 
   client->retry_interval(retry_interval_);
   client->max_retries(max_retries_);
@@ -74,6 +76,9 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   }
   if (this->on_message_) {
     client->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    client->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {

--- a/unilink/builder/tcp_client_builder.hpp
+++ b/unilink/builder/tcp_client_builder.hpp
@@ -58,6 +58,9 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -59,13 +59,20 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
   }
 
   if (this->on_data_) server->on_data(this->on_data_);
+  if (this->on_data_batch_) server->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) server->on_connect(this->on_connect_);
   if (this->on_disconnect_) server->on_disconnect(this->on_disconnect_);
   if (this->on_error_) server->on_error(this->on_error_);
+  if (this->on_backpressure_) server->on_backpressure(this->on_backpressure_);
 
   if (client_limit_enabled_) {
     server->max_clients(max_clients_);
   }
+
+  server->bind_address(bind_address_);
+  server->port_retry(port_retry_enabled_, static_cast<int>(max_port_retries_),
+                     static_cast<int>(port_retry_interval_ms_));
+  server->idle_timeout(idle_timeout_);
 
   if (this->bp_strategy_set_) server->backpressure_strategy(this->bp_strategy_);
   server->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -75,6 +82,9 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
   }
   if (this->on_message_) {
     server->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    server->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {
@@ -105,7 +115,7 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::independent_context(bool use_i
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::max_clients(uint32_t max_clients) {
   if (max_clients == 0) {
-    throw std::invalid_argument("max_clients must be greater than 0; use unlimited_clients() for no limit");
+    throw std::invalid_argument("max_clients must be greater than 0");
   }
   max_clients_ = max_clients;
   client_limit_enabled_ = true;
@@ -155,16 +165,10 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::single_client() {
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::multi_client(size_t max) {
   if (max == 0) {
-    throw std::invalid_argument("multi_client max must be greater than 0; use unlimited_clients() for no limit");
+    throw std::invalid_argument("multi_client max must be greater than 0");
   }
   max_clients_ = static_cast<uint32_t>(max);
   client_limit_enabled_ = true;
-  return *this;
-}
-
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::unlimited_clients() {
-  client_limit_enabled_ = false;
   return *this;
 }
 

--- a/unilink/builder/tcp_server_builder.hpp
+++ b/unilink/builder/tcp_server_builder.hpp
@@ -61,6 +61,9 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;
@@ -87,7 +90,6 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
   TcpServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
   TcpServerBuilder<State>& single_client();
   TcpServerBuilder<State>& multi_client(size_t max);
-  TcpServerBuilder<State>& unlimited_clients();
 
  private:
   template <uint32_t S>

--- a/unilink/builder/udp_builder.cc
+++ b/unilink/builder/udp_builder.cc
@@ -68,9 +68,11 @@ std::unique_ptr<wrapper::UdpClient> UdpClientBuilder<State>::build() {
   }
 
   if (this->on_data_) client->on_data(this->on_data_);
+  if (this->on_data_batch_) client->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) client->on_connect(this->on_connect_);
   if (this->on_disconnect_) client->on_disconnect(this->on_disconnect_);
   if (this->on_error_) client->on_error(this->on_error_);
+  if (this->on_backpressure_) client->on_backpressure(this->on_backpressure_);
 
   if (this->bp_strategy_set_) client->backpressure_strategy(this->bp_strategy_);
   client->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -80,6 +82,9 @@ std::unique_ptr<wrapper::UdpClient> UdpClientBuilder<State>::build() {
   }
   if (this->on_message_) {
     client->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    client->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {
@@ -172,9 +177,11 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder<State>::build() {
   }
 
   if (this->on_data_) server->on_data(this->on_data_);
+  if (this->on_data_batch_) server->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) server->on_connect(this->on_connect_);
   if (this->on_disconnect_) server->on_disconnect(this->on_disconnect_);
   if (this->on_error_) server->on_error(this->on_error_);
+  if (this->on_backpressure_) server->on_backpressure(this->on_backpressure_);
 
   if (this->bp_strategy_set_) server->backpressure_strategy(this->bp_strategy_);
   server->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -185,6 +192,9 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder<State>::build() {
   }
   if (this->on_message_) {
     server->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    server->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {

--- a/unilink/builder/udp_builder.hpp
+++ b/unilink/builder/udp_builder.hpp
@@ -63,6 +63,9 @@ class UNILINK_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClient,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;
@@ -127,6 +130,9 @@ class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;

--- a/unilink/builder/uds_builder.cc
+++ b/unilink/builder/uds_builder.cc
@@ -57,9 +57,11 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
   }
 
   if (this->on_data_) client->on_data(this->on_data_);
+  if (this->on_data_batch_) client->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) client->on_connect(this->on_connect_);
   if (this->on_disconnect_) client->on_disconnect(this->on_disconnect_);
   if (this->on_error_) client->on_error(this->on_error_);
+  if (this->on_backpressure_) client->on_backpressure(this->on_backpressure_);
 
   client->retry_interval(retry_interval_);
   client->max_retries(max_retries_);
@@ -73,6 +75,9 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
   }
   if (this->on_message_) {
     client->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    client->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {
@@ -146,9 +151,11 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
   }
 
   if (this->on_data_) server->on_data(this->on_data_);
+  if (this->on_data_batch_) server->on_data_batch(this->on_data_batch_);
   if (this->on_connect_) server->on_connect(this->on_connect_);
   if (this->on_disconnect_) server->on_disconnect(this->on_disconnect_);
   if (this->on_error_) server->on_error(this->on_error_);
+  if (this->on_backpressure_) server->on_backpressure(this->on_backpressure_);
 
   if (client_limit_enabled_) {
     server->max_clients(max_clients_);
@@ -166,6 +173,9 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
   }
   if (this->on_message_) {
     server->on_message(std::move(this->on_message_));
+  }
+  if (this->on_message_batch_) {
+    server->on_message_batch(std::move(this->on_message_batch_));
   }
 
   if (auto_start_) {
@@ -197,7 +207,7 @@ UdsServerBuilder<State>& UdsServerBuilder<State>::idle_timeout(std::chrono::mill
 template <uint32_t State>
 UdsServerBuilder<State>& UdsServerBuilder<State>::max_clients(uint32_t max_clients) {
   if (max_clients == 0) {
-    throw std::invalid_argument("max_clients must be greater than 0; use unlimited_clients() for no limit");
+    throw std::invalid_argument("max_clients must be greater than 0");
   }
   max_clients_ = max_clients;
   client_limit_enabled_ = true;
@@ -214,16 +224,10 @@ UdsServerBuilder<State>& UdsServerBuilder<State>::single_client() {
 template <uint32_t State>
 UdsServerBuilder<State>& UdsServerBuilder<State>::multi_client(size_t max) {
   if (max == 0) {
-    throw std::invalid_argument("multi_client max must be greater than 0; use unlimited_clients() for no limit");
+    throw std::invalid_argument("multi_client max must be greater than 0");
   }
   max_clients_ = static_cast<uint32_t>(max);
   client_limit_enabled_ = true;
-  return *this;
-}
-
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::unlimited_clients() {
-  client_limit_enabled_ = false;
   return *this;
 }
 

--- a/unilink/builder/uds_builder.hpp
+++ b/unilink/builder/uds_builder.hpp
@@ -60,6 +60,9 @@ class UNILINK_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;
@@ -120,6 +123,9 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
     this->on_connect_ = std::move(other.on_connect_);
     this->on_disconnect_ = std::move(other.on_disconnect_);
     this->on_message_ = std::move(other.on_message_);
+    this->on_data_batch_ = std::move(other.on_data_batch_);
+    this->on_message_batch_ = std::move(other.on_message_batch_);
+    this->on_backpressure_ = std::move(other.on_backpressure_);
     this->framer_factory_ = std::move(other.framer_factory_);
     this->bp_strategy_ = other.bp_strategy_;
     this->bp_threshold_ = other.bp_threshold_;
@@ -139,7 +145,6 @@ class UNILINK_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer,
   UdsServerBuilder<State>& max_clients(uint32_t max_clients);
   UdsServerBuilder<State>& single_client();
   UdsServerBuilder<State>& multi_client(size_t max);
-  UdsServerBuilder<State>& unlimited_clients();
 
  private:
   template <uint32_t S>

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -31,7 +31,7 @@ struct TcpServerConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  int max_connections = 100;  // Maximum concurrent connections
+  int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
 
   // Port binding retry configuration
   bool enable_port_retry = false;     // Enable port binding retry
@@ -58,6 +58,8 @@ struct TcpServerConfig {
 
     if (max_connections <= 0) {
       max_connections = 1;
+    } else if (max_connections > static_cast<int>(base::constants::MAX_MAX_CONNECTIONS)) {
+      max_connections = static_cast<int>(base::constants::MAX_MAX_CONNECTIONS);
     }
 
     if (idle_timeout_ms < 0) {

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -75,7 +75,7 @@ struct UdsServerConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  int max_connections = 100;
+  int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
   int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
 
   bool is_valid() const {
@@ -94,6 +94,8 @@ struct UdsServerConfig {
 
     if (max_connections <= 0) {
       max_connections = 1;
+    } else if (max_connections > static_cast<int>(base::constants::MAX_MAX_CONNECTIONS)) {
+      max_connections = static_cast<int>(base::constants::MAX_MAX_CONNECTIONS);
     }
 
     if (idle_timeout_ms < 0) {

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -656,17 +656,6 @@ void TcpServer::set_client_limit(size_t max) {
   }
 }
 
-void TcpServer::set_unlimited_clients() {
-  auto impl = get_impl();
-  std::lock_guard<std::mutex> l(impl->sessions_mutex_);
-  impl->client_limit_enabled_ = false;
-  impl->max_clients_ = 0;
-  if (impl->paused_accept_) {
-    impl->paused_accept_ = false;
-    net::post(impl->ioc_, [self = shared_from_this()] { self->get_impl()->do_accept(self); });
-  }
-}
-
 base::LinkState TcpServer::state() const { return get_impl()->state_.state(); }
 
 }  // namespace transport

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -91,7 +91,6 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   void on_multi_disconnect(MultiClientDisconnectHandler handler);
 
   void set_client_limit(size_t max_clients);
-  void set_unlimited_clients();
 
   base::LinkState state() const;
 

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -16,6 +16,7 @@
 
 #include "unilink/transport/uds/uds_server.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <cstdio>
@@ -334,6 +335,12 @@ std::vector<ClientId> UdsServer::connected_clients() const {
   return ids;
 }
 
+void UdsServer::set_client_limit(size_t max_clients) {
+  std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  impl_->cfg_.max_connections =
+      static_cast<int>(std::min(max_clients, static_cast<size_t>(base::constants::MAX_MAX_CONNECTIONS)));
+}
+
 void UdsServer::on_multi_connect(MultiClientConnectHandler handler) {
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
   impl_->on_multi_connect_ = std::move(handler);
@@ -357,13 +364,25 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
 
     if (!ec) {
       ClientId client_id;
+      {
+        std::lock_guard<std::mutex> lock(self->impl_->sessions_mutex_);
+        if (self->impl_->cfg_.max_connections > 0 &&
+            self->impl_->sessions_.size() >= static_cast<size_t>(self->impl_->cfg_.max_connections)) {
+          boost::system::error_code ignored;
+          socket.close(ignored);
+          auto* impl = self->impl_.get();
+          impl->do_accept(self);
+          return;
+        }
+        client_id = self->impl_->next_client_id_++;
+      }
+
       auto session = std::make_shared<UdsServerSession>(
           *self->impl_->ioc_, std::move(socket), self->impl_->cfg_.backpressure_threshold,
           self->impl_->cfg_.idle_timeout_ms, self->impl_->cfg_.backpressure_strategy);
 
       {
         std::lock_guard<std::mutex> lock(self->impl_->sessions_mutex_);
-        client_id = self->impl_->next_client_id_++;
         self->impl_->sessions_[client_id] = session;
       }
 

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -79,6 +79,7 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   bool send_to_client(ClientId client_id, memory::ConstByteSpan data);
   size_t client_count() const;
   std::vector<ClientId> connected_clients() const;
+  void set_client_limit(size_t max_clients);
 
   using MultiClientConnectHandler = std::function<void(ClientId client_id, const std::string& client_info)>;
   using MultiClientDataHandler = std::function<void(ClientId client_id, memory::ConstByteSpan data)>;

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -71,7 +71,7 @@ struct Serial::Impl {
   MessageHandler message_handler{nullptr};
   BatchMessageHandler message_batch_handler_{nullptr};
 
-  std::unique_ptr<framer::IFramer> framer{nullptr};
+  std::shared_ptr<framer::IFramer> framer{nullptr};
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -284,6 +284,7 @@ struct Serial::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      std::shared_ptr<framer::IFramer> framer_to_push;
       std::unique_lock<std::shared_mutex> lock(mutex_);
       if (data_batch_handler_) {
         data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
@@ -307,16 +308,22 @@ struct Serial::Impl {
       }
 
       if (framer) {
-        framer->push_bytes(data);
+        framer_to_push = framer;
       }
+      lock.unlock();
+      if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
     channel->on_backpressure([this, weak_alive](size_t queued) {
       bp_cv_.notify_all();
       auto alive = weak_alive.lock();
       if (!alive) return;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (bp_handler) bp_handler(queued);
+      std::function<void(size_t)> handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        handler = bp_handler;
+      }
+      if (handler) handler(queued);
     });
 
     channel->on_state([this, weak_alive](base::LinkState state) {
@@ -390,7 +397,7 @@ struct Serial::Impl {
 
   void set_framer(std::unique_ptr<framer::IFramer> f) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    framer = std::move(f);
+    framer = std::shared_ptr<framer::IFramer>(std::move(f));
     if (framer && (message_handler || message_batch_handler_)) attach_framer_callback();
   }
 
@@ -554,6 +561,10 @@ Serial& Serial::backpressure_threshold(size_t threshold) {
 Serial& Serial::backpressure_strategy(base::constants::BackpressureStrategy strategy) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->backpressure_strategy = strategy;
+  if (impl_->channel) {
+    auto ts = std::dynamic_pointer_cast<transport::Serial>(impl_->channel);
+    if (ts) ts->set_backpressure_strategy(strategy);
+  }
   return *this;
 }
 

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -64,7 +64,7 @@ struct TcpClient::Impl {
   MessageHandler message_handler_{nullptr};
   BatchMessageHandler message_batch_handler_{nullptr};
 
-  std::unique_ptr<framer::IFramer> framer_{nullptr};
+  std::shared_ptr<framer::IFramer> framer_{nullptr};
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -304,6 +304,7 @@ struct TcpClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      std::shared_ptr<framer::IFramer> framer_to_push;
       std::unique_lock<std::shared_mutex> lock(mutex_);
       if (data_batch_handler_) {
         data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
@@ -327,8 +328,10 @@ struct TcpClient::Impl {
       }
 
       if (framer_) {
-        framer_->push_bytes(data);
+        framer_to_push = framer_;
       }
+      lock.unlock();
+      if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
     channel_->on_state([this, weak_alive](base::LinkState state) {
@@ -425,7 +428,7 @@ struct TcpClient::Impl {
 
   void set_framer(std::unique_ptr<framer::IFramer> framer) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    framer_ = std::move(framer);
+    framer_ = std::shared_ptr<framer::IFramer>(std::move(framer));
     if (framer_ && (message_handler_ || message_batch_handler_)) attach_framer_callback();
   }
 

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -41,6 +41,7 @@ struct TcpServer::Impl {
   std::mutex bp_mutex_;
   std::condition_variable bp_cv_;
   uint16_t port_;
+  std::string bind_address_{"0.0.0.0"};
   std::shared_ptr<interface::Channel> channel_;
   std::shared_ptr<boost::asio::io_context> external_ioc_;
   std::atomic<bool> use_external_context_{false};
@@ -131,6 +132,7 @@ struct TcpServer::Impl {
         max_clients_(0),
         backpressure_threshold_(base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
         backpressure_strategy_(base::constants::BackpressureStrategy::Reliable) {
+    transport_cache_ = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
     setup_internal_handlers();
   }
 
@@ -204,6 +206,7 @@ struct TcpServer::Impl {
 
     if (!channel_) {
       config::TcpServerConfig config;
+      config.bind_address = bind_address_;
       config.port = port_;
       config.enable_port_retry = port_retry_enabled_.load();
       config.max_port_retries = max_port_retries_.load();
@@ -219,10 +222,7 @@ struct TcpServer::Impl {
       if (client_limit_enabled_.load()) {
         auto transport_server = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
         if (transport_server) {
-          if (max_clients_.load() == 0)
-            transport_server->set_unlimited_clients();
-          else
-            transport_server->set_client_limit(max_clients_.load());
+          transport_server->set_client_limit(max_clients_.load());
         }
       }
     }
@@ -431,8 +431,12 @@ struct TcpServer::Impl {
         bp_cv_.notify_all();
         auto alive = weak_alive.lock();
         if (!alive) return;
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        if (on_backpressure_) on_backpressure_(queued);
+        std::function<void(size_t)> handler;
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          handler = on_backpressure_;
+        }
+        if (handler) handler(queued);
       });
     }
     channel_->on_state([this, weak_alive](base::LinkState state) {
@@ -561,6 +565,12 @@ TcpServer& TcpServer::auto_start(bool m) {
   return *this;
 }
 
+TcpServer& TcpServer::bind_address(const std::string& address) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->bind_address_ = address;
+  return *this;
+}
+
 TcpServer& TcpServer::port_retry(bool e, int m, int i) {
   impl_->port_retry_enabled_.store(e);
   impl_->max_port_retries_.store(m);
@@ -578,13 +588,6 @@ TcpServer& TcpServer::max_clients(size_t max) {
   impl_->max_clients_.store(max);
   impl_->client_limit_enabled_.store(true);
   if (impl_->transport_cache_) impl_->transport_cache_->set_client_limit(max);
-  return *this;
-}
-
-TcpServer& TcpServer::unlimited_clients() {
-  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->client_limit_enabled_.store(false);
-  if (impl_->transport_cache_) impl_->transport_cache_->set_unlimited_clients();
   return *this;
 }
 

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -93,10 +93,10 @@ class UNILINK_API TcpServer : public ServerInterface {
 
   // Configuration (Fluent API)
   TcpServer& auto_start(bool manage = true) override;
+  TcpServer& bind_address(const std::string& address);
   TcpServer& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
   TcpServer& idle_timeout(std::chrono::milliseconds timeout);
   TcpServer& max_clients(size_t max);
-  TcpServer& unlimited_clients();
   TcpServer& backpressure_threshold(size_t threshold);
   TcpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   TcpServer& manage_external_context(bool manage);

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -62,7 +62,7 @@ struct UdpClient::Impl {
   MessageHandler message_handler{nullptr};
   BatchMessageHandler message_batch_handler_{nullptr};
 
-  std::unique_ptr<framer::IFramer> framer{nullptr};
+  std::shared_ptr<framer::IFramer> framer{nullptr};
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -268,6 +268,7 @@ struct UdpClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      std::shared_ptr<framer::IFramer> framer_to_push;
       std::unique_lock<std::shared_mutex> lock(mutex_);
       if (data_batch_handler_) {
         data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
@@ -291,16 +292,22 @@ struct UdpClient::Impl {
       }
 
       if (framer) {
-        framer->push_bytes(data);
+        framer_to_push = framer;
       }
+      lock.unlock();
+      if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
     channel->on_backpressure([this, weak_alive](size_t queued) {
       bp_cv_.notify_all();
       auto alive = weak_alive.lock();
       if (!alive) return;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (bp_handler) bp_handler(queued);
+      std::function<void(size_t)> handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        handler = bp_handler;
+      }
+      if (handler) handler(queued);
     });
 
     channel->on_state([this, weak_alive](base::LinkState state) {
@@ -375,7 +382,7 @@ struct UdpClient::Impl {
 
   void set_framer(std::unique_ptr<framer::IFramer> f) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    framer = std::move(f);
+    framer = std::shared_ptr<framer::IFramer>(std::move(f));
     if (framer && (message_handler || message_batch_handler_)) attach_framer_callback();
   }
 
@@ -457,8 +464,7 @@ UdpClient& UdpClient::on_message(MessageHandler h) {
   return *this;
 }
 UdpClient& UdpClient::on_message_batch(BatchMessageHandler h) {
-  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->message_batch_handler_ = std::move(h);
+  impl_->on_message_batch(std::move(h));
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -325,8 +325,12 @@ struct UdpServer::Impl {
 
     channel->on_backpressure([this](size_t queued) {
       bp_cv_.notify_all();
-      std::shared_lock<std::shared_mutex> lock(mutex);
-      if (bp_handler) bp_handler(queued);
+      std::function<void(size_t)> handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        handler = bp_handler;
+      }
+      if (handler) handler(queued);
     });
 
     channel->on_state([this](base::LinkState state) {
@@ -631,11 +635,6 @@ UdpServer& UdpServer::on_backpressure(std::function<void(size_t)> handler) {
 UdpServer& UdpServer::max_clients(size_t max) {
   impl_->client_limit_enabled.store(true);
   impl_->max_clients_limit.store(max);
-  return *this;
-}
-
-UdpServer& UdpServer::unlimited_clients() {
-  impl_->client_limit_enabled.store(false);
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -87,7 +87,6 @@ class UNILINK_API UdpServer : public ServerInterface {
   UdpServer& auto_start(bool manage = true) override;
   UdpServer& idle_timeout(std::chrono::milliseconds timeout);
   UdpServer& max_clients(size_t max);
-  UdpServer& unlimited_clients();
   UdpServer& backpressure_threshold(size_t threshold);
   UdpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdpServer& manage_external_context(bool manage);

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -63,7 +63,7 @@ struct UdsClient::Impl {
   MessageHandler message_handler_{nullptr};
   BatchMessageHandler message_batch_handler_{nullptr};
 
-  std::unique_ptr<framer::IFramer> framer_{nullptr};
+  std::shared_ptr<framer::IFramer> framer_{nullptr};
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -343,6 +343,7 @@ struct UdsClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      std::shared_ptr<framer::IFramer> framer_to_push;
       std::unique_lock<std::shared_mutex> lock(mutex_);
       if (data_batch_handler_) {
         data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
@@ -366,16 +367,22 @@ struct UdsClient::Impl {
       }
 
       if (framer_) {
-        framer_->push_bytes(data);
+        framer_to_push = framer_;
       }
+      lock.unlock();
+      if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
     channel_->on_backpressure([this, weak_alive](size_t queued) {
       bp_cv_.notify_all();
       auto alive = weak_alive.lock();
       if (!alive) return;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (bp_handler_) bp_handler_(queued);
+      std::function<void(size_t)> handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        handler = bp_handler_;
+      }
+      if (handler) handler(queued);
     });
   }
 
@@ -409,7 +416,7 @@ struct UdsClient::Impl {
 
   void set_framer(std::unique_ptr<framer::IFramer> framer) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    framer_ = std::move(framer);
+    framer_ = std::shared_ptr<framer::IFramer>(std::move(framer));
     if (framer_ && (message_handler_ || message_batch_handler_)) attach_framer_callback();
   }
 
@@ -547,6 +554,10 @@ UdsClient& UdsClient::backpressure_threshold(size_t threshold) {
 UdsClient& UdsClient::backpressure_strategy(base::constants::BackpressureStrategy strategy) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->backpressure_strategy_ = strategy;
+  if (impl_->channel_) {
+    auto transport_client = std::dynamic_pointer_cast<transport::UdsClient>(impl_->channel_);
+    if (transport_client) transport_client->set_backpressure_strategy(strategy);
+  }
   return *this;
 }
 

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -1,5 +1,6 @@
 #include "unilink/wrapper/uds_server/uds_server.hpp"
 
+#include <algorithm>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -36,7 +37,7 @@ struct UdsServer::Impl {
   // Configuration
   std::atomic<bool> auto_start_{false};
   std::atomic<int> idle_timeout_ms_{0};
-  std::atomic<size_t> max_clients_{1000000};
+  std::atomic<size_t> max_clients_{base::constants::DEFAULT_MAX_CONNECTIONS};
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
@@ -51,7 +52,7 @@ struct UdsServer::Impl {
   MessageHandler on_message_{nullptr};
   BatchMessageHandler on_message_batch_{nullptr};
 
-  std::unordered_map<ClientId, std::unique_ptr<framer::IFramer>> framers_;
+  std::unordered_map<ClientId, std::shared_ptr<framer::IFramer>> framers_;
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -190,6 +191,8 @@ struct UdsServer::Impl {
       config::UdsServerConfig config;
       config.socket_path = socket_path_;
       config.idle_timeout_ms = idle_timeout_ms_.load();
+      config.max_connections =
+          static_cast<int>(std::min(max_clients_.load(), static_cast<size_t>(base::constants::MAX_MAX_CONNECTIONS)));
       config.backpressure_threshold = backpressure_threshold_.load();
       config.backpressure_strategy = backpressure_strategy_.load();
       server_ = factory::ChannelFactory::create(config, external_ioc_);
@@ -293,6 +296,7 @@ struct UdsServer::Impl {
         auto alive = weak_alive.lock();
         if (!alive) return;
 
+        std::shared_ptr<framer::IFramer> framer_to_push;
         std::unique_lock<std::shared_mutex> lock(mutex_);
         if (data_batch_handler_) {
           data_batch_queue_.emplace_back(id, memory::SafeDataBuffer(data_span));
@@ -317,8 +321,10 @@ struct UdsServer::Impl {
 
         auto it = framers_.find(id);
         if (it != framers_.end()) {
-          it->second->push_bytes(data_span);
+          framer_to_push = it->second;
         }
+        lock.unlock();
+        if (framer_to_push) framer_to_push->push_bytes(data_span);
       });
       transport_server->on_multi_disconnect([this, weak_alive](ClientId id) {
         auto alive = weak_alive.lock();
@@ -337,8 +343,12 @@ struct UdsServer::Impl {
         bp_cv_.notify_all();
         auto alive = weak_alive.lock();
         if (!alive) return;
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        if (on_backpressure_) on_backpressure_(queued);
+        std::function<void(size_t)> handler;
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          handler = on_backpressure_;
+        }
+        if (handler) handler(queued);
       });
     }
 
@@ -514,11 +524,9 @@ UdsServer& UdsServer::idle_timeout(std::chrono::milliseconds timeout) {
 
 UdsServer& UdsServer::max_clients(size_t max) {
   impl_->max_clients_.store(max);
-  return *this;
-}
-
-UdsServer& UdsServer::unlimited_clients() {
-  impl_->max_clients_.store(1000000);
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  auto ts = std::dynamic_pointer_cast<transport::UdsServer>(impl_->server_);
+  if (ts) ts->set_client_limit(max);
   return *this;
 }
 

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -96,7 +96,6 @@ class UNILINK_API UdsServer : public ServerInterface {
   UdsServer& auto_start(bool manage = true) override;
   UdsServer& idle_timeout(std::chrono::milliseconds timeout);
   UdsServer& max_clients(size_t max);
-  UdsServer& unlimited_clients();
   UdsServer& backpressure_threshold(size_t threshold);
   UdsServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdsServer& manage_external_context(bool manage);


### PR DESCRIPTION
## Description
This PR unifies the client limit handling across all server types (TCP, UDS, UDP) by removing the `unlimited_clients()` method and replacing it with a consistent bounded default. It also improves the thread-safety of callback handlers in the wrapper layer and adds missing configuration options like `bind_address` for TCP servers.

## Key Changes
- **API Unification**: Removed `unlimited_clients()` and standardized on `max_clients(n)` with a library-wide default bounded limit.
- **Thread-Safety**: Fixed potential race conditions in wrapper callback handlers by capturing handlers under locks before execution.
- **Framer Management**: Refactored wrappers to use shared ownership for framers to ensure they remain valid during asynchronous callback execution.
- **TCP Server Enhancement**: Added `bind_address` configuration support.
- **Python Bindings**: Updated Python bindings to expose `bind_address`, `port_retry`, `idle_timeout`, and `max_clients`.
- **Docs & Examples**: Updated all documentation, examples, and tests to align with the revised API.

## Related Issues
- Related to the ongoing effort to improve library robustness and API consistency.

## Type of Change
- [x] **Bug Fix**
- [ ] **New Feature**
- [x] **Breaking Change**
- [ ] **Documentation**
- [x] **Refactor**
- [ ] **Performance**
- [x] **Testing**

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server configuration methods: `bind_address()`, `port_retry()`, `idle_timeout()`, and `max_clients()`
  * Introduced batch message handling via `on_data_batch()` and `on_message_batch()` 
  * Added backpressure notifications via `on_backpressure()`

* **Breaking Changes**
  * Removed `unlimited_clients()` from all server types; servers now enforce bounded connection limits by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->