### PR TITLE
Restore minimal core documentation entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Full documentation is maintained in the unilink documentation repository:
 
 https://github.com/unilink-lab/unilink-docs
 
+Core repository entrypoints:
+
+* [Quick Start](docs/quickstart.md)
+* [Installation](docs/installation.md)
+* [API Stability Summary](docs/api_stability.md)
+* [Release Checklist](docs/release_checklist.md)
+
 Useful external repositories:
 
 * [Python bindings](https://github.com/unilink-lab/unilink-python)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,20 @@
-# Documentation moved
+# unilink Core Documentation
 
-The full unilink documentation is maintained in:
+Full documentation is maintained in:
 
 https://github.com/unilink-lab/unilink-docs
+
+This core repository keeps only minimal documentation entrypoints needed for
+source users, package consumers, and release maintainers.
+
+## Core entrypoints
+
+- [Quick Start](quickstart.md)
+- [Installation](installation.md)
+- [API Stability Summary](api_stability.md)
+- [Release Checklist](release_checklist.md)
+
+## Canonical documentation
+
+Use `unilink-docs` for complete user guides, contributor guides, architecture
+notes, Doxygen API reference, tutorials, and design documents.

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -1,0 +1,45 @@
+# API Stability Summary
+
+Full policy:
+
+https://github.com/unilink-lab/unilink-docs/blob/main/docs/user/api_stability.md
+
+## Summary
+
+`unilink` is currently pre-1.0.
+
+## Stable user-facing surface
+
+Prefer:
+
+```cpp
+#include <unilink/unilink.hpp>
+```
+
+User-facing APIs include:
+
+- builders and wrappers
+- `RuntimeStats`
+- `send(...)`, `try_send(...)`
+- `send_move(...)`, `try_send_move(...)`
+- `send_shared(...)`, `try_send_shared(...)`
+- TCP/UDP socket tuning builder options
+
+## ABI
+
+C++ ABI stability is not guaranteed before v1.0.
+
+## Diagnostics
+
+`RuntimeStats` is a user-facing diagnostics snapshot. It is not a
+synchronization primitive.
+
+## Design-only APIs
+
+`SendResult` is currently design-only unless explicitly implemented in a future
+release. It is not part of the runtime API in the current release line.
+
+## Internal headers
+
+Headers under implementation/internal namespaces may change without
+compatibility guarantees before v1.0.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+Full installation guide:
+
+https://github.com/unilink-lab/unilink-docs/blob/main/docs/user/installation.md
+
+## Requirements
+
+- C++20 compiler
+- CMake 3.12+ for plain builds
+- CMake 3.21+ for repository presets
+- Boost 1.83.0+
+- spdlog dependency according to build configuration
+
+vcpkg is the recommended dependency supplier. CMake owns the dependency version
+gate and rejects Boost versions older than the configured minimum.
+
+## vcpkg
+
+```bash
+vcpkg install jwsung91-unilink
+```
+
+## Minimal CMake consumer
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_app LANGUAGES CXX)
+
+find_package(unilink CONFIG REQUIRED)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE unilink::unilink)
+target_compile_features(my_app PRIVATE cxx_std_20)
+```
+
+## Include
+
+```cpp
+#include <unilink/unilink.hpp>
+```
+
+## Source build
+
+```bash
+git clone https://github.com/jwsung91/unilink.git
+cd unilink
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+sudo cmake --install build
+```
+
+For Ubuntu 22.04 or other platforms where system Boost is older than the
+required minimum, use vcpkg or provide a newer Boost installation through the
+CMake prefix/toolchain.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,39 @@
+# Quick Start
+
+Full quickstart and tutorials:
+
+https://github.com/unilink-lab/unilink-docs
+
+## Minimal TCP client
+
+```cpp
+#include <iostream>
+#include <unilink/unilink.hpp>
+
+int main() {
+    auto client = unilink::tcp_client("127.0.0.1", 8080)
+        .on_data([](const unilink::MessageContext& ctx) {
+            std::cout << "received " << ctx.data().size() << " bytes\n";
+        })
+        .on_error([](const unilink::ErrorContext& ctx) {
+            std::cerr << "error: " << ctx.message() << "\n";
+        })
+        .build();
+
+    if (!client->start_sync()) {
+        return 1;
+    }
+
+    client->send("hello");
+    client->stop();
+    return 0;
+}
+```
+
+## Notes
+
+- Callbacks are optional for construction.
+- `on_error(...)` is recommended for production workflows.
+- `ctx.data()` is a callback-scoped view. Copy data if it must outlive the callback.
+- Use `try_send(...)` for non-blocking producer loops.
+- Use `RuntimeStats` for diagnostics and queue/drop visibility.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,61 @@
+# Release Checklist
+
+This checklist is maintained in the core repository because release packaging,
+CI, CPack, and consumer smoke workflows live here.
+
+## Version
+
+- [ ] `CMakeLists.txt` project version is updated.
+- [ ] Release tag matches the project version.
+- [ ] README version-sensitive examples are still valid.
+
+## Build and test
+
+- [ ] Full CI passed.
+- [ ] Unit tests passed.
+- [ ] Integration tests passed.
+- [ ] Installed consumer smoke passed for shared mode.
+- [ ] Installed consumer smoke passed for static mode.
+
+## Packaging
+
+- [ ] Release workflow dry-run completed.
+- [ ] CPack package was generated.
+- [ ] Package contains headers.
+- [ ] Package contains library artifacts.
+- [ ] Package contains `unilinkConfig.cmake`.
+- [ ] Package contains `unilinkTargets.cmake`.
+- [ ] Package contains `README.md`.
+- [ ] Package contains `LICENSE`.
+- [ ] Package contains `NOTICE`.
+
+## Documentation
+
+- [ ] Core README links to `unilink-docs`.
+- [ ] Core minimal docs are present:
+  - [ ] `docs/installation.md`
+  - [ ] `docs/quickstart.md`
+  - [ ] `docs/api_stability.md`
+  - [ ] `docs/release_checklist.md`
+- [ ] `unilink-docs` is updated when public API or behavior changes.
+- [ ] Doxygen workflow in `unilink-docs` passes.
+
+## Benchmark / validation
+
+- [ ] Latest relevant benchmark result is preserved in `unilink-benchmarks`.
+- [ ] Known benchmark/environment limitations are documented.
+- [ ] UDP large-payload classification is current.
+- [ ] Orin/WSL2 validation notes are current when relevant.
+
+## External repositories
+
+- [ ] `unilink-python` compatibility impact checked.
+- [ ] `unilink-examples` compatibility impact checked, if examples depend on changed API.
+- [ ] `unilink-benchmarks` compatibility impact checked, if benchmark APIs changed.
+
+## Release notes
+
+- [ ] Release notes summarize user-facing changes.
+- [ ] Breaking changes are explicitly marked.
+- [ ] Known limitations are included.
+- [ ] ABI stability disclaimer is included if pre-1.0.


### PR DESCRIPTION
## Description
This PR restores minimal documentation entrypoints in the core repository after the documentation split.

The full documentation and Doxygen API reference remain canonical in `unilink-docs`, while the core repository keeps thin entrypoints for source users, package consumers, and release maintainers.

## Key Changes
- Adds `docs/installation.md` with requirements, vcpkg install, minimal CMake consumer usage, include guidance, and source build notes.
- Adds `docs/quickstart.md` with a minimal TCP client example aligned with the public umbrella header API.
- Adds `docs/api_stability.md` summarizing the pre-1.0 API/ABI stability expectations.
- Adds `docs/release_checklist.md` for release packaging, CI, documentation, benchmark, and external repository checks.
- Expands `docs/README.md` into a minimal documentation index.
- Updates the root README documentation section with core entrypoint links.

## Related Issues
- N/A

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Validation run:

```bash
git diff --check origin/main...HEAD
grep -RIn "unilink-lab/unilink-docs" README.md docs
test -f docs/installation.md
test -f docs/quickstart.md
test -f docs/api_stability.md
test -f docs/release_checklist.md
rg -n "[ \\t]+$" README.md docs/*.md
git diff --name-only origin/main...HEAD
```

Full CMake build, ctest, and packaging smoke were not run locally because this is a documentation-only change and the local environment is known to be unstable under heavier builds. No C++ code, Doxygen workflow, CMake packaging rules, or benchmark repository files were changed.