### PR TITLE
Polish documentation entrypoints after docs split

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,20 @@ target_compile_features(my_app PRIVATE cxx_std_20)
 
 ## Source build example
 
+Source builds require Boost 1.83.0+. Ubuntu 22.04 and 24.04 system Boost
+packages may be older than this baseline, so prefer the repository development
+setup or provide Boost through vcpkg/custom CMake prefixes before configuring.
+
+For contributor/source builds with the repository-managed vcpkg checkout:
+
+```bash
+./scripts/setup_dev_env.sh
+cmake --preset dev-linux-x64
+cmake --build --preset dev-linux-x64 --parallel 1
+```
+
+For a plain source install with an existing dependency setup:
+
 ```bash
 git clone https://github.com/jwsung91/unilink.git
 cd unilink
@@ -49,7 +63,3 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel 1
 sudo cmake --install build
 ```
-
-For Ubuntu 22.04 or other platforms where system Boost is older than the
-required minimum, use vcpkg or provide a newer Boost installation through the
-CMake prefix/toolchain.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,26 @@ Full quickstart and tutorials:
 
 https://github.com/unilink-lab/unilink-docs
 
+## Minimal CMake
+
+Create `CMakeLists.txt` next to `main.cpp`:
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(unilink_quickstart LANGUAGES CXX)
+
+find_package(unilink CONFIG REQUIRED)
+
+add_executable(unilink_quickstart main.cpp)
+target_link_libraries(unilink_quickstart PRIVATE unilink::unilink)
+target_compile_features(unilink_quickstart PRIVATE cxx_std_20)
+```
+
 ## Minimal TCP client
+
+This client expects a TCP server to be listening on `127.0.0.1:8080`.
+For a runnable client/server pair, see the full tutorials in
+`unilink-docs`.
 
 ```cpp
 #include <iostream>


### PR DESCRIPTION
## Summary

This PR improves the minimal core documentation entrypoints after the docs split.

- Adds a minimal CMake snippet to `docs/quickstart.md`
- Notes that the TCP quickstart client expects a server on `127.0.0.1:8080`
- Moves the source-build Boost warning before the build commands
- Adds the repository-managed `setup_dev_env.sh` source-build path with `--parallel 1`

## Rationale

The core repository should stay lightweight, but first-time users need enough information to understand whether the quickstart can run as-is and which source-build path is least likely to fail on systems with older Boost packages.

## Non-goals

- Do not restore full docs to core.
- Do not move Doxygen back to core.
- Do not change C++ code or packaging rules.

## Validation

- `git diff --check`
- `git diff --check origin/main...HEAD`

CMake configure/build/test was not run because this is a documentation-only PR.