### PR TITLE
feat: track best-effort dropped bytes and messages

### DIFF
--- a/docs/contributor/architecture/channel_contract.md
+++ b/docs/contributor/architecture/channel_contract.md
@@ -49,6 +49,8 @@ A rejected send and a dropped queued payload are different events:
 - rejected send: the new payload was not accepted into the local send path
 - dropped queued payload: an older queued payload was removed after a newer payload was accepted
 
+A dropped queued payload must be accounted separately from a rejected send. `BestEffort` drop accounting should count only payloads that were previously accepted into the local outgoing queue. In-flight writes are not counted as dropped queued payloads.
+
 **Contract Rules:**
 1.  **Triggering (High Watermark):** When the size of queued write data (bytes pending transmission) reaches or exceeds the configured `backpressure_threshold`, the transport MUST invoke its internal `on_backpressure` callback with the current queue size. Wrapper and builder APIs may expose backpressure notifications where the wrapper supports them. See the user API guide for public callback availability.
     

--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -1053,6 +1053,10 @@ Runtime statistics are diagnostic snapshots. They are intended for monitoring an
 
 `messages_accepted` means the local send path accepted the payload. It does not guarantee remote delivery. `messages_sent` means the transport reported a successful write completion, and `messages_received` means incoming data was observed by the transport or wrapper. Use application-level acknowledgements when delivery confirmation matters.
 
+`dropped_messages` and `dropped_bytes` count payloads that were previously accepted into the local queue and later discarded by a freshness-oriented policy such as `BestEffort`.
+
+They are different from `failed_sends`. A failed send means the new payload was not accepted into the local send path.
+
 `reset_stats()` clears cumulative counters such as accepted, sent, received, failed send, drop, and backpressure event counts. Current gauges such as `queued_bytes`, `pending_bytes`, and `backpressure_active` continue to reflect the live transport state.
 
 ### When to use each

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -156,6 +156,8 @@ Use `stats()` to monitor queue pressure and drops:
 - `failed_sends`
 - `backpressure_events`
 
+When using `BestEffort`, monitor `dropped_messages` and `dropped_bytes`. A high accepted rate does not imply that every queued payload was preserved.
+
 ### 2. High-Throughput Sensors (LiDAR/Camera)
 
 For robotics perception, processing stale data is often worse than skipping frames. Use `BestEffort` with a low threshold to prevent **Bufferbloat**.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -115,6 +115,13 @@ foreach(test_file test_pool_limits.cc)
   )
 endforeach()
 
+# Diagnostics tests
+unilink_add_unit_gtest(
+  run_unit_test_runtime_stats_counter
+  ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/test_runtime_stats_counter.cc
+  "unit_diagnostics_fast" 30
+)
+
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_serial_wrapper_lifecycle.cc
                   test_serial_wrapper_options.cc test_runtime_stats.cc

--- a/test/unit/diagnostics/test_runtime_stats_counter.cc
+++ b/test/unit/diagnostics/test_runtime_stats_counter.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
+
+namespace {
+
+using unilink::diagnostics::RuntimeStatsCounters;
+
+TEST(RuntimeStatsCounterTest, DefaultSnapshotIsZero) {
+  RuntimeStatsCounters counters;
+
+  const auto stats = counters.snapshot(0, 0, false);
+
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_sent, 0u);
+  EXPECT_EQ(stats.bytes_sent, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_EQ(stats.backpressure_events, 0u);
+  EXPECT_EQ(stats.queued_bytes, 0u);
+  EXPECT_EQ(stats.pending_bytes, 0u);
+  EXPECT_EQ(stats.max_queued_bytes, 0u);
+  EXPECT_FALSE(stats.backpressure_active);
+}
+
+TEST(RuntimeStatsCounterTest, RecordsCountersAndSnapshotGauges) {
+  RuntimeStatsCounters counters;
+
+  counters.record_accepted(11);
+  counters.record_accepted(13);
+  counters.record_sent(7);
+  counters.record_received(5);
+  counters.record_failed_send();
+  counters.record_dropped(3, 17);
+  counters.record_backpressure_event();
+  counters.record_backpressure_event();
+  counters.observe_queue(12);
+  counters.observe_queue(8);
+
+  const auto stats = counters.snapshot(4, 2, true);
+
+  EXPECT_EQ(stats.messages_accepted, 2u);
+  EXPECT_EQ(stats.bytes_accepted, 24u);
+  EXPECT_EQ(stats.messages_sent, 1u);
+  EXPECT_EQ(stats.bytes_sent, 7u);
+  EXPECT_EQ(stats.messages_received, 1u);
+  EXPECT_EQ(stats.bytes_received, 5u);
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 3u);
+  EXPECT_EQ(stats.dropped_bytes, 17u);
+  EXPECT_EQ(stats.backpressure_events, 2u);
+  EXPECT_EQ(stats.queued_bytes, 4u);
+  EXPECT_EQ(stats.pending_bytes, 2u);
+  EXPECT_EQ(stats.max_queued_bytes, 12u);
+  EXPECT_TRUE(stats.backpressure_active);
+}
+
+TEST(RuntimeStatsCounterTest, ResetClearsCumulativeCountersAndSetsMaxQueueBaseline) {
+  RuntimeStatsCounters counters;
+
+  counters.record_accepted(11);
+  counters.record_sent(7);
+  counters.record_received(5);
+  counters.record_failed_send();
+  counters.record_dropped(2, 19);
+  counters.record_backpressure_event();
+  counters.observe_queue(40);
+
+  counters.reset(6);
+  const auto stats = counters.snapshot(4, 2, true);
+
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_sent, 0u);
+  EXPECT_EQ(stats.bytes_sent, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_EQ(stats.backpressure_events, 0u);
+  EXPECT_EQ(stats.queued_bytes, 4u);
+  EXPECT_EQ(stats.pending_bytes, 2u);
+  EXPECT_EQ(stats.max_queued_bytes, 6u);
+  EXPECT_TRUE(stats.backpressure_active);
+}
+
+}  // namespace

--- a/test/unit/transport/test_reconnect_decider.cc
+++ b/test/unit/transport/test_reconnect_decider.cc
@@ -208,11 +208,13 @@ TEST(BackpressureQueueUtilTest, ReliableStrategyDoesNotTrimQueue) {
   std::atomic<size_t> queue_bytes{7};
   std::atomic<bool> backpressure_active{true};
 
-  maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::Reliable, 10, 5, tx, queue_bytes,
-                              backpressure_active);
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::Reliable, 10, 5, tx,
+                                                   queue_bytes, backpressure_active);
 
   EXPECT_EQ(tx.size(), 2);
   EXPECT_EQ(queue_bytes.load(), 7);
+  EXPECT_EQ(dropped.messages, 0u);
+  EXPECT_EQ(dropped.bytes, 0u);
 }
 
 TEST(BackpressureQueueUtilTest, BestEffortDropsQueueWhenAddedBufferExceedsHighWatermark) {
@@ -222,14 +224,16 @@ TEST(BackpressureQueueUtilTest, BestEffortDropsQueueWhenAddedBufferExceedsHighWa
   std::deque<Buffer> tx;
   tx.emplace_back(std::vector<uint8_t>{1, 2, 3, 4});
   tx.emplace_back(std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{5, 6, 7, 8, 9}));
-  std::atomic<size_t> queue_bytes{3};
+  std::atomic<size_t> queue_bytes{9};
   std::atomic<bool> backpressure_active{false};
 
-  maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 10, 10, tx, queue_bytes,
-                              backpressure_active);
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 10, 10, tx,
+                                                   queue_bytes, backpressure_active);
 
   EXPECT_TRUE(tx.empty());
   EXPECT_EQ(queue_bytes.load(), 0);
+  EXPECT_EQ(dropped.messages, 2u);
+  EXPECT_EQ(dropped.bytes, 9u);
 }
 
 TEST(BackpressureQueueUtilTest, BestEffortTrimsOldestBuffersUntilAddedBufferFits) {
@@ -243,9 +247,11 @@ TEST(BackpressureQueueUtilTest, BestEffortTrimsOldestBuffersUntilAddedBufferFits
   std::atomic<size_t> queue_bytes{12};
   std::atomic<bool> backpressure_active{false};
 
-  maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 3, 10, tx, queue_bytes,
-                              backpressure_active);
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 3, 10, tx,
+                                                   queue_bytes, backpressure_active);
 
   ASSERT_EQ(tx.size(), 1);
   EXPECT_EQ(queue_bytes.load(), 4);
+  EXPECT_EQ(dropped.messages, 2u);
+  EXPECT_EQ(dropped.bytes, 8u);
 }

--- a/test/unit/transport/test_reconnect_decider.cc
+++ b/test/unit/transport/test_reconnect_decider.cc
@@ -217,6 +217,25 @@ TEST(BackpressureQueueUtilTest, ReliableStrategyDoesNotTrimQueue) {
   EXPECT_EQ(dropped.bytes, 0u);
 }
 
+TEST(BackpressureQueueUtilTest, BestEffortDoesNotDropBelowHighWatermark) {
+  using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
+  using unilink::transport::queue_util::maybe_flush_for_keep_latest;
+
+  std::deque<Buffer> tx;
+  tx.emplace_back(std::vector<uint8_t>{1, 2, 3});
+  tx.emplace_back(std::vector<uint8_t>{4, 5});
+  std::atomic<size_t> queue_bytes{5};
+  std::atomic<bool> backpressure_active{false};
+
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 4, 10, tx,
+                                                   queue_bytes, backpressure_active);
+
+  EXPECT_EQ(tx.size(), 2);
+  EXPECT_EQ(queue_bytes.load(), 5);
+  EXPECT_EQ(dropped.messages, 0u);
+  EXPECT_EQ(dropped.bytes, 0u);
+}
+
 TEST(BackpressureQueueUtilTest, BestEffortDropsQueueWhenAddedBufferExceedsHighWatermark) {
   using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
   using unilink::transport::queue_util::maybe_flush_for_keep_latest;
@@ -254,4 +273,24 @@ TEST(BackpressureQueueUtilTest, BestEffortTrimsOldestBuffersUntilAddedBufferFits
   EXPECT_EQ(queue_bytes.load(), 4);
   EXPECT_EQ(dropped.messages, 2u);
   EXPECT_EQ(dropped.bytes, 8u);
+}
+
+TEST(BackpressureQueueUtilTest, BestEffortOnlyCountsBuffersStillQueued) {
+  using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
+  using unilink::transport::queue_util::maybe_flush_for_keep_latest;
+
+  const size_t in_flight_bytes = 6;
+  std::deque<Buffer> tx;
+  tx.emplace_back(std::vector<uint8_t>{1, 2, 3, 4});
+  tx.emplace_back(std::vector<uint8_t>{5, 6});
+  std::atomic<size_t> queue_bytes{in_flight_bytes + 6};
+  std::atomic<bool> backpressure_active{false};
+
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 5, 10, tx,
+                                                   queue_bytes, backpressure_active);
+
+  EXPECT_TRUE(tx.empty());
+  EXPECT_EQ(queue_bytes.load(), in_flight_bytes);
+  EXPECT_EQ(dropped.messages, 2u);
+  EXPECT_EQ(dropped.bytes, 6u);
 }

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -437,6 +437,15 @@ TEST(TransportSerialTest, BestEffortDropsOldestWhileWriteIsInFlight) {
 
   EXPECT_GE(port_raw->write_count(), 1);
   EXPECT_TRUE(serial->is_backpressure_active());
+  auto stats = serial->stats();
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 1u);
+  EXPECT_EQ(stats.dropped_bytes, payload.size());
+  serial->reset_stats();
+  stats = serial->stats();
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_GT(stats.queued_bytes, 0u);
 
   port_raw->complete_pending_write();
   ioc.run_for(30ms);

--- a/test/unit/transport/transport_tcp_server_session.cc
+++ b/test/unit/transport/transport_tcp_server_session.cc
@@ -54,6 +54,10 @@ TEST(TransportTcpServerSessionTest, QueueLimitDropsMessage) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire as it's not queued
   std::vector<uint8_t> huge(5 * 1024 * 1024, 0xAA);
   EXPECT_FALSE(session->async_write_copy(memory::ConstByteSpan(huge.data(), huge.size())));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
@@ -78,6 +82,10 @@ TEST(TransportTcpServerSessionTest, MoveWriteRespectsQueueLimit) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire
   std::vector<uint8_t> huge(5 * 1024 * 1024, 0xBB);
   EXPECT_FALSE(session->async_write_move(std::move(huge)));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
@@ -102,11 +110,42 @@ TEST(TransportTcpServerSessionTest, SharedWriteRespectsQueueLimit) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire
   auto huge = std::make_shared<const std::vector<uint8_t>>(5 * 1024 * 1024, 0xCC);
   EXPECT_FALSE(session->async_write_shared(huge));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
   EXPECT_FALSE(backpressure_seen.load());
   EXPECT_TRUE(session->alive());
+}
+
+TEST(TransportTcpServerSessionTest, BestEffortDropStatsExcludeInFlightWrite) {
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+  size_t bp_threshold = 1024;
+
+  auto socket = std::make_unique<FakeTcpSocket>(ioc);
+  auto session = std::make_shared<TcpServerSession>(ioc, std::move(socket), bp_threshold, 0,
+                                                    base::constants::BackpressureStrategy::BestEffort);
+
+  session->start();
+  ASSERT_TRUE(session->alive());
+
+  std::vector<uint8_t> payload(bp_threshold * 2, 0xAB);
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+
+  ioc.run_for(50ms);
+
+  auto stats = session->stats();
+  EXPECT_EQ(stats.messages_accepted, 3u);
+  EXPECT_EQ(stats.bytes_accepted, payload.size() * 3);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 1u);
+  EXPECT_EQ(stats.dropped_bytes, payload.size());
 }
 
 TEST(TransportTcpServerSessionTest, BackpressureReliefAfterDrain) {

--- a/unilink/diagnostics/runtime_stats_counter.hpp
+++ b/unilink/diagnostics/runtime_stats_counter.hpp
@@ -61,9 +61,9 @@ struct RuntimeStatsCounters {
 
   void record_failed_send() { failed_sends.fetch_add(1, std::memory_order_relaxed); }
 
-  void record_dropped(size_t bytes) {
-    dropped_messages.fetch_add(1, std::memory_order_relaxed);
-    dropped_bytes.fetch_add(bytes, std::memory_order_relaxed);
+  void record_dropped(size_t messages, size_t bytes) {
+    dropped_messages.fetch_add(static_cast<uint64_t>(messages), std::memory_order_relaxed);
+    dropped_bytes.fetch_add(static_cast<uint64_t>(bytes), std::memory_order_relaxed);
   }
 
   void record_backpressure_event() { backpressure_events.fetch_add(1, std::memory_order_relaxed); }

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <memory>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 #include "unilink/base/constants.hpp"
@@ -27,6 +28,13 @@
 namespace unilink {
 namespace transport {
 namespace queue_util {
+
+struct DropAccounting {
+  size_t messages = 0;
+  size_t bytes = 0;
+
+  bool any() const { return messages > 0 || bytes > 0; }
+};
 
 // Returns the byte size of a buffer held in a transport BufferVariant alternative.
 // shared_ptr<const vector<uint8_t>> goes through ->size(); everything else via .size().
@@ -47,20 +55,24 @@ inline size_t variant_buffer_size(const T& buf) {
 //   added >= bp_high  →  drop entire tx_ (full keep-latest replacement).
 //   otherwise         →  pop oldest tx_ entries until queue_bytes + added <= bp_high.
 template <typename Deque>
-inline void maybe_flush_for_keep_latest(::unilink::base::constants::BackpressureStrategy bp_strategy, size_t added,
-                                        size_t bp_high, Deque& tx, std::atomic<size_t>& queue_bytes,
-                                        const std::atomic<bool>& backpressure_active) {
-  if (bp_strategy != ::unilink::base::constants::BackpressureStrategy::BestEffort) return;
+inline DropAccounting maybe_flush_for_keep_latest(::unilink::base::constants::BackpressureStrategy bp_strategy,
+                                                  size_t added, size_t bp_high, Deque& tx,
+                                                  std::atomic<size_t>& queue_bytes,
+                                                  const std::atomic<bool>& backpressure_active) {
+  DropAccounting dropped;
+  if (bp_strategy != ::unilink::base::constants::BackpressureStrategy::BestEffort) return dropped;
 
   if (added >= bp_high) {
     size_t removed_bytes = 0;
     for (const auto& buf : tx) {
       removed_bytes += std::visit([](const auto& b) { return variant_buffer_size(b); }, buf);
     }
+    dropped.messages = tx.size();
+    dropped.bytes = removed_bytes;
     tx.clear();
     const size_t qb = queue_bytes.load(std::memory_order_relaxed);
     queue_bytes.store(qb > removed_bytes ? qb - removed_bytes : 0, std::memory_order_relaxed);
-    return;
+    return dropped;
   }
 
   if (backpressure_active.load(std::memory_order_relaxed) ||
@@ -71,8 +83,11 @@ inline void maybe_flush_for_keep_latest(::unilink::base::constants::Backpressure
       const size_t oldest = std::visit([](const auto& b) { return variant_buffer_size(b); }, tx.front());
       queue_bytes.store(qb > oldest ? qb - oldest : 0, std::memory_order_relaxed);
       tx.pop_front();
+      ++dropped.messages;
+      dropped.bytes += oldest;
     }
   }
+  return dropped;
 }
 
 }  // namespace queue_util

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -39,6 +39,7 @@
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/iserial_port.hpp"
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
 #include "unilink/transport/serial/boost_serial_port.hpp"
 
 namespace unilink {
@@ -96,6 +97,12 @@ struct Serial::Impl {
   void observe_queue() {
     stats_.observe_queue(queued_bytes_.load(std::memory_order_relaxed) +
                          pending_bytes_.load(std::memory_order_relaxed));
+  }
+
+  void maybe_flush_for_keep_latest(size_t added) {
+    const auto dropped = queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queued_bytes_,
+                                                                 backpressure_active_);
+    if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
   }
 
   explicit Impl(const config::SerialConfig& cfg)
@@ -581,28 +588,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
           return;
         }
 
-        if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
-            (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
-          if (added >= impl->bp_high_) {
-            impl->tx_.clear();
-            impl->queued_bytes_ = 0;
-          } else {
-            while (!impl->tx_.empty() && (impl->queued_bytes_ + added > impl->bp_high_)) {
-              size_t oldest_size = std::visit(
-                  [](auto&& buf) -> size_t {
-                    using T = std::decay_t<decltype(buf)>;
-                    if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                      return buf ? buf->size() : 0;
-                    } else {
-                      return buf.size();
-                    }
-                  },
-                  impl->tx_.front());
-              impl->queued_bytes_ = (impl->queued_bytes_ > oldest_size) ? (impl->queued_bytes_ - oldest_size) : 0;
-              impl->tx_.pop_front();
-            }
-          }
-        }
+        impl->maybe_flush_for_keep_latest(added);
 
         if (impl->queued_bytes_ + added > impl->bp_limit_) {
           UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
@@ -641,28 +627,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
       return;
     }
 
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
-        (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
-      if (added >= impl->bp_high_) {
-        impl->tx_.clear();
-        impl->queued_bytes_ = 0;
-      } else {
-        while (!impl->tx_.empty() && (impl->queued_bytes_ + added > impl->bp_high_)) {
-          size_t oldest_size = std::visit(
-              [](auto&& buf) -> size_t {
-                using T = std::decay_t<decltype(buf)>;
-                if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                  return buf ? buf->size() : 0;
-                } else {
-                  return buf.size();
-                }
-              },
-              impl->tx_.front());
-          impl->queued_bytes_ = (impl->queued_bytes_ > oldest_size) ? (impl->queued_bytes_ - oldest_size) : 0;
-          impl->tx_.pop_front();
-        }
-      }
-    }
+    impl->maybe_flush_for_keep_latest(added);
 
     if (impl->queued_bytes_ + added > impl->bp_limit_) {
       impl->report_backpressure(impl->queued_bytes_ + added);
@@ -714,28 +679,7 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
       return;
     }
 
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
-        (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
-      if (added >= impl->bp_high_) {
-        impl->tx_.clear();
-        impl->queued_bytes_ = 0;
-      } else {
-        while (!impl->tx_.empty() && (impl->queued_bytes_ + added > impl->bp_high_)) {
-          size_t oldest_size = std::visit(
-              [](auto&& buf) -> size_t {
-                using T = std::decay_t<decltype(buf)>;
-                if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                  return buf ? buf->size() : 0;
-                } else {
-                  return buf.size();
-                }
-              },
-              impl->tx_.front());
-          impl->queued_bytes_ = (impl->queued_bytes_ > oldest_size) ? (impl->queued_bytes_ - oldest_size) : 0;
-          impl->tx_.pop_front();
-        }
-      }
-    }
+    impl->maybe_flush_for_keep_latest(added);
 
     if (impl->queued_bytes_ + added > impl->bp_limit_) {
       impl->report_backpressure(impl->queued_bytes_ + added);
@@ -787,28 +731,7 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
       return;
     }
 
-    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
-        (impl->backpressure_active_ || impl->queued_bytes_ + added > impl->bp_high_)) {
-      if (added >= impl->bp_high_) {
-        impl->tx_.clear();
-        impl->queued_bytes_ = 0;
-      } else {
-        while (!impl->tx_.empty() && (impl->queued_bytes_ + added > impl->bp_high_)) {
-          size_t oldest_size = std::visit(
-              [](auto&& buf) -> size_t {
-                using T = std::decay_t<decltype(buf)>;
-                if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                  return buf ? buf->size() : 0;
-                } else {
-                  return buf.size();
-                }
-              },
-              impl->tx_.front());
-          impl->queued_bytes_ = (impl->queued_bytes_ > oldest_size) ? (impl->queued_bytes_ - oldest_size) : 0;
-          impl->tx_.pop_front();
-        }
-      }
-    }
+    impl->maybe_flush_for_keep_latest(added);
 
     if (impl->queued_bytes_ + added > impl->bp_limit_) {
       impl->report_backpressure(impl->queued_bytes_ + added);

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -895,7 +895,9 @@ void TcpClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void TcpClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  const auto dropped =
+      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
 }
 
 void TcpClient::Impl::observe_queue() {

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -446,7 +446,9 @@ void TcpServerSession::do_close() {
 }
 
 void TcpServerSession::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  const auto dropped =
+      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
 }
 
 void TcpServerSession::observe_queue() {

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -39,6 +39,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
 
 namespace unilink {
 namespace transport {
@@ -480,39 +481,31 @@ struct UdpChannel::Impl {
 
     if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
         (backpressure_active_ || queue_bytes_ + size > bp_high_)) {
+      size_t dropped_messages = 0;
+      size_t dropped_bytes = 0;
       if (size >= bp_high_) {
         // Compute bytes to remove from tx_ (note: in-flight datagram already popped from tx_)
         size_t removed_bytes = 0;
         for (const auto& item : tx_) {
-          removed_bytes += std::visit(
-              [](auto&& b) -> size_t {
-                using T = std::decay_t<decltype(b)>;
-                if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                  return b ? b->size() : 0;
-                } else {
-                  return b.size();
-                }
-              },
-              item.buffer);
+          removed_bytes += std::visit([](const auto& b) { return queue_util::variant_buffer_size(b); }, item.buffer);
         }
+        dropped_messages = tx_.size();
+        dropped_bytes = removed_bytes;
         tx_.clear();
         queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
       } else {
         while (!tx_.empty() && (queue_bytes_ + size > bp_high_)) {
           auto& oldest = tx_.front();
-          size_t oldest_size = std::visit(
-              [](auto&& buf) -> size_t {
-                using T = std::decay_t<decltype(buf)>;
-                if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-                  return buf ? buf->size() : 0;
-                } else {
-                  return buf.size();
-                }
-              },
-              oldest.buffer);
+          size_t oldest_size =
+              std::visit([](const auto& buf) { return queue_util::variant_buffer_size(buf); }, oldest.buffer);
           queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
           tx_.pop_front();
+          ++dropped_messages;
+          dropped_bytes += oldest_size;
         }
+      }
+      if (dropped_messages > 0 || dropped_bytes > 0) {
+        stats_.record_dropped(dropped_messages, dropped_bytes);
       }
     }
 

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -562,7 +562,9 @@ void UdsClient::Impl::recalculate_backpressure_bounds() {
 }
 
 void UdsClient::Impl::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  const auto dropped =
+      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
 }
 
 void UdsClient::Impl::observe_queue() {

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -251,7 +251,9 @@ void UdsServerSession::do_close() {
 }
 
 void UdsServerSession::maybe_flush_for_keep_latest(size_t added) {
-  queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  const auto dropped =
+      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+  if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
 }
 
 void UdsServerSession::observe_queue() {


### PR DESCRIPTION
## Summary

This PR adds BestEffort drop accounting to runtime statistics.

- Tracks `dropped_messages`
- Tracks `dropped_bytes`
- Distinguishes dropped queued payloads from rejected sends
- Applies accounting through the shared stream queue trimming helper and UDP BestEffort trim path
- Reuses the shared helper for Serial BestEffort trimming
- Updates docs to clarify `failed_sends` vs dropped data
- Adds tests for BestEffort drop accounting, Reliable non-drop behavior, and reset behavior

## Rationale

BestEffort prioritizes freshness and may discard older queued payloads under queue pressure. Before this change, applications could observe successful send acceptance without being able to see how much queued data was discarded.

This PR makes BestEffort behavior observable through runtime stats.

## Semantics

`failed_sends` and dropped counters are intentionally separate:

- `failed_sends`: the new payload was rejected before local acceptance
- `dropped_messages` / `dropped_bytes`: an already accepted queued payload was removed by BestEffort freshness policy

In-flight writes are not counted as dropped queued payloads.

## Test

```bash
cmake --build build-stats --target run_unit_test_reconnect_decider run_unit_transport_serial -j1
./build-stats/bin/run_unit_test_reconnect_decider
./build-stats/bin/run_unit_transport_serial --gtest_filter=TransportSerialTest.BestEffortDropsOldestWhileWriteIsInFlight
cmake --build build-stats --target run_unit_test_runtime_stats -j1
./build-stats/bin/run_unit_test_runtime_stats
git diff --check
```

The checks were intentionally run with low parallelism to avoid stressing the local kernel.