### PR TITLE
test: add diagnostics tests for runtime stats and drop accounting

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -115,6 +115,13 @@ foreach(test_file test_pool_limits.cc)
   )
 endforeach()
 
+# Diagnostics tests
+unilink_add_unit_gtest(
+  run_unit_test_runtime_stats_counter
+  ${CMAKE_CURRENT_SOURCE_DIR}/diagnostics/test_runtime_stats_counter.cc
+  "unit_diagnostics_fast" 30
+)
+
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_serial_wrapper_lifecycle.cc
                   test_serial_wrapper_options.cc test_runtime_stats.cc

--- a/test/unit/diagnostics/test_runtime_stats_counter.cc
+++ b/test/unit/diagnostics/test_runtime_stats_counter.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
+
+namespace {
+
+using unilink::diagnostics::RuntimeStatsCounters;
+
+TEST(RuntimeStatsCounterTest, DefaultSnapshotIsZero) {
+  RuntimeStatsCounters counters;
+
+  const auto stats = counters.snapshot(0, 0, false);
+
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_sent, 0u);
+  EXPECT_EQ(stats.bytes_sent, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_EQ(stats.backpressure_events, 0u);
+  EXPECT_EQ(stats.queued_bytes, 0u);
+  EXPECT_EQ(stats.pending_bytes, 0u);
+  EXPECT_EQ(stats.max_queued_bytes, 0u);
+  EXPECT_FALSE(stats.backpressure_active);
+}
+
+TEST(RuntimeStatsCounterTest, RecordsCountersAndSnapshotGauges) {
+  RuntimeStatsCounters counters;
+
+  counters.record_accepted(11);
+  counters.record_accepted(13);
+  counters.record_sent(7);
+  counters.record_received(5);
+  counters.record_failed_send();
+  counters.record_dropped(3, 17);
+  counters.record_backpressure_event();
+  counters.record_backpressure_event();
+  counters.observe_queue(12);
+  counters.observe_queue(8);
+
+  const auto stats = counters.snapshot(4, 2, true);
+
+  EXPECT_EQ(stats.messages_accepted, 2u);
+  EXPECT_EQ(stats.bytes_accepted, 24u);
+  EXPECT_EQ(stats.messages_sent, 1u);
+  EXPECT_EQ(stats.bytes_sent, 7u);
+  EXPECT_EQ(stats.messages_received, 1u);
+  EXPECT_EQ(stats.bytes_received, 5u);
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 3u);
+  EXPECT_EQ(stats.dropped_bytes, 17u);
+  EXPECT_EQ(stats.backpressure_events, 2u);
+  EXPECT_EQ(stats.queued_bytes, 4u);
+  EXPECT_EQ(stats.pending_bytes, 2u);
+  EXPECT_EQ(stats.max_queued_bytes, 12u);
+  EXPECT_TRUE(stats.backpressure_active);
+}
+
+TEST(RuntimeStatsCounterTest, ResetClearsCumulativeCountersAndSetsMaxQueueBaseline) {
+  RuntimeStatsCounters counters;
+
+  counters.record_accepted(11);
+  counters.record_sent(7);
+  counters.record_received(5);
+  counters.record_failed_send();
+  counters.record_dropped(2, 19);
+  counters.record_backpressure_event();
+  counters.observe_queue(40);
+
+  counters.reset(6);
+  const auto stats = counters.snapshot(4, 2, true);
+
+  EXPECT_EQ(stats.messages_accepted, 0u);
+  EXPECT_EQ(stats.bytes_accepted, 0u);
+  EXPECT_EQ(stats.messages_sent, 0u);
+  EXPECT_EQ(stats.bytes_sent, 0u);
+  EXPECT_EQ(stats.messages_received, 0u);
+  EXPECT_EQ(stats.bytes_received, 0u);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
+  EXPECT_EQ(stats.backpressure_events, 0u);
+  EXPECT_EQ(stats.queued_bytes, 4u);
+  EXPECT_EQ(stats.pending_bytes, 2u);
+  EXPECT_EQ(stats.max_queued_bytes, 6u);
+  EXPECT_TRUE(stats.backpressure_active);
+}
+
+}  // namespace

--- a/test/unit/transport/test_reconnect_decider.cc
+++ b/test/unit/transport/test_reconnect_decider.cc
@@ -217,6 +217,25 @@ TEST(BackpressureQueueUtilTest, ReliableStrategyDoesNotTrimQueue) {
   EXPECT_EQ(dropped.bytes, 0u);
 }
 
+TEST(BackpressureQueueUtilTest, BestEffortDoesNotDropBelowHighWatermark) {
+  using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
+  using unilink::transport::queue_util::maybe_flush_for_keep_latest;
+
+  std::deque<Buffer> tx;
+  tx.emplace_back(std::vector<uint8_t>{1, 2, 3});
+  tx.emplace_back(std::vector<uint8_t>{4, 5});
+  std::atomic<size_t> queue_bytes{5};
+  std::atomic<bool> backpressure_active{false};
+
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 4, 10, tx,
+                                                   queue_bytes, backpressure_active);
+
+  EXPECT_EQ(tx.size(), 2);
+  EXPECT_EQ(queue_bytes.load(), 5);
+  EXPECT_EQ(dropped.messages, 0u);
+  EXPECT_EQ(dropped.bytes, 0u);
+}
+
 TEST(BackpressureQueueUtilTest, BestEffortDropsQueueWhenAddedBufferExceedsHighWatermark) {
   using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
   using unilink::transport::queue_util::maybe_flush_for_keep_latest;
@@ -254,4 +273,24 @@ TEST(BackpressureQueueUtilTest, BestEffortTrimsOldestBuffersUntilAddedBufferFits
   EXPECT_EQ(queue_bytes.load(), 4);
   EXPECT_EQ(dropped.messages, 2u);
   EXPECT_EQ(dropped.bytes, 8u);
+}
+
+TEST(BackpressureQueueUtilTest, BestEffortOnlyCountsBuffersStillQueued) {
+  using Buffer = std::variant<std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
+  using unilink::transport::queue_util::maybe_flush_for_keep_latest;
+
+  const size_t in_flight_bytes = 6;
+  std::deque<Buffer> tx;
+  tx.emplace_back(std::vector<uint8_t>{1, 2, 3, 4});
+  tx.emplace_back(std::vector<uint8_t>{5, 6});
+  std::atomic<size_t> queue_bytes{in_flight_bytes + 6};
+  std::atomic<bool> backpressure_active{false};
+
+  const auto dropped = maybe_flush_for_keep_latest(base::constants::BackpressureStrategy::BestEffort, 5, 10, tx,
+                                                   queue_bytes, backpressure_active);
+
+  EXPECT_TRUE(tx.empty());
+  EXPECT_EQ(queue_bytes.load(), in_flight_bytes);
+  EXPECT_EQ(dropped.messages, 2u);
+  EXPECT_EQ(dropped.bytes, 6u);
 }

--- a/test/unit/transport/transport_tcp_server_session.cc
+++ b/test/unit/transport/transport_tcp_server_session.cc
@@ -54,6 +54,10 @@ TEST(TransportTcpServerSessionTest, QueueLimitDropsMessage) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire as it's not queued
   std::vector<uint8_t> huge(5 * 1024 * 1024, 0xAA);
   EXPECT_FALSE(session->async_write_copy(memory::ConstByteSpan(huge.data(), huge.size())));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
@@ -78,6 +82,10 @@ TEST(TransportTcpServerSessionTest, MoveWriteRespectsQueueLimit) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire
   std::vector<uint8_t> huge(5 * 1024 * 1024, 0xBB);
   EXPECT_FALSE(session->async_write_move(std::move(huge)));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
@@ -102,11 +110,42 @@ TEST(TransportTcpServerSessionTest, SharedWriteRespectsQueueLimit) {
   // 5MB exceeds bp_limit (4MB): message rejected synchronously, backpressure DOES NOT fire
   auto huge = std::make_shared<const std::vector<uint8_t>>(5 * 1024 * 1024, 0xCC);
   EXPECT_FALSE(session->async_write_shared(huge));
+  auto stats = session->stats();
+  EXPECT_EQ(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   ioc.run_for(50ms);
 
   EXPECT_FALSE(backpressure_seen.load());
   EXPECT_TRUE(session->alive());
+}
+
+TEST(TransportTcpServerSessionTest, BestEffortDropStatsExcludeInFlightWrite) {
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+  size_t bp_threshold = 1024;
+
+  auto socket = std::make_unique<FakeTcpSocket>(ioc);
+  auto session = std::make_shared<TcpServerSession>(ioc, std::move(socket), bp_threshold, 0,
+                                                    base::constants::BackpressureStrategy::BestEffort);
+
+  session->start();
+  ASSERT_TRUE(session->alive());
+
+  std::vector<uint8_t> payload(bp_threshold * 2, 0xAB);
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(payload)));
+
+  ioc.run_for(50ms);
+
+  auto stats = session->stats();
+  EXPECT_EQ(stats.messages_accepted, 3u);
+  EXPECT_EQ(stats.bytes_accepted, payload.size() * 3);
+  EXPECT_EQ(stats.failed_sends, 0u);
+  EXPECT_EQ(stats.dropped_messages, 1u);
+  EXPECT_EQ(stats.dropped_bytes, payload.size());
 }
 
 TEST(TransportTcpServerSessionTest, BackpressureReliefAfterDrain) {


### PR DESCRIPTION
## Summary

This PR adds diagnostics test coverage for runtime stats and BestEffort drop accounting.

- Adds deterministic tests for `RuntimeStatsCounters`
- Verifies counter recording, drop accounting, high-watermark tracking, and reset behavior
- Extends shared BestEffort queue trim helper tests for no-drop and in-flight-not-counted cases
- Extends TCP server session tests to distinguish failed sends from dropped queued payloads
- Adds a deterministic TCP session BestEffort smoke test for dropped bytes/messages

## Rationale

PR #396 added BestEffort drop accounting to runtime statistics. Because the accounting touches multiple transport paths, this PR strengthens regression coverage without adding new public API surface.

The goal is to ensure:

- dropped queued payloads are counted as drops
- rejected new sends are counted as `failed_sends`
- in-flight writes are not counted as dropped queued payloads
- `reset_stats()` clears cumulative counters and resets max queue baseline

## Scope

This is a test-only stacked PR on top of `codex/track-besteffort-drops` / PR #396. It does not add benchmark numbers, SendResult API, socket tuning, or runtime behavior changes.

## Test

```bash
cmake -S . -B build-stats
cmake --build build-stats --target run_unit_test_runtime_stats_counter run_unit_test_reconnect_decider run_unit_transport_tcp_server_session run_unit_transport_serial run_unit_test_runtime_stats -j1
./build-stats/bin/run_unit_test_runtime_stats_counter
./build-stats/bin/run_unit_test_reconnect_decider --gtest_filter='BackpressureQueueUtilTest.*'
./build-stats/bin/run_unit_transport_tcp_server_session --gtest_filter='TransportTcpServerSessionTest.*QueueLimit*:TransportTcpServerSessionTest.BestEffortDropStatsExcludeInFlightWrite'
./build-stats/bin/run_unit_transport_serial --gtest_filter=TransportSerialTest.BestEffortDropsOldestWhileWriteIsInFlight
./build-stats/bin/run_unit_test_runtime_stats
git diff --check
```

The checks were intentionally run with low parallelism to avoid stressing the local kernel.