### PR TITLE
Align docs with C++20 and run docs snippet checks on documentation changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Docs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'test/unit/CMakeLists.txt'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'README.md'
+      - 'docs/**'
+      - 'test/unit/CMakeLists.txt'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+env:
+  CXX_STANDARD: 20
+
+jobs:
+  docs-snippets:
+    name: Docs Snippets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-docs-snippets-${{ hashFiles('**/CMakeLists.txt', 'docs/**/*.md', 'docs/scripts/*.py') }}
+          restore-keys: ccache-${{ runner.os }}-docs-snippets-
+
+      - name: Install dependencies
+        uses: ./.github/actions/apt-install
+        with:
+          packages: "build-essential cmake ccache python3"
+
+      - name: Install dependencies with vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-linux
+
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build-docs-snippets \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_STANDARD=$CXX_STANDARD \
+            -DUNILINK_ENABLE_CONFIG=ON \
+            -DUNILINK_BUILD_DOCS=OFF \
+            -DUNILINK_BUILD_TESTS=ON \
+            -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
+            -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build doc snippet smoke target
+        run: cmake --build build-docs-snippets --target doc_snippets_smoke -j $(nproc)
+
+      - name: Run doc snippet tests
+        run: ctest --test-dir build-docs-snippets --output-on-failure -L docs_snippets

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![unilink logo](docs/assets/logo/light/unilink-logo-horizontal-readme-light.png#gh-light-mode-only)
 ![unilink logo](docs/assets/logo/dark/unilink-logo-horizontal-readme-dark.png#gh-dark-mode-only)
 
-**Unified async communication for modern C++.**
+**Unified async communication for modern C++20.**
 
 Serial · TCP · UDP · UDS
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Unilink Documentation {#docs_index}
 
-**Unified async communication for modern C++.**
+**Unified async communication for modern C++20.**
 
 Serial · TCP · UDP · UDS
 

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -27,11 +27,12 @@ vcpkg install jwsung91-unilink
 
 ```cmake
 cmake_minimum_required(VERSION 3.12)
-project(my_app CXX)
+project(my_app LANGUAGES CXX)
 
 find_package(unilink CONFIG REQUIRED)
 add_executable(my_app main.cpp)
 target_link_libraries(my_app PRIVATE unilink::unilink)
+target_compile_features(my_app PRIVATE cxx_std_20)
 ```
 
 ```cpp
@@ -69,6 +70,7 @@ sudo cmake --install build
 find_package(unilink CONFIG REQUIRED)
 add_executable(my_app main.cpp)
 target_link_libraries(my_app PRIVATE unilink::unilink)
+target_compile_features(my_app PRIVATE cxx_std_20)
 ```
 
 ### Method 3: Release Packages

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -26,6 +26,7 @@ sudo cmake --install build
 
 ## Your First TCP Client
 
+<!-- doc-compile: quickstart_tcp_client -->
 ```cpp
 #include <chrono>
 #include <iostream>
@@ -61,10 +62,35 @@ int main() {
 }
 ```
 
-**Compile:**
+**Compile with CMake (recommended):**
+
+Create `CMakeLists.txt` next to `my_client.cc`:
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_client_app LANGUAGES CXX)
+
+find_package(unilink CONFIG REQUIRED)
+
+add_executable(my_client my_client.cc)
+target_link_libraries(my_client PRIVATE unilink::unilink)
+target_compile_features(my_client PRIVATE cxx_std_20)
+```
+
+Then build and run:
 
 ```bash
-g++ -std=c++17 my_client.cc -lunilink -lboost_system -pthread -o my_client
+cmake -S . -B build
+cmake --build build
+./build/my_client
+```
+
+**Direct compiler invocation:**
+
+Direct compiler invocation can need different link flags depending on how Boost and unilink were installed.
+
+```bash
+g++ -std=c++20 my_client.cc -lunilink -lboost_system -pthread -o my_client
 ./my_client
 ```
 

--- a/docs/user/tutorials/01_getting_started.md
+++ b/docs/user/tutorials/01_getting_started.md
@@ -87,7 +87,7 @@ find_package(unilink CONFIG REQUIRED)
 
 add_executable(my_first_client my_first_client.cpp)
 target_link_libraries(my_first_client PRIVATE unilink::unilink)
-target_compile_features(my_first_client PRIVATE cxx_std_17)
+target_compile_features(my_first_client PRIVATE cxx_std_20)
 ```
 
 Then build:

--- a/docs/user/tutorials/04_serial_communication.md
+++ b/docs/user/tutorials/04_serial_communication.md
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
 ## Step 3: Build And Run
 
 ```bash
-g++ -std=c++17 serial_terminal.cpp -o serial_terminal -lunilink -lboost_system -pthread
+g++ -std=c++20 serial_terminal.cpp -o serial_terminal -lunilink -lboost_system -pthread
 ```
 
 Run against a real device:

--- a/docs/user/tutorials/05_udp_communication.md
+++ b/docs/user/tutorials/05_udp_communication.md
@@ -89,8 +89,8 @@ int main() {
 If you saved the snippets as `udp_receiver.cpp` and `udp_sender.cpp`:
 
 ```bash
-g++ -std=c++17 udp_receiver.cpp -o udp_receiver -lunilink -lboost_system -pthread
-g++ -std=c++17 udp_sender.cpp -o udp_sender -lunilink -lboost_system -pthread
+g++ -std=c++20 udp_receiver.cpp -o udp_receiver -lunilink -lboost_system -pthread
+g++ -std=c++20 udp_sender.cpp -o udp_sender -lunilink -lboost_system -pthread
 ```
 
 ---

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -151,6 +151,7 @@ set(_unilink_doc_extract_script
     ${CMAKE_SOURCE_DIR}/docs/scripts/extract_doc_snippet.py
 )
 set(_unilink_doc_snippets
+    "quickstart_tcp_client|docs/user/quickstart.md"
     "tutorial_getting_started_client|docs/user/tutorials/01_getting_started.md"
     "tutorial_tcp_server_echo|docs/user/tutorials/02_tcp_server.md"
     "tutorial_uds_server|docs/user/tutorials/03_uds_communication.md"


### PR DESCRIPTION
## Summary

This PR aligns the user-facing documentation with unilink's C++20 requirement and ensures documentation snippets are validated when docs change.

- Replaced stale C++17 compile instructions with C++20
- Updated tutorial CMake examples to use `cxx_std_20`
- Reviewed Quick Start / tutorial / installation docs for C++20 consistency
- Added a docs-focused CI workflow that runs doc snippet compile checks on documentation changes
- Added the Quick Start TCP client to doc snippet compile coverage

## Rationale

unilink requires C++20, but some user-facing examples still referenced C++17. Also, the main CI contains a docs snippet compile job, but markdown/docs changes can be ignored by the workflow trigger. This PR makes the release-facing documentation consistent and ensures docs-only changes get compile-smoke coverage.

## Test

```bash
rg -n "C\\+\\+17|c\\+\\+17|cxx_std_17|std=c\\+\\+17|-std=c\\+\\+17" README.md docs CMakeLists.txt cmake test scripts .github

cmake -S . -B build-pr2 \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_STANDARD=20 \
  -DUNILINK_BUILD_TESTS=ON \
  -DUNILINK_BUILD_DOCS=OFF

cmake --build build-pr2 --target doc_snippets_smoke --parallel
ctest --test-dir build-pr2 --output-on-failure -L docs_snippets
```

The C++17 search returned no matches.