### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(BUILD_PYTHON_BINDINGS "Build Python bindings" OFF)
 
 project(
   unilink
-  VERSION 0.7.0
+  VERSION 0.7.1
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Description

Bumps the project version from 0.7.0 to 0.7.1 in preparation for the v0.7.1 patch release. The only change is the `VERSION` field in `CMakeLists.txt`; all generated artifacts (package filenames, `pkg-config`, CMake config version file) derive from this single source of truth.

## Key Changes

- `CMakeLists.txt`: `VERSION 0.7.0` → `VERSION 0.7.1`

## Related Issues

- Part of v0.7.1 pre-release cleanup (CI stabilization + UDS API naming fix)

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

No library code or behaviour is changed. This PR should be merged after #365 (UDS `get_state()` → `state()` rename) lands on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Patch release version 0.7.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->