### PR TITLE
refactor: replace std::format with fmt to lower minimum GCC requirement

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -29,7 +29,7 @@ runs:
         retry_vcpkg_install() {
           local attempt
           for attempt in 1 2 3; do
-            if "${VCPKG_ROOT}/vcpkg" install ${{ inputs.packages }} --triplet "${{ inputs.triplet }}" --clean-after-build; then
+            if "${VCPKG_ROOT}/vcpkg" install ${{ inputs.packages }} --triplet "${{ inputs.triplet }}" --overlay-triplets "${GITHUB_WORKSPACE}/vcpkg/triplets" --clean-after-build; then
               return 0
             fi
             if [ "${attempt}" -eq 3 ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -245,6 +245,8 @@ jobs:
 
       - name: Configure (macOS)
         if: runner.os == 'macOS'
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "15.0"
         run: |
           PYTHON_CMAKE_ARGS=()
           if [ "${{ matrix.build_python }}" = "ON" ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -245,9 +245,11 @@ jobs:
 
       - name: Configure (macOS)
         if: runner.os == 'macOS'
-        env:
-          MACOSX_DEPLOYMENT_TARGET: "15.0"
         run: |
+          SDK_VER=$(xcrun --sdk macosx --show-sdk-version)
+          echo "macOS SDK version: $SDK_VER"
+          export MACOSX_DEPLOYMENT_TARGET="$SDK_VER"
+
           PYTHON_CMAKE_ARGS=()
           if [ "${{ matrix.build_python }}" = "ON" ]; then
             PYTHON_CMAKE_ARGS+=("-DPython3_EXECUTABLE=$(python3 -c 'import sys; print(sys.executable)')")
@@ -258,7 +260,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
             -DCMAKE_C_COMPILER="${{ matrix.cc }}" \
             -DCMAKE_CXX_COMPILER="${{ matrix.cxx }}" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDK_VER" \
             -DUNILINK_BUILD_EXAMPLES=OFF \
             -DUNILINK_BUILD_DOCS=OFF \
             -DUNILINK_BUILD_TESTS=ON \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,8 +69,8 @@ jobs:
           - name: C++ (macOS, Clang)
             os: macos-15
             triplet: arm64-osx
-            cc: clang
-            cxx: clang++
+            cc: /opt/homebrew/opt/llvm/bin/clang
+            cxx: /opt/homebrew/opt/llvm/bin/clang++
             generator: Ninja
             build_type: Release
             build_python: OFF
@@ -116,8 +116,8 @@ jobs:
           - name: Python3 (macOS, Clang)
             os: macos-15
             triplet: arm64-osx
-            cc: clang
-            cxx: clang++
+            cc: /opt/homebrew/opt/llvm/bin/clang
+            cxx: /opt/homebrew/opt/llvm/bin/clang++
             generator: Ninja
             build_type: Release
             build_python: ON
@@ -152,12 +152,22 @@ jobs:
             sudo apt-get install -y ninja-build autoconf autoconf-archive automake libtool libtool-bin pkg-config \
               ${{ matrix.cc }} ${{ matrix.cxx }}
           else
-            brew install ninja autoconf autoconf-archive automake libtool pkg-config
+            brew install ninja autoconf autoconf-archive automake libtool pkg-config llvm
           fi
 
-      - name: Install dependencies with vcpkg (Unix)
-        if: runner.os != 'Windows'
+      - name: Install dependencies with vcpkg (Linux)
+        if: runner.os == 'Linux'
         uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: ${{ matrix.triplet }}
+          packages: boost-asio boost-system spdlog pybind11
+
+      - name: Install dependencies with vcpkg (macOS)
+        if: runner.os == 'macOS'
+        uses: ./.github/actions/setup-vcpkg
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         with:
           triplet: ${{ matrix.triplet }}
           packages: boost-asio boost-system spdlog pybind11

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,6 +48,15 @@ jobs:
             build_type: Release
             build_python: OFF
             vcpkg_features: ""
+          - name: C++ (Linux, GCC 12, Ubuntu 22.04)
+            os: ubuntu-22.04
+            triplet: x64-linux
+            cc: gcc-12
+            cxx: g++-12
+            generator: Ninja
+            build_type: Release
+            build_python: OFF
+            vcpkg_features: ""
           - name: C++ (Windows, MSVC)
             os: windows-2022
             triplet: x64-windows-static-md
@@ -82,6 +91,15 @@ jobs:
             triplet: arm64-linux
             cc: gcc-13
             cxx: g++-13
+            generator: Ninja
+            build_type: Release
+            build_python: ON
+            vcpkg_features: "python"
+          - name: Python3 (Linux, GCC 12, Ubuntu 22.04)
+            os: ubuntu-22.04
+            triplet: x64-linux
+            cc: gcc-12
+            cxx: g++-12
             generator: Ninja
             build_type: Release
             build_python: ON
@@ -130,15 +148,9 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y ca-certificates
             
-            # Install build tools and modern GCC for C++20 support
+            # Install build tools and the matrix-specified compiler
             sudo apt-get install -y ninja-build autoconf autoconf-archive automake libtool libtool-bin pkg-config \
-              gcc-13 g++-13
-            
-            # Set as default if not already
-            if [ "${{ matrix.cc }}" = "gcc" ]; then
-              sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-              sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
-            fi
+              ${{ matrix.cc }} ${{ matrix.cxx }}
           else
             brew install ninja autoconf autoconf-archive automake libtool pkg-config
           fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,7 +58,7 @@ jobs:
             build_python: OFF
             vcpkg_features: ""
           - name: C++ (macOS, Clang)
-            os: macos-26
+            os: macos-15
             triplet: arm64-osx
             cc: clang
             cxx: clang++
@@ -96,7 +96,7 @@ jobs:
             build_python: ON
             vcpkg_features: "python"
           - name: Python3 (macOS, Clang)
-            os: macos-26
+            os: macos-15
             triplet: arm64-osx
             cc: clang
             cxx: clang++
@@ -244,7 +244,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
             -DCMAKE_C_COMPILER="${{ matrix.cc }}" \
             -DCMAKE_CXX_COMPILER="${{ matrix.cxx }}" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
             -DUNILINK_BUILD_EXAMPLES=OFF \
             -DUNILINK_BUILD_DOCS=OFF \
             -DUNILINK_BUILD_TESTS=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
             release_files: |
               build/package/unilink-*.tar.gz
 
-          - os: macos-26
-            label: macOS 26
+          - os: macos-15
+            label: macOS 15
             triplet: arm64-osx
             cmake_generator: "Ninja"
             cpack_generator: "TGZ;DragNDrop"
@@ -48,7 +48,7 @@ jobs:
               build/package/unilink-*.tar.gz
               build/package/unilink-*.dmg
 
-          - os: windows-latest
+          - os: windows-2022
             label: Windows (VS 2022)
             cmake_generator: "Visual Studio 17 2022"
             cmake_arch: "x64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,12 @@ jobs:
               -DUNILINK_ENABLE_PKGCONFIG=ON \
               -DUNILINK_ENABLE_EXPORT_HEADER=ON
           elif [ "${{ runner.os }}" = "macOS" ]; then
+            SDK_VER=$(xcrun --sdk macosx --show-sdk-version)
+            echo "macOS SDK version: $SDK_VER"
+            export MACOSX_DEPLOYMENT_TARGET="$SDK_VER"
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDK_VER" \
               -DUNILINK_ENABLE_INSTALL=ON \
               -DUNILINK_ENABLE_PKGCONFIG=ON \
               -DUNILINK_ENABLE_EXPORT_HEADER=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Configure
         shell: bash
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "15.0"
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" -A "${{ matrix.cmake_arch }}" \
@@ -103,6 +105,15 @@ jobs:
               -DUNILINK_ENABLE_INSTALL=ON \
               -DUNILINK_ENABLE_PKGCONFIG=ON \
               -DUNILINK_ENABLE_EXPORT_HEADER=ON
+          elif [ "${{ runner.os }}" = "macOS" ]; then
+            cmake -S . -B build -G "${{ matrix.cmake_generator }}" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+              -DUNILINK_ENABLE_INSTALL=ON \
+              -DUNILINK_ENABLE_PKGCONFIG=ON \
+              -DUNILINK_ENABLE_EXPORT_HEADER=ON \
+              -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TOOLCHAIN_FILE}" \
+              -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
           else
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -83,6 +83,6 @@ jobs:
           echo "✅ Build: Success" >> $GITHUB_STEP_SUMMARY
           echo "✅ Tests: Passed" >> $GITHUB_STEP_SUMMARY
           echo "✅ Package: Created" >> $GITHUB_STEP_SUMMARY
-          echo "🔧 Dependencies: vcpkg (${{ matrix.triplet }}), Boost 1.84+" >> $GITHUB_STEP_SUMMARY
+          echo "🔧 Dependencies: vcpkg (${{ matrix.triplet }}), Boost 1.83+" >> $GITHUB_STEP_SUMMARY
           echo "📦 Package files:" >> $GITHUB_STEP_SUMMARY
           ls -la build/package/ >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,13 +120,9 @@ jobs:
       with:
         triplet: ${{ matrix.triplet }}
 
-    - name: Configure CMake
+    - name: Configure CMake (Linux)
+      if: runner.os == 'Linux'
       run: |
-        EXTRA_ARGS=()
-        if [ "${{ runner.os }}" = "macOS" ]; then
-          EXTRA_ARGS+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=15.0")
-        fi
-
         cmake -S . -B build-test \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_C_COMPILER=$CC \
@@ -139,8 +135,27 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
           -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          "${EXTRA_ARGS[@]}"
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Configure CMake (macOS)
+      if: runner.os == 'macOS'
+      env:
+        MACOSX_DEPLOYMENT_TARGET: "15.0"
+      run: |
+        cmake -S . -B build-test \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_C_COMPILER=$CC \
+          -DCMAKE_CXX_COMPILER=$CXX \
+          -DCMAKE_CXX_STANDARD=$CXX_STANDARD \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+          -DUNILINK_ENABLE_CONFIG=ON \
+          -DUNILINK_BUILD_EXAMPLES=OFF \
+          -DUNILINK_BUILD_DOCS=OFF \
+          -DUNILINK_BUILD_TESTS=ON \
+          -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
+          -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build tests
       run: cmake --build build-test -j ${CORE_COUNT:-4}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,11 @@ jobs:
             cc: gcc-13
             cxx: g++-13
             triplet: arm64-linux
+          - os: ubuntu-22.04
+            compiler: gcc
+            cc: gcc-12
+            cxx: g++-12
+            triplet: x64-linux
           # macOS: Clang (AppleClang, arm64)
           - os: macos-15
             compiler: clang
@@ -92,8 +97,9 @@ jobs:
         sudo apt-get install -y ca-certificates
 
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          sudo apt-get install -y gcc-13 g++-13
+          sudo apt-get install -y ${{ matrix.cc }} ${{ matrix.cxx }}
         else
+          # Clang needs GCC's C++ stdlib headers; all clang entries run on ubuntu-24.04
           sudo apt-get install -y ${{ matrix.cc }} g++-13
         fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,15 +139,16 @@ jobs:
 
     - name: Configure CMake (macOS)
       if: runner.os == 'macOS'
-      env:
-        MACOSX_DEPLOYMENT_TARGET: "15.0"
       run: |
+        SDK_VER=$(xcrun --sdk macosx --show-sdk-version)
+        echo "macOS SDK version: $SDK_VER"
+        export MACOSX_DEPLOYMENT_TARGET="$SDK_VER"
         cmake -S . -B build-test \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_C_COMPILER=$CC \
           -DCMAKE_CXX_COMPILER=$CXX \
           -DCMAKE_CXX_STANDARD=$CXX_STANDARD \
-          -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDK_VER" \
           -DUNILINK_ENABLE_CONFIG=ON \
           -DUNILINK_BUILD_EXAMPLES=OFF \
           -DUNILINK_BUILD_DOCS=OFF \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
             cc: gcc-13
             cxx: g++-13
             triplet: arm64-linux
-          # macOS: Clang with libc++ std::format support
-          - os: macos-26
+          # macOS: Clang (AppleClang, arm64)
+          - os: macos-15
             compiler: clang
             cc: clang
             cxx: clang++

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,11 @@ jobs:
 
     - name: Configure CMake
       run: |
+        EXTRA_ARGS=()
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          EXTRA_ARGS+=("-DCMAKE_OSX_DEPLOYMENT_TARGET=15.0")
+        fi
+
         cmake -S . -B build-test \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_C_COMPILER=$CC \
@@ -134,7 +139,8 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
           -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          "${EXTRA_ARGS[@]}"
 
     - name: Build tests
       run: cmake --build build-test -j ${CORE_COUNT:-4}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,11 @@ jobs:
             cc: gcc-12
             cxx: g++-12
             triplet: x64-linux
-          # macOS: Clang (AppleClang, arm64)
+          # macOS: Homebrew LLVM Clang/libc++ (arm64)
           - os: macos-15
             compiler: clang
-            cc: clang
-            cxx: clang++
+            cc: /opt/homebrew/opt/llvm/bin/clang
+            cxx: /opt/homebrew/opt/llvm/bin/clang++
             triplet: arm64-osx
 
     steps:
@@ -108,12 +108,21 @@ jobs:
 
     - name: Install tools (macOS)
       if: runner.os == 'macOS'
-      run: brew install ccache ninja
+      run: brew install ccache ninja llvm
 
     - name: Set up compiler env
       run: |
-        echo "CC=$(which ${{ matrix.cc }})" >> $GITHUB_ENV
-        echo "CXX=$(which ${{ matrix.cxx }})" >> $GITHUB_ENV
+        resolve_tool() {
+          if [ -x "$1" ]; then
+            printf '%s\n' "$1"
+          else
+            command -v "$1"
+          fi
+        }
+        CC_PATH=$(resolve_tool "${{ matrix.cc }}")
+        CXX_PATH=$(resolve_tool "${{ matrix.cxx }}")
+        echo "CC=${CC_PATH}" >> $GITHUB_ENV
+        echo "CXX=${CXX_PATH}" >> $GITHUB_ENV
 
     - name: Install dependencies with vcpkg
       uses: ./.github/actions/setup-vcpkg

--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -33,7 +33,7 @@ jobs:
             triplet: x64-windows
           - os: windows-2022
             triplet: x64-windows-static
-          - os: macos-26
+          - os: macos-15
             triplet: arm64-osx
 
     env:

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,7 +1,20 @@
 include(GNUInstallDirs)
 
 if(DEFINED Python3_EXECUTABLE AND NOT DEFINED Python3_ROOT_DIR)
-  get_filename_component(Python3_ROOT_DIR "${Python3_EXECUTABLE}" DIRECTORY)
+  get_filename_component(
+    _unilink_python_executable_dir "${Python3_EXECUTABLE}" DIRECTORY
+  )
+  get_filename_component(
+    _unilink_python_executable_dir_name "${_unilink_python_executable_dir}"
+    NAME
+  )
+  if(_unilink_python_executable_dir_name MATCHES "^(bin|Scripts)$")
+    get_filename_component(
+      Python3_ROOT_DIR "${_unilink_python_executable_dir}" DIRECTORY
+    )
+  else()
+    set(Python3_ROOT_DIR "${_unilink_python_executable_dir}")
+  endif()
 endif()
 
 # On Windows CI, vcpkg also provides a Python distribution for pybind11's
@@ -15,7 +28,7 @@ if(WIN32)
   set(Python3_FIND_ABI OFF ANY ANY)
 endif()
 
-if(WIN32 AND Python3_EXECUTABLE)
+if((WIN32 OR APPLE) AND Python3_EXECUTABLE)
   execute_process(
     COMMAND
       "${Python3_EXECUTABLE}" -c
@@ -32,12 +45,8 @@ if(WIN32 AND Python3_EXECUTABLE)
     )
     list(LENGTH _unilink_python_probe_lines _unilink_python_probe_count)
 
-    if(_unilink_python_probe_count GREATER_EQUAL 2)
+    if(_unilink_python_probe_count GREATER_EQUAL 1)
       list(GET _unilink_python_probe_lines 0 _unilink_python_include_dir)
-      list(GET _unilink_python_probe_lines 1 _unilink_python_library)
-      get_filename_component(
-        _unilink_python_library_dir "${_unilink_python_library}" DIRECTORY
-      )
 
       if(EXISTS "${_unilink_python_include_dir}/Python.h")
         set(Python3_INCLUDE_DIR
@@ -48,7 +57,14 @@ if(WIN32 AND Python3_EXECUTABLE)
         )
       endif()
 
-      if(EXISTS "${_unilink_python_library}")
+      if(_unilink_python_probe_count GREATER_EQUAL 2)
+        list(GET _unilink_python_probe_lines 1 _unilink_python_library)
+        get_filename_component(
+          _unilink_python_library_dir "${_unilink_python_library}" DIRECTORY
+        )
+      endif()
+
+      if(WIN32 AND EXISTS "${_unilink_python_library}")
         set(Python3_LIBRARY
             "${_unilink_python_library}"
             CACHE FILEPATH

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -192,14 +192,12 @@ if(CMAKE_CONFIGURATION_TYPES)
   endforeach()
 endif()
 
-# Link against the main library. On Windows, avoid the imported Python3::Module
-# target when vcpkg has installed its own Python package; it can retain vcpkg's
-# python312.lib even when the interpreter comes from actions/setup-python.
+# Link against the main library. On Windows/macOS, avoid the imported
+# Python3::Module target when vcpkg has installed its own Python package; it can
+# retain vcpkg's python312.lib or SDK include directories even when the
+# interpreter comes from actions/setup-python.
 set(_unilink_python_module_link_target Python3::Module)
-if(WIN32
-   AND _unilink_python_library
-   AND EXISTS "${_unilink_python_library}"
-)
+if((WIN32 OR APPLE) AND EXISTS "${_unilink_python_include_dir}/Python.h")
   get_target_property(_unilink_py_link_libraries unilink_py LINK_LIBRARIES)
   if(_unilink_py_link_libraries)
     list(REMOVE_ITEM _unilink_py_link_libraries Python3::Module)
@@ -212,12 +210,16 @@ if(WIN32
   endif()
 
   add_library(unilink_python_module INTERFACE)
-  target_link_libraries(
-    unilink_python_module INTERFACE "${_unilink_python_library}"
+  target_include_directories(
+    unilink_python_module INTERFACE "${_unilink_python_include_dir}"
   )
-  if(EXISTS "${_unilink_python_include_dir}/Python.h")
-    target_include_directories(
-      unilink_python_module INTERFACE "${_unilink_python_include_dir}"
+  if(WIN32 AND EXISTS "${_unilink_python_library}")
+    target_link_libraries(
+      unilink_python_module INTERFACE "${_unilink_python_library}"
+    )
+  elseif(APPLE)
+    target_link_options(
+      unilink_python_module INTERFACE -undefined dynamic_lookup
     )
   endif()
   set(_unilink_python_module_link_target unilink_python_module)
@@ -227,6 +229,26 @@ target_link_libraries(
   unilink_py PRIVATE pybind11::headers unilink::unilink
                      ${_unilink_python_module_link_target}
 )
+
+if(APPLE)
+  foreach(_unilink_py_include_property
+          INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES
+          SYSTEM_INCLUDE_DIRECTORIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+  )
+    get_target_property(
+      _unilink_py_includes unilink_py ${_unilink_py_include_property}
+    )
+    if(_unilink_py_includes)
+      list(FILTER _unilink_py_includes EXCLUDE REGEX
+           "MacOSX[^;]*\\.sdk/usr/include$"
+      )
+      set_target_properties(
+        unilink_py PROPERTIES ${_unilink_py_include_property}
+                              "${_unilink_py_includes}"
+      )
+    endif()
+  endforeach()
+endif()
 
 # Ensure extension builds use the same standard as the C++ library.
 target_compile_features(unilink_py PUBLIC cxx_std_20)

--- a/cmake/UnilinkCompiler.cmake
+++ b/cmake/UnilinkCompiler.cmake
@@ -101,6 +101,9 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
           "Bumped macOS deployment target to 15.0 (std::jthread requires Apple libc++ macOS 15+)"
       )
     endif()
+    # Belt-and-suspenders: directly add the flag so it overrides any earlier
+    # -mmacosx-version-min that CMake or vcpkg already wrote into the build rules.
+    add_compile_options(-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_compile_definitions(UNILINK_PLATFORM_LINUX=1)
     message(STATUS "Detected Linux compatibility mode")

--- a/cmake/UnilinkCompiler.cmake
+++ b/cmake/UnilinkCompiler.cmake
@@ -87,6 +87,20 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     add_compile_definitions(UNILINK_PLATFORM_MACOS=1)
     message(STATUS "Detected macOS compatibility mode")
+    # std::jthread / stop_token / stop_callback are gated on
+    # __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 150000 in Apple's libc++.
+    # The vcpkg arm64-osx triplet can lower CMAKE_OSX_DEPLOYMENT_TARGET to 11.0
+    # via its toolchain; force 15.0 here before any project targets are defined.
+    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL "15.0")
+      set(CMAKE_OSX_DEPLOYMENT_TARGET
+          "15.0"
+          CACHE STRING "Minimum macOS deployment target" FORCE
+      )
+      message(
+        STATUS
+          "Bumped macOS deployment target to 15.0 (std::jthread requires Apple libc++ macOS 15+)"
+      )
+    endif()
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_compile_definitions(UNILINK_PLATFORM_LINUX=1)
     message(STATUS "Detected Linux compatibility mode")

--- a/cmake/UnilinkCompiler.cmake
+++ b/cmake/UnilinkCompiler.cmake
@@ -105,6 +105,38 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     # -mmacosx-version-min that CMake or vcpkg already wrote into the build
     # rules.
     add_compile_options(-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
+
+    if(UNILINK_COMPILER_CLANG)
+      include(CheckCXXSourceCompiles)
+      set(_UNILINK_REQUIRED_FLAGS_SAVE "${CMAKE_REQUIRED_FLAGS}")
+      set(CMAKE_REQUIRED_FLAGS
+          "${CMAKE_REQUIRED_FLAGS} -std=c++20 -fexperimental-library"
+      )
+      check_cxx_source_compiles(
+        "#include <thread>
+#include <stop_token>
+int main() {
+  std::jthread worker([](std::stop_token) {});
+  worker.request_stop();
+  return 0;
+}"
+        UNILINK_HAS_FEXPERIMENTAL_LIBRARY
+      )
+      set(CMAKE_REQUIRED_FLAGS "${_UNILINK_REQUIRED_FLAGS_SAVE}")
+      unset(_UNILINK_REQUIRED_FLAGS_SAVE)
+      if(UNILINK_HAS_FEXPERIMENTAL_LIBRARY)
+        # libc++ still gates P0660 (std::jthread, std::stop_token and
+        # std::stop_callback) behind this flag on Apple's Clang toolchain.
+        add_compile_options(-fexperimental-library)
+        add_link_options(-fexperimental-library)
+        message(STATUS "Enabled libc++ experimental C++20 library support")
+      else()
+        message(
+          FATAL_ERROR
+            "Configured macOS Clang/libc++ does not provide std::jthread/stop_token support with -fexperimental-library"
+        )
+      endif()
+    endif()
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_compile_definitions(UNILINK_PLATFORM_LINUX=1)
     message(STATUS "Detected Linux compatibility mode")

--- a/cmake/UnilinkCompiler.cmake
+++ b/cmake/UnilinkCompiler.cmake
@@ -75,13 +75,13 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
-                                              VERSION_LESS "13.0"
+                                              VERSION_LESS "10.0"
   )
-    message(FATAL_ERROR "GCC 13.0+ is required for unilink's std::format usage")
+    message(FATAL_ERROR "GCC 10.0+ is required for unilink's C++20 features")
   elseif(UNILINK_COMPILER_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS
                                     "14.0"
   )
-    message(FATAL_ERROR "Clang 14.0+ is required for unilink's C++20 API")
+    message(FATAL_ERROR "Clang 14.0+ is required for unilink's C++20 features")
   endif()
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/cmake/UnilinkCompiler.cmake
+++ b/cmake/UnilinkCompiler.cmake
@@ -102,7 +102,8 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       )
     endif()
     # Belt-and-suspenders: directly add the flag so it overrides any earlier
-    # -mmacosx-version-min that CMake or vcpkg already wrote into the build rules.
+    # -mmacosx-version-min that CMake or vcpkg already wrote into the build
+    # rules.
     add_compile_options(-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_compile_definitions(UNILINK_PLATFORM_LINUX=1)

--- a/cmake/UnilinkDependencies.cmake
+++ b/cmake/UnilinkDependencies.cmake
@@ -7,7 +7,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.31" AND POLICY CMP0167)
 endif()
 
 set(UNILINK_MIN_BOOST_VERSION
-    1.84.0
+    1.83.0
     CACHE STRING "Minimum supported Boost version"
 )
 
@@ -86,7 +86,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT _unilink_using_vcpkg)
       CACHE PATH "Homebrew Boost include dir" FORCE
   )
   set(Boost_ADDITIONAL_VERSIONS
-      "1.89" "1.89.0" "1.84" "1.84.0"
+      "1.89" "1.89.0" "1.83" "1.83.0"
       CACHE STRING "" FORCE
   )
   list(APPEND CMAKE_PREFIX_PATH /opt/homebrew/opt/boost /opt/homebrew

--- a/cmake/UnilinkOptions.cmake
+++ b/cmake/UnilinkOptions.cmake
@@ -94,6 +94,5 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-
 # Enable position independent code
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/UnilinkOptions.cmake
+++ b/cmake/UnilinkOptions.cmake
@@ -94,26 +94,6 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(
-  [[
-    #include <format>
-    #include <string>
-    int main() {
-      const std::string value = std::format("{}", 42);
-      return value == "42" ? 0 : 1;
-    }
-  ]]
-  UNILINK_HAS_STD_FORMAT
-)
-if(NOT UNILINK_HAS_STD_FORMAT)
-  message(
-    FATAL_ERROR
-      "unilink uses std::format and requires a C++20 standard library that "
-      "implements it. Use GCC 13+, a recent MSVC toolset, or a recent "
-      "AppleClang/libc++ toolchain."
-  )
-endif()
 
 # Enable position independent code
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/scripts/apply_clang_format.sh
+++ b/scripts/apply_clang_format.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
+
+job_count() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+  elif command -v sysctl >/dev/null 2>&1; then
+    sysctl -n hw.ncpu
+  else
+    echo 2
+  fi
+}
+
+JOBS="${JOBS:-$(job_count)}"
+
 if ! command -v clang-format &> /dev/null; then
     echo "Error: clang-format is not installed."
     exit 1
 fi
-echo "Applying clang-format to all C++ files..."
-find . -type f \( -name "*.h" -o -name "*.hpp" -o -name "*.c" -o -name "*.cpp" -o -name "*.cc" -o -name "*.in" \) -not -path "*/build/*" -not -path "*/.git/*" -not -path "*/.vscode/*" -not -path "*/docs/html/*" -not -path "*/cmake/*.cmake.in" -not -path "*/package/*.pc.in" -exec clang-format -i -style=file {} +
+echo "Applying clang-format to all C++ files using ${JOBS:-2} jobs..."
+find . -type f \( -name "*.h" -o -name "*.hpp" -o -name "*.c" -o -name "*.cpp" -o -name "*.cc" -o -name "*.in" \) \
+    -not -path "*/build/*" \
+    -not -path "*/vcpkg/*" \
+    -not -path "*/.git/*" \
+    -not -path "*/.vscode/*" \
+    -not -path "*/docs/html/*" \
+    -not -path "*/cmake/*.cmake.in" \
+    -not -path "*/package/*.pc.in" \
+    -print0 | xargs -0 -P "${JOBS:-2}" -n 20 clang-format -i -style=file
 echo "✅ Code formatting complete."

--- a/scripts/apply_cmake_format.sh
+++ b/scripts/apply_cmake_format.sh
@@ -2,12 +2,30 @@
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+job_count() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+  elif command -v sysctl >/dev/null 2>&1; then
+    sysctl -n hw.ncpu
+  else
+    echo 2
+  fi
+}
+
+JOBS="${JOBS:-$(job_count)}"
+
 if ! command -v cmake-format &> /dev/null; then
     echo "Error: cmake-format is not installed."
     echo "Install it with: pip install cmakelang==0.6.13"
     exit 1
 fi
 
-echo "Applying cmake-format to all CMake files..."
-find . -type f \( -name "CMakeLists.txt" -o -name "*.cmake" -o -name "*.cmake.in" \) -not -path "*/build/*" -not -path "*/.git/*" -not -path "*/.vscode/*" -not -path "*/docs/html/*" -exec cmake-format -i {} +
+echo "Applying cmake-format to all CMake files using ${JOBS:-2} jobs..."
+find . -type f \( -name "CMakeLists.txt" -o -name "*.cmake" -o -name "*.cmake.in" \) \
+    -not -path "*/build/*" \
+    -not -path "*/vcpkg/*" \
+    -not -path "*/.git/*" \
+    -not -path "*/.vscode/*" \
+    -not -path "*/docs/html/*" \
+    -print0 | xargs -0 -P "${JOBS:-2}" -n 20 cmake-format -i
 echo "CMake formatting complete."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -17,6 +17,7 @@ job_count() {
 }
 
 JOBS="$(job_count)"
+export JOBS
 
 # ---------------------------------------------------------------------------
 # Argument parsing
@@ -78,8 +79,14 @@ fi
 # ---------------------------------------------------------------------------
 if [[ "${SKIP_FORMAT}" -eq 0 ]]; then
   section "Step 1: Formatting code"
-  ./scripts/apply_clang_format.sh
-  ./scripts/apply_cmake_format.sh
+  ./scripts/apply_clang_format.sh &
+  CLANG_PID=$!
+  ./scripts/apply_cmake_format.sh &
+  CMAKE_PID=$!
+
+  # Wait for both and check for failures
+  wait "$CLANG_PID" || { echo "clang-format failed"; exit 1; }
+  wait "$CMAKE_PID" || { echo "cmake-format failed"; exit 1; }
 else
   section "Step 1: Formatting code [SKIPPED]"
 fi

--- a/test/unit/transport/transport_tcp_server_security_test.cc
+++ b/test/unit/transport/transport_tcp_server_security_test.cc
@@ -71,7 +71,8 @@ TEST_F(TransportTcpServerSecurityTest, NoIdleTimeoutByDefault) {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   // Fix for macOS/BSD SIGPIPE on write to closed socket
   int yes = 1;
-  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
+  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes,
+                          static_cast<socklen_t>(sizeof(yes)));
   if (result < 0) {
     std::cerr << "setsockopt(SO_NOSIGPIPE) failed: " << errno << std::endl;
   }
@@ -120,7 +121,8 @@ TEST_F(TransportTcpServerSecurityTest, IdleConnectionTimeout) {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   // Fix for macOS/BSD SIGPIPE on write to closed socket
   int yes = 1;
-  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
+  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes,
+                          static_cast<socklen_t>(sizeof(yes)));
   if (result < 0) {
     std::cerr << "setsockopt(SO_NOSIGPIPE) failed: " << errno << std::endl;
   }

--- a/test/unit/transport/transport_tcp_server_security_test.cc
+++ b/test/unit/transport/transport_tcp_server_security_test.cc
@@ -71,7 +71,7 @@ TEST_F(TransportTcpServerSecurityTest, NoIdleTimeoutByDefault) {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   // Fix for macOS/BSD SIGPIPE on write to closed socket
   int yes = 1;
-  int result = setsockopt(client.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &yes, sizeof(yes));
+  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
   if (result < 0) {
     std::cerr << "setsockopt(SO_NOSIGPIPE) failed: " << errno << std::endl;
   }
@@ -120,7 +120,7 @@ TEST_F(TransportTcpServerSecurityTest, IdleConnectionTimeout) {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   // Fix for macOS/BSD SIGPIPE on write to closed socket
   int yes = 1;
-  int result = setsockopt(client.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &yes, sizeof(yes));
+  int result = setsockopt(static_cast<int>(client.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
   if (result < 0) {
     std::cerr << "setsockopt(SO_NOSIGPIPE) failed: " << errno << std::endl;
   }

--- a/test/utils/test_utils.hpp
+++ b/test/utils/test_utils.hpp
@@ -117,7 +117,7 @@ class TestUtils {
 
     // Set SO_REUSEADDR to allow binding to recently used ports
     int reuse = 1;
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, static_cast<socklen_t>(sizeof(reuse)));
 
     sockaddr_in addr{};
     addr.sin_family = AF_INET;

--- a/tools/benchmark/stability/stability_bench_cpp.cc
+++ b/tools/benchmark/stability/stability_bench_cpp.cc
@@ -227,7 +227,7 @@ void run_raw(int level, const Config& cfg) {
   auto start_server = [&] {
     int fd = ::socket(AF_INET, SOCK_STREAM, 0);
     int opt = 1;
-    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, static_cast<socklen_t>(sizeof(opt)));
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = INADDR_ANY;
@@ -255,7 +255,7 @@ void run_raw(int level, const Config& cfg) {
       struct timeval tv {
         0, 100000
       };
-      setsockopt(lfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(lfd, SOL_SOCKET, SO_RCVTIMEO, &tv, static_cast<socklen_t>(sizeof(tv)));
       sockaddr_in cli{};
       socklen_t len = sizeof(cli);
       int cfd = ::accept(lfd, reinterpret_cast<sockaddr*>(&cli), &len);
@@ -314,8 +314,8 @@ void run_raw(int level, const Config& cfg) {
         struct timeval tv {
           1, 0
         };
-        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, static_cast<socklen_t>(sizeof(tv)));
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, static_cast<socklen_t>(sizeof(tv)));
         sockaddr_in addr{};
         addr.sin_family = AF_INET;
         ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);

--- a/unilink/concurrency/io_context_manager.cc
+++ b/unilink/concurrency/io_context_manager.cc
@@ -16,9 +16,10 @@
 
 #include "unilink/concurrency/io_context_manager.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <atomic>
 #include <condition_variable>
-#include <format>
 #include <mutex>
 #include <stop_token>
 #include <thread>
@@ -150,7 +151,7 @@ void IoContextManager::start() {
         std::stop_callback cb(st, [context] { context->stop(); });
         context->run();
       } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("io_context_manager", "run", std::format("Thread error: {}", e.what()));
+        UNILINK_LOG_ERROR("io_context_manager", "run", fmt::format("Thread error: {}", e.what()));
       } catch (...) {
       }
       impl_->running_.store(false);

--- a/unilink/diagnostics/exceptions.hpp
+++ b/unilink/diagnostics/exceptions.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <format>
 #include <stdexcept>
 #include <string>
 
@@ -47,12 +46,12 @@ class UNILINK_API UnilinkException : public std::runtime_error {
       return what();
     }
     if (operation_.empty()) {
-      return std::format("[{}] {}", component_, what());
+      return "[" + component_ + "] " + what();
     }
     if (component_.empty()) {
-      return std::format("{} (operation: {})", what(), operation_);
+      return std::string(what()) + " (operation: " + operation_ + ")";
     }
-    return std::format("[{}] {} (operation: {})", component_, what(), operation_);
+    return "[" + component_ + "] " + what() + " (operation: " + operation_ + ")";
   }
 
  private:
@@ -80,7 +79,7 @@ class UNILINK_API BuilderException : public UnilinkException {
     if (builder_type_.empty()) {
       return UnilinkException::full_message();
     }
-    return std::format("[{}] {}", builder_type_, UnilinkException::full_message());
+    return "[" + builder_type_ + "] " + UnilinkException::full_message();
   }
 
  private:
@@ -109,12 +108,12 @@ class UNILINK_API ValidationException : public UnilinkException {
       return UnilinkException::full_message();
     }
     if (expected_.empty()) {
-      return std::format("{} (parameter: {})", UnilinkException::full_message(), parameter_);
+      return UnilinkException::full_message() + " (parameter: " + parameter_ + ")";
     }
     if (parameter_.empty()) {
-      return std::format("{} (expected: {})", UnilinkException::full_message(), expected_);
+      return UnilinkException::full_message() + " (expected: " + expected_ + ")";
     }
-    return std::format("{} (parameter: {}) (expected: {})", UnilinkException::full_message(), parameter_, expected_);
+    return UnilinkException::full_message() + " (parameter: " + parameter_ + ") (expected: " + expected_ + ")";
   }
 
  private:
@@ -141,7 +140,7 @@ class UNILINK_API MemoryException : public UnilinkException {
     if (size_ == 0) {
       return UnilinkException::full_message();
     }
-    return std::format("{} (size: {} bytes)", UnilinkException::full_message(), size_);
+    return UnilinkException::full_message() + " (size: " + std::to_string(size_) + " bytes)";
   }
 
  private:
@@ -168,7 +167,7 @@ class UNILINK_API ConnectionException : public UnilinkException {
     if (connection_type_.empty()) {
       return UnilinkException::full_message();
     }
-    return std::format("[{}] {}", connection_type_, UnilinkException::full_message());
+    return "[" + connection_type_ + "] " + UnilinkException::full_message();
   }
 
  private:
@@ -195,7 +194,7 @@ class UNILINK_API ConfigurationException : public UnilinkException {
     if (config_section_.empty()) {
       return UnilinkException::full_message();
     }
-    return std::format("{} (section: {})", UnilinkException::full_message(), config_section_);
+    return UnilinkException::full_message() + " (section: " + config_section_ + ")";
   }
 
  private:

--- a/unilink/diagnostics/logger.cc
+++ b/unilink/diagnostics/logger.cc
@@ -411,7 +411,7 @@ void Logger::log(LogLevel level, std::string_view component, std::string_view op
   }
 
   // Incorporate source location information into the payload
-  std::string payload = std::format("[{}] [{}] [{}:{}:{}] {}", component, operation, loc.file_name(), loc.line(),
+  std::string payload = fmt::format("[{}] [{}] [{}:{}:{}] {}", component, operation, loc.file_name(), loc.line(),
                                     loc.function_name(), message);
 
   impl_->spd_logger_->log(Impl::to_spdlog_level(level), payload);

--- a/unilink/diagnostics/logger.hpp
+++ b/unilink/diagnostics/logger.hpp
@@ -18,7 +18,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <format>
 #include <functional>
 #include <memory>
 #include <source_location>
@@ -269,15 +268,15 @@ class UNILINK_API Logger {
           ? std::chrono::high_resolution_clock::now()                                             \
           : std::chrono::high_resolution_clock::time_point()
 
-#define UNILINK_LOG_PERF_END(component, operation)                                                         \
-  do {                                                                                                     \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) {       \
-      auto _perf_end_##operation = std::chrono::high_resolution_clock::now();                              \
-      using _us_t = std::chrono::microseconds;                                                             \
-      auto _diff_##operation = _perf_end_##operation - _perf_start_##operation;                            \
-      auto _perf_duration_##operation = std::chrono::duration_cast<_us_t>(_diff_##operation).count();      \
-      UNILINK_LOG_DEBUG(component, operation, std::format("Duration: {} μs", _perf_duration_##operation)); \
-    }                                                                                                      \
+#define UNILINK_LOG_PERF_END(component, operation)                                                                \
+  do {                                                                                                            \
+    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) {              \
+      auto _perf_end_##operation = std::chrono::high_resolution_clock::now();                                     \
+      using _us_t = std::chrono::microseconds;                                                                    \
+      auto _diff_##operation = _perf_end_##operation - _perf_start_##operation;                                   \
+      auto _perf_duration_##operation = std::chrono::duration_cast<_us_t>(_diff_##operation).count();             \
+      UNILINK_LOG_DEBUG(component, operation, "Duration: " + std::to_string(_perf_duration_##operation) + " μs"); \
+    }                                                                                                             \
   } while (0)
 
 }  // namespace diagnostics

--- a/unilink/memory/safe_data_buffer.cc
+++ b/unilink/memory/safe_data_buffer.cc
@@ -16,9 +16,10 @@
 
 #include "unilink/memory/safe_data_buffer.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <algorithm>
 #include <cstring>
-#include <format>
 
 namespace unilink {
 namespace memory {
@@ -106,7 +107,7 @@ void SafeDataBuffer::validate() const {
 // Private helper methods
 void SafeDataBuffer::validate_index(size_t index) const {
   if (index >= data_.size()) {
-    throw std::out_of_range(std::format("Index {} is out of range for buffer of size {}", index, data_.size()));
+    throw std::out_of_range(fmt::format("Index {} is out of range for buffer of size {}", index, data_.size()));
   }
 }
 

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -16,11 +16,12 @@
 
 #include "unilink/transport/serial/serial.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <atomic>
 #include <boost/asio.hpp>
 #include <cstddef>
 #include <deque>
-#include <format>
 #include <memory>
 #include <optional>
 #include <stop_token>
@@ -142,21 +143,21 @@ struct Serial::Impl {
     boost::system::error_code ec;
     port_->open(cfg_.device, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "open", std::format("Failed to open device: {} - {}", cfg_.device, ec.message()));
+      UNILINK_LOG_ERROR("serial", "open", fmt::format("Failed to open device: {} - {}", cfg_.device, ec.message()));
       handle_error(self, "open", ec);
       return;
     }
 
     port_->set_option(net::serial_port_base::baud_rate(cfg_.baud_rate), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "configure", std::format("Failed baud rate: {}", ec.message()));
+      UNILINK_LOG_ERROR("serial", "configure", fmt::format("Failed baud rate: {}", ec.message()));
       handle_error(self, "baud_rate", ec);
       return;
     }
 
     port_->set_option(net::serial_port_base::character_size(cfg_.char_size), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "configure", std::format("Failed char size: {}", ec.message()));
+      UNILINK_LOG_ERROR("serial", "configure", fmt::format("Failed char size: {}", ec.message()));
       handle_error(self, "char_size", ec);
       return;
     }
@@ -164,7 +165,7 @@ struct Serial::Impl {
     using sb = net::serial_port_base::stop_bits;
     port_->set_option(sb(cfg_.stop_bits == 2 ? sb::two : sb::one), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "configure", std::format("Failed stop bits: {}", ec.message()));
+      UNILINK_LOG_ERROR("serial", "configure", fmt::format("Failed stop bits: {}", ec.message()));
       handle_error(self, "stop_bits", ec);
       return;
     }
@@ -177,7 +178,7 @@ struct Serial::Impl {
       p = pa::odd;
     port_->set_option(pa(p), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "configure", std::format("Failed parity: {}", ec.message()));
+      UNILINK_LOG_ERROR("serial", "configure", fmt::format("Failed parity: {}", ec.message()));
       handle_error(self, "parity", ec);
       return;
     }
@@ -190,12 +191,12 @@ struct Serial::Impl {
       f = fc::hardware;
     port_->set_option(fc(f), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("serial", "configure", std::format("Failed flow control: {}", ec.message()));
+      UNILINK_LOG_ERROR("serial", "configure", fmt::format("Failed flow control: {}", ec.message()));
       handle_error(self, "flow_control", ec);
       return;
     }
 
-    UNILINK_LOG_INFO("serial", "connect", std::format("Device opened: {}", cfg_.device));
+    UNILINK_LOG_INFO("serial", "connect", fmt::format("Device opened: {}", cfg_.device));
     start_read(self);
 
     opened_.store(true);
@@ -216,7 +217,7 @@ struct Serial::Impl {
             try {
               impl->on_bytes_(memory::ConstByteSpan(impl->rx_.data(), n));
             } catch (const std::exception& e) {
-              UNILINK_LOG_ERROR("serial", "on_bytes", std::format("Exception in callback: {}", e.what()));
+              UNILINK_LOG_ERROR("serial", "on_bytes", fmt::format("Exception in callback: {}", e.what()));
               if (impl->cfg_.stop_on_callback_exception) {
                 impl->opened_.store(false);
                 impl->close_port();
@@ -332,7 +333,7 @@ struct Serial::Impl {
     bool retryable = cfg_.reopen_on_error;
     diagnostics::error_reporting::report_connection_error("serial", where, ec, retryable);
 
-    UNILINK_LOG_ERROR("serial", where, std::format("Error: {}", ec.message()));
+    UNILINK_LOG_ERROR("serial", where, fmt::format("Error: {}", ec.message()));
 
     if (cfg_.reopen_on_error) {
       opened_.store(false);
@@ -350,7 +351,7 @@ struct Serial::Impl {
 
   void schedule_retry(std::shared_ptr<Serial> self, const char* where, const boost::system::error_code& ec) {
     (void)ec;
-    UNILINK_LOG_INFO("serial", "retry", std::format("Scheduling retry at {}", where));
+    UNILINK_LOG_INFO("serial", "retry", fmt::format("Scheduling retry at {}", where));
     if (stopping_.load()) return;
     retry_timer_.expires_after(std::chrono::milliseconds(cfg_.retry_interval_ms));
     retry_timer_.async_wait([self](auto e) {
@@ -429,7 +430,7 @@ void Serial::start() {
   auto impl = get_impl();
   if (impl->started_) return;
   impl->stopping_.store(false);
-  UNILINK_LOG_INFO("serial", "start", std::format("Starting device: {}", impl->cfg_.device));
+  UNILINK_LOG_INFO("serial", "start", fmt::format("Starting device: {}", impl->cfg_.device));
   if (!impl->owns_ioc_) {
     auto& manager = concurrency::IoContextManager::instance();
     if (!manager.is_running()) manager.start();

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -525,7 +525,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
           int yes = 1;
-          (void)::setsockopt(self->impl_->socket_.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &yes, sizeof(yes));
+          (void)::setsockopt(static_cast<int>(self->impl_->socket_.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
 #endif
 
           self->impl_->transition_to(LinkState::Connected);
@@ -535,8 +535,6 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
             UNILINK_LOG_INFO("tcp_client", "connect",
                              fmt::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
           }
-          self->impl_->connected_.store(true);
-          self->impl_->transition_to(LinkState::Connected);
           self->impl_->start_read(self, seq);
           net::post(self->impl_->strand_, [self, seq]() {
             self->impl_->writing_ = false;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -525,7 +525,8 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
           int yes = 1;
-          (void)::setsockopt(static_cast<int>(self->impl_->socket_.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes, static_cast<socklen_t>(sizeof(yes)));
+          (void)::setsockopt(static_cast<int>(self->impl_->socket_.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes,
+                             static_cast<socklen_t>(sizeof(yes)));
 #endif
 
           self->impl_->transition_to(LinkState::Connected);

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -20,6 +20,8 @@
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 
+#include <spdlog/fmt/fmt.h>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -27,7 +29,6 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
-#include <format>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -214,9 +215,9 @@ void TcpClient::start() {
         std::stop_callback cb(st, [ioc] { ioc->stop(); });
         ioc->run();
       } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("tcp_client", "io_context", std::format("IO context error: {}", e.what()));
+        UNILINK_LOG_ERROR("tcp_client", "io_context", fmt::format("IO context error: {}", e.what()));
         diagnostics::error_reporting::report_system_error("tcp_client", "io_context",
-                                                          std::format("Exception in IO context: {}", e.what()));
+                                                          fmt::format("Exception in IO context: {}", e.what()));
       }
     });
   }
@@ -278,7 +279,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_copy",
-                      std::format("Write size exceeds maximum allowed ({} bytes)", size));
+                      fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
     return false;
   }
 
@@ -299,7 +300,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
           if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
             UNILINK_LOG_ERROR("tcp_client", "write",
-                              std::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+                              fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
             self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION,
                                       "write", boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
             self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
@@ -314,7 +315,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
         return true;
       }
     } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("tcp_client", "async_write_copy", std::format("Failed to acquire pooled buffer: {}", e.what()));
+      UNILINK_LOG_ERROR("tcp_client", "async_write_copy", fmt::format("Failed to acquire pooled buffer: {}", e.what()));
     }
   }
 
@@ -331,7 +332,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
     if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_client", "write",
-                        std::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+                        fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
       self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
@@ -358,7 +359,7 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
   }
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_move",
-                      std::format("Write size exceeds maximum allowed ({} bytes)", size));
+                      fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
     return false;
   }
 
@@ -374,7 +375,7 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
 
     if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_client", "write",
-                        std::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+                        fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
       self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
@@ -401,7 +402,7 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   const auto size = data->size();
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_shared",
-                      std::format("Write size exceeds maximum allowed ({} bytes)", size));
+                      fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
     return false;
   }
 
@@ -417,7 +418,7 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
 
     if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_client", "write",
-                        std::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+                        fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
       self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
@@ -461,7 +462,7 @@ void TcpClient::set_reconnect_policy(ReconnectPolicy policy) {
 
 void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64_t seq) {
   resolver_.async_resolve(
-      cfg_.host, std::format("{}", cfg_.port), [self, seq](auto ec, tcp::resolver::results_type results) {
+      cfg_.host, fmt::format("{}", cfg_.port), [self, seq](auto ec, tcp::resolver::results_type results) {
         if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) {
           return;
         }
@@ -473,7 +474,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
                                           ? self->impl_->reconnect_attempt_count_
                                           : static_cast<uint32_t>(self->impl_->retry_attempts_);
           self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "resolve",
-                                    ec, std::format("Resolution failed: {}", ec.message()),
+                                    ec, fmt::format("Resolution failed: {}", ec.message()),
                                     diagnostics::is_retryable_tcp_connect_error(ec), current_attempts);
           self->impl_->schedule_retry(self, seq);
           return;
@@ -485,7 +486,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
           }
           if (!timer_ec && !self->impl_->stop_requested_.load() && !self->impl_->stopping_.load()) {
             UNILINK_LOG_ERROR("tcp_client", "connect_timeout",
-                              std::format("Connection timed out after {}ms", self->impl_->cfg_.connection_timeout_ms));
+                              fmt::format("Connection timed out after {}ms", self->impl_->cfg_.connection_timeout_ms));
             uint32_t current_attempts = self->impl_->reconnect_policy_
                                             ? self->impl_->reconnect_attempt_count_
                                             : static_cast<uint32_t>(self->impl_->retry_attempts_);
@@ -512,7 +513,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
                                             ? self->impl_->reconnect_attempt_count_
                                             : static_cast<uint32_t>(self->impl_->retry_attempts_);
             self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "connect",
-                                      ec2, std::format("Connection failed: {}", ec2.message()),
+                                      ec2, fmt::format("Connection failed: {}", ec2.message()),
                                       diagnostics::is_retryable_tcp_connect_error(ec2), current_attempts);
             self->impl_->schedule_retry(self, seq);
             return;
@@ -532,7 +533,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
           auto rep = self->impl_->socket_.remote_endpoint(ep_ec);
           if (!ep_ec) {
             UNILINK_LOG_INFO("tcp_client", "connect",
-                             std::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
+                             fmt::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
           }
           self->impl_->connected_.store(true);
           self->impl_->transition_to(LinkState::Connected);
@@ -595,7 +596,7 @@ void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t s
   transition_to(LinkState::Connecting);
 
   UNILINK_LOG_INFO("tcp_client", "retry",
-                   std::format("Scheduling retry in {:.3f}s", static_cast<double>(delay.count()) / 1000.0));
+                   fmt::format("Scheduling retry in {:.3f}s", static_cast<double>(delay.count()) / 1000.0));
 
   retry_timer_.expires_after(delay);
   retry_timer_.async_wait([self, seq](const boost::system::error_code& ec) {
@@ -632,10 +633,10 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
       try {
         on_bytes(memory::ConstByteSpan(self->impl_->rx_.data(), n));
       } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("tcp_client", "on_bytes", std::format("Exception in on_bytes callback: {}", e.what()));
+        UNILINK_LOG_ERROR("tcp_client", "on_bytes", fmt::format("Exception in on_bytes callback: {}", e.what()));
         self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "on_bytes",
                                   boost::asio::error::connection_aborted,
-                                  std::format("Exception in on_bytes: {}", e.what()), false, 0);
+                                  fmt::format("Exception in on_bytes: {}", e.what()), false, 0);
         self->impl_->handle_close(self, seq, make_error_code(boost::asio::error::connection_aborted));
         return;
       } catch (...) {
@@ -700,9 +701,9 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
       }
       self->impl_->current_write_buffer_.reset();
 
-      UNILINK_LOG_ERROR("tcp_client", "do_write", std::format("Write failed: {}", ec.message()));
+      UNILINK_LOG_ERROR("tcp_client", "do_write", fmt::format("Write failed: {}", ec.message()));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write", ec,
-                                std::format("Write failed: {}", ec.message()), false, 0);
+                                fmt::format("Write failed: {}", ec.message()), false, 0);
       self->impl_->writing_ = false;
       self->impl_->handle_close(self, seq, ec);
       return;
@@ -738,14 +739,14 @@ void TcpClient::Impl::handle_close(std::shared_ptr<TcpClient> self, uint64_t seq
   if (ec == net::error::operation_aborted || seq != current_seq_.load()) {
     return;
   }
-  UNILINK_LOG_INFO("tcp_client", "handle_close", std::format("Closing connection. Error: {}", ec.message()));
+  UNILINK_LOG_INFO("tcp_client", "handle_close", fmt::format("Closing connection. Error: {}", ec.message()));
   if (ec) {
     const bool retryable = diagnostics::is_retryable_tcp_connect_error(ec);
     const uint32_t current_attempts =
         reconnect_policy_ ? reconnect_attempt_count_ : static_cast<uint32_t>(retry_attempts_);
 
     record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "handle_close", ec,
-                 std::format("Connection closed with error: {}", ec.message()), retryable, current_attempts);
+                 fmt::format("Connection closed with error: {}", ec.message()), retryable, current_attempts);
   }
   connected_.store(false);
   writing_ = false;
@@ -815,7 +816,7 @@ void TcpClient::Impl::report_backpressure(size_t queued_bytes) {
       on_bp(queued_bytes);
     } catch (const std::exception& e) {
       UNILINK_LOG_ERROR("tcp_client", "on_backpressure",
-                        std::format("Exception in backpressure callback: {}", e.what()));
+                        fmt::format("Exception in backpressure callback: {}", e.what()));
     } catch (...) {
       UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
     }
@@ -825,7 +826,7 @@ void TcpClient::Impl::report_backpressure(size_t queued_bytes) {
       on_bp(queued_bytes);
     } catch (const std::exception& e) {
       UNILINK_LOG_ERROR("tcp_client", "on_backpressure",
-                        std::format("Exception in backpressure callback: {}", e.what()));
+                        fmt::format("Exception in backpressure callback: {}", e.what()));
     } catch (...) {
       UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
     }
@@ -875,11 +876,11 @@ void TcpClient::Impl::perform_stop_cleanup() {
     }
     transition_to(LinkState::Closed);
   } catch (const std::exception& e) {
-    UNILINK_LOG_ERROR("tcp_client", "stop_cleanup", std::format("Cleanup error: {}", e.what()));
+    UNILINK_LOG_ERROR("tcp_client", "stop_cleanup", fmt::format("Cleanup error: {}", e.what()));
     record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "stop_cleanup", {},
-                 std::format("Cleanup error: {}", e.what()), false, 0);
+                 fmt::format("Cleanup error: {}", e.what()), false, 0);
     diagnostics::error_reporting::report_system_error("tcp_client", "stop_cleanup",
-                                                      std::format("Exception in stop cleanup: {}", e.what()));
+                                                      fmt::format("Exception in stop cleanup: {}", e.what()));
   } catch (...) {
     UNILINK_LOG_ERROR("tcp_client", "stop_cleanup", "Unknown error in stop cleanup");
     diagnostics::error_reporting::report_system_error("tcp_client", "stop_cleanup", "Unknown error in stop cleanup");
@@ -964,11 +965,11 @@ void TcpClient::Impl::reset_io_objects() {
     writing_ = false;
     backpressure_active_ = false;
   } catch (const std::exception& e) {
-    UNILINK_LOG_ERROR("tcp_client", "reset_io_objects", std::format("Reset error: {}", e.what()));
+    UNILINK_LOG_ERROR("tcp_client", "reset_io_objects", fmt::format("Reset error: {}", e.what()));
     record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "reset_io_objects", {},
-                 std::format("Reset error: {}", e.what()), false, 0);
+                 fmt::format("Reset error: {}", e.what()), false, 0);
     diagnostics::error_reporting::report_system_error(
-        "tcp_client", "reset_io_objects", std::format("Exception while resetting io objects: {}", e.what()));
+        "tcp_client", "reset_io_objects", fmt::format("Exception while resetting io objects: {}", e.what()));
   } catch (...) {
     UNILINK_LOG_ERROR("tcp_client", "reset_io_objects", "Unknown reset error");
     diagnostics::error_reporting::report_system_error("tcp_client", "reset_io_objects",

--- a/unilink/transport/tcp_server/boost_tcp_socket.cc
+++ b/unilink/transport/tcp_server/boost_tcp_socket.cc
@@ -30,7 +30,8 @@ using tcp = net::ip::tcp;
 BoostTcpSocket::BoostTcpSocket(tcp::socket sock) : socket_(std::move(sock)) {
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
   int yes = 1;
-  (void)::setsockopt(socket_.native_handle(), SOL_SOCKET, SO_NOSIGPIPE, &yes, sizeof(yes));
+  (void)::setsockopt(static_cast<int>(socket_.native_handle()), SOL_SOCKET, SO_NOSIGPIPE, &yes,
+                     static_cast<socklen_t>(sizeof(yes)));
 #endif
 }
 

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -16,9 +16,10 @@
 
 #include "unilink/transport/tcp_server/tcp_server.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <atomic>
 #include <boost/asio.hpp>
-#include <format>
 #include <future>
 #include <iostream>
 #include <mutex>
@@ -136,7 +137,7 @@ struct TcpServer::Impl {
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
       UNILINK_LOG_ERROR("tcp_server", "bind",
-                        std::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message()));
+                        fmt::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message()));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -145,7 +146,7 @@ struct TcpServer::Impl {
     if (!acceptor_->is_open()) {
       acceptor_->open(address.is_v6() ? tcp::v6() : tcp::v4(), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("tcp_server", "open", std::format("Failed to open acceptor: {}", ec.message()));
+        UNILINK_LOG_ERROR("tcp_server", "open", fmt::format("Failed to open acceptor: {}", ec.message()));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -167,7 +168,7 @@ struct TcpServer::Impl {
         });
         return;
       } else {
-        UNILINK_LOG_ERROR("tcp_server", "bind", std::format("Failed to bind to port {}: {}", cfg_.port, ec.message()));
+        UNILINK_LOG_ERROR("tcp_server", "bind", fmt::format("Failed to bind to port {}: {}", cfg_.port, ec.message()));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -177,7 +178,7 @@ struct TcpServer::Impl {
     acceptor_->listen(boost::asio::socket_base::max_listen_connections, ec);
     if (ec) {
       UNILINK_LOG_ERROR("tcp_server", "listen",
-                        std::format("Failed to listen on port {}: {}", cfg_.port, ec.message()));
+                        fmt::format("Failed to listen on port {}: {}", cfg_.port, ec.message()));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -218,7 +219,7 @@ struct TcpServer::Impl {
       auto rep = sock.remote_endpoint(ep_ec);
       std::string client_info = "unknown";
       if (!ep_ec) {
-        client_info = std::format("{}:{}", rep.address().to_string(), rep.port());
+        client_info = fmt::format("{}:{}", rep.address().to_string(), rep.port());
       }
 
       if (accept_impl->client_limit_enabled_) {

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -16,12 +16,13 @@
 
 #include "unilink/transport/udp/udp.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <array>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <cstddef>
 #include <deque>
-#include <format>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -152,7 +153,7 @@ struct UdpChannel::Impl {
     boost::system::error_code ec;
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", std::format("Invalid bind address: {}", cfg_.bind_address));
+      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Invalid bind address: {}", cfg_.bind_address));
       transition_to(LinkState::Error, ec);
       return;
     }
@@ -160,7 +161,7 @@ struct UdpChannel::Impl {
     local_endpoint_ = udp::endpoint(address, cfg_.local_port);
     socket_.open(local_endpoint_.protocol(), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "open", std::format("Socket open failed: {}", ec.message()));
+      UNILINK_LOG_ERROR("udp", "open", fmt::format("Socket open failed: {}", ec.message()));
       transition_to(LinkState::Error, ec);
       return;
     }
@@ -168,7 +169,7 @@ struct UdpChannel::Impl {
     if (cfg_.reuse_address) {
       socket_.set_option(net::socket_base::reuse_address(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", std::format("Failed to set reuse_address: {}", ec.message()));
+        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set reuse_address: {}", ec.message()));
         transition_to(LinkState::Error, ec);
         return;
       }
@@ -177,7 +178,7 @@ struct UdpChannel::Impl {
     if (cfg_.enable_broadcast) {
       socket_.set_option(net::socket_base::broadcast(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", std::format("Failed to set broadcast: {}", ec.message()));
+        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set broadcast: {}", ec.message()));
         transition_to(LinkState::Error, ec);
         return;
       }
@@ -185,7 +186,7 @@ struct UdpChannel::Impl {
 
     socket_.bind(local_endpoint_, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", std::format("Bind failed: {}", ec.message()));
+      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Bind failed: {}", ec.message()));
       transition_to(LinkState::Error, ec);
       return;
     }
@@ -235,7 +236,7 @@ struct UdpChannel::Impl {
     }
 
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "receive", std::format("Receive failed: {}", ec.message()));
+      UNILINK_LOG_ERROR("udp", "receive", fmt::format("Receive failed: {}", ec.message()));
       transition_to(LinkState::Error, ec);
       return;
     }
@@ -251,7 +252,7 @@ struct UdpChannel::Impl {
         try {
           on_bytes_(memory::ConstByteSpan(rx_.data(), bytes));
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes", std::format("Exception in bytes callback: {}", e.what()));
+          UNILINK_LOG_ERROR("udp", "on_bytes", fmt::format("Exception in bytes callback: {}", e.what()));
           if (cfg_.stop_on_callback_exception) {
             transition_to(LinkState::Error);
             return;
@@ -269,7 +270,7 @@ struct UdpChannel::Impl {
         try {
           on_bytes_from_(memory::ConstByteSpan(rx_.data(), bytes), recv_endpoint_);
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes_from", std::format("Exception in bytes callback: {}", e.what()));
+          UNILINK_LOG_ERROR("udp", "on_bytes_from", fmt::format("Exception in bytes callback: {}", e.what()));
           if (cfg_.stop_on_callback_exception) {
             transition_to(LinkState::Error);
             return;
@@ -344,7 +345,7 @@ struct UdpChannel::Impl {
       }
 
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "write", std::format("Send failed: {}", ec.message()));
+        UNILINK_LOG_ERROR("udp", "write", fmt::format("Send failed: {}", ec.message()));
         impl->transition_to(LinkState::Error, ec);
         impl->writing_ = false;
         return;
@@ -393,7 +394,7 @@ struct UdpChannel::Impl {
     try {
       on_state_(state_.state());
     } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("udp", "on_state", std::format("Exception in state callback: {}", e.what()));
+      UNILINK_LOG_ERROR("udp", "on_state", fmt::format("Exception in state callback: {}", e.what()));
     } catch (...) {
       UNILINK_LOG_ERROR("udp", "on_state", "Unknown exception in state callback");
     }
@@ -407,7 +408,7 @@ struct UdpChannel::Impl {
       try {
         on_bp_(queued_bytes);
       } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", std::format("Exception in backpressure callback: {}", e.what()));
+        UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
       } catch (...) {
         UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
       }
@@ -416,7 +417,7 @@ struct UdpChannel::Impl {
       try {
         on_bp_(queued_bytes);
       } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", std::format("Exception in backpressure callback: {}", e.what()));
+        UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
       } catch (...) {
         UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
       }
@@ -449,7 +450,7 @@ struct UdpChannel::Impl {
     }
 
     if (queue_bytes_ + size > bp_limit_) {
-      UNILINK_LOG_ERROR("udp", "write", std::format("Queue limit exceeded ({} bytes)", queue_bytes_ + size));
+      UNILINK_LOG_ERROR("udp", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + size));
       report_backpressure(queue_bytes_ + size);
       return false;
     }

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -20,12 +20,13 @@
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 
+#include <spdlog/fmt/fmt.h>
+
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <deque>
-#include <format>
 #include <memory>
 #include <mutex>
 #include <stop_token>
@@ -261,7 +262,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     impl_->maybe_flush_for_keep_latest(added);
     if (impl_->queue_bytes_ + added > impl_->bp_limit_) {
       UNILINK_LOG_ERROR("uds_client", "write",
-                        std::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
+                        fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
       impl_->report_backpressure(impl_->queue_bytes_ + added);
       return;
     }
@@ -282,7 +283,7 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     impl_->maybe_flush_for_keep_latest(added);
     if (impl_->queue_bytes_ + added > impl_->bp_limit_) {
       UNILINK_LOG_ERROR("uds_client", "write",
-                        std::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
+                        fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
       impl_->report_backpressure(impl_->queue_bytes_ + added);
       return;
     }
@@ -526,7 +527,7 @@ void UdsClient::Impl::report_backpressure(size_t queued_bytes) {
       on_bp(queued_bytes);
     } catch (const std::exception& e) {
       UNILINK_LOG_ERROR("uds_client", "on_backpressure",
-                        std::format("Exception in backpressure callback: {}", e.what()));
+                        fmt::format("Exception in backpressure callback: {}", e.what()));
     } catch (...) {
       UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
     }
@@ -536,7 +537,7 @@ void UdsClient::Impl::report_backpressure(size_t queued_bytes) {
       on_bp(queued_bytes);
     } catch (const std::exception& e) {
       UNILINK_LOG_ERROR("uds_client", "on_backpressure",
-                        std::format("Exception in backpressure callback: {}", e.what()));
+                        fmt::format("Exception in backpressure callback: {}", e.what()));
     } catch (...) {
       UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
     }

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -16,11 +16,12 @@
 
 #include "unilink/transport/uds/uds_server.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <algorithm>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <cstdio>
-#include <format>
 #include <mutex>
 #include <stop_token>
 #include <string_view>
@@ -134,7 +135,7 @@ void UdsServer::start() {
   boost::system::error_code ec;
   impl_->acceptor_->open(uds(), ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", std::format("Failed to open acceptor: {}", ec.message()));
+    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to open acceptor: {}", ec.message()));
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -144,7 +145,7 @@ void UdsServer::start() {
   try {
     endpoint = uds::endpoint(impl_->cfg_.socket_path);
   } catch (const std::exception& e) {
-    UNILINK_LOG_ERROR("uds_server", "start", std::format("Invalid UDS endpoint: {}", e.what()));
+    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Invalid UDS endpoint: {}", e.what()));
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -153,7 +154,7 @@ void UdsServer::start() {
   impl_->acceptor_->bind(endpoint, ec);
   if (ec) {
     UNILINK_LOG_ERROR("uds_server", "start",
-                      std::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message()));
+                      fmt::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message()));
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -161,7 +162,7 @@ void UdsServer::start() {
 
   impl_->acceptor_->listen(net::socket_base::max_listen_connections, ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", std::format("Failed to listen: {}", ec.message()));
+    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to listen: {}", ec.message()));
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -430,7 +431,7 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
     } else {
       // Log only real errors, not operation_aborted
       if (ec != boost::asio::error::operation_aborted) {
-        UNILINK_LOG_ERROR("uds_server", "accept", std::format("Accept failed: {}", ec.message()));
+        UNILINK_LOG_ERROR("uds_server", "accept", fmt::format("Accept failed: {}", ec.message()));
       }
     }
   });

--- a/unilink/util/input_validator.hpp
+++ b/unilink/util/input_validator.hpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
-#include <format>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -91,16 +90,15 @@ class UNILINK_API InputValidator {
 // Inline implementations for simple validations
 inline void InputValidator::validate_non_empty_string(const std::string& str, const std::string& field_name) {
   if (str.empty()) {
-    throw diagnostics::ValidationException(std::format("{} cannot be empty", field_name), field_name,
-                                           "non-empty string");
+    throw diagnostics::ValidationException(field_name + " cannot be empty", field_name, "non-empty string");
   }
 }
 
 inline void InputValidator::validate_string_length(const std::string& str, size_t max_length,
                                                    const std::string& field_name) {
   if (str.length() > max_length) {
-    throw diagnostics::ValidationException(std::format("{} length exceeds maximum allowed length", field_name),
-                                           field_name, std::format("length <= {}", max_length));
+    throw diagnostics::ValidationException(field_name + " length exceeds maximum allowed length", field_name,
+                                           "length <= " + std::to_string(max_length));
   }
 }
 
@@ -112,15 +110,15 @@ inline void InputValidator::validate_positive_number(int64_t value, const std::s
 
 inline void InputValidator::validate_range(int64_t value, int64_t min, int64_t max, const std::string& field_name) {
   if (value < min || value > max) {
-    throw diagnostics::ValidationException(std::format("{} out of range", field_name), field_name,
-                                           std::format("{} <= value <= {}", min, max));
+    throw diagnostics::ValidationException(field_name + " out of range", field_name,
+                                           std::to_string(min) + " <= value <= " + std::to_string(max));
   }
 }
 
 inline void InputValidator::validate_range(size_t value, size_t min, size_t max, const std::string& field_name) {
   if (value < min || value > max) {
-    throw diagnostics::ValidationException(std::format("{} out of range", field_name), field_name,
-                                           std::format("{} <= value <= {}", min, max));
+    throw diagnostics::ValidationException(field_name + " out of range", field_name,
+                                           std::to_string(min) + " <= value <= " + std::to_string(max));
   }
 }
 
@@ -146,7 +144,8 @@ inline void InputValidator::validate_retry_count(int retry_count) {
   if (retry_count < FINITE_MIN_RETRY_COUNT || retry_count > FINITE_MAX_RETRY_COUNT) {
     throw diagnostics::ValidationException(
         "retry_count out of range", "retry_count",
-        std::format("{} <= retry_count <= {} or -1 for infinite", FINITE_MIN_RETRY_COUNT, FINITE_MAX_RETRY_COUNT));
+        std::to_string(FINITE_MIN_RETRY_COUNT) + " <= retry_count <= " + std::to_string(FINITE_MAX_RETRY_COUNT) +
+            " or -1 for infinite"));
   }
 }
 
@@ -180,7 +179,7 @@ inline void InputValidator::validate_memory_alignment(const void* ptr, size_t al
   uintptr_t address = reinterpret_cast<uintptr_t>(ptr);
   if (address % alignment != 0) {
     throw diagnostics::ValidationException("memory pointer not properly aligned", "ptr",
-                                           std::format("aligned to {} bytes", alignment));
+                                           "aligned to " + std::to_string(alignment) + " bytes");
   }
 }
 

--- a/unilink/util/input_validator.hpp
+++ b/unilink/util/input_validator.hpp
@@ -142,10 +142,9 @@ inline void InputValidator::validate_retry_count(int retry_count) {
     return;
   }
   if (retry_count < FINITE_MIN_RETRY_COUNT || retry_count > FINITE_MAX_RETRY_COUNT) {
-    throw diagnostics::ValidationException(
-        "retry_count out of range", "retry_count",
-        std::to_string(FINITE_MIN_RETRY_COUNT) + " <= retry_count <= " + std::to_string(FINITE_MAX_RETRY_COUNT) +
-            " or -1 for infinite"));
+    throw diagnostics::ValidationException("retry_count out of range", "retry_count",
+                                           std::to_string(FINITE_MIN_RETRY_COUNT) + " <= retry_count <= " +
+                                               std::to_string(FINITE_MAX_RETRY_COUNT) + " or -1 for infinite");
   }
 }
 

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -16,10 +16,11 @@
 
 #include "unilink/wrapper/udp/udp_server.hpp"
 
+#include <spdlog/fmt/fmt.h>
+
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
-#include <format>
 #include <iostream>
 #include <mutex>
 #include <shared_mutex>
@@ -202,7 +203,7 @@ struct UdpServer::Impl {
       for (auto it = sessions.begin(); it != sessions.end();) {
         if (now - it->second.last_seen > session_timeout) {
           std::string info =
-              std::format("{}:{}", it->second.endpoint.address().to_string(), it->second.endpoint.port());
+              fmt::format("{}:{}", it->second.endpoint.address().to_string(), it->second.endpoint.port());
           endpoint_to_id.erase(it->second.endpoint);
           to_remove_with_info.push_back({it->first, info});
           it = sessions.erase(it);
@@ -283,7 +284,7 @@ struct UdpServer::Impl {
       }
 
       if (is_new && connect_handler_copy) {
-        connect_handler_copy(ConnectionContext(client_id, std::format("{}:{}", ep.address().to_string(), ep.port())));
+        connect_handler_copy(ConnectionContext(client_id, fmt::format("{}:{}", ep.address().to_string(), ep.port())));
       }
 
       {


### PR DESCRIPTION
## Description

Replaces all uses of `std::format` with `fmt::format` (via spdlog's bundled fmt) in internal `.cc` files, and with plain string concatenation in public headers. This lowers the minimum GCC requirement from 13 to 10, restoring support for Ubuntu 22.04 LTS and Jetson Orin Nano (Jetpack 6 / GCC 11) without introducing any new public dependencies.

Previously, `std::format` was the sole reason for the GCC 13 hard requirement. All other C++20 features in use (`std::jthread`, `std::span`, `std::source_location`, concepts) are supported from GCC 10.

## Key Changes

- **Public headers** (`exceptions.hpp`, `logger.hpp`, `input_validator.hpp`): removed `#include <format>` and replaced `std::format(...)` calls with plain `std::string` concatenation and `std::to_string`. This eliminates the GCC 13 constraint for downstream consumers of the library.
- **Internal `.cc` files** (10 files): replaced `#include <format>` with `#include <spdlog/fmt/fmt.h>` and `std::format` with `fmt::format`. spdlog is already a PRIVATE dependency, so no new transitive dependency is introduced.
- **`cmake/UnilinkCompiler.cmake`**: lowered GCC minimum version check from `13.0` to `10.0` and updated the error message accordingly.
- **`cmake/UnilinkOptions.cmake`**: removed the `UNILINK_HAS_STD_FORMAT` compile-time probe that previously blocked configuration on GCC < 13.

## Related Issues

- N/A

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Why not use `fmt` as a public dependency?**
spdlog already bundles fmt internally. Adding fmt as a separate `PUBLIC` CMake dependency would risk ODR violations (two copies of fmt symbols) unless spdlog is rebuilt with `SPDLOG_FMT_EXTERNAL=ON`. The chosen approach avoids that complexity entirely by keeping fmt usage PRIVATE.

**Supported environment before and after:**

| Environment | Before | After |
|---|---|---|
| Ubuntu 24.04 (GCC 13) | ✅ | ✅ |
| Ubuntu 22.04 LTS (GCC 11) | ❌ | ✅ |
| Jetson Orin Nano — Jetpack 6 (GCC 11) | ❌ | ✅ |
| Ubuntu 20.04 (GCC 9) | ❌ | ❌ (GCC 10 required) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed compiler and library gates (GCC and Boost minimums lowered; Clang message wording adjusted)
  * Removed strict C++20 std::format feature check
  * Replaced std::format usage with alternative formatter for logging and error messages across networking, diagnostics, memory, and utilities
  * Updated CI/macOS and Windows runner targets and release artifact uploads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->