### PR TITLE
[codex] Prepare v0.7.5 release notes and checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## v0.7.5
+
+### Release Type
+
+Performance-readiness stabilization release.
+
+This release focuses on runtime observability, BestEffort drop visibility, send/backpressure semantics, and performance tuning surfaces ahead of the future v0.8 release line.
+
+### Added
+
+- Added runtime statistics for observing queue pressure and transport behavior.
+- Added BestEffort dropped message/byte accounting.
+- Added tests for runtime stats and drop accounting.
+- Added UDP large-payload delivery validation.
+- Added move/shared-buffer send APIs for large payload workflows.
+- Added TCP/UDP socket tuning options.
+- Added SendResult API design documentation.
+- Added transport feature and stats support matrix.
+
+### Changed
+
+- Clarified send and backpressure semantics in user and contributor docs.
+- Clarified that local send acceptance does not guarantee remote delivery.
+- Clarified that BestEffort may drop older queued payloads to keep newer data fresh.
+- Clarified that Reliable `send()` may block under backpressure.
+- Improved performance guidance around queue pressure, drops, and tuning.
+
+### Notes
+
+- This release does not declare C++ ABI stability.
+- Existing bool-based send APIs remain available.
+- `SendResult` is design-only unless separately implemented.
+- Benchmark result numbers remain in the benchmark repository, not in the core docs.
+- Python bindings remain maintained separately in `unilink-python`.
+
+### Known Limitations
+
+- C++ ABI stability is not guaranteed before v1.0.
+- Some internal headers may change before v1.0.
+- Benchmark results are environment-specific and are not performance guarantees.
+- UDP large-payload behavior should be interpreted according to the core tests and benchmark model notes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.7.4
+  VERSION 0.7.5
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -10,6 +10,7 @@ Documentation for developers building, extending, or contributing to unilink its
 - [Testing](testing.md) — Running the test suite, CI integration, writing tests
 - [Orin Nano Validation](orin_nano_validation.md) — Ubuntu 22.04 ARM64 bring-up and test runbook
 - [Release Checklist](release_checklist.md) — Release validation steps
+- [v0.7.5 Release Notes Draft](releases/v0.7.5.md) — Performance-readiness release notes draft
 - [Implementation Status](implementation_status.md) — Verified scope, known gaps, and codebase snapshot
 - [Test Structure](test_structure.md) — Test organization and coverage breakdown
 

--- a/docs/contributor/release_checklist.md
+++ b/docs/contributor/release_checklist.md
@@ -16,6 +16,9 @@ Use this checklist before publishing a unilink release.
 - [ ] Unit tests pass
 - [ ] Integration tests pass
 - [ ] E2E tests pass
+- [ ] Runtime statistics tests pass
+- [ ] BestEffort drop accounting tests pass
+- [ ] UDP large-payload delivery tests pass
 - [ ] Memory safety / sanitizer tests pass
 - [ ] Documentation snippet compile checks pass
 - [ ] Installed consumer smoke test passes
@@ -39,6 +42,9 @@ Use this checklist before publishing a unilink release.
 - [ ] Requirements Guide is current
 - [ ] API Guide matches actual builder/wrapper behavior
 - [ ] API Stability Policy is current
+- [ ] Transport Feature Matrix is current
+- [ ] Send/backpressure semantics are current
+- [ ] SendResult design status is current
 - [ ] Known limitations are documented
 - [ ] Python bindings link points to `unilink-python`
 - [ ] Examples link points to the external examples repository
@@ -60,10 +66,38 @@ Check that expected release assets exist.
 
 - [ ] vcpkg package status checked
 - [ ] External examples repository checked against this release
+- [ ] Benchmark repository release/results are linked but not copied into core docs
 - [ ] `unilink-python` compatibility checked, if applicable
 - [ ] Container image compatibility checked, if applicable
 
-## 7. Post-Release Checks
+## 7. Local Release Validation Commands
+
+```bash
+cmake -S . -B build-v075 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUNILINK_BUILD_TESTS=ON \
+  -DUNILINK_BUILD_DOCS=OFF \
+  -DUNILINK_ENABLE_INSTALL=ON \
+  -DUNILINK_ENABLE_PKGCONFIG=ON \
+  -DUNILINK_ENABLE_EXPORT_HEADER=ON
+
+cmake --build build-v075 --parallel
+ctest --test-dir build-v075 --output-on-failure
+
+cmake --build build-v075 --target doc_snippets_smoke --parallel
+ctest --test-dir build-v075 --output-on-failure -L docs_snippets
+
+scripts/verify_installed_consumer.sh --library-mode shared
+scripts/verify_installed_consumer.sh --library-mode static
+```
+
+For resource-constrained environments:
+
+```bash
+ctest --test-dir build-v075 --output-on-failure -j1
+```
+
+## 8. Post-Release Checks
 
 - [ ] GitHub Release download links work
 - [ ] Documentation site is updated

--- a/docs/contributor/releases/v0.7.5.md
+++ b/docs/contributor/releases/v0.7.5.md
@@ -1,0 +1,85 @@
+# unilink v0.7.5 Release Notes Draft {#contrib_release_v075}
+
+`v0.7.5` is a performance-readiness stabilization release for the unilink C++20 core library.
+
+It focuses on making runtime behavior easier to observe and tune before the future `v0.8` release line.
+
+## Highlights
+
+- Runtime statistics for queue pressure and transport behavior
+- BestEffort drop accounting
+- Clearer send/backpressure semantics
+- UDP large-payload behavior validation
+- Move/shared-buffer send APIs for large payload workflows
+- TCP/UDP socket tuning options
+- SendResult API design documentation
+- Transport feature and stats support matrix
+
+## What This Release Means
+
+This release improves the ability to understand and tune unilink behavior under pressure.
+
+It does not claim hardware-independent performance guarantees. Benchmark numbers are maintained separately in the benchmark repository.
+
+## Compatibility
+
+- Existing `send(...)` and `try_send(...)` APIs remain available.
+- New diagnostics/tuning APIs are additive.
+- C++ ABI stability is not guaranteed before v1.0.
+- Python bindings are maintained separately in `unilink-python`.
+
+## Known Limitations
+
+- `SendResult` remains design-only unless explicitly implemented.
+- UDP behavior depends on datagram size, OS buffering, and environment.
+- Some transport internals remain not source-stable before v1.0.
+- Benchmark results should be compared only across controlled environments.
+
+## Validation Checklist
+
+- [ ] Full CI passed
+- [ ] Docs workflow passed
+- [ ] Consumer smoke passed
+- [ ] Release workflow dry-run passed
+- [ ] Package contents smoke passed
+- [ ] Installed consumer smoke passed
+- [ ] Runtime stats tests passed
+- [ ] BestEffort drop accounting tests passed
+- [ ] UDP large-payload tests passed
+
+## Recommended Local Release Validation
+
+```bash
+cmake -S . -B build-v075 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUNILINK_BUILD_TESTS=ON \
+  -DUNILINK_BUILD_DOCS=OFF \
+  -DUNILINK_ENABLE_INSTALL=ON \
+  -DUNILINK_ENABLE_PKGCONFIG=ON \
+  -DUNILINK_ENABLE_EXPORT_HEADER=ON
+
+cmake --build build-v075 --parallel
+ctest --test-dir build-v075 --output-on-failure
+
+cmake --build build-v075 --target doc_snippets_smoke --parallel
+ctest --test-dir build-v075 --output-on-failure -L docs_snippets
+
+scripts/verify_installed_consumer.sh --library-mode shared
+scripts/verify_installed_consumer.sh --library-mode static
+```
+
+For resource-constrained environments, prefer serialized test execution:
+
+```bash
+ctest --test-dir build-v075 --output-on-failure -j1
+```
+
+## Release Workflow Dry Run
+
+Use the release workflow dry-run before creating the final tag:
+
+```text
+Actions -> Release -> Run workflow
+tag_name: v0.7.5-test
+upload: false
+```

--- a/docs/user/api_stability.md
+++ b/docs/user/api_stability.md
@@ -40,6 +40,8 @@ The following diagnostics type is user-facing:
 
 - `unilink::RuntimeStats`
 
+Runtime statistics APIs are user-facing diagnostics APIs.
+
 ## Supported But Advanced Headers
 
 These headers are supported, but most users should prefer including `<unilink/unilink.hpp>`:
@@ -113,3 +115,5 @@ Direct builder or wrapper includes are supported for advanced users, but the umb
 Move/shared buffer send APIs are user-facing advanced APIs intended for large binary payloads.
 
 Socket tuning builder options are user-facing advanced APIs intended for workload-specific latency, throughput, and tail-behavior tuning.
+
+`SendResult` is currently design-only and is not part of the public runtime API unless implemented in the release line.


### PR DESCRIPTION
## Summary

This PR prepares the core repository for the v0.7.5 release.

- Bumps project version to 0.7.5
- Adds CHANGELOG.md with the v0.7.5 release summary
- Adds a v0.7.5 release notes draft
- Updates the release checklist for runtime stats, BestEffort drop accounting, UDP large-payload tests, and transport matrix validation
- Verifies API stability and transport matrix docs reflect the current public surface

## Rationale

v0.7.5 is intended as a performance-readiness stabilization release. It collects the runtime observability, BestEffort accounting, UDP large-payload validation, move/shared send, socket tuning, and documentation work completed after v0.7.4.

Benchmark result numbers remain in the benchmark repository. The core release notes describe API and behavior changes, not hardware-specific performance results.

## Test

Documentation/release-prep change.

```bash
git diff --check
rg -n "0\\.7\\.5" CMakeLists.txt CHANGELOG.md docs/contributor/releases/v0.7.5.md
rg -n "VERSION 0\\.7" CMakeLists.txt
rg -n "0\\.7\\.4" CMakeLists.txt docs/user docs/contributor
```

`0.7.4` grep returned no matches in release-facing version/docs paths.

Recommended release validation before tagging:

```bash
cmake -S . -B build-v075 \
  -DCMAKE_BUILD_TYPE=Release \
  -DUNILINK_BUILD_TESTS=ON \
  -DUNILINK_BUILD_DOCS=OFF \
  -DUNILINK_ENABLE_INSTALL=ON \
  -DUNILINK_ENABLE_PKGCONFIG=ON \
  -DUNILINK_ENABLE_EXPORT_HEADER=ON

cmake --build build-v075 --parallel
ctest --test-dir build-v075 --output-on-failure
scripts/verify_installed_consumer.sh --library-mode shared
scripts/verify_installed_consumer.sh --library-mode static
```
