### PR TITLE
feat: add runtime queue and transport statistics

### DIFF
--- a/cmake/UnilinkSources.cmake
+++ b/cmake/UnilinkSources.cmake
@@ -77,6 +77,7 @@ set(UNILINK_HEADERS
     unilink/diagnostics/error_types.hpp
     unilink/diagnostics/exceptions.hpp
     unilink/diagnostics/logger.hpp
+    unilink/diagnostics/runtime_stats_counter.hpp
     unilink/factory/channel_factory.hpp
     unilink/interface/channel.hpp
     unilink/interface/iserial_port.hpp
@@ -109,6 +110,7 @@ set(UNILINK_HEADERS
     unilink/unilink.hpp
     unilink/util/input_validator.hpp
     unilink/wrapper/ichannel.hpp
+    unilink/wrapper/runtime_stats.hpp
     unilink/wrapper/serial/serial.hpp
     unilink/wrapper/tcp_client/tcp_client.hpp
     unilink/wrapper/tcp_server/tcp_server.hpp

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -1037,6 +1037,24 @@ Accepted throughput is not the same as delivered or received throughput.
 
 For `BestEffort`, evaluate behavior using received throughput, delivery rate, queue depth, and drop metrics when available, not accepted throughput alone.
 
+### Runtime Statistics
+
+Wrappers expose runtime statistics for monitoring queue pressure and transport behavior.
+
+```cpp
+auto stats = client->stats();
+
+std::cout << "queued bytes: " << stats.queued_bytes << "\n";
+std::cout << "accepted messages: " << stats.messages_accepted << "\n";
+std::cout << "dropped messages: " << stats.dropped_messages << "\n";
+```
+
+Runtime statistics are diagnostic snapshots. They are intended for monitoring and tuning, not for synchronization.
+
+`messages_accepted` means the local send path accepted the payload. It does not guarantee remote delivery. `messages_sent` means the transport reported a successful write completion, and `messages_received` means incoming data was observed by the transport or wrapper. Use application-level acknowledgements when delivery confirmation matters.
+
+`reset_stats()` clears cumulative counters such as accepted, sent, received, failed send, drop, and backpressure event counts. Current gauges such as `queued_bytes`, `pending_bytes`, and `backpressure_active` continue to reflect the live transport state.
+
 ### When to use each
 
 **Use `Reliable` (default) when:**

--- a/docs/user/api_stability.md
+++ b/docs/user/api_stability.md
@@ -36,6 +36,10 @@ The following callback context types are user-facing:
 - `unilink::ConnectionContext`
 - `unilink::ErrorContext`
 
+The following diagnostics type is user-facing:
+
+- `unilink::RuntimeStats`
+
 ## Supported But Advanced Headers
 
 These headers are supported, but most users should prefer including `<unilink/unilink.hpp>`:

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -146,6 +146,16 @@ In `BestEffort` mode, accepted throughput can be much higher than received throu
 
 In `Reliable` mode, throughput is usually limited by queue pressure and receiver progress, but accepted data is preserved unless the queue cannot accept more data.
 
+Use `stats()` to monitor queue pressure and drops:
+
+- `queued_bytes`
+- `pending_bytes`
+- `max_queued_bytes`
+- `dropped_messages`
+- `dropped_bytes`
+- `failed_sends`
+- `backpressure_events`
+
 ### 2. High-Throughput Sensors (LiDAR/Camera)
 
 For robotics perception, processing stale data is often worse than skipping frames. Use `BestEffort` with a low threshold to prevent **Bufferbloat**.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -117,8 +117,7 @@ endforeach()
 
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_serial_wrapper_lifecycle.cc
-                  test_serial_wrapper_options.cc
-                  test_runtime_stats.cc
+                  test_serial_wrapper_options.cc test_runtime_stats.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -118,6 +118,7 @@ endforeach()
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_serial_wrapper_lifecycle.cc
                   test_serial_wrapper_options.cc
+                  test_runtime_stats.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/wrapper/test_runtime_stats.cc
+++ b/test/unit/wrapper/test_runtime_stats.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/io_context.hpp>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "unilink/interface/channel.hpp"
+#include "unilink/unilink.hpp"
+#include "unilink/wrapper/tcp_client/tcp_client.hpp"
+
+namespace {
+
+class StatsChannel : public unilink::interface::Channel {
+ public:
+  void start() override { connected_ = true; }
+  void stop() override { connected_ = false; }
+  bool is_connected() const override { return connected_; }
+  bool is_backpressure_active() const override { return stats_.backpressure_active; }
+
+  boost::asio::any_io_executor get_executor() override { return ioc_.get_executor(); }
+
+  bool async_write_copy(unilink::memory::ConstByteSpan data) override {
+    if (fail_next_write_) {
+      fail_next_write_ = false;
+      ++stats_.failed_sends;
+      return false;
+    }
+    ++stats_.messages_accepted;
+    stats_.bytes_accepted += data.size();
+    stats_.queued_bytes += data.size();
+    stats_.max_queued_bytes = std::max(stats_.max_queued_bytes, stats_.queued_bytes);
+    return true;
+  }
+
+  bool async_write_move(std::vector<uint8_t>&& data) override {
+    return async_write_copy(unilink::memory::ConstByteSpan(data.data(), data.size()));
+  }
+
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return data ? async_write_copy(unilink::memory::ConstByteSpan(data->data(), data->size())) : false;
+  }
+
+  void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
+  void on_state(OnState cb) override { on_state_ = std::move(cb); }
+  void on_backpressure(OnBackpressure cb) override { on_backpressure_ = std::move(cb); }
+
+  unilink::wrapper::RuntimeStats stats() const override { return stats_; }
+
+  void reset_stats() override {
+    const auto queued = stats_.queued_bytes;
+    const auto pending = stats_.pending_bytes;
+    const auto active = stats_.backpressure_active;
+    stats_ = {};
+    stats_.queued_bytes = queued;
+    stats_.pending_bytes = pending;
+    stats_.max_queued_bytes = queued + pending;
+    stats_.backpressure_active = active;
+  }
+
+  void fail_next_write() { fail_next_write_ = true; }
+
+  void emit_bytes(std::string_view data) {
+    ++stats_.messages_received;
+    stats_.bytes_received += data.size();
+    if (on_bytes_) {
+      on_bytes_(unilink::memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+    }
+  }
+
+ private:
+  boost::asio::io_context ioc_;
+  bool connected_{true};
+  bool fail_next_write_{false};
+  unilink::wrapper::RuntimeStats stats_;
+  OnBytes on_bytes_;
+  OnState on_state_;
+  OnBackpressure on_backpressure_;
+};
+
+}  // namespace
+
+TEST(RuntimeStats, PublicAliasIsDefaultZero) {
+  unilink::RuntimeStats stats;
+
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_sent, 0u);
+  EXPECT_EQ(stats.bytes_sent, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_EQ(stats.backpressure_events, 0u);
+  EXPECT_EQ(stats.queued_bytes, 0u);
+  EXPECT_EQ(stats.pending_bytes, 0u);
+  EXPECT_EQ(stats.max_queued_bytes, 0u);
+  EXPECT_FALSE(stats.backpressure_active);
+}
+
+TEST(RuntimeStats, TcpClientWrapperForwardsStatsSnapshot) {
+  auto channel = std::make_shared<StatsChannel>();
+  unilink::wrapper::TcpClient client(channel);
+
+  ASSERT_TRUE(client.try_send("abc"));
+  auto stats = client.stats();
+  EXPECT_EQ(stats.messages_accepted, 1u);
+  EXPECT_EQ(stats.bytes_accepted, 3u);
+  EXPECT_EQ(stats.queued_bytes, 3u);
+  EXPECT_EQ(stats.max_queued_bytes, 3u);
+
+  channel->fail_next_write();
+  EXPECT_FALSE(client.try_send("x"));
+  stats = client.stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+
+  bool received = false;
+  client.on_data([&](const unilink::wrapper::MessageContext& ctx) {
+    received = true;
+    EXPECT_EQ(ctx.data(), "rx");
+  });
+  channel->emit_bytes("rx");
+  EXPECT_TRUE(received);
+  stats = client.stats();
+  EXPECT_EQ(stats.messages_received, 1u);
+  EXPECT_EQ(stats.bytes_received, 2u);
+}
+
+TEST(RuntimeStats, ResetClearsCountersButKeepsGauges) {
+  auto channel = std::make_shared<StatsChannel>();
+  unilink::wrapper::TcpClient client(channel);
+
+  ASSERT_TRUE(client.try_send("abcd"));
+  channel->emit_bytes("rx");
+
+  client.reset_stats();
+  auto stats = client.stats();
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.queued_bytes, 4u);
+  EXPECT_EQ(stats.max_queued_bytes, 4u);
+}

--- a/unilink/diagnostics/runtime_stats_counter.hpp
+++ b/unilink/diagnostics/runtime_stats_counter.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "unilink/wrapper/runtime_stats.hpp"
+
+namespace unilink {
+namespace diagnostics {
+
+struct RuntimeStatsCounters {
+  std::atomic<uint64_t> bytes_accepted{0};
+  std::atomic<uint64_t> messages_accepted{0};
+
+  std::atomic<uint64_t> bytes_sent{0};
+  std::atomic<uint64_t> messages_sent{0};
+
+  std::atomic<uint64_t> bytes_received{0};
+  std::atomic<uint64_t> messages_received{0};
+
+  std::atomic<uint64_t> failed_sends{0};
+
+  std::atomic<uint64_t> dropped_messages{0};
+  std::atomic<uint64_t> dropped_bytes{0};
+
+  std::atomic<uint64_t> backpressure_events{0};
+
+  std::atomic<size_t> max_queued_bytes{0};
+
+  void record_accepted(size_t bytes) {
+    messages_accepted.fetch_add(1, std::memory_order_relaxed);
+    bytes_accepted.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  void record_sent(size_t bytes) {
+    messages_sent.fetch_add(1, std::memory_order_relaxed);
+    bytes_sent.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  void record_received(size_t bytes) {
+    messages_received.fetch_add(1, std::memory_order_relaxed);
+    bytes_received.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  void record_failed_send() { failed_sends.fetch_add(1, std::memory_order_relaxed); }
+
+  void record_dropped(size_t bytes) {
+    dropped_messages.fetch_add(1, std::memory_order_relaxed);
+    dropped_bytes.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  void record_backpressure_event() { backpressure_events.fetch_add(1, std::memory_order_relaxed); }
+
+  void observe_queue(size_t queued) {
+    size_t current = max_queued_bytes.load(std::memory_order_relaxed);
+    while (queued > current && !max_queued_bytes.compare_exchange_weak(current, queued, std::memory_order_relaxed,
+                                                                       std::memory_order_relaxed)) {
+    }
+  }
+
+  wrapper::RuntimeStats snapshot(size_t queued_bytes, size_t pending_bytes, bool backpressure_active) const {
+    wrapper::RuntimeStats stats;
+    stats.bytes_accepted = bytes_accepted.load(std::memory_order_relaxed);
+    stats.messages_accepted = messages_accepted.load(std::memory_order_relaxed);
+    stats.bytes_sent = bytes_sent.load(std::memory_order_relaxed);
+    stats.messages_sent = messages_sent.load(std::memory_order_relaxed);
+    stats.bytes_received = bytes_received.load(std::memory_order_relaxed);
+    stats.messages_received = messages_received.load(std::memory_order_relaxed);
+    stats.failed_sends = failed_sends.load(std::memory_order_relaxed);
+    stats.dropped_messages = dropped_messages.load(std::memory_order_relaxed);
+    stats.dropped_bytes = dropped_bytes.load(std::memory_order_relaxed);
+    stats.backpressure_events = backpressure_events.load(std::memory_order_relaxed);
+    stats.queued_bytes = queued_bytes;
+    stats.pending_bytes = pending_bytes;
+    stats.max_queued_bytes = max_queued_bytes.load(std::memory_order_relaxed);
+    stats.backpressure_active = backpressure_active;
+    return stats;
+  }
+
+  void reset(size_t current_queued_bytes) {
+    bytes_accepted.store(0, std::memory_order_relaxed);
+    messages_accepted.store(0, std::memory_order_relaxed);
+    bytes_sent.store(0, std::memory_order_relaxed);
+    messages_sent.store(0, std::memory_order_relaxed);
+    bytes_received.store(0, std::memory_order_relaxed);
+    messages_received.store(0, std::memory_order_relaxed);
+    failed_sends.store(0, std::memory_order_relaxed);
+    dropped_messages.store(0, std::memory_order_relaxed);
+    dropped_bytes.store(0, std::memory_order_relaxed);
+    backpressure_events.store(0, std::memory_order_relaxed);
+    max_queued_bytes.store(current_queued_bytes, std::memory_order_relaxed);
+  }
+};
+
+}  // namespace diagnostics
+}  // namespace unilink

--- a/unilink/interface/channel.hpp
+++ b/unilink/interface/channel.hpp
@@ -23,6 +23,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/base/visibility.hpp"
 #include "unilink/memory/safe_span.hpp"
+#include "unilink/wrapper/runtime_stats.hpp"
 
 namespace unilink {
 namespace interface {
@@ -38,6 +39,8 @@ class UNILINK_API Channel {
   virtual void stop() = 0;
   virtual bool is_connected() const = 0;
   virtual bool is_backpressure_active() const = 0;
+  virtual wrapper::RuntimeStats stats() const { return {}; }
+  virtual void reset_stats() {}
 
   virtual boost::asio::any_io_executor get_executor() = 0;
 

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -36,6 +36,7 @@
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/iserial_port.hpp"
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/serial/boost_serial_port.hpp"
@@ -83,6 +84,7 @@ struct Serial::Impl {
   size_t bp_limit_;
   size_t bp_low_;
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
 
   OnBytes on_bytes_;
   OnState on_state_;
@@ -90,6 +92,11 @@ struct Serial::Impl {
 
   std::atomic<bool> opened_{false};
   ThreadSafeLinkState state_{LinkState::Idle};
+
+  void observe_queue() {
+    stats_.observe_queue(queued_bytes_.load(std::memory_order_relaxed) +
+                         pending_bytes_.load(std::memory_order_relaxed));
+  }
 
   explicit Impl(const config::SerialConfig& cfg)
       : ioc_(acquire_shared_serial_context()),
@@ -215,6 +222,7 @@ struct Serial::Impl {
             impl->handle_error(self, "read", ec);
             return;
           }
+          if (n > 0) impl->stats_.record_received(n);
           if (impl->on_bytes_) {
             try {
               impl->on_bytes_(memory::ConstByteSpan(impl->rx_.data(), n));
@@ -277,6 +285,7 @@ struct Serial::Impl {
         impl->handle_error(self, "write", ec);
         return;
       }
+      impl->stats_.record_sent(n);
       impl->do_write(self);
     };
 
@@ -379,13 +388,17 @@ struct Serial::Impl {
   }
 
   void report_backpressure(size_t qb) {
-    if (stopping_.load() || !on_bp_) return;
+    if (stopping_.load()) return;
+    observe_queue();
 
     if (!backpressure_active_ && qb >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp_(qb);
-      } catch (...) {
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(qb);
+        } catch (...) {
+        }
       }
     } else if (backpressure_active_ && qb <= bp_low_) {
       // Flush pending_ → tx_
@@ -395,17 +408,24 @@ struct Serial::Impl {
         tx_.emplace_back(std::move(pending_.front()));
         pending_.pop_front();
       }
+      observe_queue();
       backpressure_active_ = false;
-      try {
-        on_bp_(qb);
-      } catch (...) {
-      }  // fire OFF with pre-flush queue size
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(qb);
+        } catch (...) {
+        }  // fire OFF with pre-flush queue size
+      }
       // If post-flush queue is still high, fire ON again
       if (queued_bytes_ >= bp_high_) {
         backpressure_active_ = true;
-        try {
-          on_bp_(queued_bytes_);
-        } catch (...) {
+        stats_.record_backpressure_event();
+        if (on_bp_) {
+          try {
+            on_bp_(queued_bytes_);
+          } catch (...) {
+          }
         }
       }
     }
@@ -503,17 +523,35 @@ void Serial::stop() {
 
 bool Serial::is_connected() const { return get_impl()->opened_.load(); }
 bool Serial::is_backpressure_active() const { return get_impl()->backpressure_active_.load(); }
+wrapper::RuntimeStats Serial::stats() const {
+  auto impl = get_impl();
+  return impl->stats_.snapshot(impl->queued_bytes_.load(std::memory_order_relaxed),
+                               impl->pending_bytes_.load(std::memory_order_relaxed),
+                               impl->backpressure_active_.load(std::memory_order_relaxed));
+}
+void Serial::reset_stats() {
+  auto impl = get_impl();
+  impl->stats_.reset(impl->queued_bytes_.load(std::memory_order_relaxed) +
+                     impl->pending_bytes_.load(std::memory_order_relaxed));
+}
 
 boost::asio::any_io_executor Serial::get_executor() { return impl_->strand_; }
 
 bool Serial::async_write_copy(memory::ConstByteSpan data) {
   auto impl = get_impl();
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
     return false;
+  }
 
   size_t n = data.size();
+  if (n == 0) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   if (n > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("serial", "write", "Write size exceeds maximum");
+    impl->stats_.record_failed_send();
     return false;
   }
 
@@ -521,7 +559,11 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(n);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
-      if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) return false;
+      if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) {
+        impl->stats_.record_failed_send();
+        return false;
+      }
+      impl->stats_.record_accepted(n);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled)]() mutable {
         auto impl = self->get_impl();
         const auto added = buf.size();
@@ -535,6 +577,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
           }
           impl->pending_bytes_ += added;
           impl->pending_.emplace_back(std::move(buf));
+          impl->observe_queue();
           return;
         }
 
@@ -568,6 +611,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
         }
         impl->queued_bytes_ += added;
         impl->tx_.emplace_back(std::move(buf));
+        impl->observe_queue();
         impl->report_backpressure(impl->queued_bytes_);
         if (!impl->writing_) impl->do_write(self);
       });
@@ -575,8 +619,12 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) return false;
+  if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::vector<uint8_t> fallback(data.begin(), data.end());
+  impl->stats_.record_accepted(n);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
     auto impl = self->get_impl();
     const auto added = buf.size();
@@ -589,6 +637,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
       }
       impl->pending_bytes_ += added;
       impl->pending_.emplace_back(std::move(buf));
+      impl->observe_queue();
       return;
     }
 
@@ -627,6 +676,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
     impl->queued_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
     impl->report_backpressure(impl->queued_bytes_);
     if (!impl->writing_) impl->do_write(self);
   });
@@ -635,10 +685,20 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
 
 bool Serial::async_write_move(std::vector<uint8_t>&& data) {
   auto impl = get_impl();
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
     return false;
+  }
   const auto added = data.size();
-  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) return false;
+  if (added == 0) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  impl->stats_.record_accepted(added);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
 
@@ -650,6 +710,7 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
       }
       impl->pending_bytes_ += added;
       impl->pending_.emplace_back(std::move(buf));
+      impl->observe_queue();
       return;
     }
 
@@ -688,6 +749,7 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
     }
     impl->queued_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
     impl->report_backpressure(impl->queued_bytes_);
     if (!impl->writing_) impl->do_write(self);
   });
@@ -696,11 +758,20 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
 
 bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   auto impl = get_impl();
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
     return false;
-  if (!data || data->empty()) return false;
+  }
+  if (!data || data->empty()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   const auto added = data->size();
-  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) return false;
+  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  impl->stats_.record_accepted(added);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
 
@@ -712,6 +783,7 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
       }
       impl->pending_bytes_ += added;
       impl->pending_.emplace_back(std::move(buf));
+      impl->observe_queue();
       return;
     }
 
@@ -750,6 +822,7 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     }
     impl->queued_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
     impl->report_backpressure(impl->queued_bytes_);
     if (!impl->writing_) impl->do_write(self);
   });

--- a/unilink/transport/serial/serial.hpp
+++ b/unilink/transport/serial/serial.hpp
@@ -63,6 +63,8 @@ class UNILINK_API Serial : public interface::Channel, public std::enable_shared_
   void stop() override;
   bool is_connected() const override;
   bool is_backpressure_active() const override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
   boost::asio::any_io_executor get_executor() override;
 
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -50,6 +50,7 @@
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/tcp_client/detail/reconnect_decider.hpp"
@@ -98,6 +99,7 @@ struct TcpClient::Impl {
   size_t bp_low_;
   size_t bp_limit_;
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
   unsigned first_retry_interval_ms_ = 100;
 
   OnBytes on_bytes_;
@@ -151,6 +153,7 @@ struct TcpClient::Impl {
   void recalculate_backpressure_bounds();
   void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes);
+  void observe_queue();
   void notify_state();
   void reset_io_objects();
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
@@ -266,24 +269,36 @@ void TcpClient::stop() {
 
 bool TcpClient::is_connected() const { return get_impl()->connected_.load(); }
 bool TcpClient::is_backpressure_active() const { return get_impl()->backpressure_active_.load(); }
+wrapper::RuntimeStats TcpClient::stats() const {
+  return impl_->stats_.snapshot(impl_->queue_bytes_.load(std::memory_order_relaxed),
+                                impl_->pending_bytes_.load(std::memory_order_relaxed),
+                                impl_->backpressure_active_.load(std::memory_order_relaxed));
+}
+void TcpClient::reset_stats() {
+  impl_->stats_.reset(impl_->queue_bytes_.load(std::memory_order_relaxed) +
+                      impl_->pending_bytes_.load(std::memory_order_relaxed));
+}
 
 boost::asio::any_io_executor TcpClient::get_executor() { return impl_->socket_.get_executor(); }
 
 bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
   if (impl_->stop_requested_.load() || impl_->state_.is_state(LinkState::Closed) ||
       impl_->state_.is_state(LinkState::Error) || !impl_->ioc_) {
+    impl_->stats_.record_failed_send();
     return false;
   }
 
   size_t size = data.size();
   if (size == 0) {
     UNILINK_LOG_WARNING("tcp_client", "async_write_copy", "Ignoring zero-length write");
+    impl_->stats_.record_failed_send();
     return false;
   }
 
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_copy",
                       fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
+    impl_->stats_.record_failed_send();
     return false;
   }
 
@@ -294,8 +309,11 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
         if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-            impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+            impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+          impl_->stats_.record_failed_send();
           return false;
+        }
+        impl_->stats_.record_accepted(added);
         net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(pooled_buffer), added]() mutable {
           if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
               self->impl_->state_.is_state(LinkState::Error)) {
@@ -312,6 +330,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
             }
             self->impl_->pending_bytes_ += added;
             self->impl_->pending_.emplace_back(std::move(buf));
+            self->impl_->observe_queue();
             return;
           }
 
@@ -328,6 +347,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
           self->impl_->queue_bytes_ += added;
           self->impl_->tx_.emplace_back(std::move(buf));
+          self->impl_->observe_queue();
           self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
           if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
         });
@@ -340,6 +360,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
   std::vector<uint8_t> fallback(data.begin(), data.end());
   const auto added = fallback.size();
+  impl_->stats_.record_accepted(added);
 
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(fallback), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
@@ -357,6 +378,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
       }
       self->impl_->pending_bytes_ += added;
       self->impl_->pending_.emplace_back(std::move(buf));
+      self->impl_->observe_queue();
       return;
     }
 
@@ -380,6 +402,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
+    self->impl_->observe_queue();
     self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
@@ -389,23 +412,29 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
   if (impl_->stop_requested_.load() || impl_->state_.is_state(LinkState::Closed) ||
       impl_->state_.is_state(LinkState::Error) || !impl_->ioc_) {
+    impl_->stats_.record_failed_send();
     return false;
   }
   const auto size = data.size();
   if (size == 0) {
     UNILINK_LOG_WARNING("tcp_client", "async_write_move", "Ignoring zero-length write");
+    impl_->stats_.record_failed_send();
     return false;
   }
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_move",
                       fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
+    impl_->stats_.record_failed_send();
     return false;
   }
 
   const auto added = size;
   if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    impl_->stats_.record_failed_send();
     return false;
+  }
+  impl_->stats_.record_accepted(added);
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
@@ -422,6 +451,7 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
       }
       self->impl_->pending_bytes_ += added;
       self->impl_->pending_.emplace_back(std::move(buf));
+      self->impl_->observe_queue();
       return;
     }
 
@@ -438,6 +468,7 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
+    self->impl_->observe_queue();
     self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
@@ -447,23 +478,29 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
 bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   if (impl_->stop_requested_.load() || impl_->state_.is_state(LinkState::Closed) ||
       impl_->state_.is_state(LinkState::Error) || !impl_->ioc_) {
+    impl_->stats_.record_failed_send();
     return false;
   }
   if (!data || data->empty()) {
     UNILINK_LOG_WARNING("tcp_client", "async_write_shared", "Ignoring empty shared buffer");
+    impl_->stats_.record_failed_send();
     return false;
   }
   const auto size = data->size();
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_client", "async_write_shared",
                       fmt::format("Write size exceeds maximum allowed ({} bytes)", size));
+    impl_->stats_.record_failed_send();
     return false;
   }
 
   const auto added = size;
   if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_)
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    impl_->stats_.record_failed_send();
     return false;
+  }
+  impl_->stats_.record_accepted(added);
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (self->impl_->stop_requested_.load() || self->impl_->state_.is_state(LinkState::Closed) ||
         self->impl_->state_.is_state(LinkState::Error)) {
@@ -480,6 +517,7 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
       }
       self->impl_->pending_bytes_ += added;
       self->impl_->pending_.emplace_back(std::move(buf));
+      self->impl_->observe_queue();
       return;
     }
 
@@ -496,6 +534,7 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
 
     self->impl_->queue_bytes_ += added;
     self->impl_->tx_.emplace_back(std::move(buf));
+    self->impl_->observe_queue();
     self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
     if (!self->impl_->writing_) self->impl_->do_write(self, self->impl_->current_seq_.load());
   });
@@ -699,6 +738,8 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
       on_bytes = self->impl_->on_bytes_;
     }
 
+    self->impl_->stats_.record_received(n);
+
     if (on_bytes) {
       try {
         on_bytes(memory::ConstByteSpan(self->impl_->rx_.data(), n));
@@ -757,7 +798,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
       },
       current);
 
-  auto on_write = [self, queued_bytes, seq](auto ec, std::size_t) {
+  auto on_write = [self, queued_bytes, seq](auto ec, std::size_t bytes_written) {
     if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) {
       self->impl_->current_write_buffer_.reset();
       self->impl_->queue_bytes_ =
@@ -782,6 +823,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
     }
 
     self->impl_->current_write_buffer_.reset();
+    self->impl_->stats_.record_sent(bytes_written);
     self->impl_->queue_bytes_ =
         (self->impl_->queue_bytes_ > queued_bytes) ? (self->impl_->queue_bytes_ - queued_bytes) : 0;
     self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
@@ -856,25 +898,32 @@ void TcpClient::Impl::maybe_flush_for_keep_latest(size_t added) {
   queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
+void TcpClient::Impl::observe_queue() {
+  stats_.observe_queue(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
+
 void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes) {
   if (stop_requested_.load() || stopping_.load()) return;
+  observe_queue();
 
   OnBackpressure on_bp;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     on_bp = on_bp_;
   }
-  if (!on_bp) return;
 
   if (!backpressure_active_ && queued_bytes >= bp_high_) {
     backpressure_active_ = true;
-    try {
-      on_bp(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("tcp_client", "on_backpressure",
-                        fmt::format("Exception in backpressure callback: {}", e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
+    stats_.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (const std::exception& e) {
+        UNILINK_LOG_ERROR("tcp_client", "on_backpressure",
+                          fmt::format("Exception in backpressure callback: {}", e.what()));
+      } catch (...) {
+        UNILINK_LOG_ERROR("tcp_client", "on_backpressure", "Unknown exception in backpressure callback");
+      }
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
     // Flush pending_ → tx_
@@ -884,17 +933,24 @@ void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_
       tx_.emplace_back(std::move(pending_.front()));
       pending_.pop_front();
     }
+    observe_queue();
     backpressure_active_ = false;
-    try {
-      on_bp(queued_bytes);
-    } catch (...) {
-    }  // fire OFF with pre-flush queue size
+    stats_.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
+    }
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp(queue_bytes_);
-      } catch (...) {
+      stats_.record_backpressure_event();
+      if (on_bp) {
+        try {
+          on_bp(queue_bytes_);
+        } catch (...) {
+        }
       }
     }
     if (!writing_) do_write(self, current_seq_.load());

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -67,6 +67,8 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   void stop() override;
   bool is_connected() const override;
   bool is_backpressure_active() const override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
   boost::asio::any_io_executor get_executor() override;
 
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -31,6 +31,7 @@
 #include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/itcp_acceptor.hpp"
 #include "unilink/transport/tcp_server/boost_tcp_acceptor.hpp"
 #include "unilink/transport/tcp_server/tcp_server_session.hpp"
@@ -61,6 +62,7 @@ struct TcpServer::Impl {
   MultiClientConnectHandler on_multi_connect_;
   MultiClientDataHandler on_multi_data_;
   MultiClientDisconnectHandler on_multi_disconnect_;
+  diagnostics::RuntimeStatsCounters stats_;
 
   mutable std::mutex sessions_mutex_;
   std::unordered_map<ClientId, std::shared_ptr<TcpServerSession>> sessions_;
@@ -501,9 +503,46 @@ bool TcpServer::is_backpressure_active(ClientId client_id) const {
 
 boost::asio::any_io_executor TcpServer::get_executor() { return impl_->ioc_.get_executor(); }
 
+wrapper::RuntimeStats TcpServer::stats() const {
+  auto impl = get_impl();
+  auto aggregate = impl->stats_.snapshot(0, 0, false);
+  std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+  for (const auto& entry : impl->sessions_) {
+    if (!entry.second) continue;
+    const auto session_stats = entry.second->stats();
+    aggregate.bytes_accepted += session_stats.bytes_accepted;
+    aggregate.messages_accepted += session_stats.messages_accepted;
+    aggregate.bytes_sent += session_stats.bytes_sent;
+    aggregate.messages_sent += session_stats.messages_sent;
+    aggregate.bytes_received += session_stats.bytes_received;
+    aggregate.messages_received += session_stats.messages_received;
+    aggregate.failed_sends += session_stats.failed_sends;
+    aggregate.dropped_messages += session_stats.dropped_messages;
+    aggregate.dropped_bytes += session_stats.dropped_bytes;
+    aggregate.backpressure_events += session_stats.backpressure_events;
+    aggregate.queued_bytes += session_stats.queued_bytes;
+    aggregate.pending_bytes += session_stats.pending_bytes;
+    aggregate.max_queued_bytes += session_stats.max_queued_bytes;
+    aggregate.backpressure_active = aggregate.backpressure_active || session_stats.backpressure_active;
+  }
+  return aggregate;
+}
+
+void TcpServer::reset_stats() {
+  auto impl = get_impl();
+  impl->stats_.reset(0);
+  std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+  for (const auto& entry : impl->sessions_) {
+    if (entry.second) entry.second->reset_stats();
+  }
+}
+
 bool TcpServer::async_write_copy(memory::ConstByteSpan data) {
   auto impl = get_impl();
-  if (impl->stopping_.load()) return false;
+  if (impl->stopping_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::shared_ptr<TcpServerSession> session;
   {
     std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
@@ -513,12 +552,16 @@ bool TcpServer::async_write_copy(memory::ConstByteSpan data) {
   if (session && session->alive()) {
     return session->async_write_copy(data);
   }
+  impl->stats_.record_failed_send();
   return false;
 }
 
 bool TcpServer::async_write_move(std::vector<uint8_t>&& data) {
   auto impl = get_impl();
-  if (impl->stopping_.load()) return false;
+  if (impl->stopping_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::shared_ptr<TcpServerSession> session;
   {
     std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
@@ -528,12 +571,16 @@ bool TcpServer::async_write_move(std::vector<uint8_t>&& data) {
   if (session && session->alive()) {
     return session->async_write_move(std::move(data));
   }
+  impl->stats_.record_failed_send();
   return false;
 }
 
 bool TcpServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   auto impl = get_impl();
-  if (impl->stopping_.load() || !data) return false;
+  if (impl->stopping_.load() || !data || data->empty()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::shared_ptr<TcpServerSession> session;
   {
     std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
@@ -543,6 +590,7 @@ bool TcpServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   if (session && session->alive()) {
     return session->async_write_shared(std::move(data));
   }
+  impl->stats_.record_failed_send();
   return false;
 }
 
@@ -574,12 +622,15 @@ bool TcpServer::broadcast(std::string_view message) {
   auto impl = get_impl();
   std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
   bool sent = false;
+  bool attempted = false;
   for (auto& entry : impl->sessions_) {
     auto& session = entry.second;
     if (session && session->alive()) {
+      attempted = true;
       if (session->async_write_shared(shared_data)) sent = true;
     }
   }
+  if (!attempted) impl->stats_.record_failed_send();
   return sent;
 }
 
@@ -588,12 +639,15 @@ bool TcpServer::broadcast(memory::ConstByteSpan data) {
   auto impl = get_impl();
   std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
   bool sent = false;
+  bool attempted = false;
   for (auto& entry : impl->sessions_) {
     auto& session = entry.second;
     if (session && session->alive()) {
+      attempted = true;
       if (session->async_write_shared(shared_data)) sent = true;
     }
   }
+  if (!attempted) impl->stats_.record_failed_send();
   return sent;
 }
 
@@ -609,6 +663,7 @@ bool TcpServer::send_to_client(ClientId client_id, memory::ConstByteSpan data) {
   if (it != impl->sessions_.end() && it->second && it->second->alive()) {
     return it->second->async_write_copy(data);
   }
+  impl->stats_.record_failed_send();
   return false;
 }
 

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -71,6 +71,8 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // Multi-client support
   bool broadcast(std::string_view message);

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -75,11 +75,19 @@ void TcpServerSession::start() {
 }
 
 bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
-  if (!alive_ || closing_) return false;  // Don't queue writes if session is not alive
+  if (!alive_ || closing_) {
+    stats_.record_failed_send();
+    return false;
+  }  // Don't queue writes if session is not alive
 
   size_t size = data.size();
+  if (size == 0) {
+    stats_.record_failed_send();
+    return false;
+  }
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
+    stats_.record_failed_send();
     return false;
   }
 
@@ -89,7 +97,11 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
-      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) return false;
+      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+        stats_.record_failed_send();
+        return false;
+      }
+      stats_.record_accepted(size);
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
         if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
         const auto added = buf.size();
@@ -103,6 +115,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
           }
           self->pending_bytes_ += added;
           self->pending_.emplace_back(std::move(buf));
+          self->observe_queue();
           return;
         }
 
@@ -114,6 +127,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
         }
         self->queue_bytes_ += added;
         self->tx_.emplace_back(std::move(buf));
+        self->observe_queue();
         self->report_backpressure(self->queue_bytes_);
         if (!self->writing_) self->do_write();
       });
@@ -122,8 +136,12 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Fallback to regular allocation for large buffers or pool exhaustion
-  if (queue_bytes_ + pending_bytes_ + size > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+    stats_.record_failed_send();
+    return false;
+  }
   std::vector<uint8_t> fallback(data.begin(), data.end());
+  stats_.record_accepted(size);
 
   net::post(strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
     if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
@@ -137,6 +155,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
       }
       self->pending_bytes_ += added;
       self->pending_.emplace_back(std::move(buf));
+      self->observe_queue();
       return;
     }
 
@@ -148,6 +167,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     }
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
+    self->observe_queue();
     self->report_backpressure(self->queue_bytes_);
     if (!self->writing_) self->do_write();
   });
@@ -155,13 +175,25 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
 }
 
 bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
-  if (!alive_ || closing_) return false;
-  const auto added = data.size();
-  if (added > base::constants::MAX_BUFFER_SIZE) {
-    UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
+  if (!alive_ || closing_) {
+    stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) return false;
+  const auto added = data.size();
+  if (added == 0) {
+    stats_.record_failed_send();
+    return false;
+  }
+  if (added > base::constants::MAX_BUFFER_SIZE) {
+    UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
+    stats_.record_failed_send();
+    return false;
+  }
+  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
 
@@ -173,6 +205,7 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
       }
       self->pending_bytes_ += added;
       self->pending_.emplace_back(std::move(buf));
+      self->observe_queue();
       return;
     }
 
@@ -184,6 +217,7 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     }
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
+    self->observe_queue();
     self->report_backpressure(self->queue_bytes_);
     if (!self->writing_) self->do_write();
   });
@@ -191,13 +225,21 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
-  if (!alive_ || closing_ || !data) return false;
+  if (!alive_ || closing_ || !data || data->empty()) {
+    stats_.record_failed_send();
+    return false;
+  }
   const auto added = data->size();
   if (added > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Write size exceeds maximum allowed");
+    stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) return false;
+  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
 
@@ -209,6 +251,7 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
       }
       self->pending_bytes_ += added;
       self->pending_.emplace_back(std::move(buf));
+      self->observe_queue();
       return;
     }
 
@@ -220,6 +263,7 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     }
     self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
+    self->observe_queue();
     self->report_backpressure(self->queue_bytes_);
     if (!self->writing_) self->do_write();
   });
@@ -249,6 +293,15 @@ void TcpServerSession::on_close(OnClose cb) {
 }
 
 bool TcpServerSession::alive() const { return alive_.load(); }
+
+wrapper::RuntimeStats TcpServerSession::stats() const {
+  return stats_.snapshot(queue_bytes_.load(std::memory_order_relaxed), pending_bytes_.load(std::memory_order_relaxed),
+                         backpressure_active_.load(std::memory_order_relaxed));
+}
+
+void TcpServerSession::reset_stats() {
+  stats_.reset(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
 
 void TcpServerSession::stop() {
   if (closing_.exchange(true)) return;
@@ -287,6 +340,7 @@ void TcpServerSession::start_read() {
           return;
         }
         self->reset_idle_timer();
+        if (n > 0) self->stats_.record_received(n);
         if (self->on_bytes_) {
           try {
             self->on_bytes_(memory::ConstByteSpan(self->rx_.data(), n));
@@ -337,6 +391,7 @@ void TcpServerSession::do_write() {
       self->do_close();
       return;
     }
+    self->stats_.record_sent(n);
     self->reset_idle_timer();
     self->do_write();
   };
@@ -394,17 +449,25 @@ void TcpServerSession::maybe_flush_for_keep_latest(size_t added) {
   queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
+void TcpServerSession::observe_queue() {
+  stats_.observe_queue(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
+
 void TcpServerSession::report_backpressure(size_t queued_bytes) {
-  if (closing_ || !alive_ || !on_bp_) return;
+  if (closing_ || !alive_) return;
+  observe_queue();
   if (!backpressure_active_ && queued_bytes >= bp_high_) {
     backpressure_active_ = true;
-    try {
-      on_bp_(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure",
-                        "Exception in backpressure callback: " + std::string(e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure", "Unknown exception in backpressure callback");
+    stats_.record_backpressure_event();
+    if (on_bp_) {
+      try {
+        on_bp_(queued_bytes);
+      } catch (const std::exception& e) {
+        UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure",
+                          "Exception in backpressure callback: " + std::string(e.what()));
+      } catch (...) {
+        UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure", "Unknown exception in backpressure callback");
+      }
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
     // Flush pending_ → tx_
@@ -414,17 +477,24 @@ void TcpServerSession::report_backpressure(size_t queued_bytes) {
       tx_.emplace_back(std::move(pending_.front()));
       pending_.pop_front();
     }
+    observe_queue();
     backpressure_active_ = false;
-    try {
-      on_bp_(queued_bytes);
-    } catch (...) {
-    }  // fire OFF with pre-flush queue size
+    stats_.record_backpressure_event();
+    if (on_bp_) {
+      try {
+        on_bp_(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
+    }
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp_(queue_bytes_);
-      } catch (...) {
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(queue_bytes_);
+        } catch (...) {
+        }
       }
     }
     if (!writing_) do_write();

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -32,6 +32,7 @@
 #include "unilink/base/visibility.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/channel.hpp"
 #include "unilink/interface/itcp_socket.hpp"
 #include "unilink/memory/memory_pool.hpp"
@@ -73,6 +74,8 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   void on_close(OnClose cb);
   bool alive() const;
   bool is_backpressure_active() const { return backpressure_active_.load(); }
+  wrapper::RuntimeStats stats() const;
+  void reset_stats();
   void stop();
   void cancel();
 
@@ -83,6 +86,7 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(size_t queued_bytes);
   void reset_idle_timer();
+  void observe_queue();
 
  private:
   net::io_context& ioc_;
@@ -101,6 +105,7 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   size_t bp_limit_;  // Hard cap for queued bytes
   size_t bp_low_;    // Backpressure relief threshold
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
   int idle_timeout_ms_ = 0;
 
   OnBytes on_bytes_;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -37,6 +37,7 @@
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/memory/memory_pool.hpp"
 
 namespace unilink {
@@ -79,6 +80,7 @@ struct UdpChannel::Impl {
   size_t bp_low_;
   size_t bp_limit_;
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
 
   std::atomic<bool> stop_requested_{false};
   std::atomic<bool> stopping_{false};
@@ -250,6 +252,7 @@ struct UdpChannel::Impl {
     }
 
     if (bytes > 0) {
+      stats_.record_received(bytes);
       if (on_bytes_) {
         try {
           on_bytes_(memory::ConstByteSpan(rx_.data(), bytes));
@@ -327,7 +330,7 @@ struct UdpChannel::Impl {
         },
         current.buffer);
 
-    auto on_write = [self, bytes_queued](const boost::system::error_code& ec, std::size_t) {
+    auto on_write = [self, bytes_queued](const boost::system::error_code& ec, std::size_t bytes_written) {
       auto impl = self->get_impl();
       impl->queue_bytes_ = (impl->queue_bytes_ > bytes_queued) ? (impl->queue_bytes_ - bytes_queued) : 0;
       impl->report_backpressure(self, impl->queue_bytes_);
@@ -353,6 +356,7 @@ struct UdpChannel::Impl {
         return;
       }
 
+      impl->stats_.record_sent(bytes_written);
       impl->writing_ = false;
       impl->do_write(self);
     };
@@ -403,16 +407,20 @@ struct UdpChannel::Impl {
   }
 
   void report_backpressure(std::shared_ptr<UdpChannel> self, size_t queued_bytes) {
-    if (stop_requested_.load() || !on_bp_) return;
+    if (stop_requested_.load()) return;
+    observe_queue();
 
     if (!backpressure_active_ && queued_bytes >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp_(queued_bytes);
-      } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
-      } catch (...) {
-        UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(queued_bytes);
+        } catch (const std::exception& e) {
+          UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
+        } catch (...) {
+          UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
+        }
       }
     } else if (backpressure_active_ && queued_bytes <= bp_low_) {
       // Flush pending_ → tx_
@@ -422,21 +430,32 @@ struct UdpChannel::Impl {
         tx_.emplace_back(std::move(pending_.front()));
         pending_.pop_front();
       }
+      observe_queue();
       backpressure_active_ = false;
-      try {
-        on_bp_(queued_bytes);
-      } catch (...) {
-      }  // fire OFF with pre-flush queue size
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(queued_bytes);
+        } catch (...) {
+        }  // fire OFF with pre-flush queue size
+      }
       // If post-flush queue is still high, fire ON again
       if (queue_bytes_ >= bp_high_) {
         backpressure_active_ = true;
-        try {
-          on_bp_(queue_bytes_);
-        } catch (...) {
+        stats_.record_backpressure_event();
+        if (on_bp_) {
+          try {
+            on_bp_(queue_bytes_);
+          } catch (...) {
+          }
         }
       }
       if (!writing_) do_write(self);
     }
+  }
+
+  void observe_queue() {
+    stats_.observe_queue(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
   }
 
   bool enqueue_buffer(std::shared_ptr<UdpChannel> self, BufferVariant&& buffer, size_t size,
@@ -455,6 +474,7 @@ struct UdpChannel::Impl {
       }
       pending_bytes_ += size;
       pending_.push_back({std::move(buffer), dest});
+      observe_queue();
       return true;
     }
 
@@ -503,6 +523,7 @@ struct UdpChannel::Impl {
     }
     queue_bytes_ += size;
     tx_.push_back({std::move(buffer), dest});
+    observe_queue();
     report_backpressure(self, queue_bytes_);
     return true;
   }
@@ -690,17 +711,41 @@ void UdpChannel::stop() {
 
 bool UdpChannel::is_connected() const { return get_impl()->connected_.load(); }
 bool UdpChannel::is_backpressure_active() const { return get_impl()->backpressure_active_.load(); }
+wrapper::RuntimeStats UdpChannel::stats() const {
+  auto impl = get_impl();
+  return impl->stats_.snapshot(impl->queue_bytes_.load(std::memory_order_relaxed),
+                               impl->pending_bytes_.load(std::memory_order_relaxed),
+                               impl->backpressure_active_.load(std::memory_order_relaxed));
+}
+void UdpChannel::reset_stats() {
+  auto impl = get_impl();
+  impl->stats_.reset(impl->queue_bytes_.load(std::memory_order_relaxed) +
+                     impl->pending_bytes_.load(std::memory_order_relaxed));
+}
 
 bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   auto impl = get_impl();
-  if (data.empty()) return false;
-  if (impl->stop_requested_.load()) return false;
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (data.empty()) {
+    impl->stats_.record_failed_send();
     return false;
+  }
+  if (impl->stop_requested_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (!impl->remote_endpoint_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
 
   size_t size = data.size();
   if (size > base::constants::MAX_BUFFER_SIZE) {
     UNILINK_LOG_ERROR("udp", "write", "Write size exceeds maximum allowed");
+    impl->stats_.record_failed_send();
     return false;
   }
 
@@ -708,7 +753,11 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
+      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+        impl->stats_.record_failed_send();
+        return false;
+      }
+      impl->stats_.record_accepted(size);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size]() mutable {
         auto impl = self->get_impl();
         if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
@@ -719,6 +768,7 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   }
 
   std::vector<uint8_t> copy(data.begin(), data.end());
+  impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size]() mutable {
     auto impl = self->get_impl();
     if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
@@ -730,17 +780,34 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
 bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
   auto impl = get_impl();
   auto size = data.size();
-  if (size == 0) return false;
-  if (impl->stop_requested_.load()) return false;
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (size == 0) {
+    impl->stats_.record_failed_send();
     return false;
+  }
+  if (impl->stop_requested_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (!impl->remote_endpoint_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
 
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
     impl->transition_to(LinkState::Error);
+    impl->stats_.record_failed_send();
     return false;
   }
-  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
+  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
     if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
@@ -751,12 +818,21 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
 
 bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
   auto impl = get_impl();
-  if (!data || data->empty()) return false;
-  if (impl->stop_requested_.load()) return false;
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (!data || data->empty()) {
+    impl->stats_.record_failed_send();
     return false;
+  }
+  if (impl->stop_requested_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   if (!impl->remote_endpoint_) {
     UNILINK_LOG_WARNING("udp", "write", "Remote endpoint not set; dropping write request");
+    impl->stats_.record_failed_send();
     return false;
   }
 
@@ -764,9 +840,14 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
     impl->transition_to(LinkState::Error);
+    impl->stats_.record_failed_send();
     return false;
   }
-  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
+  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
     if (!impl->enqueue_buffer(self, std::move(buf), size)) return;
@@ -787,17 +868,34 @@ void UdpChannel::set_backpressure_strategy(base::constants::BackpressureStrategy
 
 bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::ip::udp::endpoint& destination) {
   auto impl = get_impl();
-  if (data.empty()) return false;
-  if (impl->stop_requested_.load()) return false;
-  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error))
+  if (data.empty()) {
+    impl->stats_.record_failed_send();
     return false;
+  }
+  if (impl->stop_requested_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
 
   size_t size = data.size();
+  if (size > base::constants::MAX_BUFFER_SIZE) {
+    UNILINK_LOG_ERROR("udp", "write_to", "Write size exceeds maximum allowed");
+    impl->stats_.record_failed_send();
+    return false;
+  }
   if (impl->cfg_.enable_memory_pool && size <= 65536) {
     memory::PooledBuffer pooled(size);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) return false;
+      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+        impl->stats_.record_failed_send();
+        return false;
+      }
+      impl->stats_.record_accepted(size);
       net::post(impl->strand_, [self = shared_from_this(), buf = std::move(pooled), size, destination]() mutable {
         auto impl = self->get_impl();
         if (!impl->enqueue_buffer(self, std::move(buf), size, destination)) return;
@@ -808,6 +906,7 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
   }
 
   std::vector<uint8_t> copy(data.begin(), data.end());
+  impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {
     auto impl = self->get_impl();
     if (!impl->enqueue_buffer(self, std::move(buf), size, destination)) return;

--- a/unilink/transport/udp/udp.hpp
+++ b/unilink/transport/udp/udp.hpp
@@ -59,6 +59,8 @@ class UNILINK_API UdpChannel : public interface::Channel, public std::enable_sha
   void stop() override;
   bool is_connected() const override;
   bool is_backpressure_active() const override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // 1:1 writes (using configured remote_endpoint_)
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -37,6 +37,7 @@
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
@@ -80,6 +81,7 @@ struct UdsClient::Impl {
   size_t bp_low_;
   size_t bp_limit_;
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
 
   OnBytes on_bytes_;
   OnState on_state_;
@@ -131,6 +133,7 @@ struct UdsClient::Impl {
   void recalculate_backpressure_bounds();
   void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes);
+  void observe_queue();
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
                     const boost::system::error_code& ec, std::string_view msg, bool retryable, uint32_t retry_count);
 
@@ -251,6 +254,15 @@ void UdsClient::stop() {
 
 bool UdsClient::is_connected() const { return impl_->connected_.load(); }
 bool UdsClient::is_backpressure_active() const { return impl_->backpressure_active_.load(); }
+wrapper::RuntimeStats UdsClient::stats() const {
+  return impl_->stats_.snapshot(impl_->queue_bytes_.load(std::memory_order_relaxed),
+                                impl_->pending_bytes_.load(std::memory_order_relaxed),
+                                impl_->backpressure_active_.load(std::memory_order_relaxed));
+}
+void UdsClient::reset_stats() {
+  impl_->stats_.reset(impl_->queue_bytes_.load(std::memory_order_relaxed) +
+                      impl_->pending_bytes_.load(std::memory_order_relaxed));
+}
 
 boost::asio::any_io_executor UdsClient::get_executor() { return impl_->strand_; }
 
@@ -260,8 +272,19 @@ bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
 }
 
 bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
-  if (!impl_->connected_.load() || impl_->stop_requested_.load()) return false;
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data.size() > impl_->bp_limit_) return false;
+  if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (data.empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data.size() > impl_->bp_limit_) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  impl_->stats_.record_accepted(data.size());
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     size_t added = data.size();
 
@@ -274,6 +297,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
       }
       impl_->pending_bytes_ += added;
       impl_->pending_.emplace_back(std::move(data));
+      impl_->observe_queue();
       return;
     }
 
@@ -286,6 +310,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     }
     impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
+    impl_->observe_queue();
     impl_->report_backpressure(self, impl_->queue_bytes_);
     if (!impl_->writing_) {
       impl_->do_write(self, impl_->current_seq_.load());
@@ -295,8 +320,15 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
-  if (!impl_->connected_.load() || impl_->stop_requested_.load() || !data) return false;
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data->size() > impl_->bp_limit_) return false;
+  if (!impl_->connected_.load() || impl_->stop_requested_.load() || !data || data->empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data->size() > impl_->bp_limit_) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  impl_->stats_.record_accepted(data->size());
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     size_t added = data->size();
 
@@ -309,6 +341,7 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
       }
       impl_->pending_bytes_ += added;
       impl_->pending_.emplace_back(std::move(data));
+      impl_->observe_queue();
       return;
     }
 
@@ -321,6 +354,7 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     }
     impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
+    impl_->observe_queue();
     impl_->report_backpressure(self, impl_->queue_bytes_);
     if (!impl_->writing_) impl_->do_write(self, impl_->current_seq_.load());
   });
@@ -444,6 +478,7 @@ void UdsClient::Impl::start_read(std::shared_ptr<UdsClient> self, uint64_t seq) 
                                std::lock_guard<std::mutex> lock(self->impl_->callback_mtx_);
                                cb = self->impl_->on_bytes_;
                              }
+                             if (bytes > 0) self->impl_->stats_.record_received(bytes);
                              if (cb) cb(memory::ConstByteSpan(self->impl_->rx_.data(), bytes));
                              self->impl_->start_read(self, seq);
                            }));
@@ -470,7 +505,8 @@ void UdsClient::Impl::do_write(std::shared_ptr<UdsClient> self, uint64_t seq) {
 
   size_t bytes_to_write = buffer.size();
   socket_->async_write(
-      buffer, net::bind_executor(strand_, [self, seq, bytes_to_write](const boost::system::error_code& ec, size_t) {
+      buffer,
+      net::bind_executor(strand_, [self, seq, bytes_to_write](const boost::system::error_code& ec, size_t written) {
         if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) return;
         self->impl_->writing_ = false;
         self->impl_->current_write_buffer_ = std::nullopt;
@@ -482,6 +518,7 @@ void UdsClient::Impl::do_write(std::shared_ptr<UdsClient> self, uint64_t seq) {
           self->impl_->handle_close(self, seq, ec);
           return;
         }
+        self->impl_->stats_.record_sent(written);
         if (!self->impl_->tx_.empty()) self->impl_->do_write(self, seq);
       }));
 }
@@ -528,25 +565,32 @@ void UdsClient::Impl::maybe_flush_for_keep_latest(size_t added) {
   queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
+void UdsClient::Impl::observe_queue() {
+  stats_.observe_queue(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
+
 void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_t queued_bytes) {
   if (stop_requested_.load() || stopping_.load()) return;
+  observe_queue();
 
   OnBackpressure on_bp;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     on_bp = on_bp_;
   }
-  if (!on_bp) return;
 
   if (!backpressure_active_ && queued_bytes >= bp_high_) {
     backpressure_active_ = true;
-    try {
-      on_bp(queued_bytes);
-    } catch (const std::exception& e) {
-      UNILINK_LOG_ERROR("uds_client", "on_backpressure",
-                        fmt::format("Exception in backpressure callback: {}", e.what()));
-    } catch (...) {
-      UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
+    stats_.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (const std::exception& e) {
+        UNILINK_LOG_ERROR("uds_client", "on_backpressure",
+                          fmt::format("Exception in backpressure callback: {}", e.what()));
+      } catch (...) {
+        UNILINK_LOG_ERROR("uds_client", "on_backpressure", "Unknown exception in backpressure callback");
+      }
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
     // Flush pending_ → tx_
@@ -556,17 +600,24 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
       tx_.emplace_back(std::move(pending_.front()));
       pending_.pop_front();
     }
+    observe_queue();
     backpressure_active_ = false;
-    try {
-      on_bp(queued_bytes);
-    } catch (...) {
-    }  // fire OFF with pre-flush queue size
+    stats_.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
+    }
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp(queue_bytes_);
-      } catch (...) {
+      stats_.record_backpressure_event();
+      if (on_bp) {
+        try {
+          on_bp(queue_bytes_);
+        } catch (...) {
+        }
       }
     }
     if (!writing_) do_write(self, current_seq_.load());

--- a/unilink/transport/uds/uds_client.hpp
+++ b/unilink/transport/uds/uds_client.hpp
@@ -73,6 +73,8 @@ class UNILINK_API UdsClient : public Channel, public std::enable_shared_from_thi
   void stop() override;
   bool is_connected() const override;
   bool is_backpressure_active() const override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
   boost::asio::any_io_executor get_executor() override;
 
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/iuds_acceptor.hpp"
 #include "unilink/transport/uds/boost_uds_acceptor.hpp"
 #include "unilink/transport/uds/uds_server_session.hpp"
@@ -62,6 +63,7 @@ struct UdsServer::Impl {
   MultiClientConnectHandler on_multi_connect_;
   MultiClientDataHandler on_multi_data_;
   MultiClientDisconnectHandler on_multi_disconnect_;
+  diagnostics::RuntimeStatsCounters stats_;
 
   mutable std::mutex sessions_mutex_;
   std::unordered_map<ClientId, std::shared_ptr<UdsServerSession>> sessions_;
@@ -259,6 +261,38 @@ bool UdsServer::is_backpressure_active(ClientId client_id) const {
 
 boost::asio::any_io_executor UdsServer::get_executor() { return impl_->ioc_->get_executor(); }
 
+wrapper::RuntimeStats UdsServer::stats() const {
+  auto aggregate = impl_->stats_.snapshot(0, 0, false);
+  std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  for (const auto& pair : impl_->sessions_) {
+    if (!pair.second) continue;
+    const auto session_stats = pair.second->stats();
+    aggregate.bytes_accepted += session_stats.bytes_accepted;
+    aggregate.messages_accepted += session_stats.messages_accepted;
+    aggregate.bytes_sent += session_stats.bytes_sent;
+    aggregate.messages_sent += session_stats.messages_sent;
+    aggregate.bytes_received += session_stats.bytes_received;
+    aggregate.messages_received += session_stats.messages_received;
+    aggregate.failed_sends += session_stats.failed_sends;
+    aggregate.dropped_messages += session_stats.dropped_messages;
+    aggregate.dropped_bytes += session_stats.dropped_bytes;
+    aggregate.backpressure_events += session_stats.backpressure_events;
+    aggregate.queued_bytes += session_stats.queued_bytes;
+    aggregate.pending_bytes += session_stats.pending_bytes;
+    aggregate.max_queued_bytes += session_stats.max_queued_bytes;
+    aggregate.backpressure_active = aggregate.backpressure_active || session_stats.backpressure_active;
+  }
+  return aggregate;
+}
+
+void UdsServer::reset_stats() {
+  impl_->stats_.reset(0);
+  std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  for (const auto& pair : impl_->sessions_) {
+    if (pair.second) pair.second->reset_stats();
+  }
+}
+
 bool UdsServer::async_write_copy(memory::ConstByteSpan data) {
   auto shared_data = std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end());
   return async_write_shared(shared_data);
@@ -270,14 +304,22 @@ bool UdsServer::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool UdsServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
-  if (impl_->stopping_.load() || !data || data->empty()) return false;
+  if (impl_->stopping_.load() || !data || data->empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
   bool sent = false;
+  bool attempted = false;
   for (auto& pair : impl_->sessions_) {
     if (pair.second && pair.second->alive() && pair.second->async_write_shared(data)) {
+      attempted = true;
       sent = true;
+    } else if (pair.second && pair.second->alive()) {
+      attempted = true;
     }
   }
+  if (!attempted) impl_->stats_.record_failed_send();
   return sent;
 }
 
@@ -323,6 +365,7 @@ bool UdsServer::send_to_client(ClientId client_id, memory::ConstByteSpan data) {
   if (session) {
     return session->async_write_copy(data);
   }
+  impl_->stats_.record_failed_send();
   return false;
 }
 

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -71,6 +71,8 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
+  wrapper::RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // Multi-client support
   bool broadcast(std::string_view message);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -68,14 +68,34 @@ void UdsServerSession::stop() {
 
 bool UdsServerSession::alive() const { return alive_.load(); }
 
+wrapper::RuntimeStats UdsServerSession::stats() const {
+  return stats_.snapshot(queue_bytes_.load(std::memory_order_relaxed), pending_bytes_.load(std::memory_order_relaxed),
+                         backpressure_active_.load(std::memory_order_relaxed));
+}
+
+void UdsServerSession::reset_stats() {
+  stats_.reset(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
+
 bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> vec(data.begin(), data.end());
   return async_write_move(std::move(vec));
 }
 
 bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
-  if (!alive_ || closing_) return false;
-  if (queue_bytes_ + pending_bytes_ + data.size() > bp_limit_) return false;
+  if (!alive_ || closing_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  if (data.empty()) {
+    stats_.record_failed_send();
+    return false;
+  }
+  if (queue_bytes_ + pending_bytes_ + data.size() > bp_limit_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  stats_.record_accepted(data.size());
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data.size();
@@ -88,6 +108,7 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
       }
       pending_bytes_ += added;
       pending_.emplace_back(std::move(data));
+      observe_queue();
       return;
     }
 
@@ -100,6 +121,7 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
 
     queue_bytes_ += added;
     tx_.emplace_back(std::move(data));
+    observe_queue();
     report_backpressure(queue_bytes_);
     if (!writing_) do_write();
   });
@@ -107,8 +129,15 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
 }
 
 bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
-  if (!alive_ || closing_ || !data) return false;
-  if (queue_bytes_ + pending_bytes_ + data->size() > bp_limit_) return false;
+  if (!alive_ || closing_ || !data || data->empty()) {
+    stats_.record_failed_send();
+    return false;
+  }
+  if (queue_bytes_ + pending_bytes_ + data->size() > bp_limit_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  stats_.record_accepted(data->size());
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data->size();
@@ -121,6 +150,7 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
       }
       pending_bytes_ += added;
       pending_.emplace_back(std::move(data));
+      observe_queue();
       return;
     }
 
@@ -133,6 +163,7 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
 
     queue_bytes_ += added;
     tx_.emplace_back(std::move(data));
+    observe_queue();
     report_backpressure(queue_bytes_);
     if (!writing_) do_write();
   });
@@ -152,6 +183,7 @@ void UdsServerSession::start_read() {
           do_close();
           return;
         }
+        if (bytes > 0) stats_.record_received(bytes);
         if (on_bytes_) on_bytes_(memory::ConstByteSpan(rx_.data(), bytes));
         reset_idle_timer();
         start_read();
@@ -179,7 +211,7 @@ void UdsServerSession::do_write() {
 
   size_t bytes_to_write = buffer.size();
   socket_->async_write(buffer, net::bind_executor(strand_, [this, self = shared_from_this(), bytes_to_write](
-                                                               const boost::system::error_code& ec, size_t) {
+                                                               const boost::system::error_code& ec, size_t written) {
                          if (closing_ || !alive_) return;
                          writing_ = false;
                          current_write_buffer_ = std::nullopt;
@@ -190,6 +222,7 @@ void UdsServerSession::do_write() {
                            do_close();
                            return;
                          }
+                         stats_.record_sent(written);
                          if (!tx_.empty()) do_write();
                        }));
 }
@@ -221,15 +254,22 @@ void UdsServerSession::maybe_flush_for_keep_latest(size_t added) {
   queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
 }
 
+void UdsServerSession::observe_queue() {
+  stats_.observe_queue(queue_bytes_.load(std::memory_order_relaxed) + pending_bytes_.load(std::memory_order_relaxed));
+}
+
 void UdsServerSession::report_backpressure(size_t queued_bytes) {
   if (closing_ || !alive_) return;
-  if (!on_bp_) return;
+  observe_queue();
 
   if (!backpressure_active_ && queued_bytes >= bp_high_) {
     backpressure_active_ = true;
-    try {
-      on_bp_(queued_bytes);
-    } catch (...) {
+    stats_.record_backpressure_event();
+    if (on_bp_) {
+      try {
+        on_bp_(queued_bytes);
+      } catch (...) {
+      }
     }
   } else if (backpressure_active_ && queued_bytes <= bp_low_) {
     // Flush pending_ → tx_
@@ -239,17 +279,24 @@ void UdsServerSession::report_backpressure(size_t queued_bytes) {
       tx_.emplace_back(std::move(pending_.front()));
       pending_.pop_front();
     }
+    observe_queue();
     backpressure_active_ = false;
-    try {
-      on_bp_(queued_bytes);
-    } catch (...) {
-    }  // fire OFF with pre-flush queue size
+    stats_.record_backpressure_event();
+    if (on_bp_) {
+      try {
+        on_bp_(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size
+    }
     // If post-flush queue is still high, fire ON again
     if (queue_bytes_ >= bp_high_) {
       backpressure_active_ = true;
-      try {
-        on_bp_(queue_bytes_);
-      } catch (...) {
+      stats_.record_backpressure_event();
+      if (on_bp_) {
+        try {
+          on_bp_(queue_bytes_);
+        } catch (...) {
+        }
       }
     }
     if (!writing_) do_write();

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -32,6 +32,7 @@
 #include "unilink/base/visibility.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/logger.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/channel.hpp"
 #include "unilink/interface/iuds_socket.hpp"
 #include "unilink/memory/memory_pool.hpp"
@@ -73,6 +74,8 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   void on_close(OnClose cb);
   bool alive() const;
   bool is_backpressure_active() const { return backpressure_active_.load(); }
+  wrapper::RuntimeStats stats() const;
+  void reset_stats();
   void stop();
 
  private:
@@ -82,6 +85,7 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(size_t queued_bytes);
   void reset_idle_timer();
+  void observe_queue();
 
  private:
   net::io_context& ioc_;
@@ -100,6 +104,7 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   size_t bp_low_;
   size_t bp_limit_;
   std::atomic<bool> backpressure_active_{false};
+  diagnostics::RuntimeStatsCounters stats_;
   int idle_timeout_ms_ = 0;
 
   OnBytes on_bytes_;

--- a/unilink/unilink.hpp
+++ b/unilink/unilink.hpp
@@ -27,6 +27,7 @@
 #include "unilink/wrapper/context.hpp"
 #include "unilink/wrapper/ichannel.hpp"
 #include "unilink/wrapper/iserver.hpp"
+#include "unilink/wrapper/runtime_stats.hpp"
 
 // Wrapper implementations
 #include "unilink/wrapper/serial/serial.hpp"
@@ -74,6 +75,7 @@ using UdsServer = wrapper::UdsServer;
 using MessageContext = wrapper::MessageContext;
 using ConnectionContext = wrapper::ConnectionContext;
 using ErrorContext = wrapper::ErrorContext;
+using RuntimeStats = wrapper::RuntimeStats;
 
 // === Public Builder API Convenience Functions ===
 

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -26,6 +26,7 @@
 #include "unilink/base/visibility.hpp"
 #include "unilink/framer/iframer.hpp"
 #include "unilink/wrapper/context.hpp"
+#include "unilink/wrapper/runtime_stats.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -70,6 +71,8 @@ class UNILINK_API ChannelInterface {
    */
   virtual void stop() = 0;
   virtual bool connected() const = 0;
+  virtual RuntimeStats stats() const = 0;
+  virtual void reset_stats() = 0;
 
   // Transmission
   //

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -25,6 +25,7 @@
 #include "unilink/base/visibility.hpp"
 #include "unilink/framer/iframer.hpp"
 #include "unilink/wrapper/context.hpp"
+#include "unilink/wrapper/runtime_stats.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -58,6 +59,8 @@ class UNILINK_API ServerInterface {
    */
   virtual void stop() = 0;
   virtual bool listening() const = 0;
+  virtual RuntimeStats stats() const = 0;
+  virtual void reset_stats() = 0;
 
   // Transmission
   //

--- a/unilink/wrapper/runtime_stats.hpp
+++ b/unilink/wrapper/runtime_stats.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace unilink {
+namespace wrapper {
+
+struct RuntimeStats {
+  uint64_t bytes_accepted = 0;
+  uint64_t messages_accepted = 0;
+
+  uint64_t bytes_sent = 0;
+  uint64_t messages_sent = 0;
+
+  uint64_t bytes_received = 0;
+  uint64_t messages_received = 0;
+
+  uint64_t failed_sends = 0;
+
+  uint64_t dropped_messages = 0;
+  uint64_t dropped_bytes = 0;
+
+  uint64_t backpressure_events = 0;
+
+  size_t queued_bytes = 0;
+  size_t pending_bytes = 0;
+  size_t max_queued_bytes = 0;
+
+  bool backpressure_active = false;
+};
+
+}  // namespace wrapper
+}  // namespace unilink

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -273,6 +273,16 @@ struct Serial::Impl {
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }
 
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return channel ? channel->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel) channel->reset_stats();
+  }
+
   void setup_internal_handlers() {
     if (!channel) return;
 
@@ -465,6 +475,8 @@ bool Serial::connected() const {
   std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
   return impl_->channel && impl_->channel->is_connected();
 }
+RuntimeStats Serial::stats() const { return impl_->stats(); }
+void Serial::reset_stats() { impl_->reset_stats(); }
 
 Serial& Serial::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -69,6 +69,8 @@ class UNILINK_API Serial : public ChannelInterface {
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   Serial& on_data(MessageHandler handler) override;
   Serial& on_data_batch(BatchMessageHandler handler) override;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -286,6 +286,16 @@ struct TcpClient::Impl {
     return channel_ && channel_->is_connected();
   }
 
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return channel_ ? channel_->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_) channel_->reset_stats();
+  }
+
   void setup_internal_handlers() {
     if (!channel_) return;
 
@@ -446,6 +456,8 @@ bool TcpClient::try_send_line(std::string_view line) { return impl_->try_send_li
 bool TcpClient::send_blocking(std::string_view data) { return impl_->send_blocking(data); }
 bool TcpClient::send_line_blocking(std::string_view line) { return impl_->send_line_blocking(line); }
 bool TcpClient::connected() const { return get_impl()->connected(); }
+RuntimeStats TcpClient::stats() const { return get_impl()->stats(); }
+void TcpClient::reset_stats() { impl_->reset_stats(); }
 
 TcpClient& TcpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -69,6 +69,8 @@ class UNILINK_API TcpClient : public ChannelInterface {
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   TcpClient& on_data(MessageHandler handler) override;
   TcpClient& on_data_batch(BatchMessageHandler handler) override;

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -456,6 +456,16 @@ struct TcpServer::Impl {
       }
     });
   }
+
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return channel_ ? channel_->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_) channel_->reset_stats();
+  }
 };
 
 TcpServer::TcpServer(uint16_t port) : impl_(std::make_unique<Impl>(port)) {}
@@ -470,6 +480,8 @@ TcpServer& TcpServer::operator=(TcpServer&&) noexcept = default;
 std::future<bool> TcpServer::start() { return impl_->start(); }
 void TcpServer::stop() { impl_->stop(); }
 bool TcpServer::listening() const { return get_impl()->is_listening_.load(); }
+RuntimeStats TcpServer::stats() const { return get_impl()->stats(); }
+void TcpServer::reset_stats() { impl_->reset_stats(); }
 
 bool TcpServer::broadcast(std::string_view data) { return impl_->broadcast(data); }
 bool TcpServer::try_broadcast(std::string_view data) { return impl_->try_broadcast(data); }

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -63,6 +63,8 @@ class UNILINK_API TcpServer : public ServerInterface {
   [[nodiscard]] std::future<bool> start() override;
   void stop() override;
   bool listening() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // Transmission
   bool broadcast(std::string_view data) override;

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -257,6 +257,16 @@ struct UdpClient::Impl {
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }
 
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return channel ? channel->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel) channel->reset_stats();
+  }
+
   void setup_internal_handlers() {
     if (!channel) return;
 
@@ -420,6 +430,8 @@ bool UdpClient::connected() const {
   std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
   return impl_->channel && impl_->channel->is_connected();
 }
+RuntimeStats UdpClient::stats() const { return impl_->stats(); }
+void UdpClient::reset_stats() { impl_->reset_stats(); }
 
 UdpClient& UdpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);

--- a/unilink/wrapper/udp/udp.hpp
+++ b/unilink/wrapper/udp/udp.hpp
@@ -69,6 +69,8 @@ class UNILINK_API UdpClient : public ChannelInterface {
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   UdpClient& on_data(MessageHandler handler) override;
   UdpClient& on_data_batch(BatchMessageHandler handler) override;

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -508,6 +508,16 @@ struct UdpServer::Impl {
     auto bytes = base::safe_convert::string_to_bytes(data);
     return channel->async_write_to(memory::ConstByteSpan(bytes.first, bytes.second), it->second.endpoint);
   }
+
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    return channel ? channel->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex);
+    if (channel) channel->reset_stats();
+  }
 };
 
 UdpServer::UdpServer(uint16_t port) {
@@ -531,6 +541,8 @@ UdpServer& UdpServer::operator=(UdpServer&&) noexcept = default;
 std::future<bool> UdpServer::start() { return impl_->start(); }
 void UdpServer::stop() { impl_->stop(); }
 bool UdpServer::listening() const { return impl_->is_listening.load(); }
+RuntimeStats UdpServer::stats() const { return impl_->stats(); }
+void UdpServer::reset_stats() { impl_->reset_stats(); }
 
 bool UdpServer::broadcast(std::string_view data) { return impl_->broadcast(data); }
 bool UdpServer::try_broadcast(std::string_view data) { return impl_->try_broadcast(data); }

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -55,6 +55,8 @@ class UNILINK_API UdpServer : public ServerInterface {
   [[nodiscard]] std::future<bool> start() override;
   void stop() override;
   bool listening() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // Transmission
   bool broadcast(std::string_view data) override;

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -284,6 +284,16 @@ struct UdsClient::Impl {
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }
 
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return channel_ ? channel_->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_) channel_->reset_stats();
+  }
+
   void setup_internal_handlers() {
     if (!channel_) return;
 
@@ -463,6 +473,8 @@ bool UdsClient::connected() const {
   std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
   return impl_->channel_ && impl_->channel_->is_connected();
 }
+RuntimeStats UdsClient::stats() const { return impl_->stats(); }
+void UdsClient::reset_stats() { impl_->reset_stats(); }
 
 UdsClient& UdsClient::on_data(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);

--- a/unilink/wrapper/uds_client/uds_client.hpp
+++ b/unilink/wrapper/uds_client/uds_client.hpp
@@ -69,6 +69,8 @@ class UNILINK_API UdsClient : public ChannelInterface {
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
   bool connected() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   UdsClient& on_data(MessageHandler handler) override;
   UdsClient& on_data_batch(BatchMessageHandler handler) override;

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -382,6 +382,16 @@ struct UdsServer::Impl {
     });
   }
 
+  RuntimeStats stats() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return server_ ? server_->stats() : RuntimeStats{};
+  }
+
+  void reset_stats() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (server_) server_->reset_stats();
+  }
+
   void attach_framer_callback(ClientId id) {
     auto it = framers_.find(id);
     if (it == framers_.end()) return;
@@ -428,6 +438,8 @@ std::future<bool> UdsServer::start() { return impl_->start(); }
 void UdsServer::stop() { impl_->stop(); }
 
 bool UdsServer::listening() const { return impl_->is_listening_.load(); }
+RuntimeStats UdsServer::stats() const { return impl_->stats(); }
+void UdsServer::reset_stats() { impl_->reset_stats(); }
 
 bool UdsServer::broadcast(std::string_view data) { return impl_->broadcast(data); }
 bool UdsServer::try_broadcast(std::string_view data) { return impl_->try_broadcast(data); }

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -64,6 +64,8 @@ class UNILINK_API UdsServer : public ServerInterface {
   [[nodiscard]] std::future<bool> start() override;
   void stop() override;
   bool listening() const override;
+  RuntimeStats stats() const override;
+  void reset_stats() override;
 
   // Transmission
   bool broadcast(std::string_view data) override;


### PR DESCRIPTION
## Summary

This PR adds runtime statistics for monitoring unilink queue and transport behavior.

- Added `unilink::RuntimeStats`
- Added `stats()` / `reset_stats()` to wrapper APIs
- Added counters for accepted, sent, received, failed sends, queue pressure, and backpressure events
- Added queue gauges such as `queued_bytes`, `pending_bytes`, and `max_queued_bytes`
- Added transport/session aggregation for TCP and UDS servers
- Added documentation for stats snapshot semantics
- Added tests for basic stats behavior

## Rationale

The benchmark work highlighted that boolean send success and accepted throughput are not enough to understand runtime behavior, especially under backpressure. Applications need a way to observe queue pressure, failed sends, and future drop accounting without embedding benchmark-specific logic in the core library.

This PR adds the diagnostics surface needed for that while keeping the existing `send()` / `try_send()` APIs unchanged.

## Notes

`dropped_messages` and `dropped_bytes` are part of the public stats surface and internal counter helper. Precise BestEffort drop accounting can be filled in by the follow-up PR.

Runtime statistics are diagnostic snapshots for monitoring and tuning, not synchronization primitives.

## Test

```bash
cmake --build build-stats --target run_unit_test_runtime_stats -j1
ctest --test-dir build-stats -R RuntimeStats --output-on-failure -j1
ctest --test-dir build-stats -L unit_wrapper --output-on-failure -j1
git diff --check
```

The checks were intentionally run with low parallelism to avoid stressing the local kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime statistics API with `stats()` and `reset_stats()` methods across all transports and servers
  * New `RuntimeStats` diagnostic type exposing counters for bytes/messages accepted, sent, received, failed sends, dropped messages, backpressure events, and queue pressure metrics

* **Documentation**
  * Added runtime statistics documentation covering usage, diagnostic fields, and monitoring queue pressure

* **Tests**
  * Added unit test coverage for runtime statistics functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->