### PR TITLE
fix: improve logger system reliability and API completeness

### DIFF
--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -790,6 +790,10 @@ logger.info("component", "operation", "Info message");
 logger.warning("component", "operation", "Warning message");
 logger.error("component", "operation", "Error message");
 logger.critical("component", "operation", "Critical message");
+
+// Macro form keeps source location at the call site and avoids formatting filtered messages
+UNILINK_LOG(unilink::diagnostics::LogLevel::INFO, "component", "operation", "Info message");
+UNILINK_LOG_INFO("component", "operation", "Info message");
 ```
 
 ### Log Levels

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -782,7 +782,9 @@ auto& logger = unilink::diagnostics::Logger::instance();
 // Configure logger
 logger.set_level(unilink::diagnostics::LogLevel::DEBUG);
 logger.set_console_output(true);
-logger.set_file_output("app.log");
+if (!logger.try_set_file_output("app.log")) {
+  std::cerr << logger.last_error() << std::endl;
+}
 
 // Log messages
 logger.debug("component", "operation", "Debug message");
@@ -826,6 +828,11 @@ logger.set_format("{timestamp} [{level}] [{component}] [{operation}] {message}")
 
 Supported placeholders are `{timestamp}`, `{level}`, `{component}`, `{operation}`, `{source}`, `{file}`, `{line}`,
 `{function}`, and `{message}`.
+
+### Environment
+
+`UNILINK_LOG_LEVEL` can be set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`, or `OFF`. The logger reads it
+during initialization; call `logger.reload_from_environment()` to re-apply it later.
 
 ---
 

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -807,11 +807,21 @@ logger.critical("component", "operation", "Critical message");
 ```cpp
 // Enable async logging for better performance
 unilink::diagnostics::AsyncLogConfig config;
-config.batch_size = 100;                    // Process 100 logs at once
+config.max_queue_size = 10000;              // Queue capacity
+config.enable_backpressure = true;          // Block when the queue is full
 config.flush_interval = std::chrono::milliseconds(1000); // Flush every 1 second
 
 logger.set_async_logging(true, config);
 ```
+
+### Custom Format
+
+```cpp
+logger.set_format("{timestamp} [{level}] [{component}] [{operation}] {message}");
+```
+
+Supported placeholders are `{timestamp}`, `{level}`, `{component}`, `{operation}`, `{source}`, `{file}`, `{line}`,
+`{function}`, and `{message}`.
 
 ---
 

--- a/test/unit/common/test_logger_advanced.cc
+++ b/test/unit/common/test_logger_advanced.cc
@@ -345,20 +345,56 @@ TEST_F(AdvancedLoggerCoverageTest, CallbackExceptionSafety) {
 }
 
 TEST_F(AdvancedLoggerCoverageTest, CustomFormatHandling) {
-  // spdlog format mapping is simplified in this migration.
-  // We'll just verify that setting a format doesn't crash.
+  std::vector<std::string> captured_logs;
+  Logger::instance().set_callback(
+      [&captured_logs](LogLevel /* level */, const std::string& message) { captured_logs.push_back(message); });
   Logger::instance().set_level(LogLevel::INFO);
-  Logger::instance().set_format("[{level}] {message}");
+  Logger::instance().set_format("[{level}] {component}/{operation}: {message}");
 
-  UNILINK_LOG_INFO("test", "fmt", "msg");
+  UNILINK_LOG_INFO("test_component", "fmt_operation", "formatted message");
   Logger::instance().flush();
 
+  ASSERT_FALSE(captured_logs.empty());
+  EXPECT_NE(captured_logs.back().find("[info] test_component/fmt_operation: formatted message"), std::string::npos);
+
   Logger::instance().set_format("{timestamp} [{level}] [{component}] [{operation}] {message}");
+  Logger::instance().set_callback(nullptr);
+}
+
+TEST_F(AdvancedLoggerCoverageTest, DisabledLoggerSkipsMacroMessageEvaluation) {
+  Logger::instance().set_enabled(false);
+  Logger::instance().set_level(LogLevel::DEBUG);
+
+  int evaluations = 0;
+  auto make_message = [&evaluations]() {
+    ++evaluations;
+    return std::string("expensive message");
+  };
+
+  UNILINK_LOG_DEBUG("test", "disabled", make_message());
+
+  EXPECT_EQ(evaluations, 0);
+}
+
+TEST_F(AdvancedLoggerCoverageTest, CallbackReenabledAfterOutputsDisabled) {
+  std::vector<std::string> captured_logs;
+
+  Logger::instance().set_callback([](LogLevel, const std::string&) {});
+  Logger::instance().set_outputs(0);
+  Logger::instance().set_callback(
+      [&captured_logs](LogLevel /* level */, const std::string& message) { captured_logs.push_back(message); });
+  Logger::instance().set_level(LogLevel::INFO);
+
+  UNILINK_LOG_INFO("test", "callback", "callback restored");
+  Logger::instance().flush();
+
+  ASSERT_FALSE(captured_logs.empty());
+  EXPECT_NE(captured_logs.back().find("callback restored"), std::string::npos);
 }
 
 TEST_F(AdvancedLoggerCoverageTest, OutputDisabling) {
   // Test set_file_output with empty string
-  Logger::instance().set_file_output("temp_test.log");
+  Logger::instance().set_file_output(test_log_file_.string());
   Logger::instance().set_file_output("");  // Disable
 
   // Test set_callback with nullptr

--- a/test/unit/common/test_logger_advanced.cc
+++ b/test/unit/common/test_logger_advanced.cc
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -412,6 +413,50 @@ TEST_F(AdvancedLoggerCoverageTest, ParameterizedLogMacroSkipsFilteredMessageEval
   EXPECT_EQ(evaluations, 0);
 }
 
+TEST_F(AdvancedLoggerCoverageTest, OutputsDisabledSkipsMessageEvaluation) {
+  Logger::instance().set_enabled(true);
+  Logger::instance().set_level(LogLevel::DEBUG);
+  Logger::instance().set_outputs(0);
+
+  int evaluations = 0;
+  auto make_message = [&evaluations]() {
+    ++evaluations;
+    return std::string("no output message");
+  };
+
+  UNILINK_LOG_INFO("test", "outputs_disabled", make_message());
+
+  EXPECT_FALSE(Logger::instance().has_outputs());
+  EXPECT_EQ(evaluations, 0);
+}
+
+TEST_F(AdvancedLoggerCoverageTest, ReloadsLogLevelFromEnvironment) {
+#ifdef _WIN32
+  _putenv_s("UNILINK_LOG_LEVEL", "WARNING");
+#else
+  setenv("UNILINK_LOG_LEVEL", "WARNING", 1);
+#endif
+
+  Logger::instance().reload_from_environment();
+  EXPECT_TRUE(Logger::instance().enabled());
+  EXPECT_EQ(Logger::instance().level(), LogLevel::WARNING);
+
+#ifdef _WIN32
+  _putenv_s("UNILINK_LOG_LEVEL", "OFF");
+#else
+  setenv("UNILINK_LOG_LEVEL", "OFF", 1);
+#endif
+
+  Logger::instance().reload_from_environment();
+  EXPECT_FALSE(Logger::instance().enabled());
+
+#ifdef _WIN32
+  _putenv_s("UNILINK_LOG_LEVEL", "");
+#else
+  unsetenv("UNILINK_LOG_LEVEL");
+#endif
+}
+
 TEST_F(AdvancedLoggerCoverageTest, CallbackReenabledAfterOutputsDisabled) {
   std::vector<std::string> captured_logs;
 
@@ -458,7 +503,16 @@ TEST_F(AdvancedLoggerCoverageTest, FileOpenFailure) {
 #endif
 
   // This should print error to stderr but not throw
-  EXPECT_NO_THROW(Logger::instance().set_file_output(invalid_path));
+  EXPECT_FALSE(Logger::instance().try_set_file_output(invalid_path));
+  EXPECT_FALSE(Logger::instance().last_error().empty());
+}
+
+TEST_F(AdvancedLoggerCoverageTest, UnsupportedRotationOptionsReportFailure) {
+  LogRotationConfig config;
+  config.enable_compression = true;
+
+  EXPECT_FALSE(Logger::instance().try_set_file_output_with_rotation(test_log_file_.string(), config));
+  EXPECT_FALSE(Logger::instance().last_error().empty());
 }
 
 TEST_F(AdvancedLoggerCoverageTest, ConsoleErrorStreamSelection) {

--- a/test/unit/common/test_logger_advanced.cc
+++ b/test/unit/common/test_logger_advanced.cc
@@ -376,6 +376,42 @@ TEST_F(AdvancedLoggerCoverageTest, DisabledLoggerSkipsMacroMessageEvaluation) {
   EXPECT_EQ(evaluations, 0);
 }
 
+TEST_F(AdvancedLoggerCoverageTest, ParameterizedLogMacroUsesRuntimeLevel) {
+  std::vector<std::string> captured_logs;
+  Logger::instance().set_callback(
+      [&captured_logs](LogLevel /* level */, const std::string& message) { captured_logs.push_back(message); });
+  Logger::instance().set_level(LogLevel::WARNING);
+
+  int level_evaluations = 0;
+  auto choose_level = [&level_evaluations]() {
+    ++level_evaluations;
+    return LogLevel::WARNING;
+  };
+
+  UNILINK_LOG(choose_level(), "test", "runtime_level", "runtime level message");
+  Logger::instance().flush();
+
+  EXPECT_EQ(level_evaluations, 1);
+  ASSERT_FALSE(captured_logs.empty());
+  EXPECT_NE(captured_logs.back().find("runtime level message"), std::string::npos);
+  Logger::instance().set_callback(nullptr);
+}
+
+TEST_F(AdvancedLoggerCoverageTest, ParameterizedLogMacroSkipsFilteredMessageEvaluation) {
+  Logger::instance().set_level(LogLevel::ERROR);
+
+  int evaluations = 0;
+  auto make_message = [&evaluations]() {
+    ++evaluations;
+    return std::string("filtered message");
+  };
+
+  const auto runtime_level = LogLevel::INFO;
+  UNILINK_LOG(runtime_level, "test", "filtered", make_message());
+
+  EXPECT_EQ(evaluations, 0);
+}
+
 TEST_F(AdvancedLoggerCoverageTest, CallbackReenabledAfterOutputsDisabled) {
   std::vector<std::string> captured_logs;
 

--- a/test/unit/transport/transport_udp_extended.cc
+++ b/test/unit/transport/transport_udp_extended.cc
@@ -74,7 +74,7 @@ TEST(TransportUdpExtendedTest, AsyncWriteMove) {
   size_t payload_size = payload.size();
   channel->async_write_move(std::move(payload));
 
-  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload_size; }, 200ms));
+  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload_size; }, 2000ms));
 
   channel->stop();
 }
@@ -106,7 +106,7 @@ TEST(TransportUdpExtendedTest, AsyncWriteShared) {
   size_t payload_size = payload->size();
   channel->async_write_shared(payload);
 
-  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload_size; }, 200ms));
+  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload_size; }, 2000ms));
 
   channel->stop();
 }
@@ -139,7 +139,7 @@ TEST(TransportUdpExtendedTest, PooledBufferWrite) {
   std::vector<uint8_t> payload(100, 0xCC);
   channel->async_write_copy(memory::ConstByteSpan(payload.data(), payload.size()));
 
-  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload.size(); }, 200ms));
+  EXPECT_TRUE(wait_for_condition(ioc, [&] { return received_bytes == payload.size(); }, 2000ms));
 
   channel->stop();
 }

--- a/unilink/diagnostics/logger.cc
+++ b/unilink/diagnostics/logger.cc
@@ -23,9 +23,12 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include <ctime>
 #include <future>
+#include <iomanip>
 #include <iostream>
 #include <mutex>
+#include <sstream>
 #include <string_view>
 
 namespace unilink {
@@ -50,7 +53,10 @@ class callback_sink : public spdlog::sinks::base_sink<Mutex> {
 
     spdlog::memory_buf_t formatted;
     spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-    callback_(from_spdlog_level(msg.level), fmt::to_string(formatted));
+    try {
+      callback_(from_spdlog_level(msg.level), fmt::to_string(formatted));
+    } catch (...) {
+    }
   }
 
   void flush_() override {}
@@ -92,6 +98,7 @@ struct Logger::Impl {
 
   std::string current_log_file_;
   LogRotationConfig rotation_config_;
+  std::string format_ = "{timestamp} [{level}] [{component}] [{operation}] [{source}] {message}";
 
   // Async logging support
   std::atomic<bool> async_enabled_{false};
@@ -109,7 +116,7 @@ struct Logger::Impl {
     console_sink_ = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     dist_sink_->add_sink(console_sink_);
 
-    set_format("{timestamp} [{level}] [{component}] [{operation}] {message}");
+    apply_spdlog_pattern();
   }
 
   ~Impl() {
@@ -119,43 +126,86 @@ struct Logger::Impl {
     spdlog::drop("unilink");
   }
 
-  void parse_format(const std::string& format) {
-    std::string pattern = format;
-
-    // Map unilink placeholders to spdlog pattern
-    // {timestamp} -> %Y-%m-%d %H:%M:%S.%e
-    // {level}     -> %l
-    // {message}   -> %v (Note: macros wrap component/operation into message)
-
-    auto replace_all = [](std::string& str, const std::string& from, const std::string& to) {
-      size_t pos = 0;
-      while ((pos = str.find(from, pos)) != std::string::npos) {
-        str.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    };
-
-    replace_all(pattern, "{timestamp}", "%Y-%m-%d %H:%M:%S.%e");
-    replace_all(pattern, "{level}", "%l");
-    replace_all(pattern, "{message}", "%v");
-
-    // component and operation are currently embedded in the message by macros
-    // but if they appear in format, we strip them or handle as literal since they are in %v
-    replace_all(pattern, "[{component}] ", "");
-    replace_all(pattern, "[{operation}] ", "");
-
-    dist_sink_->set_pattern(pattern);
+  void apply_spdlog_pattern() {
+    if (dist_sink_) {
+      dist_sink_->set_pattern("%v");
+    }
   }
 
-  void set_format(const std::string& format) { parse_format(format); }
+  void set_format(const std::string& format) { format_ = format; }
+
+  static void replace_all(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty()) {
+      return;
+    }
+
+    size_t pos = 0;
+    while ((pos = str.find(from, pos)) != std::string::npos) {
+      str.replace(pos, from.length(), to);
+      pos += to.length();
+    }
+  }
+
+  static std::string level_name(LogLevel level) {
+    switch (level) {
+      case LogLevel::DEBUG:
+        return "debug";
+      case LogLevel::INFO:
+        return "info";
+      case LogLevel::WARNING:
+        return "warning";
+      case LogLevel::ERROR:
+        return "error";
+      case LogLevel::CRITICAL:
+        return "critical";
+      default:
+        return "info";
+    }
+  }
+
+  static std::string timestamp_now() {
+    using namespace std::chrono;
+    const auto now = system_clock::now();
+    const auto tt = system_clock::to_time_t(now);
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &tt);
+#else
+    localtime_r(&tt, &tm);
+#endif
+    const auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%F %T") << '.' << std::setw(3) << std::setfill('0') << ms.count();
+    return oss.str();
+  }
+
+  static std::string format_message(const std::string& format, LogLevel level, std::string_view component,
+                                    std::string_view operation, std::string_view message,
+                                    const std::source_location& loc) {
+    const auto file = std::string(loc.file_name());
+    const auto line = std::to_string(loc.line());
+    const auto function = std::string(loc.function_name());
+    const auto source = fmt::format("{}:{}:{}", file, line, function);
+
+    std::string formatted = format;
+    replace_all(formatted, "{timestamp}", timestamp_now());
+    replace_all(formatted, "{level}", level_name(level));
+    replace_all(formatted, "{component}", std::string(component));
+    replace_all(formatted, "{operation}", std::string(operation));
+    replace_all(formatted, "{source}", source);
+    replace_all(formatted, "{file}", file);
+    replace_all(formatted, "{line}", line);
+    replace_all(formatted, "{function}", function);
+    replace_all(formatted, "{message}", std::string(message));
+    return formatted;
+  }
 
   void flush() {
-    if (spd_logger_) {
-      spd_logger_->flush();
-    }
-    if (dist_sink_) {
-      dist_sink_->flush();
-    }
+    auto logger = spd_logger_;
+    auto sink = dist_sink_;
+    if (logger) logger->flush();
+    if (sink) sink->flush();
   }
 
   void setup_async_logging(const AsyncLogConfig& config) {
@@ -172,6 +222,7 @@ struct Logger::Impl {
 
     spd_logger_ = std::make_shared<spdlog::async_logger>("unilink", dist_sink_, spdlog::thread_pool(), overflow_policy);
     spd_logger_->set_level(to_spdlog_level(current_level_.load()));
+    apply_spdlog_pattern();
 
     spdlog::register_logger(spd_logger_);
 
@@ -210,6 +261,7 @@ struct Logger::Impl {
     // Create sync logger
     spd_logger_ = std::make_shared<spdlog::logger>("unilink", dist_sink_);
     spd_logger_->set_level(to_spdlog_level(current_level_.load()));
+    apply_spdlog_pattern();
 
     // Only register globally if the previous drop finished, to avoid race conditions.
     // If it didn't finish, we still have spd_logger_ internally so log() works.
@@ -251,11 +303,19 @@ Logger& Logger::instance() {
 Logger& Logger::default_logger() { return instance(); }
 
 void Logger::set_level(LogLevel level) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->current_level_.store(level);
-  impl_->spd_logger_->set_level(Impl::to_spdlog_level(level));
+  if (impl_->spd_logger_) {
+    impl_->spd_logger_->set_level(Impl::to_spdlog_level(level));
+  }
 }
 
 LogLevel Logger::level() const { return get_impl()->current_level_.load(); }
+
+bool Logger::should_log(LogLevel level) const {
+  const auto* impl = get_impl();
+  return impl->enabled_.load() && level >= impl->current_level_.load();
+}
 
 void Logger::set_console_output(bool enable) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
@@ -265,6 +325,7 @@ void Logger::set_console_output(bool enable) {
     }
     impl_->dist_sink_->remove_sink(impl_->console_sink_);  // Ensure no duplicate
     impl_->dist_sink_->add_sink(impl_->console_sink_);
+    impl_->apply_spdlog_pattern();
     impl_->outputs_.fetch_or(static_cast<int>(LogOutput::CONSOLE));
   } else {
     if (impl_->console_sink_) {
@@ -300,6 +361,7 @@ void Logger::set_file_output_with_rotation(const std::string& filename, const Lo
                                                                                  config.max_files);
 
       impl_->dist_sink_->add_sink(impl_->file_sink_);
+      impl_->apply_spdlog_pattern();
       impl_->outputs_.fetch_or(static_cast<int>(LogOutput::FILE));
     } catch (const spdlog::spdlog_ex& e) {
       std::cerr << "Failed to open log file: " << filename << " (" << e.what() << ")" << std::endl;
@@ -311,6 +373,7 @@ void Logger::set_file_output_with_rotation(const std::string& filename, const Lo
 }
 
 void Logger::set_async_logging(bool enable, const AsyncLogConfig& config) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
   if (enable) {
     impl_->setup_async_logging(config);
   } else {
@@ -334,15 +397,13 @@ void Logger::set_callback(LogCallback callback) {
 
   if (impl_->callback_sink_) {
     impl_->callback_sink_->set_callback(std::move(callback));
-    // Ensure it's in the dist_sink if outputs bit is set
-    if (impl_->outputs_.load() & static_cast<int>(LogOutput::CALLBACK)) {
-      impl_->dist_sink_->remove_sink(impl_->callback_sink_);  // Avoid duplicates
-      impl_->dist_sink_->add_sink(impl_->callback_sink_);
-    }
+    impl_->dist_sink_->remove_sink(impl_->callback_sink_);  // Avoid duplicates
+    impl_->dist_sink_->add_sink(impl_->callback_sink_);
   } else {
     impl_->callback_sink_ = std::make_shared<callback_sink_mt>(std::move(callback));
     impl_->dist_sink_->add_sink(impl_->callback_sink_);
   }
+  impl_->apply_spdlog_pattern();
   impl_->outputs_.fetch_or(static_cast<int>(LogOutput::CALLBACK));
 }
 
@@ -359,6 +420,7 @@ void Logger::set_outputs(int outputs) {
     }
     impl_->dist_sink_->remove_sink(impl_->console_sink_);  // Ensure no duplicate
     impl_->dist_sink_->add_sink(impl_->console_sink_);
+    impl_->apply_spdlog_pattern();
   } else {
     if (impl_->console_sink_) {
       impl_->dist_sink_->remove_sink(impl_->console_sink_);
@@ -375,6 +437,7 @@ void Logger::set_outputs(int outputs) {
     if (impl_->file_sink_) {
       impl_->dist_sink_->remove_sink(impl_->file_sink_);  // Ensure no duplicate
       impl_->dist_sink_->add_sink(impl_->file_sink_);
+      impl_->apply_spdlog_pattern();
     }
   } else {
     if (impl_->file_sink_) {
@@ -388,6 +451,7 @@ void Logger::set_outputs(int outputs) {
     if (impl_->callback_sink_) {
       impl_->dist_sink_->remove_sink(impl_->callback_sink_);  // Ensure no duplicate
       impl_->dist_sink_->add_sink(impl_->callback_sink_);
+      impl_->apply_spdlog_pattern();
     }
   } else {
     if (impl_->callback_sink_) {
@@ -400,21 +464,43 @@ void Logger::set_enabled(bool enabled) { impl_->enabled_.store(enabled); }
 
 bool Logger::enabled() const { return get_impl()->enabled_.load(); }
 
-void Logger::set_format(const std::string& format) { impl_->parse_format(format); }
+void Logger::set_format(const std::string& format) {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
+  impl_->set_format(format);
+}
 
-void Logger::flush() { impl_->flush(); }
+void Logger::flush() {
+  std::shared_ptr<spdlog::logger> logger;
+  std::shared_ptr<spdlog::sinks::dist_sink_mt> sink;
+  {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    logger = impl_->spd_logger_;
+    sink = impl_->dist_sink_;
+  }
+  if (logger) logger->flush();
+  if (sink) sink->flush();
+}
 
 void Logger::log(LogLevel level, std::string_view component, std::string_view operation, std::string_view message,
                  const std::source_location& loc) {
-  if (!get_impl()->enabled_.load() || level < get_impl()->current_level_.load()) {
+  if (!should_log(level)) {
     return;
   }
 
-  // Incorporate source location information into the payload
-  std::string payload = fmt::format("[{}] [{}] [{}:{}:{}] {}", component, operation, loc.file_name(), loc.line(),
-                                    loc.function_name(), message);
+  std::shared_ptr<spdlog::logger> logger;
+  std::string format;
+  {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    logger = impl_->spd_logger_;
+    format = impl_->format_;
+  }
 
-  impl_->spd_logger_->log(Impl::to_spdlog_level(level), payload);
+  if (!logger) {
+    return;
+  }
+
+  const auto payload = Impl::format_message(format, level, component, operation, message, loc);
+  logger->log(Impl::to_spdlog_level(level), payload);
 }
 
 void Logger::debug(std::string_view component, std::string_view operation, std::string_view message,

--- a/unilink/diagnostics/logger.cc
+++ b/unilink/diagnostics/logger.cc
@@ -17,12 +17,17 @@
 #include "logger.hpp"
 
 #include <spdlog/async.h>
+#include <spdlog/details/thread_pool.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <ctime>
 #include <future>
 #include <iomanip>
@@ -84,6 +89,32 @@ class callback_sink : public spdlog::sinks::base_sink<Mutex> {
 
 using callback_sink_mt = callback_sink<std::mutex>;
 
+class level_range_sink final : public spdlog::sinks::sink {
+ public:
+  level_range_sink(std::shared_ptr<spdlog::sinks::sink> sink, spdlog::level::level_enum min_level,
+                   spdlog::level::level_enum max_level)
+      : sink_(std::move(sink)), min_level_(min_level), max_level_(max_level) {}
+
+  void log(const spdlog::details::log_msg& msg) override {
+    if (msg.level >= min_level_ && msg.level <= max_level_) {
+      sink_->log(msg);
+    }
+  }
+
+  void flush() override { sink_->flush(); }
+
+  void set_pattern(const std::string& pattern) override { sink_->set_pattern(pattern); }
+
+  void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override {
+    sink_->set_formatter(std::move(sink_formatter));
+  }
+
+ private:
+  std::shared_ptr<spdlog::sinks::sink> sink_;
+  spdlog::level::level_enum min_level_;
+  spdlog::level::level_enum max_level_;
+};
+
 struct Logger::Impl {
   mutable std::mutex mutex_;
   std::atomic<LogLevel> current_level_{LogLevel::INFO};
@@ -92,18 +123,23 @@ struct Logger::Impl {
 
   std::shared_ptr<spdlog::logger> spd_logger_;
   std::shared_ptr<spdlog::sinks::dist_sink_mt> dist_sink_;
-  std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> console_sink_;
+  std::shared_ptr<spdlog::sinks::stdout_color_sink_mt> console_stdout_sink_;
+  std::shared_ptr<spdlog::sinks::stderr_color_sink_mt> console_stderr_sink_;
+  std::shared_ptr<level_range_sink> console_stdout_filter_;
+  std::shared_ptr<level_range_sink> console_stderr_filter_;
   std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> file_sink_;
   std::shared_ptr<callback_sink_mt> callback_sink_;
 
   std::string current_log_file_;
   LogRotationConfig rotation_config_;
   std::string format_ = "{timestamp} [{level}] [{component}] [{operation}] [{source}] {message}";
+  std::string last_error_;
 
   // Async logging support
   std::atomic<bool> async_enabled_{false};
   AsyncLogConfig async_config_;
   std::future<void> drop_future_;
+  std::shared_ptr<spdlog::details::thread_pool> async_thread_pool_;
 
   Impl() {
     dist_sink_ = std::make_shared<spdlog::sinks::dist_sink_mt>();
@@ -112,11 +148,10 @@ struct Logger::Impl {
     spd_logger_ = std::make_shared<spdlog::logger>("unilink", dist_sink_);
     spd_logger_->set_level(to_spdlog_level(LogLevel::DEBUG));  // Allow all, filter via Logger::log or Logger::set_level
 
-    // Initial setup with console sink
-    console_sink_ = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    dist_sink_->add_sink(console_sink_);
+    add_console_sinks();
 
     apply_spdlog_pattern();
+    apply_environment_settings();
   }
 
   ~Impl() {
@@ -130,6 +165,44 @@ struct Logger::Impl {
     if (dist_sink_) {
       dist_sink_->set_pattern("%v");
     }
+  }
+
+  void set_error(std::string message) { last_error_ = std::move(message); }
+
+  void clear_error() { last_error_.clear(); }
+
+  bool has_outputs_unlocked() const { return outputs_.load() != 0; }
+
+  void add_console_sinks() {
+    if (!console_stdout_sink_) {
+      console_stdout_sink_ = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+      console_stdout_filter_ =
+          std::make_shared<level_range_sink>(console_stdout_sink_, spdlog::level::trace, spdlog::level::warn);
+    }
+    if (!console_stderr_sink_) {
+      console_stderr_sink_ = std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+      console_stderr_filter_ =
+          std::make_shared<level_range_sink>(console_stderr_sink_, spdlog::level::err, spdlog::level::critical);
+    }
+
+    dist_sink_->remove_sink(console_stdout_filter_);
+    dist_sink_->remove_sink(console_stderr_filter_);
+    dist_sink_->add_sink(console_stdout_filter_);
+    dist_sink_->add_sink(console_stderr_filter_);
+    apply_spdlog_pattern();
+  }
+
+  void remove_console_sinks() {
+    if (console_stdout_filter_) {
+      dist_sink_->remove_sink(console_stdout_filter_);
+    }
+    if (console_stderr_filter_) {
+      dist_sink_->remove_sink(console_stderr_filter_);
+    }
+    console_stdout_filter_.reset();
+    console_stderr_filter_.reset();
+    console_stdout_sink_.reset();
+    console_stderr_sink_.reset();
   }
 
   void set_format(const std::string& format) { format_ = format; }
@@ -161,6 +234,71 @@ struct Logger::Impl {
       default:
         return "info";
     }
+  }
+
+  static std::string normalize_env_value(std::string_view value) {
+    std::string normalized(value);
+    normalized.erase(normalized.begin(), std::find_if(normalized.begin(), normalized.end(),
+                                                      [](unsigned char c) { return !std::isspace(c); }));
+    normalized.erase(
+        std::find_if(normalized.rbegin(), normalized.rend(), [](unsigned char c) { return !std::isspace(c); }).base(),
+        normalized.end());
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    return normalized;
+  }
+
+  static bool parse_log_level(std::string_view value, LogLevel& level, bool& disable_logging) {
+    const auto normalized = normalize_env_value(value);
+    disable_logging = false;
+    if (normalized == "DEBUG" || normalized == "TRACE") {
+      level = LogLevel::DEBUG;
+      return true;
+    }
+    if (normalized == "INFO") {
+      level = LogLevel::INFO;
+      return true;
+    }
+    if (normalized == "WARNING" || normalized == "WARN") {
+      level = LogLevel::WARNING;
+      return true;
+    }
+    if (normalized == "ERROR" || normalized == "ERR") {
+      level = LogLevel::ERROR;
+      return true;
+    }
+    if (normalized == "CRITICAL" || normalized == "FATAL") {
+      level = LogLevel::CRITICAL;
+      return true;
+    }
+    if (normalized == "OFF" || normalized == "NONE" || normalized == "DISABLED") {
+      disable_logging = true;
+      return true;
+    }
+    return false;
+  }
+
+  void apply_environment_settings() {
+    const char* env_level = std::getenv("UNILINK_LOG_LEVEL");
+    if (!env_level || *env_level == '\0') {
+      return;
+    }
+
+    LogLevel parsed_level = current_level_.load();
+    bool disable_logging = false;
+    if (!parse_log_level(env_level, parsed_level, disable_logging)) {
+      set_error("Invalid UNILINK_LOG_LEVEL: " + std::string(env_level));
+      return;
+    }
+
+    enabled_.store(!disable_logging);
+    if (!disable_logging) {
+      current_level_.store(parsed_level);
+      if (spd_logger_) {
+        spd_logger_->set_level(to_spdlog_level(parsed_level));
+      }
+    }
+    clear_error();
   }
 
   static std::string timestamp_now() {
@@ -216,11 +354,9 @@ struct Logger::Impl {
     auto overflow_policy = config.enable_backpressure ? spdlog::async_overflow_policy::block
                                                       : spdlog::async_overflow_policy::overrun_oldest;
 
-    if (!spdlog::thread_pool()) {
-      spdlog::init_thread_pool(config.max_queue_size, 1);
-    }
+    async_thread_pool_ = std::make_shared<spdlog::details::thread_pool>(std::max<size_t>(1, config.max_queue_size), 1);
 
-    spd_logger_ = std::make_shared<spdlog::async_logger>("unilink", dist_sink_, spdlog::thread_pool(), overflow_policy);
+    spd_logger_ = std::make_shared<spdlog::async_logger>("unilink", dist_sink_, async_thread_pool_, overflow_policy);
     spd_logger_->set_level(to_spdlog_level(current_level_.load()));
     apply_spdlog_pattern();
 
@@ -256,6 +392,9 @@ struct Logger::Impl {
     }
 
     spd_logger_.reset();
+    if (drop_success) {
+      async_thread_pool_.reset();
+    }
     dist_sink_->flush();
 
     // Create sync logger
@@ -314,31 +453,30 @@ LogLevel Logger::level() const { return get_impl()->current_level_.load(); }
 
 bool Logger::should_log(LogLevel level) const {
   const auto* impl = get_impl();
-  return impl->enabled_.load() && level >= impl->current_level_.load();
+  return impl->enabled_.load() && impl->has_outputs_unlocked() && level >= impl->current_level_.load();
 }
 
 void Logger::set_console_output(bool enable) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
   if (enable) {
-    if (!impl_->console_sink_) {
-      impl_->console_sink_ = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    }
-    impl_->dist_sink_->remove_sink(impl_->console_sink_);  // Ensure no duplicate
-    impl_->dist_sink_->add_sink(impl_->console_sink_);
-    impl_->apply_spdlog_pattern();
+    impl_->add_console_sinks();
     impl_->outputs_.fetch_or(static_cast<int>(LogOutput::CONSOLE));
   } else {
-    if (impl_->console_sink_) {
-      impl_->dist_sink_->remove_sink(impl_->console_sink_);
-      impl_->console_sink_.reset();
-    }
+    impl_->remove_console_sinks();
     impl_->outputs_.fetch_and(~static_cast<int>(LogOutput::CONSOLE));
   }
+  impl_->clear_error();
 }
 
-void Logger::set_file_output(const std::string& filename) { set_file_output_with_rotation(filename); }
+void Logger::set_file_output(const std::string& filename) { (void)try_set_file_output_with_rotation(filename); }
+
+bool Logger::try_set_file_output(const std::string& filename) { return try_set_file_output_with_rotation(filename); }
 
 void Logger::set_file_output_with_rotation(const std::string& filename, const LogRotationConfig& config) {
+  (void)try_set_file_output_with_rotation(filename, config);
+}
+
+bool Logger::try_set_file_output_with_rotation(const std::string& filename, const LogRotationConfig& config) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
 
   if (filename.empty()) {
@@ -348,8 +486,18 @@ void Logger::set_file_output_with_rotation(const std::string& filename, const Lo
     }
     impl_->current_log_file_.clear();
     impl_->outputs_.fetch_and(~static_cast<int>(LogOutput::FILE));
+    impl_->clear_error();
+    return true;
   } else {
     try {
+      if (config.enable_compression) {
+        impl_->set_error("Log compression is not supported by the current rotating file sink");
+        return false;
+      }
+      if (config.file_pattern != LogRotationConfig{}.file_pattern) {
+        impl_->set_error("Custom log rotation file_pattern is not supported by the current rotating file sink");
+        return false;
+      }
       if (impl_->file_sink_) {
         impl_->dist_sink_->remove_sink(impl_->file_sink_);
       }
@@ -363,11 +511,15 @@ void Logger::set_file_output_with_rotation(const std::string& filename, const Lo
       impl_->dist_sink_->add_sink(impl_->file_sink_);
       impl_->apply_spdlog_pattern();
       impl_->outputs_.fetch_or(static_cast<int>(LogOutput::FILE));
+      impl_->clear_error();
+      return true;
     } catch (const spdlog::spdlog_ex& e) {
-      std::cerr << "Failed to open log file: " << filename << " (" << e.what() << ")" << std::endl;
+      impl_->set_error("Failed to open log file: " + filename + " (" + e.what() + ")");
+      std::cerr << impl_->last_error_ << std::endl;
       impl_->file_sink_.reset();
       impl_->current_log_file_.clear();
       impl_->outputs_.fetch_and(~static_cast<int>(LogOutput::FILE));
+      return false;
     }
   }
 }
@@ -375,6 +527,9 @@ void Logger::set_file_output_with_rotation(const std::string& filename, const Lo
 void Logger::set_async_logging(bool enable, const AsyncLogConfig& config) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
   if (enable) {
+    if (impl_->async_enabled_.load()) {
+      impl_->teardown_async_logging();
+    }
     impl_->setup_async_logging(config);
   } else {
     impl_->teardown_async_logging();
@@ -382,6 +537,11 @@ void Logger::set_async_logging(bool enable, const AsyncLogConfig& config) {
 }
 
 bool Logger::async_logging_enabled() const { return get_impl()->async_enabled_.load(); }
+
+void Logger::reload_from_environment() {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
+  impl_->apply_environment_settings();
+}
 
 void Logger::set_callback(LogCallback callback) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
@@ -392,6 +552,7 @@ void Logger::set_callback(LogCallback callback) {
       impl_->callback_sink_.reset();
     }
     impl_->outputs_.fetch_and(~static_cast<int>(LogOutput::CALLBACK));
+    impl_->clear_error();
     return;
   }
 
@@ -405,27 +566,21 @@ void Logger::set_callback(LogCallback callback) {
   }
   impl_->apply_spdlog_pattern();
   impl_->outputs_.fetch_or(static_cast<int>(LogOutput::CALLBACK));
+  impl_->clear_error();
 }
 
 void Logger::set_outputs(int outputs) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
-  impl_->outputs_.store(outputs);
+  int effective_outputs = 0;
 
   // Reconcile sinks in dist_sink_ based on the new bitmask
 
   // Console Sink
   if (outputs & static_cast<int>(LogOutput::CONSOLE)) {
-    if (!impl_->console_sink_) {
-      impl_->console_sink_ = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-    }
-    impl_->dist_sink_->remove_sink(impl_->console_sink_);  // Ensure no duplicate
-    impl_->dist_sink_->add_sink(impl_->console_sink_);
-    impl_->apply_spdlog_pattern();
+    impl_->add_console_sinks();
+    effective_outputs |= static_cast<int>(LogOutput::CONSOLE);
   } else {
-    if (impl_->console_sink_) {
-      impl_->dist_sink_->remove_sink(impl_->console_sink_);
-      impl_->console_sink_.reset();
-    }
+    impl_->remove_console_sinks();
   }
 
   // File Sink
@@ -438,6 +593,7 @@ void Logger::set_outputs(int outputs) {
       impl_->dist_sink_->remove_sink(impl_->file_sink_);  // Ensure no duplicate
       impl_->dist_sink_->add_sink(impl_->file_sink_);
       impl_->apply_spdlog_pattern();
+      effective_outputs |= static_cast<int>(LogOutput::FILE);
     }
   } else {
     if (impl_->file_sink_) {
@@ -452,21 +608,33 @@ void Logger::set_outputs(int outputs) {
       impl_->dist_sink_->remove_sink(impl_->callback_sink_);  // Ensure no duplicate
       impl_->dist_sink_->add_sink(impl_->callback_sink_);
       impl_->apply_spdlog_pattern();
+      effective_outputs |= static_cast<int>(LogOutput::CALLBACK);
     }
   } else {
     if (impl_->callback_sink_) {
       impl_->dist_sink_->remove_sink(impl_->callback_sink_);
     }
   }
+
+  impl_->outputs_.store(effective_outputs);
+  impl_->clear_error();
 }
 
 void Logger::set_enabled(bool enabled) { impl_->enabled_.store(enabled); }
 
 bool Logger::enabled() const { return get_impl()->enabled_.load(); }
 
+bool Logger::has_outputs() const { return get_impl()->has_outputs_unlocked(); }
+
+std::string Logger::last_error() const {
+  std::lock_guard<std::mutex> lock(impl_->mutex_);
+  return impl_->last_error_;
+}
+
 void Logger::set_format(const std::string& format) {
   std::lock_guard<std::mutex> lock(impl_->mutex_);
   impl_->set_format(format);
+  impl_->clear_error();
 }
 
 void Logger::flush() {

--- a/unilink/diagnostics/logger.hpp
+++ b/unilink/diagnostics/logger.hpp
@@ -147,12 +147,28 @@ class UNILINK_API Logger {
   void set_file_output(const std::string& filename);
 
   /**
+   * @brief Set file output and report whether it succeeded.
+   * @param filename Log file path (empty string to disable file output)
+   * @return True when the requested output state was applied
+   */
+  bool try_set_file_output(const std::string& filename);
+
+  /**
    * @brief Set file output with rotation
    * @param filename Log file path
    * @param config Rotation configuration
    */
   void set_file_output_with_rotation(const std::string& filename,
                                      const LogRotationConfig& config = LogRotationConfig{});
+
+  /**
+   * @brief Set file output with rotation and report whether it succeeded.
+   * @param filename Log file path
+   * @param config Rotation configuration
+   * @return True when the requested output state was applied
+   */
+  bool try_set_file_output_with_rotation(const std::string& filename,
+                                         const LogRotationConfig& config = LogRotationConfig{});
 
   /**
    * @brief Enable/disable async logging
@@ -165,6 +181,13 @@ class UNILINK_API Logger {
    * @brief Check if async logging is enabled
    */
   bool async_logging_enabled() const;
+
+  /**
+   * @brief Re-apply supported logger settings from environment variables.
+   *
+   * Currently supports UNILINK_LOG_LEVEL values DEBUG, INFO, WARNING, ERROR, CRITICAL, and OFF.
+   */
+  void reload_from_environment();
 
   /**
    * @brief Set log callback
@@ -188,6 +211,16 @@ class UNILINK_API Logger {
    * @brief Check if logging is enabled
    */
   bool enabled() const;
+
+  /**
+   * @brief Return true when at least one output destination is active.
+   */
+  bool has_outputs() const;
+
+  /**
+   * @brief Last logger configuration error, empty when the last operation succeeded.
+   */
+  std::string last_error() const;
 
   /**
    * @brief Set log format

--- a/unilink/diagnostics/logger.hpp
+++ b/unilink/diagnostics/logger.hpp
@@ -226,40 +226,28 @@ class UNILINK_API Logger {
 /**
  * @brief Convenience macros for logging
  */
-#define UNILINK_LOG_DEBUG(component, operation, message)                                              \
+#define UNILINK_LOG(level, component, operation, message)                                             \
   do {                                                                                                \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) { \
-      unilink::diagnostics::Logger::instance().debug(component, operation, message);                  \
+    const auto unilink_log_level = (level);                                                           \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink_log_level)) {                     \
+      unilink::diagnostics::Logger::instance().log(unilink_log_level, component, operation, message); \
     }                                                                                                 \
   } while (0)
 
-#define UNILINK_LOG_INFO(component, operation, message)                                              \
-  do {                                                                                               \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::INFO)) { \
-      unilink::diagnostics::Logger::instance().info(component, operation, message);                  \
-    }                                                                                                \
-  } while (0)
+#define UNILINK_LOG_DEBUG(component, operation, message) \
+  UNILINK_LOG(unilink::diagnostics::LogLevel::DEBUG, component, operation, message)
 
-#define UNILINK_LOG_WARNING(component, operation, message)                                              \
-  do {                                                                                                  \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::WARNING)) { \
-      unilink::diagnostics::Logger::instance().warning(component, operation, message);                  \
-    }                                                                                                   \
-  } while (0)
+#define UNILINK_LOG_INFO(component, operation, message) \
+  UNILINK_LOG(unilink::diagnostics::LogLevel::INFO, component, operation, message)
 
-#define UNILINK_LOG_ERROR(component, operation, message)                                              \
-  do {                                                                                                \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::ERROR)) { \
-      unilink::diagnostics::Logger::instance().error(component, operation, message);                  \
-    }                                                                                                 \
-  } while (0)
+#define UNILINK_LOG_WARNING(component, operation, message) \
+  UNILINK_LOG(unilink::diagnostics::LogLevel::WARNING, component, operation, message)
 
-#define UNILINK_LOG_CRITICAL(component, operation, message)                                              \
-  do {                                                                                                   \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::CRITICAL)) { \
-      unilink::diagnostics::Logger::instance().critical(component, operation, message);                  \
-    }                                                                                                    \
-  } while (0)
+#define UNILINK_LOG_ERROR(component, operation, message) \
+  UNILINK_LOG(unilink::diagnostics::LogLevel::ERROR, component, operation, message)
+
+#define UNILINK_LOG_CRITICAL(component, operation, message) \
+  UNILINK_LOG(unilink::diagnostics::LogLevel::CRITICAL, component, operation, message)
 
 /**
  * @brief Performance logging macros for expensive operations.
@@ -274,15 +262,16 @@ class UNILINK_API Logger {
           ? std::chrono::high_resolution_clock::now()                                              \
           : std::chrono::high_resolution_clock::time_point()
 
-#define UNILINK_LOG_PERF_END(component, operation)                                                                \
-  do {                                                                                                            \
-    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) {             \
-      auto _perf_end_##operation = std::chrono::high_resolution_clock::now();                                     \
-      using _us_t = std::chrono::microseconds;                                                                    \
-      auto _diff_##operation = _perf_end_##operation - _perf_start_##operation;                                   \
-      auto _perf_duration_##operation = std::chrono::duration_cast<_us_t>(_diff_##operation).count();             \
-      UNILINK_LOG_DEBUG(component, operation, "Duration: " + std::to_string(_perf_duration_##operation) + " μs"); \
-    }                                                                                                             \
+#define UNILINK_LOG_PERF_END(component, operation)                                                    \
+  do {                                                                                                \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) { \
+      auto _perf_end_##operation = std::chrono::high_resolution_clock::now();                         \
+      using _us_t = std::chrono::microseconds;                                                        \
+      auto _diff_##operation = _perf_end_##operation - _perf_start_##operation;                       \
+      auto _perf_duration_##operation = std::chrono::duration_cast<_us_t>(_diff_##operation).count(); \
+      UNILINK_LOG(unilink::diagnostics::LogLevel::DEBUG, component, operation,                        \
+                  "Duration: " + std::to_string(_perf_duration_##operation) + " μs");                 \
+    }                                                                                                 \
   } while (0)
 
 }  // namespace diagnostics

--- a/unilink/diagnostics/logger.hpp
+++ b/unilink/diagnostics/logger.hpp
@@ -65,8 +65,8 @@ enum class LogOutput { CONSOLE = 0x01, FILE = 0x02, CALLBACK = 0x04 };
 struct LogRotationConfig {
   size_t max_file_size_bytes = 10 * 1024 * 1024;    // 10MB default
   size_t max_files = 10;                            // Keep 10 files max
-  bool enable_compression = false;                  // Future feature
-  std::string file_pattern = "{name}.{index}.log";  // File naming pattern
+  bool enable_compression = false;                  // Reserved for future use
+  std::string file_pattern = "{name}.{index}.log";  // Reserved for future use
 
   LogRotationConfig() = default;
 
@@ -78,11 +78,11 @@ struct LogRotationConfig {
  */
 struct AsyncLogConfig {
   size_t max_queue_size = 10000;                     // Maximum queue size
-  size_t batch_size = 100;                           // [IGNORED] Batch processing size (handled by spdlog)
+  size_t batch_size = 100;                           // Reserved; spdlog manages batching internally
   std::chrono::milliseconds flush_interval{100};     // Flush interval
   std::chrono::milliseconds shutdown_timeout{5000};  // Shutdown timeout
   bool enable_backpressure = true;                   // Enable backpressure handling (maps to spdlog block policy)
-  bool enable_batch_processing = true;               // [IGNORED] Enable batch processing (handled by spdlog)
+  bool enable_batch_processing = true;               // Reserved; spdlog manages batching internally
 
   AsyncLogConfig() = default;
 
@@ -128,6 +128,11 @@ class UNILINK_API Logger {
    * @brief Get current log level
    */
   LogLevel level() const;
+
+  /**
+   * @brief Check whether a message at the given level would be logged.
+   */
+  bool should_log(LogLevel level) const;
 
   /**
    * @brief Enable/disable console output
@@ -186,7 +191,8 @@ class UNILINK_API Logger {
 
   /**
    * @brief Set log format
-   * @param format Format string with placeholders: {timestamp}, {level}, {component}, {operation}, {message}
+   * @param format Format string with placeholders: {timestamp}, {level}, {component}, {operation}, {source}, {file},
+   * {line}, {function}, {message}
    */
   void set_format(const std::string& format);
 
@@ -220,39 +226,39 @@ class UNILINK_API Logger {
 /**
  * @brief Convenience macros for logging
  */
-#define UNILINK_LOG_DEBUG(component, operation, message)                                             \
+#define UNILINK_LOG_DEBUG(component, operation, message)                                              \
+  do {                                                                                                \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) { \
+      unilink::diagnostics::Logger::instance().debug(component, operation, message);                  \
+    }                                                                                                 \
+  } while (0)
+
+#define UNILINK_LOG_INFO(component, operation, message)                                              \
   do {                                                                                               \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) { \
-      unilink::diagnostics::Logger::instance().debug(component, operation, message);                 \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::INFO)) { \
+      unilink::diagnostics::Logger::instance().info(component, operation, message);                  \
     }                                                                                                \
   } while (0)
 
-#define UNILINK_LOG_INFO(component, operation, message)                                             \
-  do {                                                                                              \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::INFO) { \
-      unilink::diagnostics::Logger::instance().info(component, operation, message);                 \
-    }                                                                                               \
-  } while (0)
-
-#define UNILINK_LOG_WARNING(component, operation, message)                                             \
-  do {                                                                                                 \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::WARNING) { \
-      unilink::diagnostics::Logger::instance().warning(component, operation, message);                 \
-    }                                                                                                  \
-  } while (0)
-
-#define UNILINK_LOG_ERROR(component, operation, message)                                             \
-  do {                                                                                               \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::ERROR) { \
-      unilink::diagnostics::Logger::instance().error(component, operation, message);                 \
-    }                                                                                                \
-  } while (0)
-
-#define UNILINK_LOG_CRITICAL(component, operation, message)                                             \
+#define UNILINK_LOG_WARNING(component, operation, message)                                              \
   do {                                                                                                  \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::CRITICAL) { \
-      unilink::diagnostics::Logger::instance().critical(component, operation, message);                 \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::WARNING)) { \
+      unilink::diagnostics::Logger::instance().warning(component, operation, message);                  \
     }                                                                                                   \
+  } while (0)
+
+#define UNILINK_LOG_ERROR(component, operation, message)                                              \
+  do {                                                                                                \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::ERROR)) { \
+      unilink::diagnostics::Logger::instance().error(component, operation, message);                  \
+    }                                                                                                 \
+  } while (0)
+
+#define UNILINK_LOG_CRITICAL(component, operation, message)                                              \
+  do {                                                                                                   \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::CRITICAL)) { \
+      unilink::diagnostics::Logger::instance().critical(component, operation, message);                  \
+    }                                                                                                    \
   } while (0)
 
 /**
@@ -262,15 +268,15 @@ class UNILINK_API Logger {
  * `component` and `operation` tokens, and each `operation` token must be
  * unique within its enclosing scope (the token becomes part of a variable name).
  */
-#define UNILINK_LOG_PERF_START(component, operation)                                              \
-  auto _perf_start_##operation =                                                                  \
-      (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) \
-          ? std::chrono::high_resolution_clock::now()                                             \
+#define UNILINK_LOG_PERF_START(component, operation)                                               \
+  auto _perf_start_##operation =                                                                   \
+      (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) \
+          ? std::chrono::high_resolution_clock::now()                                              \
           : std::chrono::high_resolution_clock::time_point()
 
 #define UNILINK_LOG_PERF_END(component, operation)                                                                \
   do {                                                                                                            \
-    if (unilink::diagnostics::Logger::instance().level() <= unilink::diagnostics::LogLevel::DEBUG) {              \
+    if (unilink::diagnostics::Logger::instance().should_log(unilink::diagnostics::LogLevel::DEBUG)) {             \
       auto _perf_end_##operation = std::chrono::high_resolution_clock::now();                                     \
       using _us_t = std::chrono::microseconds;                                                                    \
       auto _diff_##operation = _perf_end_##operation - _perf_start_##operation;                                   \


### PR DESCRIPTION
## Description

This PR fixes several issues in the logger subsystem: incorrect runtime log-level filtering in macros, missing `should_log()` API, split stdout/stderr console routing, environment-variable configuration support, and test flakiness from insufficient async timeouts.

## Key Changes

- **Unified logging macro**: Replaced five duplicated `UNILINK_LOG_*` macros with a single `UNILINK_LOG(level, ...)` base macro; all level-specific macros now delegate to it via `should_log()` for correct runtime filtering
- **stdout/stderr console split**: Replaced single `stdout_color_sink_mt` with separate stdout (TRACE–WARN) and stderr (ERROR–CRITICAL) sinks using a new internal `level_range_sink` wrapper
- **New public API**: Added `should_log()`, `has_outputs()`, `last_error()`, `reload_from_environment()`, `try_set_file_output()`, and `try_set_file_output_with_rotation()`
- **Environment variable support**: Logger now reads `UNILINK_LOG_LEVEL` at initialization and on `reload_from_environment()`, supporting DEBUG/INFO/WARNING/ERROR/CRITICAL/OFF values
- **Callback exception safety**: Wrapped user callback invocation in `callback_sink` with try/catch to prevent spdlog internal state corruption
- **Test reliability**: Increased timeouts for async write tests to reduce flakiness
- **Docs**: Updated API guide to reflect new methods and format placeholders (`{source}`, `{file}`, `{line}`, `{function}`)

## Related Issues

- Fixes #

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [ ] My changes follow the project's coding style and conventions.

## Additional Context

The `level_range_sink` class is internal to `logger.cc` and is not exposed in the public API. The `UNILINK_LOG_LEVEL=OFF` value disables logging entirely without removing sinks, so it can be re-enabled via `reload_from_environment()` or `set_enabled(true)`.