### PR TITLE
Clarify runtime, backpressure, and memory safety guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 ## Feature Highlights
 
 * **Unified transport surface**: Consistent builders and wrappers for TCP client/server, UDP, Serial, and UDS.
-* **Zero-copy memory safety via SafeSpan**: Efficient data handling without unnecessary copies.
+* **Callback-scoped data views**: Avoid unnecessary copies during callbacks, with explicit ownership-copy helpers for stored data.
 * **Fluent API with CRTP Builders**: Type-safe configuration with improved method chaining.
 * **Tested runtime behavior**: Unit, integration, and end-to-end test suites are part of the repository and documented in `test/`.
 

--- a/docs/contributor/architecture/README.md
+++ b/docs/contributor/architecture/README.md
@@ -344,14 +344,14 @@ graph TD
     Queue --> IO
 ```
 
-### Thread Safety Guarantees
+### Thread Safety Model
 
-#### 1. API Methods
+#### 1. Runtime Methods
 
-All public API methods are thread-safe:
+Runtime operations such as sending, stopping, and state inspection are designed for concurrent application use. Callback registration and configuration setters should normally be completed before startup.
 
 ```cpp
-// Safe to call from multiple threads
+// Safe to call from multiple application threads
 client->send("data1");  // Thread 1
 client->send("data2");  // Thread 2
 client->stop();         // Thread 3

--- a/docs/contributor/architecture/channel_contract.md
+++ b/docs/contributor/architecture/channel_contract.md
@@ -38,10 +38,10 @@ This rule ensures that once an application explicitly requests a channel to stop
     *   **Callbacks**: Callback member variables (`on_bytes_`, `on_multi_data_`, etc.) are protected by a mutex to prevent data races during registration and invocation.
 
 ## 4. Backpressure Policy
-To prevent memory exhaustion and manage flow control, channels implement a backpressure mechanism based on the size of the internal write queue.
+To prevent memory exhaustion and manage sender-side queue pressure, channels implement a backpressure mechanism based on the size of the internal write queue.
 
 **Contract Rules:**
-1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the transport MUST invoke its internal `on_backpressure` callback with the current queue size. Wrapper APIs may choose not to expose this directly.
+1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the transport MUST invoke its internal `on_backpressure` callback with the current queue size. Wrapper and builder APIs may expose backpressure notifications where the wrapper supports them. See the user API guide for public callback availability.
     
 2.  **Relieving (Low Watermark):** Once backpressure is active, when the queue size drops to or below a "Low Watermark" (typically defined as `threshold / 2` or `0` depending on implementation, but must be strictly less than the high watermark), the transport MUST invoke its internal `on_backpressure` callback with the new lower queue size.
 
@@ -51,7 +51,7 @@ To prevent memory exhaustion and manage flow control, channels implement a backp
 *   **TcpClient:** Implements a high watermark at `backpressure_threshold` and a low watermark at `threshold / 2` (or 1 if threshold is small). Checks are performed after every write operation (enqueue/dequeue).
 *   **Serial:** Should follow the same logic as TcpClient.
 *   **TcpServer:** Implements backpressure per-session (`TcpServerSession`).
-    *   **Note:** This is a transport concern. The current wrapper/builder API does not expose a public `on_backpressure()` hook.
+    *   **Note:** Public wrapper-level backpressure notification is exposed through the wrapper/builder API where supported, but applications should treat it as queue-pressure notification rather than protocol-level flow control.
 
 ## 5. Error Handling Consistency
 

--- a/docs/contributor/architecture/memory_safety.md
+++ b/docs/contributor/architecture/memory_safety.md
@@ -17,14 +17,14 @@
 
 ## Overview
 
-### Memory Safety Guarantees
+### Memory Safety Model
 
 | Feature             | Description                      | Performance Impact                |
 | ------------------- | -------------------------------- | --------------------------------- |
-| **Bounds Checking** | All buffer access validated      | Minimal (<1%)                     |
-| **Type Safety**     | Safe conversions prevent UB      | Zero (compile-time)               |
+| **Checked Access**  | Bounds-checked access is available through `at()` and checked slicing helpers; unchecked access remains available for performance-sensitive paths | Minimal (<1%) |
+| **Type Safety**     | Safe conversions reduce UB risk  | Zero (compile-time)               |
 | **Leak Detection**  | Track allocations/deallocations  | Zero (Release builds)             |
-| **Thread Safety**   | All state management thread-safe | Minimal (~2-5%)                   |
+| **Thread Safety**   | Thread-safe state helpers are available where shared state requires synchronization | Minimal (~2-5%) |
 | **Memory Pools**    | Reduce fragmentation             | Positive (+30% for small buffers) |
 
 ---
@@ -47,7 +47,7 @@ flowchart TD
 
 ### SafeDataBuffer
 
-Immutable, type-safe buffer wrapper around existing data:
+Immutable, type-safe buffer wrapper that owns copied data:
 
 ```cpp
 #include "unilink/memory/memory_tracker.hpp"
@@ -63,6 +63,8 @@ auto span = from_vec.as_span();      // Non-owning view
 auto byte = from_vec.at(1);          // Bounds-checked
 auto unchecked = from_vec.data()[0]; // Pointer access
 ```
+
+`SafeDataBuffer` owns its storage and provides checked `at()` access. Pointer access and unchecked indexing should be used only when the caller already controls bounds.
 
 ---
 
@@ -138,6 +140,7 @@ void process_data(unilink::memory::ConstByteSpan data) {
     }
 
     // Bounds-checked access
+    uint8_t checked = data.at(0);
     auto subset = data.subspan(1, 2);  // throws on invalid ranges
 }
 
@@ -152,6 +155,8 @@ process_data(unilink::memory::ConstByteSpan(buffer));
 - `at()/subspan()` are checked; `operator[]` is unchecked
 - Project-local span abstraction retained for API stability
 - Zero overhead in release builds
+
+`SafeSpan::at()` and checked slicing helpers validate ranges. `operator[]` follows `std::span` semantics and is unchecked.
 
 ---
 

--- a/docs/contributor/architecture/runtime_behavior.md
+++ b/docs/contributor/architecture/runtime_behavior.md
@@ -37,7 +37,7 @@ sequenceDiagram
     IO->>IO: Execute on_data callback
     Note over IO: ⚠️ Callbacks run in I/O thread<br/>Don't block here!
 
-    Note over App,Net: Thread-Safe API Calls
+    Note over App,Net: Concurrent Runtime Calls
     App->>Queue: Multiple threads can call
     App->>Queue: send(), stop(), etc.
     Queue->>IO: Serialized execution
@@ -47,20 +47,22 @@ sequenceDiagram
 
 ### Key Points
 
-#### ✅ Thread-Safe API Methods
+#### Concurrent Runtime Methods
 
-All public API methods are thread-safe and can be called from any thread:
+Runtime methods intended for concurrent application use are designed to be thread-safe. This includes methods such as `send()`, `try_send()`, `send_line()`, `stop()`, `connected()`, server `send_to()`, server `broadcast()`, and server state inspection helpers where available.
 
 ```cpp
-// Safe to call from multiple threads simultaneously
+// Runtime operations are safe to call from multiple application threads.
 std::thread t1([&client]() { client->send("data1"); });
 std::thread t2([&client]() { client->send("data2"); });
 std::thread t3([&client]() { client->stop(); });
 ```
 
+Callback registration and configuration setters should normally be completed before `start()` or `auto_start(true)`.
+
 **Implementation:**
 
-- All API calls are serialized through `boost::asio::post()`
+- Concurrent runtime operations are serialized through `boost::asio::post()`
 - Operations are queued and executed in the I/O thread
 - No manual locking required by users
 
@@ -86,6 +88,9 @@ auto client = unilink::tcp_client("server.com", 8080)
 - `on_disconnect()` - Connection lost
 - `on_data()` - Data received
 - `on_error()` - Error occurred
+- `on_backpressure()` - Sender-side queue pressure changed
+
+Callbacks should be short and non-blocking. If work must be moved to another thread, copy callback-scoped views first.
 
 ---
 
@@ -107,14 +112,15 @@ auto client = unilink::tcp_client("server.com", 8080)
 ```cpp
 .on_data([](const unilink::MessageContext& ctx) {
     // ✅ GOOD: Offload to worker thread
-    std::string payload(ctx.data());
-    std::thread([payload]() {
+    std::string payload = ctx.data_as_string();
+    std::thread([payload = std::move(payload)]() {
         heavy_computation(payload);
         database_query(payload);
     }).detach();
 
     // Or use a thread pool
-    thread_pool.submit([payload]() {
+    std::string payload_for_pool = ctx.data_as_string();
+    thread_pool.submit([payload = std::move(payload_for_pool)]() {
         heavy_computation(payload);
     });
 })
@@ -149,9 +155,9 @@ boost::asio::post(io_context, [&client]() {
 | Aspect                  | Details                                            |
 | ----------------------- | -------------------------------------------------- |
 | **I/O Thread**          | Single dedicated thread running `io_context.run()` |
-| **Application Threads** | Any number of threads calling API methods          |
+| **Application Threads** | Any number of threads calling runtime operations   |
 | **Callback Thread**     | Always I/O thread                                  |
-| **Thread Safety**       | All API methods thread-safe via `post()`           |
+| **Thread Safety**       | Concurrent runtime operations serialized via `post()` |
 | **Synchronization**     | Automatic via Boost.Asio                           |
 
 ---
@@ -340,7 +346,9 @@ client.reset();
 
 ## Backpressure Handling
 
-When the send queue grows too large (network slower than application), `unilink` applies internal backpressure protection in the transport layer. Applications can monitor backpressure via the wrapper-level `on_backpressure` builder method callback, or implement additional rate limiting and queue monitoring at the application level.
+Backpressure is sender-side queue pressure. When the local outgoing queue grows too large because the transport is slower than the application, `unilink` applies internal backpressure protection in the transport layer. Applications can monitor queue pressure via the wrapper-level `on_backpressure` builder callback where supported, or implement additional rate limiting and queue monitoring at the application level.
+
+Backpressure does not mean the remote peer has processed data. For UDP, it only describes the local sender-side queue because UDP has no receiver-side flow control.
 
 ### Backpressure Flow
 
@@ -352,13 +360,13 @@ flowchart TD
     Check -->|No| Write[Continue Normal Write]
     Write --> Complete([Data Sent])
 
-    Check -->|Yes: queue_bytes > 1MB| Protect[Internal backpressure protection]
+    Check -->|Yes: queued bytes > threshold| Protect[Internal backpressure protection]
     Protect --> AppDecision{Application Decision}
 
     AppDecision -->|Pause Sending| Wait[Wait for queue to drain]
     AppDecision -->|Rate Limit| Throttle[Reduce send rate]
     AppDecision -->|Drop Data| Drop[Skip non-critical data]
-    AppDecision -->|Continue| Force[Force send anyway<br/>⚠️ May cause memory growth]
+    AppDecision -->|Continue| Force[Continue producing<br/>May fail or trigger protection]
 
     Wait --> Monitor{Queue Size ><br/>Threshold?}
     Monitor -->|Still high| Wait
@@ -380,7 +388,7 @@ flowchart TD
 
 Use transport-layer configuration if you need direct queue-threshold control. At the wrapper level, keep your own send budget and stop producing data when downstream systems slow down.
 
-**Default threshold:** 1 MB (1,048,576 bytes)  
+**Default threshold:** Reliable defaults to 1 MiB; BestEffort defaults to 512 KiB when selected through the builder. Base transport configuration defaults to 1 MiB.
 **Configurable range:** 1 KB - 100 MB  
 **Safety cap:** ~4x the high watermark (capped at 64 MB) triggers automatic close + Error state
 
@@ -464,7 +472,7 @@ Backpressure handling ensures:
 - ✅ Queue size is monitored continuously
 - ✅ Queue growth is bounded internally in the transport layer
 - ✅ Applications can add their own send throttling policy
-- ✅ Wrapper-level backpressure callbacks are available via the `on_backpressure` builder method
+- ✅ Wrapper-level backpressure notifications are available via the `on_backpressure` builder method where supported
 - ✅ Memory pools reduce allocation overhead for small buffers (<64KB)
 
 ---
@@ -519,7 +527,7 @@ Backpressure handling ensures:
 #### ❌ DON'T
 
 - Ignore backpressure callbacks
-- Assume unlimited memory
+- Assume queue memory is unbounded
 - Send without rate limiting
 - Forget to handle high-load scenarios
 

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -42,8 +42,8 @@ auto channel = unilink::{type}(params)
 | `.on_connect(callback)`          | Handle connection events (`const ConnectionContext&`)             | None     |
 | `.on_disconnect(callback)`       | Handle disconnection (`const ConnectionContext&`)                 | None     |
 | `.on_error(callback)`            | Handle errors (`const ErrorContext&`)                             | None     |
-| `.on_backpressure(callback)`     | Handle queue threshold events (`void(size_t bytes)`)              | None     |
-| `.backpressure_threshold(bytes)` | Set queue limit for strategy or flow control                      | 512 KB   |
+| `.on_backpressure(callback)`     | Handle sender-side queue threshold events (`void(size_t bytes)`)  | None     |
+| `.backpressure_threshold(bytes)` | Set queued outgoing byte threshold                                | Reliable: 1 MiB, BestEffort: 512 KiB |
 | `.backpressure_strategy(enum)`   | Set behavior when threshold is reached (`Reliable`, `BestEffort`)  | `Reliable`|
 | `.auto_start(bool)`             | Auto-start/stop the wrapper (starts immediately when `true`)      | `false`  |
 | `.independent_context(bool)`     | Create and run a dedicated `io_context` thread managed by unilink | `false`  |
@@ -64,11 +64,13 @@ For production applications, registering `.on_error(...)` is strongly recommende
 
 At least one of `.on_data(...)`, `.on_data_batch(...)`, `.on_message(...)`, or `.on_message_batch(...)` is normally useful for receive-oriented workflows, but it is not required to build a wrapper.
 
-**`MessageContext` Data Access**
+### `MessageContext` Data Ownership
 
-Inside `on_data` and `on_message` callbacks, `ctx.data()` returns a `std::string_view` that is only valid for the duration of the callback. Do not store or capture it beyond the callback scope.
+Inside `on_data` and `on_message` callbacks, `ctx.data()` returns a callback-scoped non-owning `std::string_view`. It is intended for immediate use inside the callback only.
 
-To take ownership of the data, use:
+Do not store the returned `std::string_view`. Do not pass the view to worker threads unless you copy it first.
+
+If data needs to be stored, queued, moved to another thread, or used after the callback returns, take ownership with:
 - `ctx.data_as_string()` — returns `std::string` (copy)
 - `ctx.data_as_vector()` — returns `std::vector<uint8_t>` (copy)
 
@@ -100,7 +102,7 @@ Use `.on_message()` together with a framer when you want callback flow to operat
 **Benefits:**
 
 - **Performance**: Avoids `std::string` allocation overhead.
-- **Safety**: Bounds-checked access preventing buffer overflows.
+- **Ownership clarity**: Uses the same callback-scoped data view and explicit copy helpers as raw data callbacks.
 
 **Example:**
 
@@ -983,18 +985,24 @@ unilink::diagnostics::Logger::instance().set_async_logging(true, config);
 
 ## Backpressure Strategy
 
-When a sender produces data faster than the network can deliver it, messages accumulate in the send queue. The `BackpressureStrategy` enum controls what happens when the queue approaches its threshold — trading off **completeness** against **freshness**.
+Backpressure controls the sender-side queue maintained by unilink. It is measured in queued outgoing bytes, not message count.
+
+Backpressure does not guarantee that the remote peer has processed the data. For UDP, backpressure only applies to the local sender-side queue because UDP has no receiver-side flow control.
+
+When a sender produces data faster than the transport can deliver it, messages accumulate in the send queue. The `BackpressureStrategy` enum controls what happens when the queue approaches its threshold, trading off local queue preservation against freshness.
 
 ### Strategies
 
-| Strategy     | Behaviour at threshold                     | Use when…                                           |
+| Strategy     | Behaviour at threshold                     | Use when...                                         |
 | ------------ | ------------------------------------------ | --------------------------------------------------- |
-| `Reliable`    | Keep queuing until the hard cap is reached | Every message must arrive — files, commands, logs   |
-| `BestEffort` | Drop the entire queue; keep sending fresh data | Latency matters more than completeness — sensor streams, robot state, video telemetry |
+| `Reliable`    | Preserve queued outgoing data until the queue limit is reached | Local queue drops must be avoided, such as files, commands, logs |
+| `BestEffort` | Drop older queued data to keep newer data moving | Freshness matters more than completeness, such as sensor streams, robot state, video telemetry |
 
-`Reliable` is the default for all transports. It is the safe choice: no data is silently discarded.
+`Reliable` is the default for all transports. It prioritizes preserving queued outgoing data until the configured queue limit is reached. If the queue cannot accept more data, send APIs may fail or the transport may report an error depending on the wrapper and transport state.
 
-`BestEffort` is inspired by DDS HISTORY QoS. When the queue exceeds the backpressure threshold, all queued (stale) data is discarded and only the newest write is enqueued. The `on_backpressure` callback fires each time the queue is flushed so callers can observe drops.
+`BestEffort` is inspired by DDS HISTORY QoS. It prioritizes freshness. When the queue exceeds the configured threshold, older queued data may be dropped to make room for newer data.
+
+`on_backpressure(callback)` is a notification hook. It is not a blocking flow-control mechanism. The callback receives the current queued byte count when the queue crosses implementation-defined high/low watermark transitions. Backpressure callbacks follow the same callback execution model as other wrapper callbacks, so keep them short and non-blocking.
 
 ### When to use each
 
@@ -1022,12 +1030,12 @@ using unilink::base::constants::BackpressureStrategy;
 config::TcpClientConfig cfg;
 cfg.host = "192.168.1.10";
 cfg.port = 8080;
-cfg.backpressure_threshold = 512 * 1024;            // 512 KB flush threshold
+cfg.backpressure_threshold = 512 * 1024;            // 512 KiB threshold
 cfg.backpressure_strategy  = BackpressureStrategy::BestEffort;
 
 auto client = TcpClient::create(cfg, ioc);
-client->on_backpressure([](size_t /* dropped_bytes */) {
-    // queue was flushed — stale data discarded
+client->on_backpressure([](size_t queued_bytes) {
+    // sender-side queued byte count crossed a watermark
 });
 ```
 
@@ -1039,16 +1047,11 @@ Or via the wrapper builder (fluent API):
 auto client = unilink::tcp_client("192.168.1.10", 8080)
     .backpressure_threshold(512 * 1024)
     .backpressure_strategy(unilink::base::constants::BackpressureStrategy::BestEffort)
-    .on_backpressure([](size_t) { /* queue flushed */ })
+    .on_backpressure([](size_t) { /* queue pressure changed */ })
     .build();
 ```
 
-The strategy can also be changed at runtime on a running transport:
-
-```cpp
-// Switch strategy dynamically (e.g. entering a high-rate burst mode)
-client->set_backpressure_strategy(BackpressureStrategy::BestEffort);
-```
+Configuration should normally be completed before `start()` or `auto_start(true)`.
 
 ### Thresholds
 
@@ -1056,15 +1059,25 @@ Unilink uses **Dynamic Defaults** for the backpressure threshold based on the se
 
 | Strategy | Default Threshold | Typical Use Case |
 | :--- | :--- | :--- |
-| `Reliable` | **4 MiB** | Commands, logs, file transfers |
+| `Reliable` | **1 MiB** | Commands, logs, file transfers |
 | `BestEffort` | **512 KiB** | LiDAR, Camera, Real-time state |
 
-A hard cap (`bp_limit_`) is automatically calculated as `max(threshold * 4, 4MB)` to prevent unbounded memory use while ensuring enough room for large individual messages.
+A hard cap (`bp_limit_`) is automatically calculated as `max(threshold * 4, 4 MiB)` to prevent unbounded memory use while ensuring enough room for large individual messages.
 
 | Parameter | Default | Notes |
 | :--- | :--- | :--- |
-| `backpressure_threshold` | *Dynamic* | 4MB for Reliable, 512KB for BestEffort |
+| `backpressure_threshold` | *Dynamic* | 1 MiB for Reliable, 512 KiB for BestEffort |
 | Hard cap (`bp_limit_`) | ≥ 4 MiB | Per-message reject limit |
+
+### Transport Meaning
+
+| Transport | Backpressure meaning |
+|----------|----------------------|
+| TCP client | Local outgoing queue pressure |
+| TCP server | Per-client/session outgoing queue pressure |
+| Serial | Local outgoing queue pressure |
+| UDP client/server | Local outgoing queue pressure only; no receiver-side flow control |
+| UDS client/server | Local outgoing queue pressure |
 
 ---
 

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -129,7 +129,7 @@ Unilink provides two strategies for handling full queues:
 
 | Strategy | Behavior | Best For |
 |:---|:---|:---|
-| `Reliable` (Default) | Retains all data and applies backpressure based on the configured threshold (default: 4 MiB), bounded by system buffer limits (up to 64MB). | Reliable data (files, logs, commands). |
+| `Reliable` (Default) | Preserves queued outgoing data until the configured threshold is reached (default: 1 MiB), bounded by internal queue limits. | Reliable data (files, logs, commands). |
 | `BestEffort` | Drops oldest data when a threshold is reached. | Real-time sensors (LiDAR, Video, Telemetry). |
 
 ### 2. High-Throughput Sensors (LiDAR/Camera)
@@ -153,12 +153,12 @@ a large backlog to drain.
 
 ### 3. Critical Reliable Data
 
-For data that must not be lost, use `Reliable` combined with **Flow Control** in your application.
+For data where local queue drops are unacceptable, use `Reliable` combined with application-level send throttling.
 
 ```cpp
 bool paused = false;
 client->on_backpressure([&paused](size_t queued) {
-    // If queue exceeds 12MB, pause sending; resume when below 4MB
+    // Pause/resume based on your application's queued-byte budget.
     if (queued > 12 * 1024 * 1024) paused = true;
     else if (queued < 4 * 1024 * 1024) paused = false;
 });


### PR DESCRIPTION
## Summary

This PR clarifies unilink's runtime, backpressure, and memory safety documentation.

- Replaced over-broad zero-copy memory safety wording with callback-scoped data ownership wording
- Clarified `MessageContext::data()` lifetime and copy helpers
- Clarified SafeSpan checked vs unchecked access
- Reworded runtime thread-safety guidance to distinguish runtime methods from callback/configuration registration
- Clarified backpressure as sender-side queue pressure
- Documented UDP backpressure limitations
- Removed stale or conflicting backpressure wording from architecture docs

## Rationale

The previous docs used a few broad phrases such as "Zero-copy memory safety" and "All public API methods are thread-safe." These were directionally useful but too easy to over-read. This PR keeps the same design philosophy while making the documented guarantees more precise and aligned with the actual API behavior.

## Test

Documentation-only change.

Checked:

```bash
grep -RIn \
  -e "Zero-copy memory safety" \
  -e "All public API methods are thread-safe" \
  -e "All buffer access validated" \
  README.md docs || true

grep -RIn "callback-scoped" README.md docs || true
grep -RIn "data_as_string" docs/user/api_guide.md docs/contributor/architecture/runtime_behavior.md || true
grep -RIn "operator\\[\\].*unchecked\\|unchecked.*operator\\[\\]" docs/contributor/architecture/memory_safety.md || true
grep -RIn "sender-side queue" docs || true

git diff --check
cmake --build build/verify --target doc_snippets_smoke --parallel
ctest --test-dir build/verify --output-on-failure -L docs_snippets
```

Note: `cmake --build build --target doc_snippets_smoke --parallel` could not run because `build/` has no CMake cache in this checkout. The equivalent configured `build/verify` target and `docs_snippets` test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated threading model guidance with clarified concurrency semantics and callback behavior
  * Documented `on_backpressure()` callback for sender-side queue threshold notifications
  * Revised default backpressure thresholds: Reliable (1 MiB), BestEffort (512 KiB)
  * Enhanced callback data ownership documentation with guidance on safe copying practices
  * Improved memory safety and thread safety model documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->