### PR TITLE
fix(uds): rename UdsServer::get_state() to state() for API consistency

### DIFF
--- a/test/unit/transport/transport_uds_error_test.cc
+++ b/test/unit/transport/transport_uds_error_test.cc
@@ -35,10 +35,10 @@ TEST_F(UdsErrorTest, InvalidSocketPath) {
   server->start();
 
   // Give some time for async operation if needed
-  TestUtils::waitForCondition([&] { return server->get_state() == base::LinkState::Error; }, 500);
+  TestUtils::waitForCondition([&] { return server->state() == base::LinkState::Error; }, 500);
 
   // In some implementations, it might stay in Idle if path validation fails immediately
-  EXPECT_TRUE(server->get_state() == base::LinkState::Error || server->get_state() == base::LinkState::Idle);
+  EXPECT_TRUE(server->state() == base::LinkState::Error || server->state() == base::LinkState::Idle);
 }
 
 TEST_F(UdsErrorTest, PathPermissionDenied) {
@@ -61,7 +61,7 @@ TEST_F(UdsErrorTest, PathPermissionDenied) {
   // Wait for potential async error transition (longer timeout)
   bool error_state = TestUtils::waitForCondition(
       [&] {
-        auto s = server->get_state();
+        auto s = server->state();
         return s == base::LinkState::Error || s == base::LinkState::Idle;
       },
       1000);
@@ -104,7 +104,7 @@ TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
   server->start();
 
   // Wait for server to be ready
-  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->get_state() == base::LinkState::Listening; }, 2000));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->state() == base::LinkState::Listening; }, 2000));
 
   config::UdsClientConfig ccfg;
   ccfg.socket_path = temp_sock_;
@@ -120,7 +120,7 @@ TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
   // Just verify server reached Idle or Error state
   EXPECT_TRUE(TestUtils::waitForCondition(
       [&] {
-        auto s = server->get_state();
+        auto s = server->state();
         return s == base::LinkState::Idle || s == base::LinkState::Error;
       },
       3000));

--- a/test/unit/transport/transport_uds_server_security_test.cc
+++ b/test/unit/transport/transport_uds_server_security_test.cc
@@ -59,8 +59,8 @@ TEST_F(TransportUdsServerSecurityTest, NoIdleTimeoutByDefault) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -90,8 +90,8 @@ TEST_F(TransportUdsServerSecurityTest, IdleConnectionTimeout) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -128,8 +128,8 @@ TEST_F(TransportUdsServerSecurityTest, IdleTimeoutResetOnMessage) {
   server_ = UdsServer::create(cfg);
   server_->start();
 
-  ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;

--- a/test/unit/transport/transport_uds_server_security_test.cc
+++ b/test/unit/transport/transport_uds_server_security_test.cc
@@ -60,7 +60,7 @@ TEST_F(TransportUdsServerSecurityTest, NoIdleTimeoutByDefault) {
   server_->start();
 
   ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -91,7 +91,7 @@ TEST_F(TransportUdsServerSecurityTest, IdleConnectionTimeout) {
   server_->start();
 
   ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;
@@ -129,7 +129,7 @@ TEST_F(TransportUdsServerSecurityTest, IdleTimeoutResetOnMessage) {
   server_->start();
 
   ASSERT_TRUE(test::TestUtils::waitForCondition(
-      [&] { return server_->get_state() == unilink::base::LinkState::Listening; }, 5000))
+      [&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
       << "Server failed to enter listening state";
 
   net::io_context client_ioc;

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -357,7 +357,7 @@ void UdsServer::on_multi_disconnect(MultiClientDisconnectHandler handler) {
   impl_->on_multi_disconnect_ = std::move(handler);
 }
 
-base::LinkState UdsServer::get_state() const { return impl_->state_.state(); }
+base::LinkState UdsServer::state() const { return impl_->state_.state(); }
 
 void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
   acceptor_->async_accept([self](const boost::system::error_code& ec, uds::socket socket) {

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -89,7 +89,7 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   void on_multi_data(MultiClientDataHandler handler);
   void on_multi_disconnect(MultiClientDisconnectHandler handler);
 
-  base::LinkState get_state() const;
+  base::LinkState state() const;
 
  private:
   explicit UdsServer(const config::UdsServerConfig& cfg);


### PR DESCRIPTION
## Description

\`UdsServer\` exposed a \`get_state()\` method while every other transport class (\`TcpServer\`, \`TcpClient\`, \`Serial\`, \`UDP\`) exposes \`state()\`. This inconsistency made it impossible to write generic code against the transport layer and was a maintenance hazard. This PR renames the method to \`state()\` to restore naming uniformity.

## Key Changes

- Renamed \`UdsServer::get_state()\` to \`state()\` in \`unilink/transport/uds/uds_server.hpp\` and \`uds_server.cc\`
- Updated 5 call sites in \`test/unit/transport/transport_uds_error_test.cc\`
- Updated 3 call sites in \`test/unit/transport/transport_uds_server_security_test.cc\`

## Related Issues

- Part of v0.7.1 pre-release cleanup

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run \`./scripts/verify.sh\` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

\`get_state()\` was the only method across all transport headers using the \`get_\` prefix for a simple accessor. No functional behaviour is changed — the implementation body is identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal API naming conventions updated for improved consistency.
  * Unit tests updated to match the revised API names; no behavior changes.
  * Changes are implementation-only and do not affect end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->