### PR TITLE
fix: docker ubuntu compiler selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update && apt-get install -y \
     unzip \
     wget \
     zip \
-    gcc-10 \
-    g++-10 \
     python3 \
     doxygen \
     graphviz \
@@ -37,8 +35,6 @@ RUN rm -rf build && mkdir build && cd build && \
     cmake .. \
         -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=gcc-10 \
-        -DCMAKE_CXX_COMPILER=g++-10 \
         -DCMAKE_CXX_STANDARD=20 \
         -DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake \
         -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic \


### PR DESCRIPTION
## Description
Fix the Docker release build failure on `ubuntu:26.04` by removing hard-coded GCC 10 package and compiler selections. The current base image no longer provides `gcc-10`/`g++-10`, so the Docker build failed during `apt-get install` before CMake could run.

## Key Changes
- Remove `gcc-10` and `g++-10` from the Docker builder package install list.
- Remove the matching `-DCMAKE_C_COMPILER=gcc-10` and `-DCMAKE_CXX_COMPILER=g++-10` CMake options so the image uses the default compiler from `build-essential`.

## Related Issues
- None

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
- Observed failing GitHub Actions run: `Docker Build and Push` for tag `v0.7.2`, failing at Dockerfile package installation with `E: Unable to locate package gcc-10` and `E: Package 'g++-10' has no installation candidate`.
- Local `cmake --build build/dev-linux-x64 -j 2` completed successfully.
- Local `git diff --check` completed successfully.
- Local `./scripts/verify.sh` was run. Formatting and build completed, but the unit test phase failed in this sandbox with socket/port errors such as `Unable to find available test port after many attempts` and `Operation not permitted` while binding TCP/UDS sockets.
- Local Docker build could not be run because Docker is not available in this WSL environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration in Dockerfile. Removed pinned compiler version specifications and added Python, documentation generation, and graphing tools to the builder stage. Multi-stage build and production deployment flow remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/378)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->