### PR TITLE
feat: expose move and shared-buffer send APIs

### DIFF
--- a/docs/user/api_guide.md
+++ b/docs/user/api_guide.md
@@ -130,6 +130,26 @@ Use `.on_message()` together with a framer when you want callback flow to operat
 
 For producer loops that must not block, prefer `try_send()` or configure `BestEffort`. In `Reliable` mode, `send()` may wait for queue pressure to clear.
 
+### Move And Shared Buffer Sends
+
+For large binary payloads, client-style wrappers provide advanced send APIs that can avoid unnecessary wrapper-level copies.
+
+```cpp
+std::vector<uint8_t> payload = build_frame();
+client->send_move(std::move(payload));
+```
+
+After calling `send_move(...)` or `try_send_move(...)`, treat the vector as consumed regardless of the return value.
+
+For immutable payloads that should be shared with unilink:
+
+```cpp
+auto payload = std::make_shared<const std::vector<uint8_t>>(build_frame());
+client->try_send_shared(payload);
+```
+
+`send_move(...)` and `send_shared(...)` follow the same Reliable/BestEffort backpressure semantics as `send(...)`. The `try_send_move(...)` and `try_send_shared(...)` variants are non-blocking escape hatches like `try_send(...)`.
+
 **Builder Flow**
 
 ```

--- a/docs/user/api_stability.md
+++ b/docs/user/api_stability.md
@@ -109,3 +109,5 @@ Most applications should include:
 ```
 
 Direct builder or wrapper includes are supported for advanced users, but the umbrella header is the recommended stable entry point for application code.
+
+Move/shared buffer send APIs are user-facing advanced APIs intended for large binary payloads.

--- a/docs/user/performance.md
+++ b/docs/user/performance.md
@@ -72,13 +72,21 @@ Never perform heavy computation or blocking operations (like `sleep`) inside cal
 Use move semantics and avoid unnecessary string copies.
 
 ```cpp
-// ✅ GOOD: Move (no copy)
-std::string large_data = generate_data(1024 * 1024);
-client->send(std::move(large_data));
+// GOOD: transfer a large binary buffer into the send path
+std::vector<uint8_t> large_data = generate_frame(1024 * 1024);
+client->send_move(std::move(large_data));
 
-// ✅ GOOD: Use string_view for parsing (if supported)
+// GOOD: Use string_view for parsing (if supported)
 void parse(std::string_view msg) { ... }
 ```
+
+For large binary payloads, prefer move/shared send APIs when available:
+
+- `send_move(...)` transfers vector ownership into the send path.
+- `send_shared(...)` shares immutable payload ownership with unilink.
+- `try_send_move(...)` and `try_send_shared(...)` provide non-blocking variants.
+
+After calling `send_move(...)` or `try_send_move(...)`, treat the moved vector as consumed regardless of the return value.
 
 ### 2. Reserve Vector Capacity
 When building vectors of data, always `reserve` capacity to avoid reallocations.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -123,9 +123,9 @@ unilink_add_unit_gtest(
 )
 
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
-foreach(test_file test_serial_wrapper_lifecycle.cc
-                  test_serial_wrapper_options.cc test_runtime_stats.cc
-                  test_send_buffer_apis.cc
+foreach(test_file
+        test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
+        test_runtime_stats.cc test_send_buffer_apis.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -125,6 +125,7 @@ unilink_add_unit_gtest(
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(test_file test_serial_wrapper_lifecycle.cc
                   test_serial_wrapper_options.cc test_runtime_stats.cc
+                  test_send_buffer_apis.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/wrapper/test_send_buffer_apis.cc
+++ b/test/unit/wrapper/test_send_buffer_apis.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/io_context.hpp>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "unilink/interface/channel.hpp"
+#include "unilink/wrapper/serial/serial.hpp"
+#include "unilink/wrapper/tcp_client/tcp_client.hpp"
+#include "unilink/wrapper/udp/udp.hpp"
+#include "unilink/wrapper/uds_client/uds_client.hpp"
+
+namespace {
+
+class CountingChannel : public unilink::interface::Channel {
+ public:
+  void start() override { connected_ = true; }
+  void stop() override { connected_ = false; }
+  bool is_connected() const override { return connected_; }
+  bool is_backpressure_active() const override { return false; }
+
+  boost::asio::any_io_executor get_executor() override { return ioc_.get_executor(); }
+
+  bool async_write_copy(unilink::memory::ConstByteSpan data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++copy_calls_;
+    last_payload_.assign(data.begin(), data.end());
+    return write_result_;
+  }
+
+  bool async_write_move(std::vector<uint8_t>&& data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++move_calls_;
+    last_payload_ = std::move(data);
+    return write_result_;
+  }
+
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++shared_calls_;
+    if (data) {
+      last_payload_ = *data;
+    } else {
+      last_payload_.clear();
+    }
+    return write_result_ && data && !data->empty();
+  }
+
+  void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
+  void on_state(OnState cb) override { on_state_ = std::move(cb); }
+  void on_backpressure(OnBackpressure cb) override { on_backpressure_ = std::move(cb); }
+
+  int copy_calls() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return copy_calls_;
+  }
+
+  int move_calls() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return move_calls_;
+  }
+
+  int shared_calls() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return shared_calls_;
+  }
+
+  std::vector<uint8_t> last_payload() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return last_payload_;
+  }
+
+ private:
+  boost::asio::io_context ioc_;
+  bool connected_{true};
+  bool write_result_{true};
+  mutable std::mutex mutex_;
+  int copy_calls_{0};
+  int move_calls_{0};
+  int shared_calls_{0};
+  std::vector<uint8_t> last_payload_;
+  OnBytes on_bytes_;
+  OnState on_state_;
+  OnBackpressure on_backpressure_;
+};
+
+template <typename Wrapper>
+void expect_try_send_move_uses_move_path() {
+  auto channel = std::make_shared<CountingChannel>();
+  Wrapper wrapper(channel);
+
+  std::vector<uint8_t> payload{1, 2, 3, 4};
+  EXPECT_TRUE(wrapper.try_send_move(std::move(payload)));
+
+  EXPECT_EQ(channel->copy_calls(), 0);
+  EXPECT_EQ(channel->move_calls(), 1);
+  EXPECT_EQ(channel->shared_calls(), 0);
+  EXPECT_EQ(channel->last_payload(), (std::vector<uint8_t>{1, 2, 3, 4}));
+}
+
+template <typename Wrapper>
+void expect_try_send_shared_uses_shared_path() {
+  auto channel = std::make_shared<CountingChannel>();
+  Wrapper wrapper(channel);
+
+  auto payload = std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{5, 6, 7});
+  EXPECT_TRUE(wrapper.try_send_shared(payload));
+
+  EXPECT_EQ(channel->copy_calls(), 0);
+  EXPECT_EQ(channel->move_calls(), 0);
+  EXPECT_EQ(channel->shared_calls(), 1);
+  EXPECT_EQ(channel->last_payload(), (std::vector<uint8_t>{5, 6, 7}));
+}
+
+template <typename Wrapper>
+void expect_empty_or_null_shared_is_rejected_before_transport() {
+  auto channel = std::make_shared<CountingChannel>();
+  Wrapper wrapper(channel);
+
+  EXPECT_FALSE(wrapper.try_send_shared(nullptr));
+  EXPECT_FALSE(wrapper.try_send_shared(std::make_shared<const std::vector<uint8_t>>()));
+
+  EXPECT_EQ(channel->copy_calls(), 0);
+  EXPECT_EQ(channel->move_calls(), 0);
+  EXPECT_EQ(channel->shared_calls(), 0);
+}
+
+template <typename Wrapper>
+void expect_strategy_send_uses_move_and_shared_paths() {
+  auto channel = std::make_shared<CountingChannel>();
+  Wrapper wrapper(channel);
+  wrapper.backpressure_strategy(unilink::base::constants::BackpressureStrategy::BestEffort);
+
+  EXPECT_TRUE(wrapper.send_move(std::vector<uint8_t>{8, 9}));
+  auto shared = std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{10, 11});
+  EXPECT_TRUE(wrapper.send_shared(shared));
+
+  EXPECT_EQ(channel->copy_calls(), 0);
+  EXPECT_EQ(channel->move_calls(), 1);
+  EXPECT_EQ(channel->shared_calls(), 1);
+}
+
+}  // namespace
+
+TEST(WrapperSendBufferApis, TcpClientRoutesMoveAndSharedToTransportPaths) {
+  expect_try_send_move_uses_move_path<unilink::wrapper::TcpClient>();
+  expect_try_send_shared_uses_shared_path<unilink::wrapper::TcpClient>();
+  expect_empty_or_null_shared_is_rejected_before_transport<unilink::wrapper::TcpClient>();
+  expect_strategy_send_uses_move_and_shared_paths<unilink::wrapper::TcpClient>();
+}
+
+TEST(WrapperSendBufferApis, UdpClientRoutesMoveAndSharedToTransportPaths) {
+  expect_try_send_move_uses_move_path<unilink::wrapper::UdpClient>();
+  expect_try_send_shared_uses_shared_path<unilink::wrapper::UdpClient>();
+  expect_empty_or_null_shared_is_rejected_before_transport<unilink::wrapper::UdpClient>();
+  expect_strategy_send_uses_move_and_shared_paths<unilink::wrapper::UdpClient>();
+}
+
+TEST(WrapperSendBufferApis, SerialRoutesMoveAndSharedToTransportPaths) {
+  expect_try_send_move_uses_move_path<unilink::wrapper::Serial>();
+  expect_try_send_shared_uses_shared_path<unilink::wrapper::Serial>();
+  expect_empty_or_null_shared_is_rejected_before_transport<unilink::wrapper::Serial>();
+  expect_strategy_send_uses_move_and_shared_paths<unilink::wrapper::Serial>();
+}
+
+TEST(WrapperSendBufferApis, UdsClientRoutesMoveAndSharedToTransportPaths) {
+  expect_try_send_move_uses_move_path<unilink::wrapper::UdsClient>();
+  expect_try_send_shared_uses_shared_path<unilink::wrapper::UdsClient>();
+  expect_empty_or_null_shared_is_rejected_before_transport<unilink::wrapper::UdsClient>();
+  expect_strategy_send_uses_move_and_shared_paths<unilink::wrapper::UdsClient>();
+}

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -142,6 +142,44 @@ class UNILINK_API ChannelInterface {
    */
   virtual bool try_send_line(std::string_view line) = 0;
 
+  /**
+   * @brief Enqueue a vector payload by transferring ownership, honouring the backpressure strategy.
+   *
+   * After this call, the caller must treat the moved-from vector as consumed regardless
+   * of the return value. Existing string_view send APIs remain available for borrowed data.
+   *
+   * @return true Data was accepted. @return false Data was dropped or rejected.
+   */
+  virtual bool send_move(std::vector<uint8_t>&& data) = 0;
+
+  /**
+   * @brief Non-blocking ownership-transfer send.
+   *
+   * Always returns without waiting for backpressure. The moved-from vector is consumed
+   * regardless of the return value.
+   *
+   * @return true Data was accepted. @return false Data was dropped or rejected.
+   */
+  virtual bool try_send_move(std::vector<uint8_t>&& data) = 0;
+
+  /**
+   * @brief Enqueue an immutable shared vector payload, honouring the backpressure strategy.
+   *
+   * The shared buffer must be non-null and non-empty.
+   *
+   * @return true Data was accepted. @return false Data was dropped or rejected.
+   */
+  virtual bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) = 0;
+
+  /**
+   * @brief Non-blocking shared-buffer send.
+   *
+   * The shared buffer must be non-null and non-empty.
+   *
+   * @return true Data was accepted. @return false Data was dropped or rejected.
+   */
+  virtual bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) = 0;
+
   // Event handlers
   virtual ChannelInterface& on_data(MessageHandler handler) = 0;
 

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -243,9 +243,56 @@ struct Serial::Impl {
     return false;
   }
 
+  bool try_send_move(std::vector<uint8_t>&& data) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
+      return channel->async_write_move(std::move(data));
+    }
+    return false;
+  }
+
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
+      return channel->async_write_shared(std::move(data));
+    }
+    return false;
+  }
+
   bool send(std::string_view data) {
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) return send_blocking(data);
     return try_send(data);
+  }
+
+  bool send_move(std::vector<uint8_t>&& data) {
+    if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      while (true) {
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          if (!started_.load() || !channel || !channel->is_connected()) return false;
+          if (!channel->is_backpressure_active()) break;
+        }
+        bp_cv_.wait(bp_lock);
+      }
+    }
+    return try_send_move(std::move(data));
+  }
+
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      while (true) {
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          if (!started_.load() || !channel || !channel->is_connected()) return false;
+          if (!channel->is_backpressure_active()) break;
+        }
+        bp_cv_.wait(bp_lock);
+      }
+    }
+    return try_send_shared(std::move(data));
   }
 
   bool send_line(std::string_view line) {
@@ -469,6 +516,14 @@ bool Serial::send(std::string_view data) { return impl_->send(data); }
 bool Serial::try_send(std::string_view data) { return impl_->try_send(data); }
 bool Serial::send_line(std::string_view line) { return impl_->send_line(line); }
 bool Serial::try_send_line(std::string_view line) { return impl_->try_send_line(line); }
+bool Serial::send_move(std::vector<uint8_t>&& data) { return impl_->send_move(std::move(data)); }
+bool Serial::try_send_move(std::vector<uint8_t>&& data) { return impl_->try_send_move(std::move(data)); }
+bool Serial::send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->send_shared(std::move(data));
+}
+bool Serial::try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->try_send_shared(std::move(data));
+}
 bool Serial::send_blocking(std::string_view data) { return impl_->send_blocking(data); }
 bool Serial::send_line_blocking(std::string_view line) { return impl_->send_line_blocking(line); }
 bool Serial::connected() const {

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "unilink/base/constants.hpp"
 #include "unilink/base/visibility.hpp"
@@ -68,6 +69,10 @@ class UNILINK_API Serial : public ChannelInterface {
   bool send_line_blocking(std::string_view line) override;
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
+  bool send_move(std::vector<uint8_t>&& data) override;
+  bool try_send_move(std::vector<uint8_t>&& data) override;
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   bool connected() const override;
   RuntimeStats stats() const override;
   void reset_stats() override;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -258,9 +258,48 @@ struct TcpClient::Impl {
     return false;
   }
 
+  bool try_send_move(std::vector<uint8_t>&& data) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_ && channel_->is_connected()) {
+      return channel_->async_write_move(std::move(data));
+    }
+    return false;
+  }
+
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_ && channel_->is_connected()) {
+      return channel_->async_write_shared(std::move(data));
+    }
+    return false;
+  }
+
   bool send(std::string_view data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) return send_blocking(data);
     return try_send(data);
+  }
+
+  bool send_move(std::vector<uint8_t>&& data) {
+    if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel_ || !channel_->is_backpressure_active();
+      });
+    }
+    return try_send_move(std::move(data));
+  }
+
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel_ || !channel_->is_backpressure_active();
+      });
+    }
+    return try_send_shared(std::move(data));
   }
 
   bool send_line(std::string_view line) {
@@ -453,6 +492,14 @@ bool TcpClient::send(std::string_view data) { return impl_->send(data); }
 bool TcpClient::try_send(std::string_view data) { return impl_->try_send(data); }
 bool TcpClient::send_line(std::string_view line) { return impl_->send_line(line); }
 bool TcpClient::try_send_line(std::string_view line) { return impl_->try_send_line(line); }
+bool TcpClient::send_move(std::vector<uint8_t>&& data) { return impl_->send_move(std::move(data)); }
+bool TcpClient::try_send_move(std::vector<uint8_t>&& data) { return impl_->try_send_move(std::move(data)); }
+bool TcpClient::send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->send_shared(std::move(data));
+}
+bool TcpClient::try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->try_send_shared(std::move(data));
+}
 bool TcpClient::send_blocking(std::string_view data) { return impl_->send_blocking(data); }
 bool TcpClient::send_line_blocking(std::string_view line) { return impl_->send_line_blocking(line); }
 bool TcpClient::connected() const { return get_impl()->connected(); }

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "unilink/base/constants.hpp"
 #include "unilink/base/visibility.hpp"
@@ -68,6 +69,10 @@ class UNILINK_API TcpClient : public ChannelInterface {
   bool send_line_blocking(std::string_view line) override;
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
+  bool send_move(std::vector<uint8_t>&& data) override;
+  bool try_send_move(std::vector<uint8_t>&& data) override;
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   bool connected() const override;
   RuntimeStats stats() const override;
   void reset_stats() override;

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -230,6 +230,28 @@ struct UdpClient::Impl {
     return try_send(data);
   }
 
+  bool send_move(std::vector<uint8_t>&& data) {
+    if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
+      });
+    }
+    return try_send_move(std::move(data));
+  }
+
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
+      });
+    }
+    return try_send_shared(std::move(data));
+  }
+
   bool send_line(std::string_view line) {
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) return send_line_blocking(line);
     return try_send_line(line);
@@ -251,6 +273,23 @@ struct UdpClient::Impl {
     if (channel && channel->is_connected()) {
       auto binary_view = base::safe_convert::string_to_bytes(data);
       return channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+    }
+    return false;
+  }
+
+  bool try_send_move(std::vector<uint8_t>&& data) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
+      return channel->async_write_move(std::move(data));
+    }
+    return false;
+  }
+
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel && channel->is_connected()) {
+      return channel->async_write_shared(std::move(data));
     }
     return false;
   }
@@ -424,6 +463,14 @@ bool UdpClient::send(std::string_view data) { return impl_->send(data); }
 bool UdpClient::try_send(std::string_view data) { return impl_->try_send(data); }
 bool UdpClient::send_line(std::string_view line) { return impl_->send_line(line); }
 bool UdpClient::try_send_line(std::string_view line) { return impl_->try_send_line(line); }
+bool UdpClient::send_move(std::vector<uint8_t>&& data) { return impl_->send_move(std::move(data)); }
+bool UdpClient::try_send_move(std::vector<uint8_t>&& data) { return impl_->try_send_move(std::move(data)); }
+bool UdpClient::send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->send_shared(std::move(data));
+}
+bool UdpClient::try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->try_send_shared(std::move(data));
+}
 bool UdpClient::send_blocking(std::string_view data) { return impl_->send_blocking(data); }
 bool UdpClient::send_line_blocking(std::string_view line) { return impl_->send_line_blocking(line); }
 bool UdpClient::connected() const {

--- a/unilink/wrapper/udp/udp.hpp
+++ b/unilink/wrapper/udp/udp.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "unilink/base/constants.hpp"
 #include "unilink/base/visibility.hpp"
@@ -68,6 +69,10 @@ class UNILINK_API UdpClient : public ChannelInterface {
   bool send_line_blocking(std::string_view line) override;
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
+  bool send_move(std::vector<uint8_t>&& data) override;
+  bool try_send_move(std::vector<uint8_t>&& data) override;
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   bool connected() const override;
   RuntimeStats stats() const override;
   void reset_stats() override;

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -257,6 +257,28 @@ struct UdsClient::Impl {
     return try_send(data);
   }
 
+  bool send_move(std::vector<uint8_t>&& data) {
+    if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
+      });
+    }
+    return try_send_move(std::move(data));
+  }
+
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      bp_cv_.wait(bp_lock, [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
+      });
+    }
+    return try_send_shared(std::move(data));
+  }
+
   bool send_line(std::string_view line) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) return send_line_blocking(line);
     return try_send_line(line);
@@ -278,6 +300,23 @@ struct UdsClient::Impl {
     if (channel_ && channel_->is_connected()) {
       return channel_->async_write_copy(
           memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+    }
+    return false;
+  }
+
+  bool try_send_move(std::vector<uint8_t>&& data) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_ && channel_->is_connected()) {
+      return channel_->async_write_move(std::move(data));
+    }
+    return false;
+  }
+
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (channel_ && channel_->is_connected()) {
+      return channel_->async_write_shared(std::move(data));
     }
     return false;
   }
@@ -461,6 +500,14 @@ void UdsClient::stop() { impl_->stop(); }
 
 bool UdsClient::send(std::string_view data) { return impl_->send(data); }
 bool UdsClient::try_send(std::string_view data) { return impl_->try_send(data); }
+bool UdsClient::send_move(std::vector<uint8_t>&& data) { return impl_->send_move(std::move(data)); }
+bool UdsClient::try_send_move(std::vector<uint8_t>&& data) { return impl_->try_send_move(std::move(data)); }
+bool UdsClient::send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->send_shared(std::move(data));
+}
+bool UdsClient::try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  return impl_->try_send_shared(std::move(data));
+}
 
 bool UdsClient::send_line(std::string_view line) { return impl_->send_line(line); }
 bool UdsClient::try_send_line(std::string_view line) { return impl_->try_send_line(line); }

--- a/unilink/wrapper/uds_client/uds_client.hpp
+++ b/unilink/wrapper/uds_client/uds_client.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "unilink/base/constants.hpp"
 #include "unilink/base/visibility.hpp"
@@ -68,6 +69,10 @@ class UNILINK_API UdsClient : public ChannelInterface {
   bool send_line_blocking(std::string_view line) override;
   bool try_send(std::string_view data) override;
   bool try_send_line(std::string_view line) override;
+  bool send_move(std::vector<uint8_t>&& data) override;
+  bool try_send_move(std::vector<uint8_t>&& data) override;
+  bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool try_send_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   bool connected() const override;
   RuntimeStats stats() const override;
   void reset_stats() override;


### PR DESCRIPTION
## Summary

This PR exposes move and shared-buffer send APIs through the client-style wrapper layer.

- Adds `send_move(...)` / `try_send_move(...)` to `ChannelInterface`
- Adds `send_shared(...)` / `try_send_shared(...)` to `ChannelInterface`
- Implements the APIs for `TcpClient`, `UdpClient`, `Serial`, and `UdsClient`
- Wires wrapper calls directly to transport `async_write_move(...)` / `async_write_shared(...)`
- Preserves existing `send(std::string_view)` / `try_send(std::string_view)` APIs
- Documents moved-buffer and shared-buffer ownership semantics
- Adds wrapper unit tests that verify move/shared calls do not route through `async_write_copy(...)`

## Scope

This PR focuses on client-style wrappers, where transport move/shared write paths already exist behind the public wrapper API.

Server-side `send_to_shared(...)` / `broadcast_shared(...)` are intentionally left for a follow-up so per-client routing and broadcast semantics can be added consistently across TCP, UDP, and UDS without expanding this PR beyond the client send path.

## Rationale

The transport layer already supports move/shared buffer write paths, but public wrapper APIs primarily route through copy-based sends. Large binary payload users need a way to transfer or share buffer ownership without unnecessary wrapper-level copies.

The new APIs are explicit rather than overload-based:

- `send_move(...)` / `try_send_move(...)` transfer vector ownership into the send path.
- `send_shared(...)` / `try_send_shared(...)` share immutable payload ownership with unilink.

After calling a move send API, callers should treat the vector as consumed regardless of the return value.

## Test

```bash
cmake -S . -B build-send-buffer \
  -DCMAKE_BUILD_TYPE=Debug \
  -DUNILINK_BUILD_TESTS=ON \
  -DUNILINK_BUILD_DOCS=OFF

cmake --build build-send-buffer --target run_unit_test_send_buffer_apis -j1
./build-send-buffer/bin/run_unit_test_send_buffer_apis
ctest --test-dir build-send-buffer --output-on-failure -L unit_wrapper -j1
cmake --build build-send-buffer --target doc_snippets_smoke -j1
git diff --check
```

Local result:

- `run_unit_test_send_buffer_apis`: passed
- `ctest -L unit_wrapper`: passed
- `doc_snippets_smoke`: passed
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `send_move`, `try_send_move`, `send_shared`, and `try_send_shared` methods across all transport wrappers (Serial, TCP, UDP, UDS) for binary payload transmission.

* **Documentation**
  * Updated API guide, stability policy, and performance documentation with usage examples and semantics for the new move and shared-buffer send operations.

* **Tests**
  * Added unit tests verifying send-buffer API routing across all transport wrappers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->