### PR TITLE
ci: stabilize release workflows and expand Ubuntu 22.04 ARM support

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -75,4 +75,5 @@ runs:
           echo "VCPKG_ROOT=${VCPKG_ROOT}"
           echo "VCPKG_TARGET_TRIPLET=${{ inputs.triplet }}"
           echo "CMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+          echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite"
         } >> "$GITHUB_ENV"

--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -18,28 +18,59 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        VCPKG_ROOT="${{ inputs.vcpkg-root }}"
-        if [ -z "${VCPKG_ROOT}" ]; then
-          VCPKG_ROOT="${GITHUB_WORKSPACE}/vcpkg"
+        
+        # Determine VCPKG_ROOT and VCPKG_EXE based on OS
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+          # Use pre-installed vcpkg on Windows runner if available, otherwise use workspace
+          if [ -d "C:/vcpkg" ]; then
+            VCPKG_ROOT="C:/vcpkg"
+          else
+            VCPKG_ROOT="${GITHUB_WORKSPACE}/vcpkg-repo"
+          fi
+          VCPKG_EXE="${VCPKG_ROOT}/vcpkg.exe"
+          
+          if [ ! -f "${VCPKG_EXE}" ]; then
+            echo "vcpkg not found at ${VCPKG_ROOT}, cloning..."
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
+            "${VCPKG_ROOT}/bootstrap-vcpkg.bat" -disableMetrics
+          fi
+        else
+          VCPKG_ROOT="${{ inputs.vcpkg-root }}"
+          if [ -z "${VCPKG_ROOT}" ]; then
+            VCPKG_ROOT="${GITHUB_WORKSPACE}/vcpkg-repo"
+          fi
+          if [ ! -d "${VCPKG_ROOT}/.git" ]; then
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
+          fi
+          if [ ! -f "${VCPKG_ROOT}/vcpkg" ]; then
+            "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
+          fi
+          VCPKG_EXE="${VCPKG_ROOT}/vcpkg"
         fi
-        if [ ! -d "${VCPKG_ROOT}/.git" ]; then
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
-        fi
-        "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
+
+        echo "Using vcpkg at: ${VCPKG_ROOT}"
+
         retry_vcpkg_install() {
           local attempt
-          for attempt in 1 2 3; do
-            if "${VCPKG_ROOT}/vcpkg" install ${{ inputs.packages }} --triplet "${{ inputs.triplet }}" --overlay-triplets "${GITHUB_WORKSPACE}/vcpkg/triplets" --clean-after-build; then
+          local max_attempts=3
+          for attempt in $(seq 1 $max_attempts); do
+            echo "vcpkg install attempt ${attempt} of ${max_attempts}..."
+            if "${VCPKG_EXE}" install ${{ inputs.packages }} \
+                --triplet "${{ inputs.triplet }}" \
+                --overlay-triplets "${GITHUB_WORKSPACE}/vcpkg/triplets" \
+                --clean-after-build; then
               return 0
             fi
-            if [ "${attempt}" -eq 3 ]; then
+            if [ "${attempt}" -eq "${max_attempts}" ]; then
               return 1
             fi
-            echo "vcpkg install failed; retrying attempt $((attempt + 1)) of 3..."
+            echo "vcpkg install failed; retrying in $((attempt * 10)) seconds..."
             sleep $((attempt * 10))
           done
         }
+        
         retry_vcpkg_install
+        
         {
           echo "VCPKG_ROOT=${VCPKG_ROOT}"
           echo "VCPKG_TARGET_TRIPLET=${{ inputs.triplet }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
             cc: clang-18
             cxx: clang++-18
             triplet: x64-linux
+          - os: ubuntu-22.04-arm
+            compiler: gcc
+            cc: gcc-13
+            cxx: g++-13
+            triplet: arm64-linux
 
     steps:
     - name: Checkout code
@@ -62,11 +67,16 @@ jobs:
           build-essential \
           cmake \
           doxygen \
-          graphviz
+          graphviz \
+          software-properties-common
 
         echo "Installing compiler: ${{ matrix.compiler }} for ${{ matrix.os }}"
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          sudo apt-get install -y gcc-13 g++-13
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]] && [[ "${{ matrix.cc }}" == "gcc-13" ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+          fi
+          sudo apt-get install -y ${{ matrix.cc }} ${{ matrix.cxx }}
         else
           sudo apt-get install -y ${{ matrix.cc }} g++-13
         fi
@@ -146,64 +156,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set CMake path without spaces
+    - name: Set up C++ toolchain (Windows)
       shell: pwsh
       run: |
+        choco install ninja --no-progress -y
         echo "CMAKE_EXE=C:/PROGRA~1/CMake/bin/cmake.exe" >> $env:GITHUB_ENV
         echo "CTEST_EXE=C:/PROGRA~1/CMake/bin/ctest.exe" >> $env:GITHUB_ENV
 
-    - name: Clone vcpkg
-      run: git clone --depth 1 https://github.com/microsoft/vcpkg.git "${{ github.workspace }}/vcpkg"
-
-    - name: Bootstrap vcpkg
-      shell: pwsh
-      working-directory: ${{ github.workspace }}/vcpkg
-      run: .\bootstrap-vcpkg.bat
-
-    - name: Create Custom Triplet
-      shell: pwsh
-      run: |
-        $tripletPath = Join-Path "${{ github.workspace }}\vcpkg" "triplets/x64-windows-static-md.cmake"
-        Set-Content -Path $tripletPath -Value @"
-        set(VCPKG_TARGET_ARCHITECTURE x64)
-        set(VCPKG_CRT_LINKAGE dynamic)
-        set(VCPKG_LIBRARY_LINKAGE static)
-        "@
-
-    - name: Install Dependencies (vcpkg)
-      shell: pwsh
-      env:
-        VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-        VCPKG_USE_SYSTEM_BINARIES: "1"
-      run: |
-        $retries = 3
-        $count = 0
-        $success = $false
-        do {
-          try {
-            & "$env:VCPKG_ROOT\vcpkg.exe" install boost-system boost-asio spdlog --triplet x64-windows-static-md
-            if ($LASTEXITCODE -eq 0) {
-              $success = $true
-            } else {
-              throw "vcpkg install failed with exit code $LASTEXITCODE"
-            }
-          } catch {
-            $count++
-            if ($count -lt $retries) {
-              Write-Host "Command failed. Retrying ($count/$retries) in 10s..."
-              Start-Sleep -Seconds 10
-            } else {
-              Write-Error "Command failed after $retries attempts."
-              exit 1
-            }
-          }
-        } until ($success)
+    - name: Install dependencies with vcpkg
+      uses: ./.github/actions/setup-vcpkg
+      with:
+        triplet: x64-windows
+        packages: boost-system boost-asio spdlog
 
     - name: Configure CMake (MSVC + vcpkg)
       shell: pwsh
-      env:
-        VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-        VCPKG_USE_SYSTEM_BINARIES: "1"
       run: |
         & "$env:CMAKE_EXE" -S . -B build-windows `
           -G "Visual Studio 17 2022" -A x64 `
@@ -212,8 +179,8 @@ jobs:
           -DUNILINK_ENABLE_CONFIG=ON `
           -DUNILINK_BUILD_EXAMPLES=OFF `
           -DUNILINK_BUILD_TESTS=ON `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
-          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
+          -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" `
+          -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
 
     - name: Build (Release)
       shell: pwsh

--- a/.github/workflows/ci-install-consume.yml
+++ b/.github/workflows/ci-install-consume.yml
@@ -20,22 +20,36 @@ on:
 
 jobs:
   build-test-install-consume:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        compiler: [gcc, clang]
+        include:
+          - os: ubuntu-24.04
+            compiler: gcc
+          - os: ubuntu-24.04
+            compiler: clang
+          - os: ubuntu-22.04-arm
+            compiler: gcc
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up C++ toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build
+          sudo apt-get install -y build-essential cmake ninja-build software-properties-common
           
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
-            sudo apt-get install -y gcc-13 g++-13
-            echo "CC=gcc-13" >> $GITHUB_ENV
-            echo "CXX=g++-13" >> $GITHUB_ENV
+            if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]]; then
+              sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+              sudo apt-get update
+              sudo apt-get install -y gcc-13 g++-13
+              echo "CC=gcc-13" >> $GITHUB_ENV
+              echo "CXX=g++-13" >> $GITHUB_ENV
+            else
+              sudo apt-get install -y gcc-13 g++-13
+              echo "CC=gcc-13" >> $GITHUB_ENV
+              echo "CXX=g++-13" >> $GITHUB_ENV
+            fi
           else
             sudo apt-get install -y clang-18 g++-13
             echo "CC=clang-18" >> $GITHUB_ENV
@@ -46,7 +60,7 @@ jobs:
       - name: Install dependencies with vcpkg
         uses: ./.github/actions/setup-vcpkg
         with:
-          triplet: x64-linux
+          triplet: ${{ contains(matrix.os, 'arm') && 'arm64-linux' || 'x64-linux' }}
 
       - name: Configure
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,6 +48,15 @@ jobs:
             build_type: Release
             build_python: OFF
             vcpkg_features: ""
+          - name: C++ (Linux ARM64, GCC, Ubuntu 22.04)
+            os: ubuntu-22.04-arm
+            triplet: arm64-linux
+            cc: gcc-13
+            cxx: g++-13
+            generator: Ninja
+            build_type: Release
+            build_python: OFF
+            vcpkg_features: ""
           - name: C++ (Linux, GCC 12, Ubuntu 22.04)
             os: ubuntu-22.04
             triplet: x64-linux
@@ -88,6 +97,15 @@ jobs:
             vcpkg_features: "python"
           - name: Python3 (Linux ARM64, GCC, Ubuntu 24.04)
             os: ubuntu-24.04-arm
+            triplet: arm64-linux
+            cc: gcc-13
+            cxx: g++-13
+            generator: Ninja
+            build_type: Release
+            build_python: ON
+            vcpkg_features: "python"
+          - name: Python3 (Linux ARM64, GCC, Ubuntu 22.04)
+            os: ubuntu-22.04-arm
             triplet: arm64-linux
             cc: gcc-13
             cxx: g++-13
@@ -146,8 +164,13 @@ jobs:
         run: |
           if [ "${{ runner.os }}" = "Linux" ]; then
             sudo apt-get update
-            sudo apt-get install -y ca-certificates
+            sudo apt-get install -y ca-certificates software-properties-common
             
+            if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]] && [[ "${{ matrix.cc }}" == "gcc-13" ]]; then
+              sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+              sudo apt-get update
+            fi
+
             # Install build tools and the matrix-specified compiler
             sudo apt-get install -y ninja-build autoconf autoconf-archive automake libtool libtool-bin pkg-config \
               ${{ matrix.cc }} ${{ matrix.cxx }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
 
   security-scan:
     name: Security Scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
 
           - os: windows-2022
             label: Windows (VS 2022)
+            triplet: x64-windows
             cmake_generator: "Visual Studio 17 2022"
             cmake_arch: "x64"
             cpack_generator: "ZIP"
@@ -72,8 +73,13 @@ jobs:
         run: |
           brew install cmake ninja
 
-      - name: Install dependencies with vcpkg (Unix)
-        if: runner.os != 'Windows'
+      - name: Set up C++ toolchain (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install ninja --no-progress -y
+
+      - name: Install dependencies with vcpkg
         uses: ./.github/actions/setup-vcpkg
         with:
           triplet: ${{ matrix.triplet }}
@@ -86,13 +92,6 @@ jobs:
           security unlock-keychain -p "" build.keychain
           security set-keychain-settings -t 3600 -u build.keychain
 
-      - name: Set up C++ toolchain (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install ninja --no-progress -y
-          & "C:\vcpkg\vcpkg.exe" install boost-asio:x64-windows boost-system:x64-windows spdlog:x64-windows
-
       - name: Configure
         shell: bash
         env:
@@ -100,8 +99,8 @@ jobs:
         run: |
           if [ "${{ runner.os }}" = "Windows" ]; then
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" -A "${{ matrix.cmake_arch }}" \
-              -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
-              -DVCPKG_TARGET_TRIPLET=x64-windows \
+              -DCMAKE_TOOLCHAIN_FILE="${CMAKE_TOOLCHAIN_FILE}" \
+              -DVCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}" \
               -DUNILINK_ENABLE_INSTALL=ON \
               -DUNILINK_ENABLE_PKGCONFIG=ON \
               -DUNILINK_ENABLE_EXPORT_HEADER=ON
@@ -150,7 +149,21 @@ jobs:
         shell: bash
         run: |
           cd build
-          cpack -C Release -B package -G "${{ matrix.cpack_generator }}"
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+          SUCCESS=0
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if cpack -C Release -B package -G "${{ matrix.cpack_generator }}"; then
+              SUCCESS=1
+              break
+            fi
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            echo "CPack failed. Retry $RETRY_COUNT of $MAX_RETRIES..."
+            sleep 10
+          done
+          if [ $SUCCESS -ne 1 ]; then
+            exit 1
+          fi
           ls -la package/
 
       - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ jobs:
             release_files: |
               build/package/unilink-*.tar.gz
 
+          - os: ubuntu-22.04-arm
+            label: Linux ARM64 (Ubuntu 22.04)
+            triplet: arm64-linux
+            cmake_generator: "Ninja"
+            cpack_generator: "TGZ"
+            release_files: |
+              build/package/unilink-*.tar.gz
+
           - os: macos-15
             label: macOS 15
             triplet: arm64-osx
@@ -66,7 +74,18 @@ jobs:
           # Remove problematic Microsoft repository to avoid 421 Misdirected Request error
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update --allow-releaseinfo-change
-          sudo apt-get install -y build-essential cmake ninja-build
+          sudo apt-get install -y build-essential cmake ninja-build software-properties-common
+          
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+            sudo apt-get install -y gcc-13 g++-13
+            echo "CC=gcc-13" >> $GITHUB_ENV
+            echo "CXX=g++-13" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+          fi
 
       - name: Set up C++ toolchain (macOS)
         if: runner.os == 'macOS'
@@ -119,6 +138,8 @@ jobs:
           else
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=$CC \
+              -DCMAKE_CXX_COMPILER=$CXX \
               -DUNILINK_ENABLE_INSTALL=ON \
               -DUNILINK_ENABLE_PKGCONFIG=ON \
               -DUNILINK_ENABLE_EXPORT_HEADER=ON \

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -19,10 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
         include:
           - os: ubuntu-24.04
             triplet: x64-linux
+          - os: ubuntu-22.04-arm
+            triplet: arm64-linux
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -32,7 +33,12 @@ jobs:
           # Remove problematic Microsoft repository to avoid 421 Misdirected Request error
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update --allow-releaseinfo-change
-          sudo apt-get install -y build-essential cmake ninja-build
+          sudo apt-get install -y build-essential cmake ninja-build software-properties-common
+          
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+          fi
           sudo apt-get install -y gcc-13 g++-13
 
       - name: Install dependencies with vcpkg
@@ -62,7 +68,21 @@ jobs:
       - name: Package
         run: |
           cd build
-          cpack -B package -G TGZ
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+          SUCCESS=0
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if cpack -B package -G TGZ; then
+              SUCCESS=1
+              break
+            fi
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            echo "CPack failed. Retry $RETRY_COUNT of $MAX_RETRIES..."
+            sleep 10
+          done
+          if [ $SUCCESS -ne 1 ]; then
+            exit 1
+          fi
           ls -la package/
 
       - name: Show package contents

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,11 @@ jobs:
             cc: gcc-12
             cxx: g++-12
             triplet: x64-linux
+          - os: ubuntu-22.04-arm
+            compiler: gcc
+            cc: gcc-13
+            cxx: g++-13
+            triplet: arm64-linux
           # macOS: Homebrew LLVM Clang/libc++ (arm64)
           - os: macos-15
             compiler: clang
@@ -94,9 +99,13 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y ca-certificates
+        sudo apt-get install -y ca-certificates software-properties-common
 
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]] && [[ "${{ matrix.cc }}" == "gcc-13" ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+          fi
           sudo apt-get install -y ${{ matrix.cc }} ${{ matrix.cxx }}
         else
           # Clang needs GCC's C++ stdlib headers; all clang entries run on ubuntu-24.04

--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -29,6 +29,8 @@ jobs:
             triplet: x64-linux
           - os: ubuntu-24.04
             triplet: x64-linux-dynamic
+          - os: ubuntu-22.04-arm
+            triplet: arm64-linux
           - os: windows-2022
             triplet: x64-windows
           - os: windows-2022
@@ -43,6 +45,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Set up C++ toolchain (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build software-properties-common
+          
+          if [[ "${{ matrix.os }}" == "ubuntu-22.04"* ]]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+            sudo apt-get install -y gcc-13 g++-13
+            echo "CC=gcc-13" >> $GITHUB_ENV
+            echo "CXX=g++-13" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+          fi
 
       - name: Export GitHub Actions Cache Environment Variables
         uses: actions/github-script@v9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Multi-stage build for optimized production image
-FROM ubuntu:24.04 AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS builder
+
+ARG TARGETARCH
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -26,14 +29,25 @@ WORKDIR /app
 # Copy source code
 COPY . .
 
+# Map Docker arch to vcpkg triplet
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        echo "x64-linux-dynamic" > /tmp/triplet; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        echo "arm64-linux-dynamic" > /tmp/triplet; \
+    else \
+        echo "x64-linux-dynamic" > /tmp/triplet; \
+    fi
+
 # Install third-party C++ dependencies. Boost version policy is enforced by
 # CMake; vcpkg is only the dependency supplier.
 RUN git clone --depth 1 https://github.com/microsoft/vcpkg.git /opt/vcpkg && \
     /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics && \
-    /opt/vcpkg/vcpkg install boost-asio boost-system spdlog --triplet x64-linux-dynamic --clean-after-build
+    TRIPLET=$(cat /tmp/triplet) && \
+    /opt/vcpkg/vcpkg install boost-asio boost-system spdlog --triplet $TRIPLET --clean-after-build
 
 # Configure and build
-RUN rm -rf build && mkdir build && cd build && \
+RUN TRIPLET=$(cat /tmp/triplet) && \
+    rm -rf build && mkdir build && cd build && \
     cmake .. \
         -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
@@ -41,7 +55,7 @@ RUN rm -rf build && mkdir build && cd build && \
         -DCMAKE_CXX_COMPILER=g++-13 \
         -DCMAKE_CXX_STANDARD=20 \
         -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
-        -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic \
+        -DVCPKG_TARGET_TRIPLET=$TRIPLET \
         -DUNILINK_ENABLE_CONFIG=ON \
         -DUNILINK_ENABLE_INSTALL=ON \
         -DUNILINK_ENABLE_PKGCONFIG=ON \
@@ -57,7 +71,7 @@ FROM ubuntu:24.04 AS production
 RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
-RUN useradd -m -u 1000 appuser
+RUN useradd -m -u 1001 appuser
 
 # Set working directory
 WORKDIR /app
@@ -66,7 +80,8 @@ WORKDIR /app
 COPY --from=builder /app/build/lib/libunilink_static.a /app/lib/libunilink.a
 COPY --from=builder /app/build/lib/libunilink.so* /app/lib/
 COPY --from=builder /app/build/bin /app/bin
-COPY --from=builder /opt/vcpkg/installed/x64-linux-dynamic/lib/*.so* /app/lib/
+COPY --from=builder /app/build-test/vcpkg_installed/*/lib/*.so* /app/lib/ 2>/dev/null || \
+    COPY --from=builder /opt/vcpkg/installed/*/lib/*.so* /app/lib/
 
 ENV LD_LIBRARY_PATH=/app/lib
 


### PR DESCRIPTION
## Description
This PR re-applies the CI stabilization and platform expansion changes.

## Key Changes
- **Robustness**: 3-attempt retry logic for `vcpkg` and `cpack`.
- **Expansion**: Ubuntu 22.04 ARM64 support with GCC 13.
- **Docker**: Multi-arch build and UID conflict fix.
- **Performance**: vcpkg binary caching via unified action.

**Note**: This PR will stay open for manual review and merge. No auto-merge will be performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ARM64 (arm64-linux) build and test support for Ubuntu 22.04
  * Docker images now support multi-architecture builds (x86-64 and ARM64)

* **Improvements**
  * Enhanced build reliability with automatic retry logic for package installation
  * Improved cross-platform toolchain configuration for better compiler support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->