### PR TITLE
Fix core documentation links after docs split

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ https://github.com/unilink-lab/unilink-docs
 
 Core repository entrypoints:
 
-- [Quick Start](docs/quickstart.md)
-- [Installation](docs/installation.md)
-- [API Stability Summary](docs/api_stability.md)
-- [Release Checklist](docs/release_checklist.md)
+- [Quick Start](https://github.com/jwsung91/unilink/blob/main/docs/quickstart.md)
+- [Installation](https://github.com/jwsung91/unilink/blob/main/docs/installation.md)
+- [API Stability Summary](https://github.com/jwsung91/unilink/blob/main/docs/api_stability.md)
+- [Release Checklist](https://github.com/jwsung91/unilink/blob/main/docs/release_checklist.md)
 
 Useful external repositories:
 


### PR DESCRIPTION
## Summary

This PR fixes core documentation entrypoint links after the documentation split.

- Changes core docs links in README to GitHub absolute URLs
- Keeps minimal core docs in the repository
- Avoids broken README links in release packages
- Leaves CPack documentation packaging unchanged

## Rationale

The core repository now keeps only minimal documentation entrypoints while full documentation lives in `unilink-docs`. The release package installs README, LICENSE, and NOTICE, but not the `docs/*.md` files. Absolute GitHub links keep README documentation links valid both on GitHub and inside release packages.

## Test

```bash
git diff --check
grep -RIn "https://github.com/jwsung91/unilink/blob/main/docs" README.md
grep -RIn "(docs/quickstart.md)" README.md
cmake -S . -B build-doc-link-check -DCMAKE_BUILD_TYPE=Debug -DUNILINK_BUILD_TESTS=OFF -DUNILINK_BUILD_DOCS=OFF
cmake --build build-doc-link-check --parallel 1
```

The relative-link grep returned no matches, as expected. Packaging rules were not changed.