### PR TITLE
feat: Reliable auto flow-control, bp_utils extraction, Serial/UdsClient fixes, and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(UNILINK_HEADERS
     unilink/memory/safe_span.hpp
     unilink/transport/serial/boost_serial_port.hpp
     unilink/transport/serial/serial.hpp
+    unilink/transport/base/bp_utils.hpp
     unilink/transport/base/reconnect_policy.hpp
     unilink/transport/tcp_client/tcp_client.hpp
     unilink/transport/tcp_server/boost_tcp_acceptor.hpp

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -413,6 +413,26 @@ int main() {
 
 ---
 
+### Problem: UDP with Reliable Strategy Still Drops Packets
+
+**Symptoms:**
+
+- UDP channel uses `BackpressureStrategy::Reliable` but the receiver still loses packets.
+
+**Explanation:**
+
+`Reliable` only controls the *sender-side* tx queue: it blocks the calling thread instead of dropping data when the queue is full. Because UDP is connectionless, there is no receiver-side flow control — the OS network stack or the remote receiver can still discard datagrams independently of the sender queue strategy. If you need guaranteed delivery over UDP, implement an application-level acknowledgment protocol.
+
+```cpp
+// Reliable prevents sender-side queue drops, but cannot prevent
+// network-level or receiver-side packet loss.
+auto udp = unilink::udp_client("192.168.1.100", 9000)
+    .backpressure_strategy(unilink::BackpressureStrategy::Reliable)
+    .build();
+```
+
+---
+
 ## Performance Issues
 
 ### Problem: High CPU Usage

--- a/examples/gateway/tcp_uds_gateway.cc
+++ b/examples/gateway/tcp_uds_gateway.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+#include <csignal>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include "unilink/unilink.hpp"
+
+/**
+ * @brief TCP-to-UDS Gateway Example
+ *
+ * Demonstrates a multi-protocol gateway pattern:
+ *   - A TCP server accepts connections from external clients.
+ *   - A UDS client connects to a local backend service.
+ *   - Data arriving on TCP is forwarded to the UDS backend.
+ *   - Data arriving on UDS is broadcast to all connected TCP clients.
+ *
+ * Usage:
+ *   ./tcp_uds_gateway [tcp_port] [uds_socket_path]
+ *
+ * Defaults:
+ *   tcp_port        = 9000
+ *   uds_socket_path = /tmp/unilink_backend.sock
+ */
+
+static volatile bool g_running = true;
+
+int main(int argc, char* argv[]) {
+  uint16_t tcp_port = 9000;
+  std::string uds_path = "/tmp/unilink_backend.sock";
+
+  if (argc > 1) tcp_port = static_cast<uint16_t>(std::stoi(argv[1]));
+  if (argc > 2) uds_path = argv[2];
+
+  // Handle Ctrl+C for clean shutdown
+  std::signal(SIGINT, [](int) { g_running = false; });
+  std::signal(SIGTERM, [](int) { g_running = false; });
+
+  std::cout << "--- TCP-to-UDS Gateway ---\n";
+  std::cout << "TCP listen port : " << tcp_port << "\n";
+  std::cout << "UDS backend path: " << uds_path << "\n";
+  std::cout << "Press Ctrl+C to stop.\n\n";
+
+  // --- TCP Server (external-facing) ---
+  std::shared_ptr<unilink::wrapper::TcpServer> tcp_srv;
+  std::shared_ptr<unilink::wrapper::UdsClient> uds_cli;
+
+  auto tcp_builder = unilink::tcp_server(tcp_port);
+  tcp_builder
+      .on_connect([](const unilink::ConnectionContext& ctx) {
+        std::cout << "[TCP] Client connected: ID=" << ctx.client_id() << "\n";
+      })
+      .on_data([&uds_cli](const unilink::MessageContext& ctx) {
+        std::cout << "[TCP->UDS] " << ctx.client_id() << ": " << ctx.data() << "\n";
+        if (uds_cli && uds_cli->connected()) {
+          uds_cli->send(ctx.data());
+        } else {
+          std::cerr << "[Gateway] UDS backend not connected — message dropped.\n";
+        }
+      })
+      .on_disconnect([](const unilink::ConnectionContext& ctx) {
+        std::cout << "[TCP] Client disconnected: ID=" << ctx.client_id() << "\n";
+      })
+      .on_error([](const unilink::ErrorContext& ctx) {
+        std::cerr << "[TCP Error] " << ctx.message() << "\n";
+      });
+
+  tcp_srv = tcp_builder.build();
+
+  // --- UDS Client (backend-facing) ---
+  auto uds_builder = unilink::uds_client(uds_path);
+  uds_builder
+      .on_connect([](const unilink::ConnectionContext&) {
+        std::cout << "[UDS] Connected to backend service.\n";
+      })
+      .on_data([&tcp_srv](const unilink::MessageContext& ctx) {
+        std::cout << "[UDS->TCP] Broadcasting: " << ctx.data() << "\n";
+        if (tcp_srv) {
+          tcp_srv->broadcast(ctx.data());
+        }
+      })
+      .on_disconnect([](const unilink::ConnectionContext&) {
+        std::cout << "[UDS] Disconnected from backend service.\n";
+      })
+      .on_error([](const unilink::ErrorContext& ctx) {
+        std::cerr << "[UDS Error] " << ctx.message() << "\n";
+      });
+
+  uds_cli = uds_builder.build();
+
+  // Start both sides
+  tcp_srv->start();
+  uds_cli->start();
+
+  std::cout << "Gateway running.\n\n";
+
+  // Main loop — sleep until Ctrl+C
+  while (g_running) {
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+    if (!g_running) break;
+    auto clients = tcp_srv->connected_clients();
+    std::cout << "[Status] TCP clients: " << clients.size()
+              << " | UDS backend: " << (uds_cli->connected() ? "connected" : "disconnected") << "\n";
+  }
+
+  std::cout << "\n[Gateway] Shutting down...\n";
+  uds_cli->stop();
+  tcp_srv->stop();
+  std::cout << "[Gateway] Stopped.\n";
+
+  return 0;
+}

--- a/examples/gateway/tcp_uds_gateway.cc
+++ b/examples/gateway/tcp_uds_gateway.cc
@@ -78,30 +78,23 @@ int main(int argc, char* argv[]) {
       .on_disconnect([](const unilink::ConnectionContext& ctx) {
         std::cout << "[TCP] Client disconnected: ID=" << ctx.client_id() << "\n";
       })
-      .on_error([](const unilink::ErrorContext& ctx) {
-        std::cerr << "[TCP Error] " << ctx.message() << "\n";
-      });
+      .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "[TCP Error] " << ctx.message() << "\n"; });
 
   tcp_srv = tcp_builder.build();
 
   // --- UDS Client (backend-facing) ---
   auto uds_builder = unilink::uds_client(uds_path);
   uds_builder
-      .on_connect([](const unilink::ConnectionContext&) {
-        std::cout << "[UDS] Connected to backend service.\n";
-      })
+      .on_connect([](const unilink::ConnectionContext&) { std::cout << "[UDS] Connected to backend service.\n"; })
       .on_data([&tcp_srv](const unilink::MessageContext& ctx) {
         std::cout << "[UDS->TCP] Broadcasting: " << ctx.data() << "\n";
         if (tcp_srv) {
           tcp_srv->broadcast(ctx.data());
         }
       })
-      .on_disconnect([](const unilink::ConnectionContext&) {
-        std::cout << "[UDS] Disconnected from backend service.\n";
-      })
-      .on_error([](const unilink::ErrorContext& ctx) {
-        std::cerr << "[UDS Error] " << ctx.message() << "\n";
-      });
+      .on_disconnect(
+          [](const unilink::ConnectionContext&) { std::cout << "[UDS] Disconnected from backend service.\n"; })
+      .on_error([](const unilink::ErrorContext& ctx) { std::cerr << "[UDS Error] " << ctx.message() << "\n"; });
 
   uds_cli = uds_builder.build();
 

--- a/test/unit/transport/test_backpressure_strategy.cc
+++ b/test/unit/transport/test_backpressure_strategy.cc
@@ -19,11 +19,15 @@
 #include <atomic>
 #include <boost/asio.hpp>
 #include <chrono>
+#include <deque>
+#include <functional>
 #include <thread>
 #include <vector>
 
 #include "test_utils.hpp"
 #include "unilink/base/constants.hpp"
+#include "unilink/interface/itcp_socket.hpp"
+#include "unilink/transport/tcp_server/tcp_server_session.hpp"
 #include "unilink/builder/tcp_client_builder.hpp"
 #include "unilink/builder/udp_builder.hpp"
 #include "unilink/builder/uds_builder.hpp"
@@ -234,4 +238,250 @@ TEST(BackpressureStrategyTest, UdpChannel_SetBackpressureStrategyRuntime) {
   // Must not crash when called before start
   channel->set_backpressure_strategy(BackpressureStrategy::BestEffort);
   channel->set_backpressure_strategy(BackpressureStrategy::Reliable);
+}
+
+// ─── StallingTcpSocket: test double that holds write completions ──────────────
+// async_write stores the handler without completing it.  complete_one() posts
+// the completion to the ioc so ioc.poll() drives on_write on the strand.
+// Tests must use net::make_work_guard(ioc) + ioc.poll() — not ioc.run_for() —
+// because run_for() marks the ioc stopped when outstanding_work_==0, causing
+// subsequent calls to silently skip all posted handlers.
+
+namespace {
+class StallingTcpSocket : public unilink::interface::TcpSocketInterface {
+ public:
+  struct WriteEntry {
+    size_t size;
+    std::function<void(const boost::system::error_code&, std::size_t)> handler;
+  };
+
+  explicit StallingTcpSocket(net::io_context& ioc) : ioc_(ioc) {}
+
+  void async_read_some(const net::mutable_buffer&,
+                       std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    read_handler_ = std::move(handler);
+  }
+
+  void async_write(const net::const_buffer& buf,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    write_queue_.push_back({buf.size(), std::move(handler)});
+  }
+
+  bool complete_one(boost::system::error_code ec = {}) {
+    if (write_queue_.empty()) return false;
+    auto entry = std::move(write_queue_.front());
+    write_queue_.pop_front();
+    total_bytes_completed_ += entry.size;
+    net::post(ioc_, [h = std::move(entry.handler), ec, n = entry.size]() mutable { h(ec, n); });
+    return true;
+  }
+
+  size_t total_bytes_completed() const { return total_bytes_completed_; }
+  size_t pending_write_count() const { return write_queue_.size(); }
+
+  void shutdown(tcp::socket::shutdown_type, boost::system::error_code& ec) override { ec.clear(); }
+
+  void close(boost::system::error_code& ec) override {
+    if (read_handler_) {
+      auto h = std::move(read_handler_);
+      net::post(ioc_, [h = std::move(h)]() mutable { h(boost::asio::error::operation_aborted, 0); });
+    }
+    ec.clear();
+  }
+
+  tcp::endpoint remote_endpoint(boost::system::error_code& ec) const override {
+    ec.clear();
+    return tcp::endpoint(net::ip::make_address("127.0.0.1"), 12345);
+  }
+
+ private:
+  net::io_context& ioc_;
+  std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
+  std::deque<WriteEntry> write_queue_;
+  size_t total_bytes_completed_ = 0;
+};
+}  // namespace
+
+// drain_and_stop: stops the session and completes any stalled writes to break
+// the shared_ptr cycle between the session and the write handlers it owns.
+static void drain_and_stop(StallingTcpSocket* sock, std::shared_ptr<transport::TcpServerSession> session,
+                            net::io_context& ioc) {
+  session->stop();
+  ioc.poll();
+  while (sock->pending_write_count() > 0) {
+    sock->complete_one();
+    ioc.poll();
+  }
+}
+
+// ─── Reliable auto-FC: pending_ queue tests ───────────────────────────────────
+
+// Writes during active backpressure go to pending_ and return true (not dropped).
+TEST(BackpressureStrategyTest, Reliable_PendingQueue_AccumulatesWhenBackpressureActive) {
+  constexpr size_t kBpHigh = 1024;
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);  // prevents ioc from stopping between polls
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
+                                                               BackpressureStrategy::Reliable);
+
+  std::vector<size_t> bp_events;
+  session->on_backpressure([&](size_t q) { bp_events.push_back(q); });
+  session->start();
+  ioc.poll();
+
+  // chunk1 (600 B) → tx_, socket stalls (no completion yet)
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAA)));
+  ioc.poll();
+
+  // chunk2 (600 B) → tx_, queue=1200 > bp_high_=1024 → BP ON fires
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAB)));
+  ioc.poll();
+  ASSERT_EQ(bp_events.size(), 1u);
+  EXPECT_GE(bp_events[0], kBpHigh);
+  EXPECT_TRUE(session->is_backpressure_active());
+
+  // chunk3 during active BP → Reliable: must return true and go to pending_
+  bool result = session->async_write_move(std::vector<uint8_t>(300, 0xAC));
+  ioc.poll();
+  EXPECT_TRUE(result);
+  EXPECT_EQ(bp_events.size(), 1u);  // no new BP event; chunk3 is buffered
+  EXPECT_TRUE(session->is_backpressure_active());
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
+// All bytes written to pending_ during backpressure are eventually delivered.
+TEST(BackpressureStrategyTest, Reliable_PendingQueue_DeliveredAfterBackpressureClears) {
+  constexpr size_t kBpHigh = 1024;
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
+                                                               BackpressureStrategy::Reliable);
+
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.poll();
+
+  // Establish BP ON: chunk1 in-flight (stalled), chunk2 queued → queue=1200
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAA)));
+  ioc.poll();
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAB)));
+  ioc.poll();
+  EXPECT_TRUE(session->is_backpressure_active());
+
+  // chunk3 goes to pending_ (300 B)
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(300, 0xAC)));
+  ioc.poll();
+
+  // Complete chunk1: queue=600, still above bp_low_(512), no OFF yet
+  EXPECT_TRUE(sock->complete_one());
+  ioc.poll();
+
+  // Complete chunk2: queue=0 <= bp_low_(512) → OFF fires, pending_ flushed to tx_
+  EXPECT_TRUE(sock->complete_one());
+  ioc.poll();
+
+  // chunk3 is now in tx_ (moved from pending_), complete it
+  EXPECT_TRUE(sock->complete_one());
+  ioc.poll();
+
+  // All three chunks must have reached the socket
+  EXPECT_EQ(sock->total_bytes_completed(), 600u + 600u + 300u);
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
+// async_write returns false when queue_bytes_ + pending_bytes_ + new > bp_limit_.
+TEST(BackpressureStrategyTest, Reliable_CombinedLimit_LargeWriteRejected) {
+  constexpr size_t kBpHigh = 1024;
+  // bp_limit_ = min(max(kBpHigh*4, DEFAULT_BACKPRESSURE_THRESHOLD), MAX_BUFFER_SIZE)
+  //           = min(max(4096, 1MiB), 64MiB) = 1 MiB
+  constexpr size_t kBpLimit = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;  // 1 MiB
+  constexpr size_t kHalfLimit = kBpLimit / 2;                                  // 512 KiB
+
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
+                                                               BackpressureStrategy::Reliable);
+
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.poll();
+
+  // Establish BP ON
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAA)));
+  ioc.poll();
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAB)));
+  ioc.poll();
+  EXPECT_TRUE(session->is_backpressure_active());
+
+  // Fill pending_ with ~512 KiB: queue(1200) + pending(0) + 512K < 1MiB → accepted
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(kHalfLimit, 0xAC)));
+  ioc.poll();  // pending_bytes_ updated to 512K on strand
+
+  // Second 512 KiB: queue(1200) + pending(512K) + 512K > 1MiB → rejected
+  bool result = session->async_write_move(std::vector<uint8_t>(kHalfLimit, 0xAD));
+  EXPECT_FALSE(result);
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
+// When OFF fires and the flushed pending_ bytes push queue above bp_high_,
+// the ON callback is re-fired immediately in the same report_backpressure call.
+TEST(BackpressureStrategyTest, Reliable_BurstOnOFF_ImmediateOnReactivation) {
+  constexpr size_t kBpHigh = 1024;
+  constexpr size_t kBpLow = kBpHigh / 2;  // 512
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
+                                                               BackpressureStrategy::Reliable);
+
+  std::vector<size_t> bp_events;
+  session->on_backpressure([&](size_t q) { bp_events.push_back(q); });
+  session->start();
+  ioc.poll();
+
+  // chunk1 (600 B) in-flight (stalled), chunk2 (600 B) in tx_ → queue=1200 → ON
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAA)));
+  ioc.poll();
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAB)));
+  ioc.poll();
+  ASSERT_EQ(bp_events.size(), 1u);
+  EXPECT_GE(bp_events[0], kBpHigh);
+
+  // big_chunk (2000 B) in pending_; post-flush queue will be 2000 > kBpHigh → burst
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(2000, 0xAC)));
+  ioc.poll();
+
+  // Complete chunk1: queue=1200-600=600, 600 > kBpLow(512) → no OFF
+  EXPECT_TRUE(sock->complete_one());
+  ioc.poll();
+  EXPECT_EQ(bp_events.size(), 1u);
+
+  // Complete chunk2: queue=600-600=0, 0 <= kBpLow → OFF fires,
+  // pending_ (2000 B) flushed to tx_, queue=2000 >= kBpHigh → ON re-fires
+  EXPECT_TRUE(sock->complete_one());
+  ioc.poll();
+
+  ASSERT_EQ(bp_events.size(), 3u);
+  EXPECT_GE(bp_events[0], kBpHigh);  // first ON
+  EXPECT_LE(bp_events[1], kBpLow);   // OFF (value is pre-flush queue size)
+  EXPECT_GE(bp_events[2], kBpHigh);  // ON re-fired (burst-on-OFF)
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
 }

--- a/test/unit/transport/test_backpressure_strategy.cc
+++ b/test/unit/transport/test_backpressure_strategy.cc
@@ -26,8 +26,6 @@
 
 #include "test_utils.hpp"
 #include "unilink/base/constants.hpp"
-#include "unilink/interface/itcp_socket.hpp"
-#include "unilink/transport/tcp_server/tcp_server_session.hpp"
 #include "unilink/builder/tcp_client_builder.hpp"
 #include "unilink/builder/udp_builder.hpp"
 #include "unilink/builder/uds_builder.hpp"
@@ -35,8 +33,10 @@
 #include "unilink/config/tcp_server_config.hpp"
 #include "unilink/config/udp_config.hpp"
 #include "unilink/config/uds_config.hpp"
+#include "unilink/interface/itcp_socket.hpp"
 #include "unilink/transport/tcp_client/tcp_client.hpp"
 #include "unilink/transport/tcp_server/tcp_server.hpp"
+#include "unilink/transport/tcp_server/tcp_server_session.hpp"
 #include "unilink/transport/udp/udp.hpp"
 #include "unilink/transport/uds/uds_client.hpp"
 #include "unilink/transport/uds/uds_server.hpp"
@@ -305,7 +305,7 @@ class StallingTcpSocket : public unilink::interface::TcpSocketInterface {
 // drain_and_stop: stops the session and completes any stalled writes to break
 // the shared_ptr cycle between the session and the write handlers it owns.
 static void drain_and_stop(StallingTcpSocket* sock, std::shared_ptr<transport::TcpServerSession> session,
-                            net::io_context& ioc) {
+                           net::io_context& ioc) {
   session->stop();
   ioc.poll();
   while (sock->pending_write_count() > 0) {
@@ -324,8 +324,8 @@ TEST(BackpressureStrategyTest, Reliable_PendingQueue_AccumulatesWhenBackpressure
 
   auto socket = std::make_unique<StallingTcpSocket>(ioc);
   auto* sock = socket.get();
-  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
-                                                               BackpressureStrategy::Reliable);
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
 
   std::vector<size_t> bp_events;
   session->on_backpressure([&](size_t q) { bp_events.push_back(q); });
@@ -362,8 +362,8 @@ TEST(BackpressureStrategyTest, Reliable_PendingQueue_DeliveredAfterBackpressureC
 
   auto socket = std::make_unique<StallingTcpSocket>(ioc);
   auto* sock = socket.get();
-  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
-                                                               BackpressureStrategy::Reliable);
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
 
   session->on_backpressure([](size_t) {});
   session->start();
@@ -405,14 +405,14 @@ TEST(BackpressureStrategyTest, Reliable_CombinedLimit_LargeWriteRejected) {
   // bp_limit_ = min(max(kBpHigh*4, DEFAULT_BACKPRESSURE_THRESHOLD), MAX_BUFFER_SIZE)
   //           = min(max(4096, 1MiB), 64MiB) = 1 MiB
   constexpr size_t kBpLimit = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;  // 1 MiB
-  constexpr size_t kHalfLimit = kBpLimit / 2;                                  // 512 KiB
+  constexpr size_t kHalfLimit = kBpLimit / 2;                                   // 512 KiB
 
   net::io_context ioc;
   auto work = net::make_work_guard(ioc);
   auto socket = std::make_unique<StallingTcpSocket>(ioc);
   auto* sock = socket.get();
-  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
-                                                               BackpressureStrategy::Reliable);
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
 
   session->on_backpressure([](size_t) {});
   session->start();
@@ -447,8 +447,8 @@ TEST(BackpressureStrategyTest, Reliable_BurstOnOFF_ImmediateOnReactivation) {
 
   auto socket = std::make_unique<StallingTcpSocket>(ioc);
   auto* sock = socket.get();
-  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
-                                                               BackpressureStrategy::Reliable);
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
 
   std::vector<size_t> bp_events;
   session->on_backpressure([&](size_t q) { bp_events.push_back(q); });

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -27,7 +27,7 @@ namespace constants {
 
 // Backpressure strategy
 enum class BackpressureStrategy {
-  Reliable,    // Queue until hard limit; completeness first (default, safe for all transports)
+  Reliable,    // Queue until hard limit; completeness first (default). For UDP: prevents sender-side queue drops only — no receiver-side flow control (UDP is connectionless).
   BestEffort,  // Drop oldest queued data when threshold is reached; freshness first (real-time/sensor use)
 };
 

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -27,7 +27,8 @@ namespace constants {
 
 // Backpressure strategy
 enum class BackpressureStrategy {
-  Reliable,    // Queue until hard limit; completeness first (default). For UDP: prevents sender-side queue drops only — no receiver-side flow control (UDP is connectionless).
+  Reliable,  // Queue until hard limit; completeness first (default). For UDP: prevents sender-side queue drops only —
+             // no receiver-side flow control (UDP is connectionless).
   BestEffort,  // Drop oldest queued data when threshold is reached; freshness first (real-time/sensor use)
 };
 

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include "unilink/base/constants.hpp"
+
+namespace unilink {
+namespace transport {
+namespace queue_util {
+
+// Returns the byte size of a buffer held in a transport BufferVariant alternative.
+// shared_ptr<const vector<uint8_t>> goes through ->size(); everything else via .size().
+template <typename T>
+inline size_t variant_buffer_size(const T& buf) {
+  if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
+    return buf ? buf->size() : 0;
+  } else {
+    return buf.size();
+  }
+}
+
+// BestEffort queue-trimming shared by all stream transports (TCP client/server, UDS client/server).
+// Must be called on the strand immediately before enqueueing a new buffer of `added` bytes.
+//
+// No-op for Reliable strategy.
+// For BestEffort:
+//   added >= bp_high  →  drop entire tx_ (full keep-latest replacement).
+//   otherwise         →  pop oldest tx_ entries until queue_bytes + added <= bp_high.
+template <typename Deque>
+inline void maybe_flush_for_keep_latest(::unilink::base::constants::BackpressureStrategy bp_strategy, size_t added,
+                                        size_t bp_high, Deque& tx, std::atomic<size_t>& queue_bytes,
+                                        const std::atomic<bool>& backpressure_active) {
+  if (bp_strategy != ::unilink::base::constants::BackpressureStrategy::BestEffort) return;
+
+  if (added >= bp_high) {
+    size_t removed_bytes = 0;
+    for (const auto& buf : tx) {
+      removed_bytes += std::visit([](const auto& b) { return variant_buffer_size(b); }, buf);
+    }
+    tx.clear();
+    const size_t qb = queue_bytes.load(std::memory_order_relaxed);
+    queue_bytes.store(qb > removed_bytes ? qb - removed_bytes : 0, std::memory_order_relaxed);
+    return;
+  }
+
+  if (backpressure_active.load(std::memory_order_relaxed) ||
+      queue_bytes.load(std::memory_order_relaxed) + added > bp_high) {
+    while (!tx.empty()) {
+      const size_t qb = queue_bytes.load(std::memory_order_relaxed);
+      if (qb + added <= bp_high) break;
+      const size_t oldest = std::visit([](const auto& b) { return variant_buffer_size(b); }, tx.front());
+      queue_bytes.store(qb > oldest ? qb - oldest : 0, std::memory_order_relaxed);
+      tx.pop_front();
+    }
+  }
+}
+
+}  // namespace queue_util
+}  // namespace transport
+}  // namespace unilink

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -556,13 +556,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
         }
 
         if (impl->queued_bytes_ + added > impl->bp_limit_) {
+          UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
           impl->report_backpressure(impl->queued_bytes_ + added);
-          impl->tx_.clear();
-          impl->queued_bytes_ = 0;
-          impl->writing_ = false;
-          impl->state_.set_state(LinkState::Error);
-          impl->notify_state();
-          impl->handle_error(self, "write_queue_overflow", make_error_code(boost::system::errc::no_buffer_space));
           return;
         }
         impl->queued_bytes_ += added;

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -73,6 +73,8 @@ struct Serial::Impl {
 
   std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
+  std::deque<BufferVariant> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queued_bytes_{0};
@@ -304,6 +306,8 @@ struct Serial::Impl {
       close_port();
       tx_.clear();
       queued_bytes_ = 0;
+      pending_.clear();
+      pending_bytes_ = 0;
       writing_ = false;
       report_backpressure(queued_bytes_);
       opened_.store(false);
@@ -384,10 +388,19 @@ struct Serial::Impl {
       } catch (...) {
       }
     } else if (backpressure_active_ && qb <= bp_low_) {
+      // Flush pending_ → tx_
+      const size_t moved = pending_bytes_.exchange(0);
+      queued_bytes_ += moved;
+      while (!pending_.empty()) {
+        tx_.emplace_back(std::move(pending_.front()));
+        pending_.pop_front();
+      }
       backpressure_active_ = false;
-      try {
-        on_bp_(qb);
-      } catch (...) {
+      try { on_bp_(qb); } catch (...) {}  // fire OFF with pre-flush queue size
+      // If post-flush queue is still high, fire ON again
+      if (queued_bytes_ >= bp_high_) {
+        backpressure_active_ = true;
+        try { on_bp_(queued_bytes_); } catch (...) {}
       }
     }
   }
@@ -502,10 +515,23 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(n);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
-      if (impl->queued_bytes_ + n > impl->bp_limit_) return false;
+      if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) return false;
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled)]() mutable {
         auto impl = self->get_impl();
         const auto added = buf.size();
+
+        // Reliable: route to pending_ when backpressure is active
+        if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+            impl->backpressure_active_.load()) {
+          if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+            UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
+            return;
+          }
+          impl->pending_bytes_ += added;
+          impl->pending_.emplace_back(std::move(buf));
+          return;
+        }
+
         if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
             (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
           if (added >= impl->bp_high_) {
@@ -548,11 +574,24 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (impl->queued_bytes_ + n > impl->bp_limit_) return false;
+  if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) return false;
   std::vector<uint8_t> fallback(data.begin(), data.end());
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
     auto impl = self->get_impl();
     const auto added = buf.size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        impl->backpressure_active_.load()) {
+      if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+        UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      impl->pending_bytes_ += added;
+      impl->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
         (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
       if (added >= impl->bp_high_) {
@@ -599,9 +638,22 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
   if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
     return false;
   const auto added = data.size();
-  if (impl->queued_bytes_ + added > impl->bp_limit_) return false;
+  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) return false;
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        impl->backpressure_active_.load()) {
+      if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+        UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      impl->pending_bytes_ += added;
+      impl->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
         (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
       if (added >= impl->bp_high_) {
@@ -649,9 +701,22 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     return false;
   if (!data || data->empty()) return false;
   const auto added = data->size();
-  if (impl->queued_bytes_ + added > impl->bp_limit_) return false;
+  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) return false;
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        impl->backpressure_active_.load()) {
+      if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+        UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      impl->pending_bytes_ += added;
+      impl->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
         (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
       if (added >= impl->bp_high_) {

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -396,11 +396,17 @@ struct Serial::Impl {
         pending_.pop_front();
       }
       backpressure_active_ = false;
-      try { on_bp_(qb); } catch (...) {}  // fire OFF with pre-flush queue size
+      try {
+        on_bp_(qb);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
       // If post-flush queue is still high, fire ON again
       if (queued_bytes_ >= bp_high_) {
         backpressure_active_ = true;
-        try { on_bp_(queued_bytes_); } catch (...) {}
+        try {
+          on_bp_(queued_bytes_);
+        } catch (...) {
+        }
       }
     }
   }
@@ -576,8 +582,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     const auto added = buf.size();
 
     // Reliable: route to pending_ when backpressure is active
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        impl->backpressure_active_.load()) {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && impl->backpressure_active_.load()) {
       if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
         UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
         return;
@@ -638,8 +643,7 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
     auto impl = self->get_impl();
 
     // Reliable: route to pending_ when backpressure is active
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        impl->backpressure_active_.load()) {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && impl->backpressure_active_.load()) {
       if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
         UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
         return;
@@ -701,8 +705,7 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     auto impl = self->get_impl();
 
     // Reliable: route to pending_ when backpressure is active
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        impl->backpressure_active_.load()) {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && impl->backpressure_active_.load()) {
       if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
         UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
         return;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -87,6 +87,8 @@ struct TcpClient::Impl {
 
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
+  std::deque<BufferVariant> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
@@ -129,6 +131,7 @@ struct TcpClient::Impl {
     connected_ = false;
     writing_ = false;
     queue_bytes_ = 0;
+    pending_bytes_ = 0;
     cfg_.validate_and_clamp();
     recalculate_backpressure_bounds();
     first_retry_interval_ms_ = std::min(first_retry_interval_ms_, cfg_.retry_interval_ms);
@@ -146,7 +149,7 @@ struct TcpClient::Impl {
   void close_socket();
   void recalculate_backpressure_bounds();
   void maybe_flush_for_keep_latest(size_t added);
-  void report_backpressure(size_t queued_bytes);
+  void report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes);
   void notify_state();
   void reset_io_objects();
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
@@ -289,10 +292,23 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
       if (pooled_buffer.valid()) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
-        if (impl_->queue_bytes_ + added > impl_->bp_limit_) return false;
+        if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
         net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(pooled_buffer), added]() mutable {
           if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
               self->impl_->state_.is_state(LinkState::Error)) {
+            return;
+          }
+
+          // Reliable: route to pending_ when backpressure is active
+          if (self->impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+              self->impl_->backpressure_active_.load()) {
+            if (self->impl_->queue_bytes_ + self->impl_->pending_bytes_ + added > self->impl_->bp_limit_) {
+              UNILINK_LOG_ERROR("tcp_client", "write",
+                                fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+              return;
+            }
+            self->impl_->pending_bytes_ += added;
+            self->impl_->pending_.emplace_back(std::move(buf));
             return;
           }
 
@@ -303,13 +319,13 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
                               fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
             self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION,
                                       "write", boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
-            self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
+            self->impl_->report_backpressure(self, self->impl_->queue_bytes_ + added);
             return;
           }
 
           self->impl_->queue_bytes_ += added;
           self->impl_->tx_.emplace_back(std::move(buf));
-          self->impl_->report_backpressure(self->impl_->queue_bytes_);
+          self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
           if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
         });
         return true;
@@ -328,6 +344,19 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
       return;
     }
 
+    // Reliable: route to pending_ when backpressure is active
+    if (self->impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->impl_->backpressure_active_.load()) {
+      if (self->impl_->queue_bytes_ + self->impl_->pending_bytes_ + added > self->impl_->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_client", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+        return;
+      }
+      self->impl_->pending_bytes_ += added;
+      self->impl_->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     self->impl_->maybe_flush_for_keep_latest(added);
 
     if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
@@ -335,13 +364,13 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
                         fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
-      self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
+      self->impl_->report_backpressure(self, self->impl_->queue_bytes_ + added);
       return;
     }
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
-    self->impl_->report_backpressure(self->impl_->queue_bytes_);
+    self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
   return true;
@@ -364,10 +393,23 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
   }
 
   const auto added = size;
-  if (impl_->queue_bytes_ + added > impl_->bp_limit_) return false;
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
+      return;
+    }
+
+    // Reliable: route to pending_ when backpressure is active
+    if (self->impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->impl_->backpressure_active_.load()) {
+      if (self->impl_->queue_bytes_ + self->impl_->pending_bytes_ + added > self->impl_->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_client", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+        return;
+      }
+      self->impl_->pending_bytes_ += added;
+      self->impl_->pending_.emplace_back(std::move(buf));
       return;
     }
 
@@ -378,13 +420,13 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
                         fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
-      self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
+      self->impl_->report_backpressure(self, self->impl_->queue_bytes_ + added);
       return;
     }
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
-    self->impl_->report_backpressure(self->impl_->queue_bytes_);
+    self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
   return true;
@@ -407,10 +449,23 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   }
 
   const auto added = size;
-  if (impl_->queue_bytes_ + added > impl_->bp_limit_) return false;
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
+      return;
+    }
+
+    // Reliable: route to pending_ when backpressure is active
+    if (self->impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->impl_->backpressure_active_.load()) {
+      if (self->impl_->queue_bytes_ + self->impl_->pending_bytes_ + added > self->impl_->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_client", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+        return;
+      }
+      self->impl_->pending_bytes_ += added;
+      self->impl_->pending_.emplace_back(std::move(buf));
       return;
     }
 
@@ -421,13 +476,13 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
                         fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                                 boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
-      self->impl_->report_backpressure(self->impl_->queue_bytes_ + added);
+      self->impl_->report_backpressure(self, self->impl_->queue_bytes_ + added);
       return;
     }
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
-    self->impl_->report_backpressure(self->impl_->queue_bytes_);
+    self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
   return true;
@@ -654,8 +709,10 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
   if (stop_requested_.load()) {
     tx_.clear();
     queue_bytes_ = 0;
+    pending_.clear();
+    pending_bytes_ = 0;
     writing_ = false;
-    report_backpressure(queue_bytes_);
+    report_backpressure(self, queue_bytes_);
     return;
   }
 
@@ -691,7 +748,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
       self->impl_->current_write_buffer_.reset();
       self->impl_->queue_bytes_ =
           (self->impl_->queue_bytes_ > queued_bytes) ? (self->impl_->queue_bytes_ - queued_bytes) : 0;
-      self->impl_->report_backpressure(self->impl_->queue_bytes_);
+      self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
       self->impl_->writing_ = false;
       return;
     }
@@ -713,7 +770,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
     self->impl_->current_write_buffer_.reset();
     self->impl_->queue_bytes_ =
         (self->impl_->queue_bytes_ > queued_bytes) ? (self->impl_->queue_bytes_ - queued_bytes) : 0;
-    self->impl_->report_backpressure(self->impl_->queue_bytes_);
+    self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
 
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
@@ -822,7 +879,7 @@ void TcpClient::Impl::maybe_flush_for_keep_latest(size_t added) {
   }
 }
 
-void TcpClient::Impl::report_backpressure(size_t queued_bytes) {
+void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes) {
   if (stop_requested_.load() || stopping_.load()) return;
 
   OnBackpressure on_bp;
@@ -843,15 +900,21 @@ void TcpClient::Impl::report_backpressure(size_t queued_bytes) {
       UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    backpressure_active_ = false;
-    try {
-      on_bp(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("tcp_client", "on_backpressure",
-                        fmt::format("Exception in backpressure callback: {}", e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
+    // Flush pending_ → tx_
+    const size_t moved = pending_bytes_.exchange(0);
+    queue_bytes_ += moved;
+    while (!pending_.empty()) {
+      tx_.emplace_back(std::move(pending_.front()));
+      pending_.pop_front();
     }
+    backpressure_active_ = false;
+    try { on_bp(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    // If post-flush queue is still high, fire ON again
+    if (queue_bytes_ >= bp_high_) {
+      backpressure_active_ = true;
+      try { on_bp(queue_bytes_); } catch (...) {}
+    }
+    if (!writing_) do_write(self, current_seq_.load());
   }
 }
 
@@ -889,6 +952,8 @@ void TcpClient::Impl::perform_stop_cleanup() {
     close_socket();
     tx_.clear();
     queue_bytes_ = 0;
+    pending_.clear();
+    pending_bytes_ = 0;
     writing_ = false;
     connected_.store(false);
     backpressure_active_ = false;
@@ -919,6 +984,8 @@ void TcpClient::Impl::reset_start_state() {
   connected_.store(false);
   writing_ = false;
   queue_bytes_ = 0;
+  pending_.clear();
+  pending_bytes_ = 0;
   backpressure_active_ = false;
   state_.set_state(LinkState::Idle);
 }
@@ -984,6 +1051,8 @@ void TcpClient::Impl::reset_io_objects() {
     connect_timer_ = net::steady_timer(strand_);
     tx_.clear();
     queue_bytes_ = 0;
+    pending_.clear();
+    pending_bytes_ = 0;
     writing_ = false;
     backpressure_active_ = false;
   } catch (const std::exception& e) {

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -840,8 +840,7 @@ void TcpClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void TcpClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
-                                               backpressure_active_);
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
 void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes) {
@@ -873,11 +872,17 @@ void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_
       pending_.pop_front();
     }
     backpressure_active_ = false;
-    try { on_bp(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    try {
+      on_bp(queued_bytes);
+    } catch (...) {
+    }  // fire OFF with pre-flush queue size
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try { on_bp(queue_bytes_); } catch (...) {}
+      try {
+        on_bp(queue_bytes_);
+      } catch (...) {
+      }
     }
     if (!writing_) do_write(self, current_seq_.load());
   }

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -293,7 +293,9 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
       if (pooled_buffer.valid()) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
-        if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
+        if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+            impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+          return false;
         net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(pooled_buffer), added]() mutable {
           if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
               self->impl_->state_.is_state(LinkState::Error)) {
@@ -360,6 +362,13 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
     self->impl_->maybe_flush_for_keep_latest(added);
 
+    if (self->impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->impl_->queue_bytes_ + self->impl_->pending_bytes_ + added > self->impl_->bp_limit_) {
+      UNILINK_LOG_ERROR("tcp_client", "write",
+                        fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
+      return;
+    }
+
     if (self->impl_->queue_bytes_ + added > self->impl_->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_client", "write",
                         fmt::format("Queue limit exceeded ({} bytes)", self->impl_->queue_bytes_ + added));
@@ -394,7 +403,9 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
   }
 
   const auto added = size;
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
+  if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+    return false;
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
@@ -450,7 +461,9 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   }
 
   const auto added = size;
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) return false;
+  if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+    return false;
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -51,6 +51,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/tcp_client/detail/reconnect_decider.hpp"
 
 namespace unilink {
@@ -839,44 +840,8 @@ void TcpClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void TcpClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  if (bp_strategy_ != base::constants::BackpressureStrategy::BestEffort) return;
-
-  if (added >= bp_high_) {
-    // Compute bytes to remove from tx_ (excluding current_write_buffer_ which is in-flight)
-    size_t removed_bytes = 0;
-    for (const auto& buf : tx_) {
-      removed_bytes += std::visit(
-          [](auto&& b) -> size_t {
-            using T = std::decay_t<decltype(b)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return b ? b->size() : 0;
-            } else {
-              return b.size();
-            }
-          },
-          buf);
-    }
-    tx_.clear();
-    queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
-    return;
-  }
-
-  if (backpressure_active_ || queue_bytes_ + added > bp_high_) {
-    while (!tx_.empty() && (queue_bytes_ + added > bp_high_)) {
-      size_t oldest_size = std::visit(
-          [](auto&& buf) -> size_t {
-            using T = std::decay_t<decltype(buf)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return buf ? buf->size() : 0;
-            } else {
-              return buf.size();
-            }
-          },
-          tx_.front());
-      queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
-      tx_.pop_front();
-    }
-  }
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
+                                               backpressure_active_);
 }
 
 void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes) {

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/tcp_server/boost_tcp_socket.hpp"
 
 namespace unilink {
@@ -393,44 +394,8 @@ void TcpServerSession::do_close() {
 }
 
 void TcpServerSession::maybe_flush_for_keep_latest(size_t added) {
-  if (bp_strategy_ != base::constants::BackpressureStrategy::BestEffort) return;
-
-  if (added >= bp_high_) {
-    // Compute bytes to remove from tx_ (excluding current_write_buffer_ which is in-flight)
-    size_t removed_bytes = 0;
-    for (const auto& buf : tx_) {
-      removed_bytes += std::visit(
-          [](auto&& b) -> size_t {
-            using T = std::decay_t<decltype(b)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return b ? b->size() : 0;
-            } else {
-              return b.size();
-            }
-          },
-          buf);
-    }
-    tx_.clear();
-    queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
-    return;
-  }
-
-  if (backpressure_active_ || queue_bytes_ + added > bp_high_) {
-    while (!tx_.empty() && (queue_bytes_ + added > bp_high_)) {
-      size_t oldest_size = std::visit(
-          [](auto&& buf) -> size_t {
-            using T = std::decay_t<decltype(buf)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return buf ? buf->size() : 0;
-            } else {
-              return buf.size();
-            }
-          },
-          tx_.front());
-      queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
-      tx_.pop_front();
-    }
-  }
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
+                                               backpressure_active_);
 }
 
 void TcpServerSession::report_backpressure(size_t queued_bytes) {

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -130,8 +130,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     const auto added = buf.size();
 
     // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        self->backpressure_active_.load()) {
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
       if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
         UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
         return;
@@ -167,8 +166,7 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     if (!self->alive_ || self->closing_) return;
 
     // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        self->backpressure_active_.load()) {
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
       if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
         UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
         return;
@@ -204,8 +202,7 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     if (!self->alive_ || self->closing_) return;
 
     // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        self->backpressure_active_.load()) {
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
       if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
         UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
         return;
@@ -394,8 +391,7 @@ void TcpServerSession::do_close() {
 }
 
 void TcpServerSession::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
-                                               backpressure_active_);
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
 void TcpServerSession::report_backpressure(size_t queued_bytes) {
@@ -419,11 +415,17 @@ void TcpServerSession::report_backpressure(size_t queued_bytes) {
       pending_.pop_front();
     }
     backpressure_active_ = false;
-    try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    try {
+      on_bp_(queued_bytes);
+    } catch (...) {
+    }  // fire OFF with pre-flush queue size
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try { on_bp_(queue_bytes_); } catch (...) {}
+      try {
+        on_bp_(queue_bytes_);
+      } catch (...) {
+      }
     }
     if (!writing_) do_write();
   }

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -88,17 +88,29 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
-      if (queue_bytes_ + size > bp_limit_) return false;
+      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) return false;
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
         if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
         const auto added = buf.size();
+
+        // Reliable: route to pending_ when backpressure is active
+        if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+            self->backpressure_active_.load()) {
+          if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+            UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+            return;
+          }
+          self->pending_bytes_ += added;
+          self->pending_.emplace_back(std::move(buf));
+          return;
+        }
+
         self->maybe_flush_for_keep_latest(added);
         if (self->queue_bytes_ + added > self->bp_limit_) {
           UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
           self->report_backpressure(self->queue_bytes_ + added);
           return;
         }
-
         self->queue_bytes_ += added;
         self->tx_.emplace_back(std::move(buf));
         self->report_backpressure(self->queue_bytes_);
@@ -109,19 +121,31 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Fallback to regular allocation for large buffers or pool exhaustion
-  if (queue_bytes_ + size > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + size > bp_limit_) return false;
   std::vector<uint8_t> fallback(data.begin(), data.end());
 
   net::post(strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
     if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
     const auto added = buf.size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->backpressure_active_.load()) {
+      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      self->pending_bytes_ += added;
+      self->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     self->maybe_flush_for_keep_latest(added);
     if (self->queue_bytes_ + added > self->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
       self->report_backpressure(self->queue_bytes_ + added);
       return;
     }
-
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
     self->report_backpressure(self->queue_bytes_);
@@ -137,16 +161,28 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
     return false;
   }
-  if (queue_bytes_ + added > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) return false;
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
+
+    // Reliable: route to pending_ when backpressure is active
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->backpressure_active_.load()) {
+      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      self->pending_bytes_ += added;
+      self->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     self->maybe_flush_for_keep_latest(added);
     if (self->queue_bytes_ + added > self->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
       self->report_backpressure(self->queue_bytes_ + added);
       return;
     }
-
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
     self->report_backpressure(self->queue_bytes_);
@@ -162,16 +198,28 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
     return false;
   }
-  if (queue_bytes_ + added > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) return false;
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
+
+    // Reliable: route to pending_ when backpressure is active
+    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        self->backpressure_active_.load()) {
+      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      self->pending_bytes_ += added;
+      self->pending_.emplace_back(std::move(buf));
+      return;
+    }
+
     self->maybe_flush_for_keep_latest(added);
     if (self->queue_bytes_ + added > self->bp_limit_) {
       UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
       self->report_backpressure(self->queue_bytes_ + added);
       return;
     }
-
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
     self->report_backpressure(self->queue_bytes_);
@@ -330,6 +378,8 @@ void TcpServerSession::do_close() {
   // Release memory immediately
   tx_.clear();
   queue_bytes_ = 0;
+  pending_.clear();
+  pending_bytes_ = 0;
 
   if (close_cb) {
     try {
@@ -396,15 +446,21 @@ void TcpServerSession::report_backpressure(size_t queued_bytes) {
       UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure", "Unknown exception in backpressure callback");
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    backpressure_active_ = false;
-    try {
-      on_bp_(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure",
-                        "Exception in backpressure callback: " + std::string(e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure", "Unknown exception in backpressure callback");
+    // Flush pending_ → tx_
+    const size_t moved = pending_bytes_.exchange(0);
+    queue_bytes_ += moved;
+    while (!pending_.empty()) {
+      tx_.emplace_back(std::move(pending_.front()));
+      pending_.pop_front();
     }
+    backpressure_active_ = false;
+    try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    // If post-flush queue is still high, fire ON again
+    if (queue_bytes_ >= bp_high_) {
+      backpressure_active_ = true;
+      try { on_bp_(queue_bytes_); } catch (...) {}
+    }
+    if (!writing_) do_write();
   }
 }
 

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -91,6 +91,8 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   std::unique_ptr<interface::TcpSocketInterface> socket_;
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
+  std::deque<BufferVariant> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -423,17 +423,24 @@ struct UdpChannel::Impl {
         pending_.pop_front();
       }
       backpressure_active_ = false;
-      try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+      try {
+        on_bp_(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
       // If post-flush queue is still high, fire ON again
       if (queue_bytes_ >= bp_high_) {
         backpressure_active_ = true;
-        try { on_bp_(queue_bytes_); } catch (...) {}
+        try {
+          on_bp_(queue_bytes_);
+        } catch (...) {
+        }
       }
       if (!writing_) do_write(self);
     }
   }
 
-  bool enqueue_buffer(std::shared_ptr<UdpChannel> self, BufferVariant&& buffer, size_t size, std::optional<udp::endpoint> dest = std::nullopt) {
+  bool enqueue_buffer(std::shared_ptr<UdpChannel> self, BufferVariant&& buffer, size_t size,
+                      std::optional<udp::endpoint> dest = std::nullopt) {
     if (stopping_.load() || stop_requested_.load() || state_.is_state(LinkState::Closed) ||
         state_.is_state(LinkState::Error)) {
       return false;
@@ -442,7 +449,8 @@ struct UdpChannel::Impl {
     // Reliable: route to pending_ when backpressure is active
     if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
       if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
-        UNILINK_LOG_ERROR("udp", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + pending_bytes_ + size));
+        UNILINK_LOG_ERROR("udp", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + pending_bytes_ + size));
         return false;
       }
       pending_bytes_ += size;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -69,6 +69,8 @@ struct UdpChannel::Impl {
 
   std::array<uint8_t, 65536> rx_{};
   std::deque<TxItem> tx_;
+  std::deque<TxItem> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   bool writing_{false};
   std::atomic<size_t> queue_bytes_{0};
   config::UdpConfig cfg_;
@@ -296,7 +298,7 @@ struct UdpChannel::Impl {
       queue_bytes_ = 0;
       writing_ = false;
       backpressure_active_ = false;
-      report_backpressure(queue_bytes_);
+      report_backpressure(self, queue_bytes_);
       return;
     }
 
@@ -328,7 +330,7 @@ struct UdpChannel::Impl {
     auto on_write = [self, bytes_queued](const boost::system::error_code& ec, std::size_t) {
       auto impl = self->get_impl();
       impl->queue_bytes_ = (impl->queue_bytes_ > bytes_queued) ? (impl->queue_bytes_ - bytes_queued) : 0;
-      impl->report_backpressure(impl->queue_bytes_);
+      impl->report_backpressure(self, impl->queue_bytes_);
 
       if (ec == boost::asio::error::operation_aborted) {
         impl->writing_ = false;
@@ -340,7 +342,7 @@ struct UdpChannel::Impl {
         impl->writing_ = false;
         impl->tx_.clear();
         impl->queue_bytes_ = 0;
-        impl->report_backpressure(impl->queue_bytes_);
+        impl->report_backpressure(self, impl->queue_bytes_);
         return;
       }
 
@@ -400,7 +402,7 @@ struct UdpChannel::Impl {
     }
   }
 
-  void report_backpressure(size_t queued_bytes) {
+  void report_backpressure(std::shared_ptr<UdpChannel> self, size_t queued_bytes) {
     if (stop_requested_.load() || !on_bp_) return;
 
     if (!backpressure_active_ && queued_bytes >= bp_high_) {
@@ -413,21 +415,39 @@ struct UdpChannel::Impl {
         UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
       }
     } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-      backpressure_active_ = false;
-      try {
-        on_bp_(queued_bytes);
-      } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
-      } catch (...) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
+      // Flush pending_ → tx_
+      const size_t moved = pending_bytes_.exchange(0);
+      queue_bytes_ += moved;
+      while (!pending_.empty()) {
+        tx_.emplace_back(std::move(pending_.front()));
+        pending_.pop_front();
       }
+      backpressure_active_ = false;
+      try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+      // If post-flush queue is still high, fire ON again
+      if (queue_bytes_ >= bp_high_) {
+        backpressure_active_ = true;
+        try { on_bp_(queue_bytes_); } catch (...) {}
+      }
+      if (!writing_) do_write(self);
     }
   }
 
-  bool enqueue_buffer(BufferVariant&& buffer, size_t size, std::optional<udp::endpoint> dest = std::nullopt) {
+  bool enqueue_buffer(std::shared_ptr<UdpChannel> self, BufferVariant&& buffer, size_t size, std::optional<udp::endpoint> dest = std::nullopt) {
     if (stopping_.load() || stop_requested_.load() || state_.is_state(LinkState::Closed) ||
         state_.is_state(LinkState::Error)) {
       return false;
+    }
+
+    // Reliable: route to pending_ when backpressure is active
+    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
+      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+        UNILINK_LOG_ERROR("udp", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + pending_bytes_ + size));
+        return false;
+      }
+      pending_bytes_ += size;
+      pending_.push_back({std::move(buffer), dest});
+      return true;
     }
 
     if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
@@ -470,12 +490,12 @@ struct UdpChannel::Impl {
 
     if (queue_bytes_ + size > bp_limit_) {
       UNILINK_LOG_ERROR("udp", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + size));
-      report_backpressure(queue_bytes_ + size);
+      report_backpressure(self, queue_bytes_ + size);
       return false;
     }
     queue_bytes_ += size;
     tx_.push_back({std::move(buffer), dest});
-    report_backpressure(queue_bytes_);
+    report_backpressure(self, queue_bytes_);
     return true;
   }
 
@@ -517,6 +537,8 @@ struct UdpChannel::Impl {
       close_socket();
       tx_.clear();
       queue_bytes_ = 0;
+      pending_.clear();
+      pending_bytes_ = 0;
       writing_ = false;
       const bool had_backpressure = backpressure_active_;
       backpressure_active_ = false;
@@ -678,10 +700,10 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + size > impl->bp_limit_) return false;
+      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size]() mutable {
         auto impl = self->get_impl();
-        if (!impl->enqueue_buffer(std::move(buf), size)) return;
+        if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
         impl->do_write(self);
       });
       return true;
@@ -691,7 +713,7 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> copy(data.begin(), data.end());
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size]() mutable {
     auto impl = self->get_impl();
-    if (!impl->enqueue_buffer(std::move(buf), size)) return;
+    if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
     impl->do_write(self);
   });
   return true;
@@ -710,10 +732,10 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
     impl->transition_to(LinkState::Error);
     return false;
   }
-  if (impl->queue_bytes_ + size > impl->bp_limit_) return false;
+  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
-    if (!impl->enqueue_buffer(std::move(buf), size)) return;
+    if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
     impl->do_write(self);
   });
   return true;
@@ -736,10 +758,10 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
     impl->transition_to(LinkState::Error);
     return false;
   }
-  if (impl->queue_bytes_ + size > impl->bp_limit_) return false;
+  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
-    if (!impl->enqueue_buffer(std::move(buf), size)) return;
+    if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
     impl->do_write(self);
   });
   return true;
@@ -767,10 +789,10 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + size > impl->bp_limit_) return false;
+      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size, destination]() mutable {
         auto impl = self->get_impl();
-        if (!impl->enqueue_buffer(std::move(buf), size, destination)) return;
+        if (!impl->enqueue_buffer(self, std::move(buf), size, destination)) return;
         impl->do_write(self);
       });
       return true;
@@ -780,7 +802,7 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
   std::vector<uint8_t> copy(data.begin(), data.end());
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {
     auto impl = self->get_impl();
-    if (!impl->enqueue_buffer(std::move(buf), size, destination)) return;
+    if (!impl->enqueue_buffer(self, std::move(buf), size, destination)) return;
     impl->do_write(self);
   });
   return true;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -38,6 +38,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
 #include "unilink/transport/uds/detail/reconnect_decider.hpp"
 
@@ -525,44 +526,8 @@ void UdsClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void UdsClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  if (bp_strategy_ != base::constants::BackpressureStrategy::BestEffort) return;
-
-  if (added >= bp_high_) {
-    // Compute bytes to remove from tx_ (excluding current_write_buffer_ which is in-flight)
-    size_t removed_bytes = 0;
-    for (const auto& buf : tx_) {
-      removed_bytes += std::visit(
-          [](auto&& b) -> size_t {
-            using T = std::decay_t<decltype(b)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return b ? b->size() : 0;
-            } else {
-              return b.size();
-            }
-          },
-          buf);
-    }
-    tx_.clear();
-    queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
-    return;
-  }
-
-  if (backpressure_active_ || queue_bytes_ + added > bp_high_) {
-    while (!tx_.empty() && (queue_bytes_ + added > bp_high_)) {
-      size_t oldest_size = std::visit(
-          [](auto&& buf) -> size_t {
-            using T = std::decay_t<decltype(buf)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return buf ? buf->size() : 0;
-            } else {
-              return buf.size();
-            }
-          },
-          tx_.front());
-      queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
-      tx_.pop_front();
-    }
-  }
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
+                                               backpressure_active_);
 }
 
 void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes) {

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -266,8 +266,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     size_t added = data.size();
 
     // Reliable: route to pending_ when backpressure is active
-    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        impl_->backpressure_active_.load()) {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && impl_->backpressure_active_.load()) {
       if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
         UNILINK_LOG_ERROR("uds_client", "write",
                           fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
@@ -302,8 +301,7 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     size_t added = data->size();
 
     // Reliable: route to pending_ when backpressure is active
-    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-        impl_->backpressure_active_.load()) {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && impl_->backpressure_active_.load()) {
       if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
         UNILINK_LOG_ERROR("uds_client", "write",
                           fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
@@ -527,8 +525,7 @@ void UdsClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void UdsClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
-                                               backpressure_active_);
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
 void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes) {
@@ -560,11 +557,17 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
       pending_.pop_front();
     }
     backpressure_active_ = false;
-    try { on_bp(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    try {
+      on_bp(queued_bytes);
+    } catch (...) {
+    }  // fire OFF with pre-flush queue size
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try { on_bp(queue_bytes_); } catch (...) {}
+      try {
+        on_bp(queue_bytes_);
+      } catch (...) {
+      }
     }
     if (!writing_) do_write(self, current_seq_.load());
   }

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -200,6 +200,7 @@ void UdsClient::start() {
     return;
   }
 
+  impl_->recalculate_backpressure_bounds();
   impl_->stop_requested_ = false;
   impl_->stopping_ = false;
   impl_->current_seq_++;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -69,6 +69,8 @@ struct UdsClient::Impl {
 
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
+  std::deque<BufferVariant> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
@@ -113,6 +115,7 @@ struct UdsClient::Impl {
     connected_ = false;
     writing_ = false;
     queue_bytes_ = 0;
+    pending_bytes_ = 0;
     cfg_.validate_and_clamp();
     recalculate_backpressure_bounds();
   }
@@ -126,7 +129,7 @@ struct UdsClient::Impl {
   void close_socket();
   void recalculate_backpressure_bounds();
   void maybe_flush_for_keep_latest(size_t added);
-  void report_backpressure(size_t queued_bytes);
+  void report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes);
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
                     const boost::system::error_code& ec, std::string_view msg, bool retryable, uint32_t retry_count);
 
@@ -256,19 +259,33 @@ bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
 
 bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
   if (!impl_->connected_.load() || impl_->stop_requested_.load()) return false;
-  if (impl_->queue_bytes_ + data.size() > impl_->bp_limit_) return false;
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data.size() > impl_->bp_limit_) return false;
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     size_t added = data.size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        impl_->backpressure_active_.load()) {
+      if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+        UNILINK_LOG_ERROR("uds_client", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
+        return;
+      }
+      impl_->pending_bytes_ += added;
+      impl_->pending_.emplace_back(std::move(data));
+      return;
+    }
+
     impl_->maybe_flush_for_keep_latest(added);
     if (impl_->queue_bytes_ + added > impl_->bp_limit_) {
       UNILINK_LOG_ERROR("uds_client", "write",
                         fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
-      impl_->report_backpressure(impl_->queue_bytes_ + added);
+      impl_->report_backpressure(self, impl_->queue_bytes_ + added);
       return;
     }
     impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
-    impl_->report_backpressure(impl_->queue_bytes_);
+    impl_->report_backpressure(self, impl_->queue_bytes_);
     if (!impl_->writing_) {
       impl_->do_write(self, impl_->current_seq_.load());
     }
@@ -278,19 +295,33 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
 
 bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   if (!impl_->connected_.load() || impl_->stop_requested_.load() || !data) return false;
-  if (impl_->queue_bytes_ + data->size() > impl_->bp_limit_) return false;
-  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() {
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data->size() > impl_->bp_limit_) return false;
+  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     size_t added = data->size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
+        impl_->backpressure_active_.load()) {
+      if (impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+        UNILINK_LOG_ERROR("uds_client", "write",
+                          fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
+        return;
+      }
+      impl_->pending_bytes_ += added;
+      impl_->pending_.emplace_back(std::move(data));
+      return;
+    }
+
     impl_->maybe_flush_for_keep_latest(added);
     if (impl_->queue_bytes_ + added > impl_->bp_limit_) {
       UNILINK_LOG_ERROR("uds_client", "write",
                         fmt::format("Queue limit exceeded ({} bytes)", impl_->queue_bytes_ + added));
-      impl_->report_backpressure(impl_->queue_bytes_ + added);
+      impl_->report_backpressure(self, impl_->queue_bytes_ + added);
       return;
     }
     impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
-    impl_->report_backpressure(impl_->queue_bytes_);
+    impl_->report_backpressure(self, impl_->queue_bytes_);
     if (!impl_->writing_) impl_->do_write(self, impl_->current_seq_.load());
   });
   return true;
@@ -443,8 +474,9 @@ void UdsClient::Impl::do_write(std::shared_ptr<UdsClient> self, uint64_t seq) {
         if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) return;
         self->impl_->writing_ = false;
         self->impl_->current_write_buffer_ = std::nullopt;
-        self->impl_->queue_bytes_ -= bytes_to_write;
-        self->impl_->report_backpressure(self->impl_->queue_bytes_);
+        self->impl_->queue_bytes_ =
+            (self->impl_->queue_bytes_ >= bytes_to_write) ? (self->impl_->queue_bytes_ - bytes_to_write) : 0;
+        self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
 
         if (ec) {
           self->impl_->handle_close(self, seq, ec);
@@ -533,7 +565,7 @@ void UdsClient::Impl::maybe_flush_for_keep_latest(size_t added) {
   }
 }
 
-void UdsClient::Impl::report_backpressure(size_t queued_bytes) {
+void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes) {
   if (stop_requested_.load() || stopping_.load()) return;
 
   OnBackpressure on_bp;
@@ -554,15 +586,21 @@ void UdsClient::Impl::report_backpressure(size_t queued_bytes) {
       UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    backpressure_active_ = false;
-    try {
-      on_bp(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("uds_client", "on_backpressure",
-                        fmt::format("Exception in backpressure callback: {}", e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
+    // Flush pending_ → tx_
+    const size_t moved = pending_bytes_.exchange(0);
+    queue_bytes_ += moved;
+    while (!pending_.empty()) {
+      tx_.emplace_back(std::move(pending_.front()));
+      pending_.pop_front();
     }
+    backpressure_active_ = false;
+    try { on_bp(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    // If post-flush queue is still high, fire ON again
+    if (queue_bytes_ >= bp_high_) {
+      backpressure_active_ = true;
+      try { on_bp(queue_bytes_); } catch (...) {}
+    }
+    if (!writing_) do_write(self, current_seq_.load());
   }
 }
 

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -74,10 +74,22 @@ bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
 
 bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
   if (!alive_ || closing_) return false;
-  if (queue_bytes_ + data.size() > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + data.size() > bp_limit_) return false;
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data.size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
+      if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+        UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      pending_bytes_ += added;
+      pending_.emplace_back(std::move(data));
+      return;
+    }
+
     maybe_flush_for_keep_latest(added);
     if (queue_bytes_ + added > bp_limit_) {
       UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
@@ -95,10 +107,22 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
 
 bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   if (!alive_ || closing_ || !data) return false;
-  if (queue_bytes_ + data->size() > bp_limit_) return false;
-  net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() {
+  if (queue_bytes_ + pending_bytes_ + data->size() > bp_limit_) return false;
+  net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data->size();
+
+    // Reliable: route to pending_ when backpressure is active
+    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
+      if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+        UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
+        return;
+      }
+      pending_bytes_ += added;
+      pending_.emplace_back(std::move(data));
+      return;
+    }
+
     maybe_flush_for_keep_latest(added);
     if (queue_bytes_ + added > bp_limit_) {
       UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
@@ -179,6 +203,8 @@ void UdsServerSession::do_close() {
   tx_.clear();
   current_write_buffer_ = std::nullopt;
   queue_bytes_ = 0;
+  pending_.clear();
+  pending_bytes_ = 0;
   writing_ = false;
   boost::system::error_code ec;
   socket_->close(ec);
@@ -242,11 +268,21 @@ void UdsServerSession::report_backpressure(size_t queued_bytes) {
     } catch (...) {
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    backpressure_active_ = false;
-    try {
-      on_bp_(queued_bytes);
-    } catch (...) {
+    // Flush pending_ → tx_
+    const size_t moved = pending_bytes_.exchange(0);
+    queue_bytes_ += moved;
+    while (!pending_.empty()) {
+      tx_.emplace_back(std::move(pending_.front()));
+      pending_.pop_front();
     }
+    backpressure_active_ = false;
+    try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    // If post-flush queue is still high, fire ON again
+    if (queue_bytes_ >= bp_high_) {
+      backpressure_active_ = true;
+      try { on_bp_(queue_bytes_); } catch (...) {}
+    }
+    if (!writing_) do_write();
   }
 }
 

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -218,8 +218,7 @@ void UdsServerSession::do_close() {
 }
 
 void UdsServerSession::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
-                                               backpressure_active_);
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
 void UdsServerSession::report_backpressure(size_t queued_bytes) {
@@ -241,11 +240,17 @@ void UdsServerSession::report_backpressure(size_t queued_bytes) {
       pending_.pop_front();
     }
     backpressure_active_ = false;
-    try { on_bp_(queued_bytes); } catch (...) {}  // fire OFF with pre-flush queue size
+    try {
+      on_bp_(queued_bytes);
+    } catch (...) {
+    }  // fire OFF with pre-flush queue size
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try { on_bp_(queue_bytes_); } catch (...) {}
+      try {
+        on_bp_(queue_bytes_);
+      } catch (...) {
+      }
     }
     if (!writing_) do_write();
   }

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -16,6 +16,7 @@
 
 #include "unilink/transport/uds/uds_server_session.hpp"
 
+#include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
 
 namespace unilink {
@@ -217,44 +218,8 @@ void UdsServerSession::do_close() {
 }
 
 void UdsServerSession::maybe_flush_for_keep_latest(size_t added) {
-  if (bp_strategy_ != base::constants::BackpressureStrategy::BestEffort) return;
-
-  if (added >= bp_high_) {
-    // Compute bytes to remove from tx_ (excluding current_write_buffer_ which is in-flight)
-    size_t removed_bytes = 0;
-    for (const auto& buf : tx_) {
-      removed_bytes += std::visit(
-          [](auto&& b) -> size_t {
-            using T = std::decay_t<decltype(b)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return b ? b->size() : 0;
-            } else {
-              return b.size();
-            }
-          },
-          buf);
-    }
-    tx_.clear();
-    queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
-    return;
-  }
-
-  if (backpressure_active_ || queue_bytes_ + added > bp_high_) {
-    while (!tx_.empty() && (queue_bytes_ + added > bp_high_)) {
-      size_t oldest_size = std::visit(
-          [](auto&& buf) -> size_t {
-            using T = std::decay_t<decltype(buf)>;
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-              return buf ? buf->size() : 0;
-            } else {
-              return buf.size();
-            }
-          },
-          tx_.front());
-      queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
-      tx_.pop_front();
-    }
-  }
+  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_,
+                                               backpressure_active_);
 }
 
 void UdsServerSession::report_backpressure(size_t queued_bytes) {

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -90,6 +90,8 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   std::unique_ptr<interface::UdsSocketInterface> socket_;
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
+  std::deque<BufferVariant> pending_;
+  std::atomic<size_t> pending_bytes_{0};
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -43,10 +43,22 @@ class UNILINK_API ChannelInterface {
   virtual ~ChannelInterface() = default;
 
   // Lifecycle
+
+  /**
+   * @brief Start the channel asynchronously.
+   *
+   * @return A future that resolves to true when the channel is connected/listening,
+   *         or false if startup failed (e.g. connection refused, max retries exhausted).
+   *         On false, the registered on_error() callback will have been invoked with
+   *         the specific failure reason.
+   */
   [[nodiscard]] virtual std::future<bool> start() = 0;
 
   /**
-   * @brief Synchronously start the channel/server and wait for the result.
+   * @brief Synchronously start the channel and wait for the result.
+   *
+   * @return true if connected/listening, false on failure. On false, the registered
+   *         on_error() callback will have been invoked with the specific failure reason.
    */
   [[nodiscard]] virtual bool start_sync() { return start().get(); }
 


### PR DESCRIPTION
## Description

This PR introduces Reliable strategy auto flow-control via a 2-tier queue, along with four completeness improvements: unit tests for the new FC logic, deduplication of `maybe_flush_for_keep_latest`, Serial overflow behavior alignment, and a UdsClient backpressure restart bug fix.

## Key Changes

- **Reliable auto-FC (2-tier queue)**: When backpressure is ON, incoming writes accumulate in a `pending_` queue instead of being dropped. When BP clears (OFF event), `pending_` is flushed into `tx_`. If flushing pushes the queue back to `bp_high_`, BP re-fires immediately within the same `report_backpressure` call.
- **Reliable auto-FC unit tests**: Added `StallingTcpSocket` test double (defers `async_write` completions until `complete_one()` is called) and 4 deterministic single-threaded tests covering: pending accumulation during BP, post-BP byte delivery, combined-limit rejection, and burst-on-OFF immediate re-activation. All 493 tests pass.
- **`maybe_flush_for_keep_latest` deduplication**: Extracted the verbatim-duplicated BestEffort queue-trimming logic (4 copies across TcpClient, TcpServerSession, UdsClient, UdsServerSession) into `unilink/transport/base/bp_utils.hpp` under the `queue_util` namespace. Each call site is now a one-liner delegation.
- **Serial overflow behavior alignment**: Serial was the only transport that transitioned to `LinkState::Error` and called `handle_error()` on strand-side queue overflow. Aligned with all other transports: `LOG_ERROR` + `return` (soft reject, no Error state transition).
- **UdsClient backpressure restart fix**: `backpressure_active_` was not reset across a `stop()` → `start()` cycle, causing the client to start in a permanently-throttled state after a reconnect. Fixed by calling `recalculate_backpressure_bounds()` at the top of `start()`, matching the existing TcpClient pattern.
- **UDP Reliable semantics docs + gateway example**: Clarified UDP Reliable behavior in documentation and added a gateway usage example.

## Related Issues

- Fixes #

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Test infrastructure note**: The new Reliable auto-FC tests use `net::make_work_guard(ioc)` + `ioc.poll()` instead of `ioc.run_for(N ms)`. `run_for()` sets `stopped_=true` when the work queue empties, causing subsequent calls to silently skip newly-posted handlers. A `work_guard` keeps `outstanding_work_ > 0`, and `poll()` drains all currently-ready handlers without latching the stopped state — enabling reliable multi-step single-threaded tests.

**Namespace choice for bp_utils.hpp**: The extracted header uses `queue_util` (not `transport::base`) to avoid shadowing the existing `unilink::base` namespace, which would cause `base::constants::BackpressureStrategy` lookups in transport `.cc` files to resolve to the wrong scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TCP→UDS gateway example demonstrating forwarding and connection bridging.
  * New public header installed to expose queue/backpressure utilities.

* **Behavior**
  * Enhanced Reliable backpressure: writes are buffered while backpressure is active and flushed on recovery to reduce drops across transports.

* **Documentation**
  * Added troubleshooting note about UDP packet-loss semantics with Reliable backpressure.
  * Clarified async vs sync channel startup docs.

* **Tests**
  * Added unit tests validating Reliable backpressure behavior and transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/374)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->