### PR TITLE
fix(ci): resolve release and docker CI failures on v0.7.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Show package contents (Unix)
         if: runner.os != 'Windows'
         shell: bash
-        run: tar -tzf build/package/unilink-*.tar.gz | head -20 || true
+        run: tar -tzf build/package/unilink-*.tar.gz | sed -n '1,20p'
 
       - name: Summary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Show package contents (Unix)
         if: runner.os != 'Windows'
         shell: bash
-        run: tar -tzf build/package/unilink-*.tar.gz | head -20
+        run: tar -tzf build/package/unilink-*.tar.gz | head -20 || true
 
       - name: Summary
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ FROM ubuntu:24.04 AS production
 RUN apt-get update && apt-get install -y libstdc++6 && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
-RUN useradd -m -u 1000 appuser
+RUN userdel -r ubuntu 2>/dev/null || true && useradd -m -u 1000 appuser
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Description

Fixes two CI failures introduced on the \`v0.7.1\` release tag:

1. **Release workflow**: \`tar -tzf ... | head -20\` was run under \`bash -e -o pipefail\`. When \`head\` exits after reading 20 lines, \`tar\` receives SIGPIPE and exits with code 2. With \`pipefail\` enabled, this propagates as a step failure even though the build itself succeeded. Fix: append \`|| true\` to suppress the false-positive.

2. **Docker workflow**: \`ubuntu:24.04\` now ships with a built-in \`ubuntu\` user at UID 1000. The existing \`useradd -m -u 1000 appuser\` therefore fails with exit code 4 (UID already in use). Fix: remove the pre-existing \`ubuntu\` user before creating \`appuser\`.

## Key Changes

- \`.github/workflows/release.yml\`: append \`|| true\` to \`tar | head -20\` to absorb SIGPIPE under \`pipefail\`
- \`Dockerfile\`: prepend \`userdel -r ubuntu 2>/dev/null || true\` before \`useradd -m -u 1000 appuser\`

## Related Issues

- N/A

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.

## Checklist

- [ ] I have run \`./scripts/verify.sh\` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Both failures affected the \`v0.7.1\` tag CI run:
- Release workflow: all four matrix targets (ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm) failed at the "Show package contents" step
- Docker workflow: \`Build and Push Docker Image\` job failed at the \`useradd\` instruction in the production stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability with enhanced error handling and more reliable artifact listing
  * Strengthened production Docker image security by refining non-root user configuration for container deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->