### PR TITLE
Document API stability policy and release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Documentation is split by audience. Visit our **[Online Documentation](https://j
 * [Installation Guide](docs/user/installation.md) – Package, source, and build options
 * [Requirements](docs/user/requirements.md) – Supported platforms and dependencies
 * [API Reference](docs/user/api_guide.md) – Public API overview
+* [API Stability](docs/user/api_stability.md) – Public API and compatibility policy
 * [Python Bindings](https://github.com/unilink-lab/unilink-python) – External repository
 * [Troubleshooting](docs/user/troubleshooting.md) – Common issues and resolutions
 * [Tutorials](docs/user/tutorials/)
@@ -74,6 +75,7 @@ Documentation is split by audience. Visit our **[Online Documentation](https://j
 * [Build Guide](docs/contributor/build_guide.md) – Build configurations, CMake flags, sanitizers
 * [Testing Guide](docs/contributor/testing.md) – Running tests and CI integration
 * [Orin Nano Validation](docs/contributor/orin_nano_validation.md) – Ubuntu 22.04 ARM64 bring-up and test runbook
+* [Release Checklist](docs/contributor/release_checklist.md) – Release validation checklist
 * [Implementation Status](docs/contributor/implementation_status.md) – Verified scope and known gaps
 * [Architecture Overview](docs/contributor/architecture/README.md) – High-level structure and layer responsibilities
 * [Runtime Behavior](docs/contributor/architecture/runtime_behavior.md) – Threading model, reconnection, backpressure

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -9,6 +9,7 @@ Documentation for developers building, extending, or contributing to unilink its
 - [Build Guide](build_guide.md) — CMake options, build profiles, sanitizers, platform-specific notes
 - [Testing](testing.md) — Running the test suite, CI integration, writing tests
 - [Orin Nano Validation](orin_nano_validation.md) — Ubuntu 22.04 ARM64 bring-up and test runbook
+- [Release Checklist](release_checklist.md) — Release validation steps
 - [Implementation Status](implementation_status.md) — Verified scope, known gaps, and codebase snapshot
 - [Test Structure](test_structure.md) — Test organization and coverage breakdown
 

--- a/docs/contributor/release_checklist.md
+++ b/docs/contributor/release_checklist.md
@@ -1,0 +1,72 @@
+# Release Checklist {#contrib_release_checklist}
+
+Use this checklist before publishing a unilink release.
+
+## 1. Versioning
+
+- [ ] Update `project(VERSION ...)` in `CMakeLists.txt`
+- [ ] Confirm CPack package version matches the project version
+- [ ] Confirm Git tag matches the release version
+- [ ] Confirm release notes mention breaking changes, if any
+- [ ] Confirm `unilink-python` compatibility status, if applicable
+
+## 2. Build And Test
+
+- [ ] Full CI passes
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] E2E tests pass
+- [ ] Memory safety / sanitizer tests pass
+- [ ] Documentation snippet compile checks pass
+- [ ] Installed consumer smoke test passes
+
+## 3. Packaging
+
+- [ ] CPack artifacts are generated successfully
+- [ ] Package names match `docs/user/installation.md`
+- [ ] Package contents include public headers
+- [ ] Package contents include CMake package files
+- [ ] Package contents include `LICENSE`
+- [ ] Package contents include `NOTICE`
+- [ ] Package contents include `README.md`
+- [ ] External CMake consumer can use `find_package(unilink CONFIG REQUIRED)`
+- [ ] External CMake consumer can link against `unilink::unilink`
+
+## 4. Documentation
+
+- [ ] README is current
+- [ ] Installation Guide is current
+- [ ] Requirements Guide is current
+- [ ] API Guide matches actual builder/wrapper behavior
+- [ ] API Stability Policy is current
+- [ ] Known limitations are documented
+- [ ] Python bindings link points to `unilink-python`
+- [ ] Examples link points to the external examples repository
+
+## 5. Release Assets
+
+Check that expected release assets exist.
+
+- [ ] Linux x64 package
+- [ ] Linux ARM64 package
+- [ ] macOS package
+- [ ] Windows x64 package
+- [ ] Windows ARM64 package, if supported
+- [ ] Source archive
+- [ ] Draft GitHub Release created
+- [ ] Release notes include known limitations
+
+## 6. Compatibility Checks
+
+- [ ] vcpkg package status checked
+- [ ] External examples repository checked against this release
+- [ ] `unilink-python` compatibility checked, if applicable
+- [ ] Container image compatibility checked, if applicable
+
+## 7. Post-Release Checks
+
+- [ ] GitHub Release download links work
+- [ ] Documentation site is updated
+- [ ] Coverage badge still resolves
+- [ ] Installation Guide commands work with the released artifacts
+- [ ] Any follow-up issues are created for known limitations

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ You are building an application using unilink.
 | [Installation](user/installation.md) | vcpkg, source, release packages, containers |
 | [Requirements](user/requirements.md) | Platform and dependency expectations |
 | [API Reference](user/api_guide.md) | Full public API: builders, wrappers, callbacks |
+| [API Stability](user/api_stability.md) | Public API, source compatibility, ABI, and deprecation policy |
 | [Troubleshooting](user/troubleshooting.md) | Common failures and debugging steps |
 | [Python Bindings](user/python_bindings.md) | Moved to unilink-python |
 | [Performance](user/performance.md) | Build and runtime tuning |
@@ -48,6 +49,7 @@ You are developing or extending unilink itself.
 | [Build Guide](contributor/build_guide.md) | CMake options, build profiles, sanitizers |
 | [Testing](contributor/testing.md) | Running tests, CI integration |
 | [Orin Nano Validation](contributor/orin_nano_validation.md) | Ubuntu 22.04 ARM64 build and test runbook |
+| [Release Checklist](contributor/release_checklist.md) | Release validation and packaging checklist |
 | [Implementation Status](contributor/implementation_status.md) | Verified scope and known gaps |
 | [Test Structure](contributor/test_structure.md) | Test organization and coverage |
 | [Architecture Overview](contributor/architecture/README.md) | Layers, responsibilities, design patterns |

--- a/docs/user/api_stability.md
+++ b/docs/user/api_stability.md
@@ -1,0 +1,107 @@
+# API Stability Policy {#user_api_stability}
+
+This document defines which parts of unilink are considered user-facing public API, which parts are supported but advanced, and which parts are internal implementation details.
+
+Before v1.0, unilink aims to preserve source compatibility within the same minor release line where practical, but minor releases may still refine APIs when needed to improve clarity, safety, or runtime predictability.
+
+## Stable Public Surface
+
+The primary public entry point is:
+
+- `<unilink/unilink.hpp>`
+
+The following facade aliases and builder functions are considered user-facing API:
+
+- `unilink::tcp_client(...)`
+- `unilink::tcp_server(...)`
+- `unilink::udp_client(...)`
+- `unilink::udp_server(...)`
+- `unilink::serial(...)`
+- `unilink::uds_client(...)`
+- `unilink::uds_server(...)`
+
+The following wrapper aliases are also user-facing:
+
+- `unilink::TcpClient`
+- `unilink::TcpServer`
+- `unilink::UdpClient`
+- `unilink::UdpServer`
+- `unilink::Serial`
+- `unilink::UdsClient`
+- `unilink::UdsServer`
+
+The following callback context types are user-facing:
+
+- `unilink::MessageContext`
+- `unilink::ConnectionContext`
+- `unilink::ErrorContext`
+
+## Supported But Advanced Headers
+
+These headers are supported, but most users should prefer including `<unilink/unilink.hpp>`:
+
+- `unilink/builder/*`
+- `unilink/wrapper/*`
+- `unilink/wrapper/context.hpp`
+
+Use these headers directly only when you need narrower includes or lower-level wrapper control.
+
+## Internal Or Not Source-Stable Before v1.0
+
+The following areas are implementation details or advanced internals and may change before v1.0:
+
+- `unilink/transport/*`
+- `unilink/interface/*`
+- `unilink/factory/*`
+- `unilink/concurrency/*`
+- `unilink/config/*`
+- `unilink/memory/*`
+- Boost adapter headers
+
+Some memory utilities are documented to explain callback data ownership and safety rules. They should still be treated as advanced APIs unless they are exposed through the public facade or callback context types.
+
+## Source Compatibility
+
+Before v1.0, unilink aims to preserve source compatibility within the same minor release line where practical.
+
+However, minor releases may still refine APIs when needed to improve:
+
+- API clarity
+- runtime predictability
+- memory safety
+- packaging correctness
+- cross-platform behavior
+
+## ABI Compatibility
+
+C++ ABI compatibility is not guaranteed before v1.0.
+
+Applications and binary packages should be rebuilt against the exact unilink version they consume. Source compatibility is the primary compatibility goal before v1.0.
+
+## Deprecation Policy
+
+Deprecated APIs should normally remain available for at least one minor release before removal.
+
+Exceptions may be made when an API is:
+
+- unsafe
+- broken
+- misleading
+- preventing correct runtime behavior
+- incompatible with the documented public API contract
+
+## Python Bindings
+
+Python bindings are maintained separately in `unilink-python`.
+
+This API stability policy applies to the C++ core repository. Python package compatibility is documented in the `unilink-python` repository.
+
+## Recommended Include Policy
+
+Most applications should include:
+
+```cpp
+#include <unilink/unilink.hpp>
+```
+
+Direct builder or wrapper includes are supported for advanced users, but the umbrella header is the recommended stable entry point for application code.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -15,6 +15,7 @@ Documentation for developers using unilink as a library in their applications.
 ## API Reference
 
 - [API Guide](api_guide.md) — Full public API: builders, wrappers, context types, error handling
+- [API Stability](api_stability.md) — Public API and compatibility policy
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds release-readiness documentation for the C++ core library.

- Added API stability policy
- Defined stable public API surface
- Clarified supported advanced headers
- Clarified internal/not source-stable areas before v1.0
- Documented source compatibility and ABI policy
- Documented deprecation policy
- Added release checklist for versioning, CI, packaging, docs, compatibility, and post-release validation
- Linked the new documents from the documentation index and README

## Rationale

As unilink moves toward a user-facing release, users need to know which APIs are supported and which headers are implementation details. Contributors also need a repeatable release checklist to avoid regressions in packaging, documentation, and installed-package consumption.

## Test

Documentation-only change.

Checked:

```bash
test -f docs/user/api_stability.md
test -f docs/contributor/release_checklist.md
grep -RIn "api_stability" docs README.md
grep -RIn "release_checklist" docs README.md
```