### PR TITLE
test: investigate udp large-payload receive path

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -105,6 +105,13 @@ foreach(
   )
 endforeach()
 
+unilink_add_integration_gtest(
+  run_integration_udp_large_payload_receive
+  ${CMAKE_CURRENT_SOURCE_DIR}/wrapper/test_udp_large_payload_receive.cc
+  "integration_udp_large_payload_diagnostic" 60
+  "tcp_port_allocation"
+)
+
 # Transport real-I/O integration tests
 foreach(
   test_file
@@ -141,6 +148,13 @@ foreach(
     "${resource_lock}"
   )
 endforeach()
+
+unilink_add_integration_gtest(
+  run_integration_udp_large_payload_transport
+  ${CMAKE_CURRENT_SOURCE_DIR}/transport/test_udp_large_payload_transport.cc
+  "integration_udp_large_payload_diagnostic" 60
+  "tcp_port_allocation"
+)
 
 unilink_add_integration_gtest(
   run_integration_test_contract_compliance

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -108,8 +108,7 @@ endforeach()
 unilink_add_integration_gtest(
   run_integration_udp_large_payload_receive
   ${CMAKE_CURRENT_SOURCE_DIR}/wrapper/test_udp_large_payload_receive.cc
-  "integration_udp_large_payload_diagnostic" 60
-  "tcp_port_allocation"
+  "integration_udp_large_payload_diagnostic" 60 "tcp_port_allocation"
 )
 
 # Transport real-I/O integration tests
@@ -152,8 +151,7 @@ endforeach()
 unilink_add_integration_gtest(
   run_integration_udp_large_payload_transport
   ${CMAKE_CURRENT_SOURCE_DIR}/transport/test_udp_large_payload_transport.cc
-  "integration_udp_large_payload_diagnostic" 60
-  "tcp_port_allocation"
+  "integration_udp_large_payload_diagnostic" 60 "tcp_port_allocation"
 )
 
 unilink_add_integration_gtest(

--- a/test/integration/transport/test_udp_large_payload_transport.cc
+++ b/test/integration/transport/test_udp_large_payload_transport.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <future>
+#include <mutex>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "unilink/base/constants.hpp"
+#include "unilink/config/udp_config.hpp"
+#include "unilink/memory/safe_span.hpp"
+#include "unilink/transport/udp/udp.hpp"
+
+namespace unilink {
+namespace test {
+namespace {
+
+using unilink::base::constants::BackpressureStrategy;
+using namespace std::chrono_literals;
+namespace net = boost::asio;
+using udp = net::ip::udp;
+
+constexpr size_t kControlPayloadSize = 1024;
+
+struct UdpLargePayloadTransportParam {
+  size_t payload_size;
+  BackpressureStrategy strategy;
+};
+
+struct ReceiveState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::vector<uint8_t> received;
+  udp::endpoint sender;
+  bool ready = false;
+};
+
+uint16_t allocate_udp_port() {
+  net::io_context ioc;
+  udp::socket socket(ioc);
+  socket.open(udp::v4());
+  socket.bind({net::ip::address_v4::loopback(), 0});
+  const auto port = socket.local_endpoint().port();
+  socket.close();
+  return port;
+}
+
+std::vector<uint8_t> make_payload(size_t size, uint64_t seed) {
+  std::vector<uint8_t> payload(size);
+  for (size_t i = 0; i < size; ++i) {
+    payload[i] = static_cast<uint8_t>((i * 131 + seed * 17) & 0xFF);
+  }
+  return payload;
+}
+
+bool wait_for_receive(ReceiveState& state, std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(state.mutex);
+  return state.cv.wait_for(lock, timeout, [&] { return state.ready; });
+}
+
+bool large_payload_diagnostics_enabled() {
+  const char* value = std::getenv("UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS");
+  return value != nullptr && std::string_view(value) == "1";
+}
+
+std::string strategy_name(BackpressureStrategy strategy) {
+  switch (strategy) {
+    case BackpressureStrategy::Reliable:
+      return "Reliable";
+    case BackpressureStrategy::BestEffort:
+      return "BestEffort";
+  }
+  return "Unknown";
+}
+
+void PrintTo(const UdpLargePayloadTransportParam& param, std::ostream* os) {
+  *os << strategy_name(param.strategy) << "_" << param.payload_size << "Bytes";
+}
+
+std::string test_param_name(const ::testing::TestParamInfo<UdpLargePayloadTransportParam>& info) {
+  return strategy_name(info.param.strategy) + "_" + std::to_string(info.param.payload_size) + "Bytes";
+}
+
+std::string format_stats(const char* label, const wrapper::RuntimeStats& stats) {
+  std::ostringstream out;
+  out << label << "{accepted=" << stats.messages_accepted << "/" << stats.bytes_accepted
+      << ", sent=" << stats.messages_sent << "/" << stats.bytes_sent << ", received=" << stats.messages_received << "/"
+      << stats.bytes_received << ", failed_sends=" << stats.failed_sends << ", dropped=" << stats.dropped_messages
+      << "/" << stats.dropped_bytes << ", queued=" << stats.queued_bytes << ", pending=" << stats.pending_bytes << "}";
+  return out.str();
+}
+
+config::UdpConfig make_receiver_config(uint16_t port, BackpressureStrategy strategy) {
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = port;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+}  // namespace
+
+class UdpLargePayloadTransportTest : public ::testing::TestWithParam<UdpLargePayloadTransportParam> {};
+
+TEST_P(UdpLargePayloadTransportTest, RawDatagramReachesUdpChannel) {
+  const auto param = GetParam();
+  if (param.payload_size > kControlPayloadSize && !large_payload_diagnostics_enabled()) {
+    GTEST_SKIP() << "set UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS=1 to run large UDP payload diagnostics";
+  }
+
+  const auto payload = make_payload(param.payload_size, 7);
+  const auto port = allocate_udp_port();
+  auto receiver = transport::UdpChannel::create(make_receiver_config(port, param.strategy));
+  ReceiveState state;
+  std::atomic<bool> ready{false};
+
+  receiver->on_state([&](base::LinkState link_state) {
+    if (link_state == base::LinkState::Listening || link_state == base::LinkState::Connected) {
+      ready = true;
+    }
+  });
+  receiver->on_bytes_from([&](memory::ConstByteSpan data, const udp::endpoint& sender) {
+    std::vector<uint8_t> copy(data.begin(), data.end());
+    {
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.received = std::move(copy);
+      state.sender = sender;
+      state.ready = true;
+    }
+    state.cv.notify_one();
+  });
+
+  receiver->start();
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return ready.load(); }, 1000));
+
+  net::io_context ioc;
+  udp::socket sender(ioc, udp::endpoint(udp::v4(), 0));
+  sender.send_to(net::buffer(payload), udp::endpoint(net::ip::make_address("127.0.0.1"), port));
+
+  const bool received = wait_for_receive(state, 3s);
+  const auto receiver_stats = receiver->stats();
+  ASSERT_TRUE(received) << format_stats("receiver", receiver_stats);
+
+  std::vector<uint8_t> actual;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    actual = state.received;
+  }
+
+  EXPECT_EQ(actual, payload);
+  EXPECT_GE(receiver_stats.messages_received, 1u);
+  EXPECT_GE(receiver_stats.bytes_received, payload.size());
+
+  receiver->stop();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllStrategiesAndPayloads, UdpLargePayloadTransportTest,
+    ::testing::Values(UdpLargePayloadTransportParam{kControlPayloadSize, BackpressureStrategy::Reliable},
+                      UdpLargePayloadTransportParam{4096, BackpressureStrategy::Reliable},
+                      UdpLargePayloadTransportParam{16384, BackpressureStrategy::Reliable},
+                      UdpLargePayloadTransportParam{kControlPayloadSize, BackpressureStrategy::BestEffort},
+                      UdpLargePayloadTransportParam{4096, BackpressureStrategy::BestEffort},
+                      UdpLargePayloadTransportParam{16384, BackpressureStrategy::BestEffort}),
+    test_param_name);
+
+}  // namespace test
+}  // namespace unilink

--- a/test/integration/wrapper/test_udp_large_payload_receive.cc
+++ b/test/integration/wrapper/test_udp_large_payload_receive.cc
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <future>
+#include <mutex>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "unilink/base/constants.hpp"
+#include "unilink/config/udp_config.hpp"
+#include "unilink/wrapper/udp/udp.hpp"
+#include "unilink/wrapper/udp/udp_server.hpp"
+
+namespace unilink {
+namespace test {
+namespace {
+
+using unilink::base::constants::BackpressureStrategy;
+using namespace std::chrono_literals;
+
+constexpr size_t kControlPayloadSize = 1024;
+
+struct UdpLargePayloadParam {
+  size_t payload_size;
+  BackpressureStrategy strategy;
+};
+
+struct ReceiveState {
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::vector<uint8_t> received;
+  ClientId client_id = 0;
+  bool ready = false;
+};
+
+uint16_t allocate_udp_port() {
+  boost::asio::io_context ioc;
+  boost::asio::ip::udp::socket socket(ioc);
+  socket.open(boost::asio::ip::udp::v4());
+  socket.bind({boost::asio::ip::address_v4::loopback(), 0});
+  const auto port = socket.local_endpoint().port();
+  socket.close();
+  return port;
+}
+
+std::vector<uint8_t> make_payload(size_t size, uint64_t seed) {
+  std::vector<uint8_t> payload(size);
+  for (size_t i = 0; i < size; ++i) {
+    payload[i] = static_cast<uint8_t>((i * 131 + seed * 17) & 0xFF);
+  }
+  return payload;
+}
+
+bool wait_for_receive(ReceiveState& state, std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(state.mutex);
+  return state.cv.wait_for(lock, timeout, [&] { return state.ready; });
+}
+
+bool wait_for_start(std::future<bool>& started, std::chrono::milliseconds timeout) {
+  if (started.wait_for(timeout) != std::future_status::ready) {
+    return false;
+  }
+  return started.get();
+}
+
+bool large_payload_diagnostics_enabled() {
+  const char* value = std::getenv("UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS");
+  return value != nullptr && std::string_view(value) == "1";
+}
+
+std::string strategy_name(BackpressureStrategy strategy) {
+  switch (strategy) {
+    case BackpressureStrategy::Reliable:
+      return "Reliable";
+    case BackpressureStrategy::BestEffort:
+      return "BestEffort";
+  }
+  return "Unknown";
+}
+
+void PrintTo(const UdpLargePayloadParam& param, std::ostream* os) {
+  *os << strategy_name(param.strategy) << "_" << param.payload_size << "Bytes";
+}
+
+std::string test_param_name(const ::testing::TestParamInfo<UdpLargePayloadParam>& info) {
+  return strategy_name(info.param.strategy) + "_" + std::to_string(info.param.payload_size) + "Bytes";
+}
+
+std::string format_stats(const char* label, const wrapper::RuntimeStats& stats) {
+  std::ostringstream out;
+  out << label << "{accepted=" << stats.messages_accepted << "/" << stats.bytes_accepted
+      << ", sent=" << stats.messages_sent << "/" << stats.bytes_sent << ", received=" << stats.messages_received << "/"
+      << stats.bytes_received << ", failed_sends=" << stats.failed_sends << ", dropped=" << stats.dropped_messages
+      << "/" << stats.dropped_bytes << ", queued=" << stats.queued_bytes << ", pending=" << stats.pending_bytes << "}";
+  return out.str();
+}
+
+config::UdpConfig make_server_config(uint16_t port, BackpressureStrategy strategy) {
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = port;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+config::UdpConfig make_client_config(uint16_t port, BackpressureStrategy strategy) {
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = 0;
+  cfg.remote_address = "127.0.0.1";
+  cfg.remote_port = port;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+std::string_view payload_view(const std::vector<uint8_t>& payload) {
+  return std::string_view(reinterpret_cast<const char*>(payload.data()), payload.size());
+}
+
+}  // namespace
+
+class UdpLargePayloadReceiveTest : public ::testing::TestWithParam<UdpLargePayloadParam> {};
+
+TEST_P(UdpLargePayloadReceiveTest, ClientToServerPayloadArrives) {
+  const auto param = GetParam();
+  if (param.payload_size > kControlPayloadSize && !large_payload_diagnostics_enabled()) {
+    GTEST_SKIP() << "set UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS=1 to run large UDP payload diagnostics";
+  }
+
+  const auto payload = make_payload(param.payload_size, 42);
+  const auto port = allocate_udp_port();
+  ReceiveState state;
+
+  wrapper::UdpServer server(make_server_config(port, param.strategy));
+  server.on_data([&](const wrapper::MessageContext& ctx) {
+    auto data = ctx.data_as_vector();
+    {
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.received = std::move(data);
+      state.client_id = ctx.client_id();
+      state.ready = true;
+    }
+    state.cv.notify_one();
+  });
+
+  auto server_started = server.start();
+  ASSERT_TRUE(wait_for_start(server_started, 2s));
+
+  wrapper::UdpClient client(make_client_config(port, param.strategy));
+  auto client_started = client.start();
+  ASSERT_TRUE(wait_for_start(client_started, 2s));
+
+  ASSERT_TRUE(client.send_blocking(payload_view(payload)));
+
+  const bool received = wait_for_receive(state, 3s);
+  const auto client_stats = client.stats();
+  const auto server_stats = server.stats();
+  ASSERT_TRUE(received) << format_stats("client", client_stats) << " " << format_stats("server", server_stats);
+
+  std::vector<uint8_t> actual;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    actual = state.received;
+  }
+
+  EXPECT_EQ(actual, payload);
+  EXPECT_EQ(client_stats.failed_sends, 0u);
+  EXPECT_EQ(client_stats.dropped_messages, 0u);
+  EXPECT_GE(server_stats.messages_received, 1u);
+  EXPECT_GE(server_stats.bytes_received, payload.size());
+
+  client.stop();
+  server.stop();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllStrategiesAndPayloads, UdpLargePayloadReceiveTest,
+                         ::testing::Values(UdpLargePayloadParam{kControlPayloadSize, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{4096, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{16384, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{kControlPayloadSize, BackpressureStrategy::BestEffort},
+                                           UdpLargePayloadParam{4096, BackpressureStrategy::BestEffort},
+                                           UdpLargePayloadParam{16384, BackpressureStrategy::BestEffort}),
+                         test_param_name);
+
+class UdpLargePayloadEchoTest : public ::testing::TestWithParam<UdpLargePayloadParam> {};
+
+TEST_P(UdpLargePayloadEchoTest, ServerEchoReturnsPayloadToClient) {
+  const auto param = GetParam();
+  if (param.payload_size > kControlPayloadSize && !large_payload_diagnostics_enabled()) {
+    GTEST_SKIP() << "set UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS=1 to run large UDP payload diagnostics";
+  }
+
+  const auto payload = make_payload(param.payload_size, 99);
+  const auto port = allocate_udp_port();
+  ReceiveState server_state;
+  ReceiveState client_state;
+
+  wrapper::UdpServer server(make_server_config(port, param.strategy));
+  server.on_data([&](const wrapper::MessageContext& ctx) {
+    auto data = ctx.data_as_vector();
+    {
+      std::lock_guard<std::mutex> lock(server_state.mutex);
+      server_state.received = data;
+      server_state.client_id = ctx.client_id();
+      server_state.ready = true;
+    }
+    server_state.cv.notify_one();
+    const std::string_view echo_view(reinterpret_cast<const char*>(data.data()), data.size());
+    (void)server.send_to(ctx.client_id(), echo_view);
+  });
+
+  auto server_started = server.start();
+  ASSERT_TRUE(wait_for_start(server_started, 2s));
+
+  wrapper::UdpClient client(make_client_config(port, param.strategy));
+  client.on_data([&](const wrapper::MessageContext& ctx) {
+    auto data = ctx.data_as_vector();
+    {
+      std::lock_guard<std::mutex> lock(client_state.mutex);
+      client_state.received = std::move(data);
+      client_state.ready = true;
+    }
+    client_state.cv.notify_one();
+  });
+
+  auto client_started = client.start();
+  ASSERT_TRUE(wait_for_start(client_started, 2s));
+
+  ASSERT_TRUE(client.send_blocking(payload_view(payload)));
+
+  const bool server_received = wait_for_receive(server_state, 3s);
+  auto client_stats = client.stats();
+  auto server_stats = server.stats();
+  ASSERT_TRUE(server_received) << format_stats("client", client_stats) << " " << format_stats("server", server_stats);
+
+  const bool client_received = wait_for_receive(client_state, 3s);
+  client_stats = client.stats();
+  server_stats = server.stats();
+  ASSERT_TRUE(client_received) << format_stats("client", client_stats) << " " << format_stats("server", server_stats);
+
+  std::vector<uint8_t> server_actual;
+  std::vector<uint8_t> client_actual;
+  {
+    std::lock_guard<std::mutex> lock(server_state.mutex);
+    server_actual = server_state.received;
+  }
+  {
+    std::lock_guard<std::mutex> lock(client_state.mutex);
+    client_actual = client_state.received;
+  }
+
+  EXPECT_EQ(server_actual, payload);
+  EXPECT_EQ(client_actual, payload);
+  EXPECT_EQ(client_stats.failed_sends, 0u);
+  EXPECT_EQ(client_stats.dropped_messages, 0u);
+  EXPECT_GE(client_stats.messages_received, 1u);
+  EXPECT_GE(client_stats.bytes_received, payload.size());
+  EXPECT_GE(server_stats.messages_received, 1u);
+  EXPECT_GE(server_stats.bytes_received, payload.size());
+
+  client.stop();
+  server.stop();
+}
+
+INSTANTIATE_TEST_SUITE_P(AllStrategiesAndPayloads, UdpLargePayloadEchoTest,
+                         ::testing::Values(UdpLargePayloadParam{kControlPayloadSize, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{4096, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{16384, BackpressureStrategy::Reliable},
+                                           UdpLargePayloadParam{kControlPayloadSize, BackpressureStrategy::BestEffort},
+                                           UdpLargePayloadParam{4096, BackpressureStrategy::BestEffort},
+                                           UdpLargePayloadParam{16384, BackpressureStrategy::BestEffort}),
+                         test_param_name);
+
+}  // namespace test
+}  // namespace unilink


### PR DESCRIPTION
## Summary

This PR adds diagnostic integration tests for UDP large-payload receive behavior.

- Adds UDP 1024-byte control receive tests
- Adds UDP 4096 / 16384 opt-in diagnostic receive tests
- Covers Reliable and BestEffort strategies
- Separates wrapper-level receive/echo behavior from transport-level receive behavior
- Records RuntimeStats sanity checks in success and failure output

## Rationale

v0.7.5 benchmark results showed that UDP 1024-byte payloads echo successfully, while 4096/16384-byte payloads are accepted by the client but not observed by the server in the WSL2 benchmark environment.

This PR adds core-side diagnostic tests to determine whether the behavior is a core UDP path issue, benchmark-model issue, or environment-specific issue. Large-payload cases are present but skipped by default unless `UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS=1` is set, so default CI is not broken by known diagnostic failures.

## Tests

```bash
cmake -S . -B build-udp-large \
  -DCMAKE_BUILD_TYPE=Debug \
  -DUNILINK_BUILD_TESTS=ON \
  -DUNILINK_BUILD_DOCS=OFF

cmake --build build-udp-large \
  --target run_integration_udp_large_payload_receive run_integration_udp_large_payload_transport \
  --parallel

ctest --test-dir build-udp-large \
  --output-on-failure \
  -L integration_udp_large_payload \
  -j1
```

Default diagnostic label run:

- Passed: 1024-byte wrapper receive, wrapper echo, and transport receive for Reliable and BestEffort
- Skipped by default: 4096 / 16384 diagnostic cases

Opt-in diagnostic run:

```bash
UNILINK_RUN_UDP_LARGE_PAYLOAD_DIAGNOSTICS=1 \
  ctest --test-dir build-udp-large \
  --output-on-failure \
  -L integration_udp_large_payload \
  -j1
```

Observed locally:

- 1024-byte cases passed
- 4096 / 16384 wrapper receive cases failed for Reliable and BestEffort
- 4096 / 16384 wrapper echo cases failed before echo because server receive did not occur
- 4096 / 16384 transport receive cases also failed for Reliable and BestEffort

Failure stats showed client sends accepted/sent with `failed_sends=0` and `dropped_messages=0`, while the server/receiver stayed at `messages_received=0` and `bytes_received=0`.

## Classification

`transport-level failure`

The large-payload failure is not isolated to `UdpClient` / `UdpServer` wrapper endpoint mapping or echo behavior because the raw datagram to `UdpChannel` diagnostic also fails with zero received messages/bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for UDP large payload handling, validating transmission and reception across multiple backpressure strategies and payload sizes (up to 16KB).
  * Tests verify payload integrity, receiver connectivity, and successful message delivery statistics.
  * Large payload tests gated behind optional environment variable for diagnostic purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jwsung91/unilink/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->