### PR TITLE
docs: clarify send and backpressure semantics

### DIFF
--- a/docs/contributor/architecture/channel_contract.md
+++ b/docs/contributor/architecture/channel_contract.md
@@ -40,6 +40,15 @@ This rule ensures that once an application explicitly requests a channel to stop
 ## 4. Backpressure Policy
 To prevent memory exhaustion and manage sender-side queue pressure, channels implement a backpressure mechanism based on the size of the internal write queue.
 
+Backpressure is a sender-side queue management mechanism. It does not guarantee that the remote peer has processed data.
+
+A transport may accept a new payload while dropping older queued payloads when using a freshness-oriented policy such as `BestEffort`.
+
+A rejected send and a dropped queued payload are different events:
+
+- rejected send: the new payload was not accepted into the local send path
+- dropped queued payload: an older queued payload was removed after a newer payload was accepted
+
 **Contract Rules:**
 1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the transport MUST invoke its internal `on_backpressure` callback with the current queue size. Wrapper and builder APIs may expose backpressure notifications where the wrapper supports them. See the user API guide for public callback availability.
     
@@ -52,6 +61,7 @@ To prevent memory exhaustion and manage sender-side queue pressure, channels imp
 *   **Serial:** Should follow the same logic as TcpClient.
 *   **TcpServer:** Implements backpressure per-session (`TcpServerSession`).
     *   **Note:** Public wrapper-level backpressure notification is exposed through the wrapper/builder API where supported, but applications should treat it as queue-pressure notification rather than protocol-level flow control.
+*   **UDP:** Backpressure applies only to the local sender-side queue. UDP does not provide receiver-side flow control or delivery guarantees.
 
 ## 5. Error Handling Consistency
 

--- a/docs/contributor/architecture/runtime_behavior.md
+++ b/docs/contributor/architecture/runtime_behavior.md
@@ -51,6 +51,8 @@ sequenceDiagram
 
 Runtime methods intended for concurrent application use are designed to be thread-safe. This includes methods such as `send()`, `try_send()`, `send_line()`, `stop()`, `connected()`, server `send_to()`, server `broadcast()`, and server state inspection helpers where available.
 
+Thread-safe does not mean non-blocking. In `Reliable` mode, `send()` may wait for backpressure to clear. Use `try_send()` for non-blocking producer loops.
+
 ```cpp
 // Runtime operations are safe to call from multiple application threads.
 std::thread t1([&client]() { client->send("data1"); });
@@ -349,6 +351,13 @@ client.reset();
 Backpressure is sender-side queue pressure. When the local outgoing queue grows too large because the transport is slower than the application, `unilink` applies internal backpressure protection in the transport layer. Applications can monitor queue pressure via the wrapper-level `on_backpressure` builder callback where supported, or implement additional rate limiting and queue monitoring at the application level.
 
 Backpressure does not mean the remote peer has processed data. For UDP, it only describes the local sender-side queue because UDP has no receiver-side flow control.
+
+Applications that produce data faster than the transport can send it should choose an explicit policy:
+
+- use `Reliable` when completeness is more important than latency
+- use `BestEffort` when freshness is more important than preserving every queued payload
+- use `try_send()` when producer threads must not block
+- monitor queue pressure and dropped data when available
 
 ### Backpressure Flow
 

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -54,6 +54,10 @@ auto channel = unilink::{type}(params)
 
 Default `None` means no callback is invoked.
 
+`backpressure_threshold(bytes)` is measured in queued outgoing bytes, not message count.
+
+`on_backpressure(...)` is a notification hook. It is not a blocking flow-control mechanism.
+
 ### Callback Registration Policy
 
 Callback registration is optional.
@@ -119,11 +123,12 @@ Use `.on_message()` together with a framer when you want callback flow to operat
 | `->start()` | Start the connection (returns `std::future<bool>`) |
 | `->start_sync()` | Start the connection and block until established (returns `bool`) |
 | `->stop()` | Stop the connection |
-| `TcpClient` / `Serial` / `UdpClient` / `UdsClient`: `->send(data)` / `->send_line(text)` | Send data to the configured peer |
+| `TcpClient` / `Serial` / `UdpClient` / `UdsClient`: `->send(data)` / `->try_send(data)` / `->send_line(text)` | Send data to the configured peer |
 | `TcpClient` / `Serial` / `UdpClient` / `UdsClient`: `->connected()` | Check channel state |
-
 | `TcpServer` / `UdsServer`: `->broadcast(data)` / `->send_to(client_id, data)` | Send data to one or more connected clients |
 | `TcpServer` / `UdsServer`: `->listening()` | Check if the server socket is bound and listening |
+
+For producer loops that must not block, prefer `try_send()` or configure `BestEffort`. In `Reliable` mode, `send()` may wait for queue pressure to clear.
 
 **Builder Flow**
 
@@ -1003,6 +1008,34 @@ When a sender produces data faster than the transport can deliver it, messages a
 `BestEffort` is inspired by DDS HISTORY QoS. It prioritizes freshness. When the queue exceeds the configured threshold, older queued data may be dropped to make room for newer data.
 
 `on_backpressure(callback)` is a notification hook. It is not a blocking flow-control mechanism. The callback receives the current queued byte count when the queue crosses implementation-defined high/low watermark transitions. Backpressure callbacks follow the same callback execution model as other wrapper callbacks, so keep them short and non-blocking.
+
+### Send And Backpressure Semantics
+
+`unilink` separates send acceptance, queue preservation, and remote delivery.
+
+A successful `send()` or `try_send()` means that the payload was accepted by the local wrapper/transport send path. It does not guarantee that the remote peer has already received or processed the data.
+
+#### Reliable
+
+`Reliable` is the default strategy. It prioritizes preserving queued outgoing data.
+
+In `Reliable` mode, `send()` may block when the local outgoing queue is under backpressure. Use `try_send()` when producer code must remain non-blocking.
+
+If the queue cannot accept more data, send APIs may return `false`.
+
+#### BestEffort
+
+`BestEffort` prioritizes freshness over preserving every queued payload.
+
+In `BestEffort` mode, a successful send means the new payload was accepted into the local send path. It does not imply that older queued payloads were preserved. Older queued data may be dropped when queue pressure is high.
+
+This is useful for telemetry, sensor frames, or other freshness-oriented data where processing stale payloads is worse than dropping them.
+
+#### Throughput Interpretation
+
+Accepted throughput is not the same as delivered or received throughput.
+
+For `BestEffort`, evaluate behavior using received throughput, delivery rate, queue depth, and drop metrics when available, not accepted throughput alone.
 
 ### When to use each
 

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -132,6 +132,20 @@ Unilink provides two strategies for handling full queues:
 | `Reliable` (Default) | Preserves queued outgoing data until the configured threshold is reached (default: 1 MiB), bounded by internal queue limits. | Reliable data (files, logs, commands). |
 | `BestEffort` | Drops oldest data when a threshold is reached. | Real-time sensors (LiDAR, Video, Telemetry). |
 
+### Interpreting Strategy Results
+
+For throughput or pressure tests, distinguish between:
+
+- **accepted throughput**: data accepted into the local send path
+- **received throughput**: data observed by the receiver
+- **delivery rate**: received data relative to accepted data
+- **failed sends**: send calls that were rejected before being accepted
+- **dropped data**: queued data discarded by a freshness-oriented policy such as `BestEffort`
+
+In `BestEffort` mode, accepted throughput can be much higher than received throughput because older queued payloads may be dropped to keep newer data fresh. This is expected for unbounded producer pressure, but it must be monitored in real applications.
+
+In `Reliable` mode, throughput is usually limited by queue pressure and receiver progress, but accepted data is preserved unless the queue cannot accept more data.
+
 ### 2. High-Throughput Sensors (LiDAR/Camera)
 
 For robotics perception, processing stale data is often worse than skipping frames. Use `BestEffort` with a low threshold to prevent **Bufferbloat**.
@@ -151,9 +165,13 @@ Aggressive flushing during network disconnects ensures that once reconnection
 occurs, the receiver instantly gets the most recent frame instead of waiting for
 a large backlog to drain.
 
+For freshness-oriented streams, monitor dropped data and received rate. A high accepted rate alone does not mean the receiver is processing every payload.
+
 ### 3. Critical Reliable Data
 
 For data where local queue drops are unacceptable, use `Reliable` combined with application-level send throttling.
+
+For producer loops that must never block, use `try_send()` and handle `false` explicitly. `send()` in `Reliable` mode may block while waiting for backpressure to clear.
 
 ```cpp
 bool paused = false;


### PR DESCRIPTION
## Summary

This PR clarifies send and backpressure semantics in the core documentation.

- Clarifies that successful local send acceptance does not guarantee remote delivery
- Clarifies that `send()` may block in `Reliable` mode under backpressure
- Recommends `try_send()` for non-blocking producer loops
- Clarifies that `BestEffort` may drop older queued payloads to keep newer data fresh
- Distinguishes rejected sends from dropped queued payloads
- Clarifies accepted throughput vs received/delivered throughput
- Clarifies UDP sender-side-only backpressure semantics

## Rationale

The benchmark results highlighted that users can easily over-read accepted throughput or boolean send success. The core docs should explain the runtime semantics without embedding hardware-specific benchmark numbers.

Benchmark result tables and hardware-specific measurements remain in the benchmark repository. This PR only documents core API behavior.

## Test

Documentation-only change.

Checked:

```bash
rg -n "BestEffort|Reliable|backpressure|try_send|send\\(\\)" docs/user docs/contributor/architecture

rg -n "3428|1020\\.19|4897\\.38|p50|p99|WSL2" docs/user docs/contributor

rg -n "accepted throughput|received throughput|send\\(\\) may block|try_send|older queued" docs/user docs/contributor

git diff --check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified backpressure as sender-side queue management mechanism
  * Expanded API documentation with complete lifecycle methods and send semantics
  * Added guidance on choosing between Reliable and BestEffort strategies
  * New section on interpreting backpressure metrics and delivery outcomes
  * Enhanced non-blocking producer recommendations with try_send() best practices

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->