### PR TITLE
fix: send contract consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,11 +252,7 @@ endfunction()
 
 # Link dependencies and set include directories
 if(TARGET unilink_shared)
-  target_link_libraries(
-    unilink_shared
-    PUBLIC unilink_dependencies
-    PRIVATE spdlog::spdlog
-  )
+  target_link_libraries(unilink_shared PUBLIC unilink_dependencies)
   target_compile_features(unilink_shared PUBLIC cxx_std_20)
   target_include_directories(
     unilink_shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -264,11 +260,7 @@ if(TARGET unilink_shared)
   )
 endif()
 if(TARGET unilink_static)
-  target_link_libraries(
-    unilink_static
-    PUBLIC unilink_dependencies
-    PRIVATE spdlog::spdlog
-  )
+  target_link_libraries(unilink_static PUBLIC unilink_dependencies)
   target_compile_features(unilink_static PUBLIC cxx_std_20)
   target_include_directories(
     unilink_static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -279,11 +271,7 @@ if(TARGET unilink
    AND NOT TARGET unilink_shared
    AND NOT TARGET unilink_static
 )
-  target_link_libraries(
-    unilink
-    PUBLIC unilink_dependencies
-    PRIVATE spdlog::spdlog
-  )
+  target_link_libraries(unilink PUBLIC unilink_dependencies)
   target_compile_features(unilink PUBLIC cxx_std_20)
   target_include_directories(
     unilink PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 ## Requirements
 
 * **C++20 compiler and standard library**: GCC 10+, recent Clang/libc++, or MSVC 2022 (required)
-* CMake 3.12 or later
+* CMake 3.12 or later for plain builds; CMake 3.21 or later for the repository presets
 * Boost 1.83.0 or later. vcpkg is the recommended dependency supplier; OS package manager Boost versions are supported only when they meet this minimum.
 
 ## 📦 Installation
@@ -48,6 +48,7 @@ cmake --build --preset dev-linux-x64
 ```
 
 The setup script installs Boost and spdlog through a local `vcpkg/` checkout. CMake remains the version gate and rejects Boost versions older than 1.83.0.
+The preset-based contributor workflow uses `CMakePresets.json` schema version 3, so those `cmake --preset ...` commands require CMake 3.21+.
 
 ## 🐍 Python Bindings
 

--- a/bindings/python/tests/test_bindings_api.py
+++ b/bindings/python/tests/test_bindings_api.py
@@ -31,6 +31,23 @@ def reserve_tcp_port():
         pytest.skip(f"socket creation is blocked in this environment: {exc}")
 
 
+def call_from_thread(callback, *args):
+    errors = []
+
+    def run():
+        try:
+            callback(*args)
+        except Exception as exc:  # pragma: no cover - re-raised in the test thread
+            errors.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join(timeout=1.0)
+    assert not thread.is_alive()
+    if errors:
+        raise errors[0]
+
+
 def test_standard_python_surface_uses_canonical_names():
     assert hasattr(unilink.TcpClient, "connected")
     assert not hasattr(unilink.TcpClient, "is_connected")
@@ -121,6 +138,49 @@ class FakeClient:
         self.packet_framer_args = args
 
 
+class FakeServer:
+    def __init__(self):
+        self._on_connect = None
+        self._on_disconnect = None
+        self._on_data = None
+        self._on_message = None
+        self.sent = []
+
+    def on_connect(self, handler):
+        self._on_connect = handler
+
+    def on_disconnect(self, handler):
+        self._on_disconnect = handler
+
+    def on_data(self, handler):
+        self._on_data = handler
+
+    def on_message(self, handler):
+        self._on_message = handler
+
+    def start(self):
+        return True
+
+    def stop(self):
+        return None
+
+    def listening(self):
+        return True
+
+    def broadcast(self, _data):
+        return True
+
+    def send_to(self, client_id, data):
+        self.sent.append((client_id, data))
+        return True
+
+    def use_line_framer(self, *args):
+        self.line_framer_args = args
+
+    def use_packet_framer(self, *args):
+        self.packet_framer_args = args
+
+
 def test_asyncio_wrapper_uses_start_not_connect():
     async def run():
         wrapper = unilink_asyncio.AsyncChannelBase(FakeClient())
@@ -130,12 +190,52 @@ def test_asyncio_wrapper_uses_start_not_connect():
         assert wrapper.send(b"payload") is True
 
         wrapper.use_line_framer("\n", False, 1024)
-        wrapper._raw_client._on_data(SimpleNamespace(client_id=0, client_info="", data=b"raw"))
+        call_from_thread(wrapper._raw_client._on_data, SimpleNamespace(client_id=0, client_info="", data=b"raw"))
         raw_ctx = await asyncio.wait_for(wrapper.read(), timeout=1.0)
         assert raw_ctx.data == b"raw"
 
-        wrapper._raw_client._on_message(SimpleNamespace(client_id=0, client_info="", data=b"framed"))
+        call_from_thread(wrapper._raw_client._on_message, SimpleNamespace(client_id=0, client_info="", data=b"framed"))
         msg_ctx = await asyncio.wait_for(wrapper.read_message(), timeout=1.0)
         assert msg_ctx.data == b"framed"
+
+    asyncio.run(run())
+
+
+def test_asyncio_server_callbacks_are_loop_thread_safe():
+    async def run():
+        wrapper = unilink_asyncio.AsyncServerBase(FakeServer())
+        wrapper._ensure_loop()
+
+        call_from_thread(
+            wrapper._raw_server._on_connect,
+            SimpleNamespace(client_id=7, client_info="client-7"),
+        )
+        session = await asyncio.wait_for(wrapper.__anext__(), timeout=1.0)
+        assert session.id == 7
+        assert session.info == "client-7"
+
+        call_from_thread(
+            wrapper._raw_server._on_data,
+            SimpleNamespace(client_id=7, client_info="client-7", data=b"raw"),
+        )
+        raw_ctx = await asyncio.wait_for(session.read(), timeout=1.0)
+        assert raw_ctx.data == b"raw"
+
+        call_from_thread(
+            wrapper._raw_server._on_message,
+            SimpleNamespace(client_id=7, client_info="client-7", data=b"framed"),
+        )
+        msg_ctx = await asyncio.wait_for(session.read_message(), timeout=1.0)
+        assert msg_ctx.data == b"framed"
+
+        assert await session.send(b"reply") is True
+        assert wrapper._raw_server.sent == [(7, b"reply")]
+
+        call_from_thread(
+            wrapper._raw_server._on_disconnect,
+            SimpleNamespace(client_id=7, client_info="client-7"),
+        )
+        await asyncio.wait_for(session._closed.wait(), timeout=1.0)
+        assert 7 not in wrapper._sessions
 
     asyncio.run(run())

--- a/bindings/python/unilink/asyncio.py
+++ b/bindings/python/unilink/asyncio.py
@@ -29,11 +29,18 @@ class AsyncChannelBase:
             self._loop = _get_loop()
         return self._loop
 
+    def _schedule_on_loop(self, callback, *args):
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return False
+        loop.call_soon_threadsafe(callback, *args)
+        return True
+
     def _on_data_bridge(self, ctx):
-        self._ensure_loop().call_soon_threadsafe(self._data_queue.put_nowait, ctx)
+        self._schedule_on_loop(self._data_queue.put_nowait, ctx)
 
     def _on_message_bridge(self, ctx):
-        self._ensure_loop().call_soon_threadsafe(self._message_queue.put_nowait, ctx)
+        self._schedule_on_loop(self._message_queue.put_nowait, ctx)
 
     async def start(self) -> bool:
         """Starts the channel and waits for the connection attempt to complete."""
@@ -143,26 +150,44 @@ class AsyncServerBase:
             self._loop = _get_loop()
         return self._loop
 
+    def _schedule_on_loop(self, callback, *args):
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return False
+        loop.call_soon_threadsafe(callback, *args)
+        return True
+
     def _on_connect_bridge(self, ctx):
-        loop = self._ensure_loop()
-        session = AsyncServerSession(self._raw_server, ctx.client_id, ctx.client_info, loop)
-        self._sessions[ctx.client_id] = session
-        loop.call_soon_threadsafe(self._session_queue.put_nowait, session)
+        def attach_session():
+            session = AsyncServerSession(self._raw_server, ctx.client_id, ctx.client_info, self._loop)
+            self._sessions[ctx.client_id] = session
+            self._session_queue.put_nowait(session)
+
+        self._schedule_on_loop(attach_session)
 
     def _on_disconnect_bridge(self, ctx):
-        session = self._sessions.pop(ctx.client_id, None)
-        if session:
-            session._notify_disconnect()
+        def detach_session():
+            session = self._sessions.pop(ctx.client_id, None)
+            if session:
+                session._closed.set()
+
+        self._schedule_on_loop(detach_session)
 
     def _on_data_bridge(self, ctx):
-        session = self._sessions.get(ctx.client_id)
-        if session:
-            session._push_data(ctx)
+        def push_data():
+            session = self._sessions.get(ctx.client_id)
+            if session:
+                session._data_queue.put_nowait(ctx)
+
+        self._schedule_on_loop(push_data)
 
     def _on_message_bridge(self, ctx):
-        session = self._sessions.get(ctx.client_id)
-        if session:
-            session._push_message(ctx)
+        def push_message():
+            session = self._sessions.get(ctx.client_id)
+            if session:
+                session._message_queue.put_nowait(ctx)
+
+        self._schedule_on_loop(push_message)
 
     async def start(self) -> bool:
         loop = self._ensure_loop()

--- a/bindings/python/unilink/asyncio.py
+++ b/bindings/python/unilink/asyncio.py
@@ -19,6 +19,11 @@ class AsyncChannelBase:
         self._loop = None
         self._data_queue = asyncio.Queue()
         self._message_queue = asyncio.Queue()
+
+        try:
+            self._loop = _get_loop()
+        except RuntimeError:
+            self._loop = None
         
         # Setup internal handlers
         self._raw_client.on_data(self._on_data_bridge)
@@ -138,6 +143,11 @@ class AsyncServerBase:
         self._loop = None
         self._sessions = {}
         self._session_queue = asyncio.Queue()
+
+        try:
+            self._loop = _get_loop()
+        except RuntimeError:
+            self._loop = None
         
         # Setup bridges
         self._raw_server.on_connect(self._on_connect_bridge)

--- a/cmake/UnilinkConfig.cmake.in
+++ b/cmake/UnilinkConfig.cmake.in
@@ -10,6 +10,7 @@ include(CMakeFindDependencyMacro)
 # Find required dependencies.
 find_dependency(Boost @UNILINK_MIN_BOOST_VERSION@ REQUIRED COMPONENTS system)
 find_dependency(Threads REQUIRED)
+find_dependency(spdlog 1.9 CONFIG REQUIRED)
 
 # Define proxy targets for compatibility with FetchContent builds.
 if(NOT TARGET unilink_boost_system_proxy)
@@ -25,6 +26,15 @@ if(NOT TARGET unilink_boost_asio_proxy)
     target_link_libraries(unilink_boost_asio_proxy INTERFACE Boost::asio)
   elseif(TARGET Boost::system)
     target_link_libraries(unilink_boost_asio_proxy INTERFACE Boost::system)
+  endif()
+endif()
+
+if(NOT TARGET unilink_spdlog_proxy)
+  add_library(unilink_spdlog_proxy INTERFACE IMPORTED)
+  if(TARGET spdlog::spdlog)
+    target_link_libraries(unilink_spdlog_proxy INTERFACE spdlog::spdlog)
+  elseif(TARGET spdlog)
+    target_link_libraries(unilink_spdlog_proxy INTERFACE spdlog)
   endif()
 endif()
 

--- a/cmake/UnilinkDependencies.cmake
+++ b/cmake/UnilinkDependencies.cmake
@@ -232,8 +232,22 @@ endif()
 # Create interface library for dependencies
 add_library(unilink_dependencies INTERFACE)
 
+set(_UNILINK_SPDLOG_BUILD_TARGET "")
+if(TARGET spdlog::spdlog)
+  set(_UNILINK_SPDLOG_BUILD_TARGET spdlog::spdlog)
+elseif(TARGET spdlog)
+  set(_UNILINK_SPDLOG_BUILD_TARGET spdlog)
+endif()
+
 # Link common dependencies
 target_link_libraries(unilink_dependencies INTERFACE Threads::Threads)
+if(_UNILINK_SPDLOG_BUILD_TARGET)
+  target_link_libraries(
+    unilink_dependencies
+    INTERFACE $<BUILD_INTERFACE:${_UNILINK_SPDLOG_BUILD_TARGET}>
+              $<INSTALL_INTERFACE:unilink_spdlog_proxy>
+  )
+endif()
 if(UNILINK_LINK_BOOST_SYSTEM)
   if(UNILINK_BOOST_FETCHED)
     # For local targets (FetchContent), use BUILD_INTERFACE to avoid export
@@ -317,6 +331,9 @@ endif()
 
 # Export dependencies for downstream projects
 set(_UNILINK_DEPENDENCY_TARGETS Threads::Threads)
+if(_UNILINK_SPDLOG_BUILD_TARGET)
+  list(APPEND _UNILINK_DEPENDENCY_TARGETS ${_UNILINK_SPDLOG_BUILD_TARGET})
+endif()
 if(UNILINK_LINK_BOOST_SYSTEM)
   list(APPEND _UNILINK_DEPENDENCY_TARGETS Boost::system)
 endif()

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -5,10 +5,10 @@
 set(CPACK_PACKAGE_NAME "unilink")
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
-    "Cross-platform async C++ communication library for Serial, TCP, and UDP"
+    "Cross-platform async C++ communication library for Serial, TCP, UDP, and UDS"
 )
 set(CPACK_PACKAGE_DESCRIPTION
-    "A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, and UDP transports"
+    "A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, UDP, and UDS transports"
 )
 set(CPACK_PACKAGE_VENDOR "Jinwoo Sung")
 set(CPACK_PACKAGE_CONTACT "jwsung91@gmail.com")

--- a/docs/contributor/build_guide.md
+++ b/docs/contributor/build_guide.md
@@ -38,6 +38,7 @@ cmake --install build/dev-linux-x64 --prefix /opt/unilink
 ```
 
 The repository intentionally does not use a root `vcpkg.json` manifest. Dependency packages are installed explicitly by the setup script and CI actions, while CMake owns the Boost baseline through `UNILINK_MIN_BOOST_VERSION`.
+The preset-based contributor workflow requires CMake 3.21+ because `CMakePresets.json` uses schema version 3. Plain source builds without presets remain supported on CMake 3.12+.
 
 ---
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -4,7 +4,7 @@ This guide covers the supported ways to install and use the **unilink** library 
 
 ## Prerequisites
 
-- **CMake**: 3.12 or higher
+- **CMake**: 3.12 or higher for plain builds; 3.21 or higher for the repository presets
 - **C++ Compiler**: C++20 compatible (GCC 10+, recent Clang/libc++, MSVC 2022+)
 - **Boost**: 1.83.0 or higher
 - **Platform**: Linux, Windows, macOS

--- a/docs/user/requirements.md
+++ b/docs/user/requirements.md
@@ -10,7 +10,7 @@ This guide describes the system requirements and dependencies needed to build an
 
 - **Ubuntu 22.04 LTS or later**
 - **C++20 compatible compiler and standard library** (GCC 10+, recent Clang/libc++, or MSVC 2022+)
-- **CMake 3.12 or later**
+- **CMake 3.12 or later** for plain builds; **CMake 3.21 or later** for the repository presets
 - **Boost 1.83.0 or later**, preferably supplied by vcpkg
 
 ### Supported Platforms
@@ -50,7 +50,7 @@ If you use system packages instead of vcpkg, the selected Boost installation mus
 | ----------- | -------------- | ------------ | ------------------------------------------------------------------------- |
 | **GCC/G++** | 10+            | GPL          | C++20 compiler                                                            |
 | **Clang**   | 14+ (optional) | Apache 2.0   | Alternative C++20 compiler                                                |
-| **CMake**   | 3.12+          | BSD-3-Clause | Build system                                                              |
+| **CMake**   | 3.12+ / 3.21+  | BSD-3-Clause | Build system; 3.21+ is needed only for repository presets                 |
 | **Boost**   | 1.83.0+        | BSL 1.0      | Asio for async I/O                                                        |
 
 ---
@@ -136,14 +136,14 @@ clang++ --version
 
 ```bash
 cmake --version
-# Should show version 3.12 or higher
+# Should show 3.12 or higher for plain builds, or 3.21 or higher for repository presets
 ```
 
 ### Check Boost Version
 
 ```bash
 grep BOOST_LIB_VERSION /path/to/boost/include/boost/version.hpp
-# Should show 1_84 or higher
+# Should show 1_83 or higher
 ```
 
 ### Quick Environment Test
@@ -197,6 +197,3 @@ sudo apt install cmake
 - [Quick Start Guide](quickstart.md) - Get started with unilink
 - [Installation Guide](installation.md) - Installation options
 - [Troubleshooting](troubleshooting.md) - Common issues and solutions
-olutions
-[Troubleshooting](troubleshooting.md) - Common issues and solutions
-

--- a/package/unilink.pc.in
+++ b/package/unilink.pc.in
@@ -4,7 +4,7 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: unilink
-Description: A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, and UDP transports
+Description: A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, UDP, and UDS transports
 URL: https://github.com/jwsung91/unilink
 Version: @PROJECT_VERSION@
 Requires: @PKGCONFIG_REQUIRES@

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -53,6 +53,9 @@ Development dependencies are ready.
 VCPKG_ROOT=${VCPKG_ROOT}
 VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}
 
+The preset commands below require CMake 3.21+.
+Plain non-preset builds remain supported with CMake 3.12+.
+
 Configure with one of:
   cmake --preset dev-linux-x64
   cmake --preset dev-linux-arm64

--- a/test/unit/common/test_input_validator.cc
+++ b/test/unit/common/test_input_validator.cc
@@ -16,8 +16,11 @@
 
 #include <gtest/gtest.h>
 
+#include <cctype>
 #include <limits>
+#include <ostream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -25,6 +28,34 @@
 
 using namespace unilink;
 using namespace unilink::util;
+
+namespace {
+
+std::string make_param_name(std::string_view description) {
+  std::string name;
+  for (const unsigned char ch : description) {
+    if (std::isalnum(ch)) {
+      name.push_back(static_cast<char>(ch));
+    } else if (!name.empty() && name.back() != '_') {
+      name.push_back('_');
+    }
+  }
+
+  while (!name.empty() && name.back() == '_') {
+    name.pop_back();
+  }
+  if (name.empty() || std::isdigit(static_cast<unsigned char>(name.front()))) {
+    name.insert(0, "Case_");
+  }
+  return name;
+}
+
+template <typename T>
+std::string param_name_from_description(const ::testing::TestParamInfo<T>& info) {
+  return make_param_name(info.param.description) + "_" + std::to_string(info.index);
+}
+
+}  // namespace
 
 // Existing tests
 TEST(InputValidatorTest, ValidatePort) {
@@ -285,6 +316,8 @@ struct IPv4TestCase {
   std::string description;
 };
 
+void PrintTo(const IPv4TestCase& param, std::ostream* os) { *os << param.description; }
+
 class IPv4ParamTest : public ::testing::TestWithParam<IPv4TestCase> {};
 
 TEST_P(IPv4ParamTest, ValidateAddress) {
@@ -308,13 +341,16 @@ INSTANTIATE_TEST_SUITE_P(IPv4Scenarios, IPv4ParamTest,
                                            IPv4TestCase{"tcp://1.1.1.1", true, "Protocol prefix"},
                                            IPv4TestCase{"1.1.1.1", false, "Valid simple address"},
                                            IPv4TestCase{"255.255.255.255", false, "Valid max address"},
-                                           IPv4TestCase{"0.0.0.0", false, "Valid min address"}));
+                                           IPv4TestCase{"0.0.0.0", false, "Valid min address"}),
+                         param_name_from_description<IPv4TestCase>);
 
 struct HostTestCase {
   std::string host;
   bool should_throw;
   std::string description;
 };
+
+void PrintTo(const HostTestCase& param, std::ostream* os) { *os << param.description; }
 
 class HostParamTest : public ::testing::TestWithParam<HostTestCase> {};
 
@@ -336,13 +372,16 @@ INSTANTIATE_TEST_SUITE_P(HostScenarios, HostParamTest,
                                            HostTestCase{"[::1]:80", true, "IPv6 with port"},
                                            HostTestCase{"::1", false, "IPv6 address"},
                                            HostTestCase{"localhost", false, "Simple hostname"},
-                                           HostTestCase{"1.1.1.1", false, "IPv4 address"}));
+                                           HostTestCase{"1.1.1.1", false, "IPv4 address"}),
+                         param_name_from_description<HostTestCase>);
 
 struct DevicePathTestCase {
   std::string path;
   bool should_throw;
   std::string description;
 };
+
+void PrintTo(const DevicePathTestCase& param, std::ostream* os) { *os << param.description; }
 
 class DevicePathParamTest : public ::testing::TestWithParam<DevicePathTestCase> {};
 
@@ -367,13 +406,16 @@ INSTANTIATE_TEST_SUITE_P(
         DevicePathTestCase{"/etc/passwd", true, "Non-device path (rejected)"},
         DevicePathTestCase{"/dev/ttyUSB0", false, "Linux device path"},
         // Invalid
-        DevicePathTestCase{"", true, "Empty path"}, DevicePathTestCase{"/dev/bad?", true, "Invalid char ?"}));
+        DevicePathTestCase{"", true, "Empty path"}, DevicePathTestCase{"/dev/bad?", true, "Invalid char ?"}),
+    param_name_from_description<DevicePathTestCase>);
 
 struct PortTestCase {
   uint16_t port;
   bool should_throw;
   std::string description;
 };
+
+void PrintTo(const PortTestCase& param, std::ostream* os) { *os << param.description; }
 
 class PortParamTest : public ::testing::TestWithParam<PortTestCase> {};
 
@@ -391,7 +433,8 @@ INSTANTIATE_TEST_SUITE_P(PortScenarios, PortParamTest,
                          ::testing::Values(PortTestCase{0, true, "Port 0 (invalid)"},
                                            PortTestCase{1, false, "Port 1 (min valid)"},
                                            PortTestCase{65535, false, "Port 65535 (max valid)"},
-                                           PortTestCase{8080, false, "Standard port"}));
+                                           PortTestCase{8080, false, "Standard port"}),
+                         param_name_from_description<PortTestCase>);
 
 TEST(InputValidatorTest, ValidateSecurityExtendedAscii) {
   // Extended ASCII chars (negative when char is signed)

--- a/test/unit/transport/test_backpressure_strategy.cc
+++ b/test/unit/transport/test_backpressure_strategy.cc
@@ -22,6 +22,7 @@
 #include <thread>
 #include <vector>
 
+#include "test_utils.hpp"
 #include "unilink/base/constants.hpp"
 #include "unilink/builder/tcp_client_builder.hpp"
 #include "unilink/builder/udp_builder.hpp"
@@ -145,18 +146,19 @@ TEST(BackpressureStrategyTest, SetBackpressureStrategyChangesMode) {
 
 TEST(BackpressureStrategyTest, UdsClient_ReportBackpressureHysteresis) {
   constexpr size_t kThreshold = 1024;
-  auto tmp_path = std::string("/tmp/unilink_bp_hysteresis_") + std::to_string(getpid()) + ".sock";
+  auto tmp_path = test::TestUtils::makeUniqueUdsSocketPath("bp_hys");
+  test::TestUtils::removeFileIfExists(tmp_path);
 
   // Start a UDS server to accept the connection (manages its own ioc)
   config::UdsServerConfig srv_cfg;
-  srv_cfg.socket_path = tmp_path;
+  srv_cfg.socket_path = tmp_path.string();
   auto server = transport::UdsServer::create(srv_cfg);
   server->start();
   std::this_thread::sleep_for(50ms);
 
   // Client with small threshold (manages its own ioc)
   config::UdsClientConfig cli_cfg;
-  cli_cfg.socket_path = tmp_path;
+  cli_cfg.socket_path = tmp_path.string();
   cli_cfg.backpressure_threshold = kThreshold;
   cli_cfg.backpressure_strategy = BackpressureStrategy::BestEffort;
 
@@ -181,6 +183,7 @@ TEST(BackpressureStrategyTest, UdsClient_ReportBackpressureHysteresis) {
 
   client->stop();
   server->stop();
+  test::TestUtils::removeFileIfExists(tmp_path);
 
   // Hysteresis: with BestEffort and flooding, must fire at least once
   std::lock_guard<std::mutex> lock(bp_mtx);
@@ -200,8 +203,8 @@ TEST(BackpressureStrategyTest, BuilderFluentBackpressureStrategy) {
 }
 
 TEST(BackpressureStrategyTest, UdsBuilderFluentBackpressureStrategy) {
-  auto tmp_path = std::string("/tmp/unilink_bp_builder_") + std::to_string(getpid()) + ".sock";
-  auto client = builder::UdsClientBuilder(tmp_path)
+  auto tmp_path = test::TestUtils::makeUniqueUdsSocketPath("bp_builder");
+  auto client = builder::UdsClientBuilder(tmp_path.string())
                     .backpressure_strategy(BackpressureStrategy::BestEffort)
                     .backpressure_threshold(256 * 1024)
                     .on_data([](auto&&) {})

--- a/test/unit/transport/transport_tcp_server.cc
+++ b/test/unit/transport/transport_tcp_server.cc
@@ -61,6 +61,22 @@ TEST_F(TransportTcpServerTest, LifecycleStartStop) {
   EXPECT_NO_THROW(server_->stop());
 }
 
+TEST_F(TransportTcpServerTest, WriteWithoutActiveSessionReturnsFalse) {
+  config::TcpServerConfig cfg;
+  cfg.port = TestUtils::getAvailableTestPort();
+
+  server_ = TcpServer::create(cfg);
+
+  std::vector<uint8_t> payload = {1, 2, 3};
+  auto shared_payload = std::make_shared<const std::vector<uint8_t>>(payload);
+
+  EXPECT_FALSE(server_->async_write_copy(memory::ConstByteSpan(payload.data(), payload.size())));
+  EXPECT_FALSE(server_->async_write_move(std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_FALSE(server_->async_write_shared(shared_payload));
+  EXPECT_FALSE(server_->broadcast("payload"));
+  EXPECT_FALSE(server_->broadcast(memory::ConstByteSpan(payload.data(), payload.size())));
+}
+
 TEST_F(TransportTcpServerTest, BindFailureTriggerError) {
   // First server occupies the port
 

--- a/test/unit/transport/transport_tcp_server.cc
+++ b/test/unit/transport/transport_tcp_server.cc
@@ -68,8 +68,7 @@ TEST_F(TransportTcpServerTest, WriteWithoutActiveSessionReturnsFalse) {
   server_ = TcpServer::create(cfg);
   ASSERT_NE(server_, nullptr);
   server_->start();
-  ASSERT_TRUE(
-      TestUtils::waitForCondition([&] { return server_->state() == base::LinkState::Listening; }, 1000));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server_->state() == base::LinkState::Listening; }, 1000));
 
   std::vector<uint8_t> payload = {1, 2, 3};
   auto shared_payload = std::make_shared<const std::vector<uint8_t>>(payload);

--- a/test/unit/transport/transport_tcp_server.cc
+++ b/test/unit/transport/transport_tcp_server.cc
@@ -66,6 +66,10 @@ TEST_F(TransportTcpServerTest, WriteWithoutActiveSessionReturnsFalse) {
   cfg.port = TestUtils::getAvailableTestPort();
 
   server_ = TcpServer::create(cfg);
+  ASSERT_NE(server_, nullptr);
+  server_->start();
+  ASSERT_TRUE(
+      TestUtils::waitForCondition([&] { return server_->state() == base::LinkState::Listening; }, 1000));
 
   std::vector<uint8_t> payload = {1, 2, 3};
   auto shared_payload = std::make_shared<const std::vector<uint8_t>>(payload);

--- a/test/unit/transport/transport_uds_error_test.cc
+++ b/test/unit/transport/transport_uds_error_test.cc
@@ -14,7 +14,7 @@ using namespace unilink::test;
 class UdsErrorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    temp_sock_ = "/tmp/unilink_error_" + std::to_string(TestUtils::getAvailableTestPort()) + ".sock";
+    temp_sock_ = TestUtils::makeUniqueUdsSocketPath("ul_err").string();
     TestUtils::removeFileIfExists(temp_sock_);
   }
 
@@ -39,6 +39,7 @@ TEST_F(UdsErrorTest, InvalidSocketPath) {
 
   // In some implementations, it might stay in Idle if path validation fails immediately
   EXPECT_TRUE(server->state() == base::LinkState::Error || server->state() == base::LinkState::Idle);
+  server->stop();
 }
 
 TEST_F(UdsErrorTest, PathPermissionDenied) {
@@ -48,7 +49,7 @@ TEST_F(UdsErrorTest, PathPermissionDenied) {
   config::UdsServerConfig cfg;
 
   // Create a temporary directory and remove all permissions
-  std::string restricted_dir = "/tmp/unilink_restricted_" + std::to_string(TestUtils::getAvailableTestPort());
+  std::string restricted_dir = TestUtils::makeUniqueTempFilePath("unilink_restricted").string();
   std::filesystem::create_directory(restricted_dir);
   std::filesystem::permissions(restricted_dir, std::filesystem::perms::none);
 
@@ -67,6 +68,7 @@ TEST_F(UdsErrorTest, PathPermissionDenied) {
       1000);
 
   EXPECT_TRUE(error_state);
+  server->stop();
 
   // Cleanup: Restore permissions so directory can be deleted
   std::filesystem::permissions(restricted_dir, std::filesystem::perms::owner_all);
@@ -76,7 +78,7 @@ TEST_F(UdsErrorTest, PathPermissionDenied) {
 
 TEST_F(UdsErrorTest, ClientConnectWithoutServer) {
   config::UdsClientConfig cfg;
-  cfg.socket_path = "/tmp/non_existent_server.sock";
+  cfg.socket_path = TestUtils::makeUniqueUdsSocketPath("ul_missing").string();
   cfg.max_retries = 1;
   cfg.retry_interval_ms = 10;
 
@@ -90,14 +92,12 @@ TEST_F(UdsErrorTest, ClientConnectWithoutServer) {
 
   client->start();
 
-  // Wait for retry attempt
-  EXPECT_TRUE(TestUtils::waitForCondition([&] { return error_state_seen.load() || !client->is_connected(); }, 1000));
+  // Wait for the async connect attempt to fail before the next UDS test starts.
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return error_state_seen.load(); }, 1000));
+  client->stop();
 }
 
-// This test is currently disabled due to intermittent timing issues with UDS session cleanup.
-// It consistently reaches 81%+ coverage even when disabled because the logic is exercised
-// by other tests, but this specific scenario is flaky in high-load environments.
-TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
+TEST_F(UdsErrorTest, ServerStopWithActiveSessions) {
   config::UdsServerConfig scfg;
   scfg.socket_path = temp_sock_;
   auto server = UdsServer::create(scfg);
@@ -111,8 +111,9 @@ TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
   auto client = UdsClient::create(ccfg);
   client->start();
 
-  // Wait for connection
-  ASSERT_TRUE(TestUtils::waitForCondition([&] { return client->is_connected(); }, 2000));
+  // Wait until both sides observe the active session before stopping the server.
+  ASSERT_TRUE(
+      TestUtils::waitForCondition([&] { return client->is_connected() && server->client_count() == 1; }, 2000));
 
   // Stop server while client is connected - this must not crash
   server->stop();
@@ -124,6 +125,7 @@ TEST_F(UdsErrorTest, DISABLED_ServerStopWithActiveSessions) {
         return s == base::LinkState::Idle || s == base::LinkState::Error;
       },
       3000));
+  EXPECT_EQ(server->client_count(), 0u);
 
   client->stop();
 }

--- a/test/unit/transport/transport_uds_error_test.cc
+++ b/test/unit/transport/transport_uds_error_test.cc
@@ -112,8 +112,7 @@ TEST_F(UdsErrorTest, ServerStopWithActiveSessions) {
   client->start();
 
   // Wait until both sides observe the active session before stopping the server.
-  ASSERT_TRUE(
-      TestUtils::waitForCondition([&] { return client->is_connected() && server->client_count() == 1; }, 2000));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return client->is_connected() && server->client_count() == 1; }, 2000));
 
   // Stop server while client is connected - this must not crash
   server->stop();

--- a/test/unit/transport/transport_uds_server.cc
+++ b/test/unit/transport/transport_uds_server.cc
@@ -20,6 +20,7 @@
 #include <boost/asio.hpp>
 #include <memory>
 #include <thread>
+#include <vector>
 
 #include "test/mocks/mock_uds_acceptor.hpp"
 #include "test_constants.hpp"
@@ -86,6 +87,17 @@ TEST_F(TransportUdsServerTest, SuccessfulStart) {
 
   EXPECT_TRUE(server->is_connected());
   EXPECT_TRUE(listening);
+}
+
+TEST_F(TransportUdsServerTest, WriteWithoutActiveSessionReturnsFalse) {
+  std::vector<uint8_t> payload = {1, 2, 3};
+  auto shared_payload = std::make_shared<const std::vector<uint8_t>>(payload);
+
+  EXPECT_FALSE(server->async_write_copy(memory::ConstByteSpan(payload.data(), payload.size())));
+  EXPECT_FALSE(server->async_write_move(std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_FALSE(server->async_write_shared(shared_payload));
+  EXPECT_FALSE(server->broadcast("payload"));
+  EXPECT_FALSE(server->broadcast(memory::ConstByteSpan(payload.data(), payload.size())));
 }
 
 TEST_F(TransportUdsServerTest, BindFailure) {

--- a/test/unit/transport/transport_uds_session_coverage.cc
+++ b/test/unit/transport/transport_uds_session_coverage.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <boost/asio.hpp>
+#include <vector>
 
 #include "../../mocks/mock_uds_socket.hpp"
 #include "test_utils.hpp"
@@ -52,9 +53,8 @@ TEST_F(UdsServerSessionCoverageTest, BackpressureLimitEnforced) {
   auto mock_socket = std::make_unique<unilink::test::mocks::MockUdsSocket>();
   auto session = std::make_shared<UdsServerSession>(ioc, std::move(mock_socket), 100, 0);
 
-  // threshold is 100, limit is threshold * 4 = 400
-  std::vector<uint8_t> large_data(500, 'A');
-  session->async_write_copy(memory::ConstByteSpan(large_data.data(), large_data.size()));
+  std::vector<uint8_t> large_data(base::constants::DEFAULT_BACKPRESSURE_THRESHOLD + 1, 'A');
+  EXPECT_FALSE(session->async_write_copy(memory::ConstByteSpan(large_data.data(), large_data.size())));
 
   // We can't easily check internal state but we can verify it doesn't crash
   // and exercises the bp_limit check.

--- a/test/unit/wrapper/test_tcp_client_advanced.cc
+++ b/test/unit/wrapper/test_tcp_client_advanced.cc
@@ -190,4 +190,17 @@ TEST(TcpClientWrapperContractTest, StopSuppressesLateCallbacks) {
   EXPECT_EQ(callbacks.load(), 0);
 }
 
+TEST(TcpClientWrapperContractTest, BestEffortDisconnectedSendReturnsFalse) {
+  auto fake_channel = std::make_shared<wrapper_support::FakeChannel>();
+  wrapper::TcpClient client(fake_channel);
+  client.backpressure_strategy(base::constants::BackpressureStrategy::BestEffort);
+
+  EXPECT_FALSE(client.try_send("payload"));
+  EXPECT_FALSE(client.send("payload"));
+  EXPECT_EQ(fake_channel->write_count(), 0);
+
+  fake_channel->emit_state(base::LinkState::Connected);
+  EXPECT_EQ(fake_channel->write_count(), 0);
+}
+
 }  // namespace

--- a/test/unit/wrapper/wrapper_contract_test_utils.hpp
+++ b/test/unit/wrapper/wrapper_contract_test_utils.hpp
@@ -40,9 +40,18 @@ class FakeChannel : public interface::Channel {
     return ioc.get_executor();
   }
 
-  bool async_write_copy(memory::ConstByteSpan) override { return true; }
-  bool async_write_move(std::vector<uint8_t>&&) override { return true; }
-  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return true; }
+  bool async_write_copy(memory::ConstByteSpan) override {
+    ++write_count_;
+    return true;
+  }
+  bool async_write_move(std::vector<uint8_t>&&) override {
+    ++write_count_;
+    return true;
+  }
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override {
+    ++write_count_;
+    return true;
+  }
 
   bool is_backpressure_active() const override { return false; }
 
@@ -67,8 +76,11 @@ class FakeChannel : public interface::Channel {
     }
   }
 
+  int write_count() const { return write_count_; }
+
  private:
   bool connected_{false};
+  int write_count_{0};
   OnBytes on_bytes_;
   OnState on_state_;
   OnBackpressure on_backpressure_;

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -513,7 +513,7 @@ bool TcpServer::async_write_copy(memory::ConstByteSpan data) {
   if (session && session->alive()) {
     return session->async_write_copy(data);
   }
-  return true;
+  return false;
 }
 
 bool TcpServer::async_write_move(std::vector<uint8_t>&& data) {
@@ -528,7 +528,7 @@ bool TcpServer::async_write_move(std::vector<uint8_t>&& data) {
   if (session && session->alive()) {
     return session->async_write_move(std::move(data));
   }
-  return true;
+  return false;
 }
 
 bool TcpServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
@@ -543,7 +543,7 @@ bool TcpServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   if (session && session->alive()) {
     return session->async_write_shared(std::move(data));
   }
-  return true;
+  return false;
 }
 
 void TcpServer::on_bytes(OnBytes cb) {
@@ -578,7 +578,6 @@ bool TcpServer::broadcast(std::string_view message) {
     auto& session = entry.second;
     if (session && session->alive()) {
       if (session->async_write_shared(shared_data)) sent = true;
-      sent = true;
     }
   }
   return sent;
@@ -593,7 +592,6 @@ bool TcpServer::broadcast(memory::ConstByteSpan data) {
     auto& session = entry.second;
     if (session && session->alive()) {
       if (session->async_write_shared(shared_data)) sent = true;
-      sent = true;
     }
   }
   return sent;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -251,11 +251,11 @@ boost::asio::any_io_executor UdsClient::get_executor() { return impl_->strand_; 
 
 bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> vec(data.begin(), data.end());
-  async_write_move(std::move(vec));
-  return true;
+  return async_write_move(std::move(vec));
 }
 
 bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
+  if (!impl_->connected_.load() || impl_->stop_requested_.load()) return false;
   if (impl_->queue_bytes_ + data.size() > impl_->bp_limit_) return false;
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     size_t added = data.size();
@@ -277,6 +277,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!impl_->connected_.load() || impl_->stop_requested_.load() || !data) return false;
   if (impl_->queue_bytes_ + data->size() > impl_->bp_limit_) return false;
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() {
     size_t added = data->size();

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -261,22 +261,24 @@ boost::asio::any_io_executor UdsServer::get_executor() { return impl_->ioc_->get
 
 bool UdsServer::async_write_copy(memory::ConstByteSpan data) {
   auto shared_data = std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end());
-  async_write_shared(shared_data);
-  return true;
+  return async_write_shared(shared_data);
 }
 
 bool UdsServer::async_write_move(std::vector<uint8_t>&& data) {
   auto shared_data = std::make_shared<const std::vector<uint8_t>>(std::move(data));
-  async_write_shared(shared_data);
-  return true;
+  return async_write_shared(shared_data);
 }
 
 bool UdsServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (impl_->stopping_.load() || !data || data->empty()) return false;
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  bool sent = false;
   for (auto& pair : impl_->sessions_) {
-    pair.second->async_write_shared(data);
+    if (pair.second && pair.second->alive() && pair.second->async_write_shared(data)) {
+      sent = true;
+    }
   }
-  return true;
+  return sent;
 }
 
 void UdsServer::on_bytes(OnBytes cb) {

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -69,11 +69,11 @@ bool UdsServerSession::alive() const { return alive_.load(); }
 
 bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> vec(data.begin(), data.end());
-  async_write_move(std::move(vec));
-  return true;
+  return async_write_move(std::move(vec));
 }
 
 bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
+  if (!alive_ || closing_) return false;
   if (queue_bytes_ + data.size() > bp_limit_) return false;
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
@@ -94,6 +94,7 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!alive_ || closing_ || !data) return false;
   if (queue_bytes_ + data->size() > bp_limit_) return false;
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() {
     if (!alive_) return;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -22,7 +22,6 @@
 #include <boost/asio/steady_timer.hpp>
 #include <chrono>
 #include <mutex>
-#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <thread>
@@ -79,7 +78,6 @@ struct TcpClient::Impl {
   std::chrono::milliseconds connection_timeout_{5000};
   size_t backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   base::constants::BackpressureStrategy backpressure_strategy_{base::constants::BackpressureStrategy::Reliable};
-  std::optional<std::string> pending_best_effort_msg_;
 
   Impl(const std::string& host, uint16_t port) : host_(host), port_(port), started_(false) {}
 
@@ -257,11 +255,6 @@ struct TcpClient::Impl {
       auto binary_view = base::safe_convert::string_to_bytes(data);
       return channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     }
-    // Store as pending if in BestEffort mode to send upon reconnection
-    if (backpressure_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-      pending_best_effort_msg_ = std::string(data);
-      return true;  // Accepted for later delivery
-    }
     return false;
   }
 
@@ -347,16 +340,6 @@ struct TcpClient::Impl {
           std::unique_lock<std::shared_mutex> lock(mutex_);
           fulfill_all_locked(true);
           connect_handler = connect_handler_;
-
-          // Recovery: Send the latest pending frame if exists
-          if (pending_best_effort_msg_) {
-            auto data = std::move(*pending_best_effort_msg_);
-            pending_best_effort_msg_.reset();
-            auto binary_view = base::safe_convert::string_to_bytes(data);
-            if (channel_) {
-              channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
-            }
-          }
         }
         if (connect_handler) connect_handler(ConnectionContext(0));
       } else if (state == base::LinkState::Closed || state == base::LinkState::Error) {


### PR DESCRIPTION
## Description

This PR fixes consistency issues found during the transport and wrapper contract review. Send APIs now report whether a write was actually accepted more consistently across TCP and UDS, and TCP `BestEffort` disconnected sends no longer defer stale payloads until reconnect. It also cleans up related usability issues in metadata, documentation, test naming, UDS cleanup coverage, and Python asyncio callback handling.

## Key Changes

- Normalize TCP/UDS transport send return contracts so calls return `false` when no live recipient accepts the write.
- Make TCP wrapper `BestEffort` disconnected sends fail fast instead of retaining one pending payload for reconnect.
- Add regression coverage for disconnected/no-session send behavior and queue-limit rejection paths.
- Align package metadata and documentation for supported transports and CMake preset version requirements.
- Add readable names and `PrintTo` output for input-validator parameterized gtests.
- Re-enable `UdsErrorTest.ServerStopWithActiveSessions` by using UDS-specific temp paths, waiting for both sides to observe the session, and tightening async error-test cleanup.
- Harden Python asyncio client/server callback bridges so transport callback threads schedule queue/session mutations onto the event loop thread.

## Related Issues

- N/A

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Validation performed:

- `ctest --test-dir build/dev-linux-x64 --output-on-failure -j 4` -> 482/482 passed
- `./build/dev-linux-x64/bin/run_unit_transport_uds_error_test --gtest_filter=UdsErrorTest.ServerStopWithActiveSessions --gtest_repeat=50 --gtest_break_on_failure` -> passed
- `ctest --test-dir build/dev-linux-x64 -R UdsErrorTest --output-on-failure -j 2` -> 4/4 passed
- `python3 -m py_compile bindings/python/unilink/asyncio.py bindings/python/tests/test_bindings_api.py` -> passed
- Python asyncio fake-module smoke test for thread-safe client/server callback bridges -> passed

Not run:

- Full Python pytest suite. The current local build does not include the `unilink_py` extension module, so collection stops at import time.
- `./scripts/verify.sh`. I ran the targeted build/test checks and full CTest sweep listed above instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded documentation of UDS (Unix Domain Socket) transport support in package metadata.

* **Bug Fixes**
  * Corrected write operation return values to accurately reflect success/failure across TCP and UDS transports.
  * Fixed thread-safety issues in Python asyncio server callbacks.
  * Removed unintended message buffering in best-effort backpressure strategy.

* **Documentation**
  * Updated build requirements: CMake 3.21+ for preset-based builds; 3.12+ for plain builds.
  * Clarified Boost minimum version requirement (1.83+).

* **Tests**
  * Expanded test coverage and utility functions for improved transport validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/368)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->