### PR TITLE
Stabilize send/try_send and broadcast contracts for v1.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,37 +33,24 @@ jobs:
           cmake -S . -B build-benchmark -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DUNILINK_BUILD_TESTS=ON \
+            -DUNILINK_ENABLE_INSTALL=ON \
             -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
             -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
 
       - name: Build benchmark inputs
         run: cmake --build build-benchmark --parallel
 
+      - name: Install benchmark package
+        run: cmake --install build-benchmark --prefix build-benchmark-install
+
       - name: Run benchmark soft gate
         run: |
           set -euo pipefail
           mkdir -p benchmark-artifacts
-
-          if [ -x scripts/run_benchmarks.sh ]; then
-            scripts/run_benchmarks.sh \
-              --output-json benchmark-artifacts/benchmark-result.json \
-              --output-summary benchmark-artifacts/benchmark-summary.md
-          else
-            cat > benchmark-artifacts/benchmark-result.json <<EOF
-          {
-            "status": "not_configured",
-            "message": "No scripts/run_benchmarks.sh harness is present in the core repository.",
-            "soft_gate": true
-          }
-          EOF
-            cat > benchmark-artifacts/benchmark-summary.md <<'EOF'
-          # Benchmark Summary
-
-          Benchmark workflow ran successfully, but no core benchmark harness was
-          found. Add `scripts/run_benchmarks.sh` to produce release-comparable
-          latency, throughput, queue, and allocation metrics.
-          EOF
-          fi
+          bash scripts/run_benchmarks.sh \
+            --cmake-prefix "$PWD/build-benchmark-install" \
+            --output-json benchmark-artifacts/benchmark-result.json \
+            --output-summary benchmark-artifacts/benchmark-summary.md
 
       - name: Upload benchmark artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,74 @@
+name: Benchmark
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *"
+
+jobs:
+  benchmark:
+    name: Benchmark soft gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install tools
+        uses: ./.github/actions/apt-install
+        with:
+          packages: "build-essential cmake ninja-build"
+
+      - name: Install dependencies with vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-linux
+
+      - name: Configure release build
+        run: |
+          cmake -S . -B build-benchmark -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DUNILINK_BUILD_TESTS=ON \
+            -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
+            -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
+
+      - name: Build benchmark inputs
+        run: cmake --build build-benchmark --parallel
+
+      - name: Run benchmark soft gate
+        run: |
+          set -euo pipefail
+          mkdir -p benchmark-artifacts
+
+          if [ -x scripts/run_benchmarks.sh ]; then
+            scripts/run_benchmarks.sh \
+              --output-json benchmark-artifacts/benchmark-result.json \
+              --output-summary benchmark-artifacts/benchmark-summary.md
+          else
+            cat > benchmark-artifacts/benchmark-result.json <<EOF
+          {
+            "status": "not_configured",
+            "message": "No scripts/run_benchmarks.sh harness is present in the core repository.",
+            "soft_gate": true
+          }
+          EOF
+            cat > benchmark-artifacts/benchmark-summary.md <<'EOF'
+          # Benchmark Summary
+
+          Benchmark workflow ran successfully, but no core benchmark harness was
+          found. Add `scripts/run_benchmarks.sh` to produce release-comparable
+          latency, throughput, queue, and allocation metrics.
+          EOF
+          fi
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-artifacts
+          path: benchmark-artifacts/
+          retention-days: 30
+          overwrite: true

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,62 @@
+name: ThreadSanitizer
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 19 * * *"
+
+jobs:
+  tsan:
+    name: TSAN focused contract tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install tools
+        uses: ./.github/actions/apt-install
+        with:
+          packages: "build-essential cmake ninja-build clang"
+
+      - name: Install dependencies with vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-linux
+
+      - name: Configure TSAN build
+        run: |
+          cmake -S . -B build-tsan -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DUNILINK_BUILD_TESTS=ON \
+            -DUNILINK_ENABLE_SANITIZERS=ON \
+            -DUNILINK_ENABLE_TSAN=ON \
+            -DUNILINK_ENABLE_ASAN=OFF \
+            -DUNILINK_ENABLE_UBSAN=OFF \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
+            -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
+
+      - name: Build TSAN targets
+        run: cmake --build build-tsan --parallel
+
+      - name: Run focused TSAN tests
+        env:
+          TSAN_OPTIONS: halt_on_error=1 second_deadlock_stack=1 history_size=7
+        run: |
+          ctest --test-dir build-tsan --output-on-failure --parallel 2 \
+            -R "StopContract|StopFromCallback|TcpClientLifecycle|TcpServerWrapperLifecycle|UdsClientWrapperLifecycle|UdsServerWrapperLifecycle|BackpressureStrategyTest|WrapperSendContractTest|ServerBroadcastContractTest"
+
+      - name: Upload TSAN test logs
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: tsan-test-results
+          path: build-tsan/Testing/
+          retention-days: 14
+          overwrite: true

--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -172,17 +172,18 @@ jobs:
           EOF
 
           cat > "${WORKDIR}/main.cpp" <<'EOF'
-          #include <unilink/wrapper/tcp_client/tcp_client.hpp>
+          #include <unilink/unilink.hpp>
           #include <chrono>
           #include <iostream>
 
           int main() {
-            unilink::wrapper::TcpClient client("127.0.0.1", 9000);
-            client.retry_interval(std::chrono::milliseconds(250));
-            client.max_retries(1);
-            client.auto_manage(false);
+            auto client = unilink::tcp_client("127.0.0.1", 9000)
+                .retry_interval(std::chrono::milliseconds(250))
+                .max_retries(1)
+                .auto_start(false)
+                .build();
             std::cout << "unilink vcpkg package loaded" << std::endl;
-            return 0;
+            return client ? 0 : 1;
           }
           EOF
 
@@ -215,17 +216,18 @@ jobs:
           "@ | Set-Content -Path (Join-Path $workDir "CMakeLists.txt")
 
           @"
-          #include <unilink/wrapper/tcp_client/tcp_client.hpp>
+          #include <unilink/unilink.hpp>
           #include <chrono>
           #include <iostream>
 
           int main() {
-            unilink::wrapper::TcpClient client("127.0.0.1", 9000);
-            client.retry_interval(std::chrono::milliseconds(250));
-            client.max_retries(1);
-            client.auto_manage(false);
+            auto client = unilink::tcp_client("127.0.0.1", 9000)
+                .retry_interval(std::chrono::milliseconds(250))
+                .max_retries(1)
+                .auto_start(false)
+                .build();
             std::cout << "unilink vcpkg package loaded" << std::endl;
-            return 0;
+            return client ? 0 : 1;
           }
           "@ | Set-Content -Path (Join-Path $workDir "main.cpp")
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Core repository entrypoints:
 - [Quick Start](https://github.com/jwsung91/unilink/blob/main/docs/quickstart.md)
 - [Installation](https://github.com/jwsung91/unilink/blob/main/docs/installation.md)
 - [API Stability Summary](https://github.com/jwsung91/unilink/blob/main/docs/api_stability.md)
+- [Error Model](https://github.com/jwsung91/unilink/blob/main/docs/error_model.md)
+- [Callback Data Lifetime](https://github.com/jwsung91/unilink/blob/main/docs/callbacks.md)
+- [Performance Validation](https://github.com/jwsung91/unilink/blob/main/docs/performance_validation.md)
 - [Release Checklist](https://github.com/jwsung91/unilink/blob/main/docs/release_checklist.md)
 
 Useful external repositories:

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -20,10 +20,19 @@ User-facing APIs include:
 
 - builders and wrappers
 - `RuntimeStats`
+- `MessageContext`, `ConnectionContext`, `ErrorContext`
 - `send(...)`, `try_send(...)`
 - `send_move(...)`, `try_send_move(...)`
 - `send_shared(...)`, `try_send_shared(...)`
 - TCP/UDP socket tuning builder options
+
+## Supported but pre-1.0 unstable APIs
+
+These APIs are available, but may still change before v1.0:
+
+- framer APIs
+- config APIs
+- diagnostics APIs
 
 ## ABI
 
@@ -44,3 +53,15 @@ release. It is not part of the runtime API in the current release line.
 Internal headers are not part of the compatibility guarantee before v1.0.
 Prefer the public facade and documented wrapper/builder APIs for application
 code.
+
+Compatibility is not guaranteed for deep includes under:
+
+- `transport/*`
+- `interface/*`
+- `memory/*`
+- `concurrency/*`
+- `factory/*`
+
+These headers are installed for implementation and advanced integration needs,
+but application code should include `<unilink/unilink.hpp>` unless a documented
+advanced API requires otherwise.

--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -1,0 +1,29 @@
+# Callback Data Lifetime
+
+`MessageContext::data()` returns a callback-scoped view. The view is valid only
+while the current callback is running.
+
+Use an ownership-copy helper before sending data to another thread, queue,
+coroutine, or longer-lived object.
+
+```cpp
+client->on_data([](const unilink::MessageContext& ctx) {
+    auto owned = ctx.data_as_string();
+    post_to_worker([owned = std::move(owned)] {
+        process(owned);
+    });
+});
+```
+
+Do not store `std::string_view` or spans returned from callback context objects.
+
+```cpp
+client->on_data([](const unilink::MessageContext& ctx) {
+    auto view = ctx.data();
+    post_to_worker([view] {
+        process(view);  // dangling risk
+    });
+});
+```
+
+For binary payloads, use `data_as_vector()` before the callback returns.

--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -1,0 +1,67 @@
+# Error Model
+
+`unilink` reports runtime failures through explicit return values, callbacks,
+and exceptions. The expected path depends on when the failure is detected.
+
+## Lifecycle errors
+
+`start()` returns `std::future<bool>` and `start_sync()` returns `bool`.
+
+- `true`: the channel or server reached its connected/listening state.
+- `false`: startup failed. A registered `on_error(...)` callback receives the
+  specific failure when the implementation can classify it.
+
+`stop()` is idempotent and blocks until pending async operations are cancelled.
+After `stop()` returns, no further callbacks should fire.
+
+## Send errors
+
+`send(...)` follows the configured `BackpressureStrategy`.
+
+- `Reliable`: waits for queue pressure to clear or uses the transport's
+  Reliable pending queue.
+- `BestEffort`: may drop when the queue is full.
+
+`try_send(...)`, `try_send_move(...)`, and `try_send_shared(...)` are always
+non-blocking. They return `false` when the channel is stopped, disconnected,
+backpressured, or full. Reliable `try_send*` calls do not enqueue into pending
+queues.
+
+`send_blocking(...)` waits until queue pressure is relieved, then enqueues using
+the normal strategy-aware write path. It returns `false` if the channel stops
+while waiting or cannot accept the write.
+
+Use `RuntimeStats` to inspect accepted bytes, sent bytes, failed sends, drops,
+queued bytes, pending bytes, and backpressure state.
+
+## Async runtime errors
+
+Use `on_error(...)` for production workflows. `ErrorContext` contains:
+
+- `code()`: structured `ErrorCode`
+- `message()`: diagnostic message
+- `client_id()`: optional server-side client identifier
+
+Transport callbacks may also log internal diagnostic details.
+
+## Validation and configuration errors
+
+Builder and config validation errors may throw `diagnostics::ValidationException`
+or related `diagnostics::UnilinkException` types when invalid input is detected
+synchronously.
+
+Configuration APIs can also return validation results or boolean status where
+the API is designed as a query/update operation.
+
+## Exceptions
+
+Public-facing exceptions should prefer the `diagnostics::UnilinkException`
+hierarchy. Some lower-level utility APIs intentionally preserve standard C++
+exception behavior, such as `std::out_of_range` for bounds-checked access or
+`std::invalid_argument` for invalid memory helper arguments.
+
+## Callback exceptions
+
+Callbacks should not throw. When a callback throws, transports catch the
+exception, log it, and may transition to an error state depending on the
+transport configuration, such as `stop_on_callback_exception`.

--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -60,6 +60,18 @@ hierarchy. Some lower-level utility APIs intentionally preserve standard C++
 exception behavior, such as `std::out_of_range` for bounds-checked access or
 `std::invalid_argument` for invalid memory helper arguments.
 
+Known standard-exception APIs:
+
+- `memory::SafeDataBuffer::operator[]` and `at(...)` throw
+  `std::out_of_range` for invalid indexes.
+- `memory::SafeDataBuffer` raw-pointer constructors throw
+  `std::invalid_argument` for null data with non-zero size or oversize input.
+- `memory::SafeDataBuffer::validate()` throws `std::runtime_error` when the
+  buffer exceeds the configured safety limit.
+- `config::ConfigManager::get(...)` and `get_type(...)` throw
+  `std::runtime_error` when a required key is missing. Use `has(...)`,
+  `get(key, default_value)`, or `validate(key)` when absence is expected.
+
 ## Callback exceptions
 
 Callbacks should not throw. When a callback throws, transports catch the

--- a/docs/performance_validation.md
+++ b/docs/performance_validation.md
@@ -1,0 +1,40 @@
+# Performance Validation
+
+Performance validation for releases should preserve benchmark artifacts that can
+be compared across versions and environments.
+
+## Required measurements
+
+- TCP loopback latency: p50, p95, p99
+- UDS loopback latency: p50, p95, p99
+- UDP latency, loss, and payload-size behavior
+- Throughput by payload size: 64 B, 1 KiB, 16 KiB, 64 KiB, 1 MiB
+- `send` vs `try_send` vs `send_move` vs `send_shared`
+- `Reliable` vs `BestEffort`
+- slow-consumer fan-out behavior
+- queue growth, `pending_bytes`, and `dropped_bytes`
+- callback throughput
+
+## Initial soft gates
+
+Nightly and manual benchmark runs should start as warning-only checks:
+
+- p99 latency regression greater than 30%
+- throughput regression greater than 20%
+- unexpected allocation-count increase
+- unexpected growth in `queued_bytes` or `pending_bytes`
+
+Hard gates should be limited to stable, low-noise checks until v1.0 release
+candidates establish a reliable baseline.
+
+## Artifacts
+
+Benchmark runs should preserve:
+
+- `benchmark-result.json`
+- `benchmark-summary.md`
+- environment metadata: OS, kernel, compiler, Boost version, CPU model, governor,
+  and container/VM status when applicable
+
+Release notes and `docs/release_checklist.md` should link the latest relevant
+benchmark artifact or the corresponding `unilink-benchmarks` result.

--- a/docs/performance_validation.md
+++ b/docs/performance_validation.md
@@ -38,3 +38,10 @@ Benchmark runs should preserve:
 
 Release notes and `docs/release_checklist.md` should link the latest relevant
 benchmark artifact or the corresponding `unilink-benchmarks` result.
+
+`scripts/run_benchmarks.sh` is the core repository's manual/nightly harness. It
+consumes an installed `unilink` package via `--cmake-prefix`, builds a small
+external benchmark consumer, and records TCP loopback latency, payload-size
+throughput, send variant acceptance, and queue snapshot metrics. The benchmark
+workflow runs this harness as a soft gate; compare the generated JSON against
+the current release baseline before promoting any metric to a hard gate.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,3 +56,8 @@ int main() {
 - `ctx.data()` is a callback-scoped view. Copy data if it must outlive the callback.
 - Use `try_send(...)` for non-blocking producer loops.
 - Use `RuntimeStats` for diagnostics and queue/drop visibility.
+
+Related docs:
+
+- [Callback data lifetime](callbacks.md)
+- [Error model](error_model.md)

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -44,6 +44,7 @@ CI, CPack, and consumer smoke workflows live here.
 ## Benchmark / validation
 
 - [ ] Latest relevant benchmark result is preserved in `unilink-benchmarks`.
+- [ ] Latest benchmark artifact or `unilink-benchmarks` result is linked from the release notes.
 - [ ] Benchmark result links were checked.
 - [ ] Known benchmark/environment limitations are documented.
 - [ ] UDP large-payload classification is current.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -45,6 +45,9 @@ CI, CPack, and consumer smoke workflows live here.
 
 - [ ] Latest relevant benchmark result is preserved in `unilink-benchmarks`.
 - [ ] Latest benchmark artifact or `unilink-benchmarks` result is linked from the release notes.
+- [ ] `.github/workflows/benchmark.yml` was run manually or by the latest nightly schedule.
+- [ ] Installed consumer runtime smoke passed for the release candidate package.
+- [ ] Optional TSAN workflow was reviewed or run for concurrency-sensitive changes.
 - [ ] Benchmark result links were checked.
 - [ ] Known benchmark/environment limitations are documented.
 - [ ] UDP large-payload classification is current.

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_JSON="benchmark-result.json"
+OUTPUT_SUMMARY="benchmark-summary.md"
+CMAKE_PREFIX_PATH_VALUE="${CMAKE_PREFIX_PATH:-}"
+CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
+CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run_benchmarks.sh [options]
+
+Options:
+  --output-json PATH       JSON output path
+  --output-summary PATH    Markdown summary output path
+  --cmake-prefix PATH      Installed unilink CMake package prefix
+  --help                   Show this help message
+EOF
+}
+
+require_arg() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "error: $option requires a value" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-json)
+      require_arg "$1" "${2:-}"
+      OUTPUT_JSON="$2"
+      shift 2
+      ;;
+    --output-summary)
+      require_arg "$1" "${2:-}"
+      OUTPUT_SUMMARY="$2"
+      shift 2
+      ;;
+    --cmake-prefix)
+      require_arg "$1" "${2:-}"
+      CMAKE_PREFIX_PATH_VALUE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CMAKE_PREFIX_PATH_VALUE" ]]; then
+  echo "error: --cmake-prefix or CMAKE_PREFIX_PATH is required" >&2
+  exit 1
+fi
+
+OUTPUT_JSON="$(realpath -m "$OUTPUT_JSON")"
+OUTPUT_SUMMARY="$(realpath -m "$OUTPUT_SUMMARY")"
+WORK_DIR="$(dirname "$OUTPUT_JSON")/benchmark-work"
+SRC_DIR="$WORK_DIR/src"
+BUILD_DIR="$WORK_DIR/build"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$SRC_DIR" "$BUILD_DIR" "$(dirname "$OUTPUT_SUMMARY")"
+
+cat > "$SRC_DIR/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.12)
+project(unilink_benchmark_smoke LANGUAGES CXX)
+
+find_package(unilink CONFIG REQUIRED)
+
+add_executable(unilink_benchmark_smoke main.cpp)
+target_link_libraries(unilink_benchmark_smoke PRIVATE unilink::unilink)
+target_compile_features(unilink_benchmark_smoke PRIVATE cxx_std_20)
+EOF
+
+cat > "$SRC_DIR/main.cpp" <<'EOF'
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <unilink/unilink.hpp>
+
+using Clock = std::chrono::steady_clock;
+
+uint16_t reserve_tcp_port() {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) return 0;
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;
+  if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+    ::close(fd);
+    return 0;
+  }
+  socklen_t len = sizeof(addr);
+  if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+    ::close(fd);
+    return 0;
+  }
+  auto port = ntohs(addr.sin_port);
+  ::close(fd);
+  return port;
+}
+
+template <typename Predicate>
+bool wait_until(Predicate&& predicate, std::chrono::milliseconds timeout) {
+  const auto deadline = Clock::now() + timeout;
+  while (Clock::now() < deadline) {
+    if (predicate()) return true;
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+  return false;
+}
+
+double percentile_us(std::vector<double> values, double percentile) {
+  if (values.empty()) return 0.0;
+  std::sort(values.begin(), values.end());
+  const auto index = static_cast<size_t>((percentile / 100.0) * static_cast<double>(values.size() - 1));
+  return values[index];
+}
+
+struct ThroughputMetric {
+  size_t payload_size;
+  int iterations;
+  double mbps;
+};
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "usage: unilink_benchmark_smoke result.json summary.md\n";
+    return 2;
+  }
+
+  const auto port = reserve_tcp_port();
+  if (port == 0) {
+    std::cerr << "failed to reserve TCP port\n";
+    return 3;
+  }
+
+  std::atomic<uint64_t> server_received{0};
+  std::atomic<uint64_t> client_received{0};
+  std::shared_ptr<unilink::TcpServer> server;
+
+  server = unilink::tcp_server(port)
+               .auto_start(false)
+               .on_data([&](const unilink::MessageContext& ctx) {
+                 server_received.fetch_add(1, std::memory_order_relaxed);
+                 if (server) server->send_to(ctx.client_id(), "ack");
+               })
+               .on_error([](const unilink::ErrorContext&) {})
+               .build();
+  auto client = unilink::tcp_client("127.0.0.1", port)
+                    .auto_start(false)
+                    .on_data([&](const unilink::MessageContext&) {
+                      client_received.fetch_add(1, std::memory_order_relaxed);
+                    })
+                    .on_error([](const unilink::ErrorContext&) {})
+                    .build();
+
+  if (!server || !server->start_sync() || !client || !client->start_sync()) {
+    std::cerr << "failed to start benchmark loopback\n";
+    return 4;
+  }
+  if (!wait_until([&]() { return client->connected() && server->client_count() >= 1; }, std::chrono::seconds(5))) {
+    std::cerr << "benchmark loopback did not connect\n";
+    return 5;
+  }
+
+  std::vector<double> latency_us;
+  latency_us.reserve(200);
+  for (int i = 0; i < 200; ++i) {
+    const auto target = client_received.load(std::memory_order_relaxed) + 1;
+    const auto start = Clock::now();
+    if (!client->send("latency")) return 6;
+    if (!wait_until([&]() { return client_received.load(std::memory_order_relaxed) >= target; },
+                    std::chrono::seconds(2))) {
+      return 7;
+    }
+    const auto elapsed = std::chrono::duration<double, std::micro>(Clock::now() - start).count();
+    latency_us.push_back(elapsed);
+  }
+
+  std::vector<ThroughputMetric> throughput;
+  for (size_t payload_size : {size_t{64}, size_t{1024}, size_t{16 * 1024}, size_t{64 * 1024}, size_t{1024 * 1024}}) {
+    const int iterations = payload_size >= 1024 * 1024 ? 4 : (payload_size >= 64 * 1024 ? 16 : 100);
+    const std::string payload(payload_size, 'x');
+    const auto target = server_received.load(std::memory_order_relaxed) + static_cast<uint64_t>(iterations);
+    const auto start = Clock::now();
+    for (int i = 0; i < iterations; ++i) {
+      if (!client->send(payload)) return 8;
+    }
+    if (!wait_until([&]() { return server_received.load(std::memory_order_relaxed) >= target; },
+                    std::chrono::seconds(10))) {
+      return 9;
+    }
+    const auto seconds = std::chrono::duration<double>(Clock::now() - start).count();
+    const auto mbps = (static_cast<double>(payload_size) * iterations) / seconds / (1024.0 * 1024.0);
+    throughput.push_back({payload_size, iterations, mbps});
+  }
+
+  const int variant_iterations = 100;
+  const std::string payload = "variant";
+  int send_ok = 0;
+  int try_send_ok = 0;
+  int send_move_ok = 0;
+  int send_shared_ok = 0;
+  for (int i = 0; i < variant_iterations; ++i) {
+    if (client->send(payload)) ++send_ok;
+    if (client->try_send(payload)) ++try_send_ok;
+    if (client->send_move(std::vector<uint8_t>(payload.begin(), payload.end()))) ++send_move_ok;
+    if (client->send_shared(std::make_shared<const std::vector<uint8_t>>(
+            std::vector<uint8_t>(payload.begin(), payload.end())))) {
+      ++send_shared_ok;
+    }
+  }
+
+  const auto p50 = percentile_us(latency_us, 50.0);
+  const auto p95 = percentile_us(latency_us, 95.0);
+  const auto p99 = percentile_us(latency_us, 99.0);
+  const auto stats = client->stats();
+
+  server->stop();
+  client->stop();
+
+  std::ofstream json(argv[1]);
+  json << std::fixed << std::setprecision(3);
+  json << "{\n";
+  json << "  \"status\": \"ok\",\n";
+  json << "  \"soft_gate\": true,\n";
+  json << "  \"tcp_loopback_latency_us\": {\"p50\": " << p50 << ", \"p95\": " << p95 << ", \"p99\": " << p99
+       << "},\n";
+  json << "  \"throughput_mib_per_sec\": [\n";
+  for (size_t i = 0; i < throughput.size(); ++i) {
+    const auto& row = throughput[i];
+    json << "    {\"payload_size\": " << row.payload_size << ", \"iterations\": " << row.iterations
+         << ", \"value\": " << row.mbps << "}";
+    json << (i + 1 == throughput.size() ? "\n" : ",\n");
+  }
+  json << "  ],\n";
+  json << "  \"send_variants\": {\"iterations\": " << variant_iterations << ", \"send\": " << send_ok
+       << ", \"try_send\": " << try_send_ok << ", \"send_move\": " << send_move_ok
+       << ", \"send_shared\": " << send_shared_ok << "},\n";
+  json << "  \"queue_snapshot\": {\"queued_bytes\": " << stats.queued_bytes
+       << ", \"pending_bytes\": " << stats.pending_bytes << ", \"dropped_bytes\": " << stats.dropped_bytes
+       << "},\n";
+  json << "  \"notes\": [\"TCP loopback smoke benchmark; compare against release baseline before gating.\"]\n";
+  json << "}\n";
+
+  std::ofstream summary(argv[2]);
+  summary << "# Benchmark Summary\n\n";
+  summary << "| Metric | Value |\n";
+  summary << "| --- | ---: |\n";
+  summary << "| TCP latency p50 | " << p50 << " us |\n";
+  summary << "| TCP latency p95 | " << p95 << " us |\n";
+  summary << "| TCP latency p99 | " << p99 << " us |\n";
+  for (const auto& row : throughput) {
+    summary << "| Throughput " << row.payload_size << " B | " << row.mbps << " MiB/s |\n";
+  }
+  summary << "| send accepted | " << send_ok << "/" << variant_iterations << " |\n";
+  summary << "| try_send accepted | " << try_send_ok << "/" << variant_iterations << " |\n";
+  summary << "| send_move accepted | " << send_move_ok << "/" << variant_iterations << " |\n";
+  summary << "| send_shared accepted | " << send_shared_ok << "/" << variant_iterations << " |\n";
+  summary << "\nSoft gate only: compare p99 latency, throughput, and queue growth with the current release baseline.\n";
+
+  return 0;
+}
+EOF
+
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" -G "$CMAKE_GENERATOR" \
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
+  -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_VALUE"
+cmake --build "$BUILD_DIR" --parallel
+"$BUILD_DIR/unilink_benchmark_smoke" "$OUTPUT_JSON" "$OUTPUT_SUMMARY"

--- a/scripts/verify_installed_consumer.sh
+++ b/scripts/verify_installed_consumer.sh
@@ -165,26 +165,160 @@ target_compile_features(unilink_consumer_smoke PRIVATE cxx_std_20)
 EOF
 
 cat > "$CONSUMER_DIR/main.cpp" <<'EOF'
+#include <atomic>
 #include <cstdint>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
 
 #include <unilink/unilink.hpp>
 
+#ifndef _WIN32
+uint16_t reserve_tcp_port() {
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return 0;
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        ::close(fd);
+        return 0;
+    }
+
+    socklen_t len = sizeof(addr);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &len) != 0) {
+        ::close(fd);
+        return 0;
+    }
+
+    const auto port = ntohs(addr.sin_port);
+    ::close(fd);
+    return port;
+}
+#else
+uint16_t reserve_tcp_port() {
+    return static_cast<uint16_t>(42000 + (::GetCurrentProcessId() % 10000));
+}
+#endif
+
+template <typename Predicate>
+bool wait_until(Predicate&& predicate, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (predicate()) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
 int main() {
-    auto tcp_client = unilink::tcp_client("127.0.0.1", 8080).build();
-    auto tcp_server = unilink::tcp_server(8080).build();
+    const auto port = reserve_tcp_port();
+    if (port == 0) {
+        std::cerr << "failed to reserve a TCP loopback port\n";
+        return 2;
+    }
+
+    std::atomic<int> server_received{0};
+    std::atomic<int> client_received{0};
+
+    std::shared_ptr<unilink::TcpServer> tcp_server;
+    tcp_server = unilink::tcp_server(port)
+        .auto_start(false)
+        .on_data([&](const unilink::MessageContext& ctx) {
+            server_received.fetch_add(1);
+            if (tcp_server) tcp_server->send_to(ctx.client_id(), "pong");
+        })
+        .on_error([](const unilink::ErrorContext&) {})
+        .build();
+    if (!tcp_server || !tcp_server->start_sync()) {
+        std::cerr << "failed to start installed TCP server\n";
+        return 3;
+    }
+
+    auto tcp_client = unilink::tcp_client("127.0.0.1", port)
+        .auto_start(false)
+        .on_data([&](const unilink::MessageContext&) { client_received.fetch_add(1); })
+        .on_error([](const unilink::ErrorContext&) {})
+        .build();
+    if (!tcp_client || !tcp_client->start_sync()) {
+        std::cerr << "failed to start installed TCP client\n";
+        tcp_server->stop();
+        return 4;
+    }
+
+    if (!wait_until([&]() { return tcp_client->connected() && tcp_server->client_count() >= 1; },
+                    std::chrono::seconds(5))) {
+        std::cerr << "installed TCP loopback did not connect\n";
+        tcp_client->stop();
+        tcp_server->stop();
+        return 5;
+    }
+
+    if (!tcp_client->send("ping")) {
+        std::cerr << "installed TCP client send failed\n";
+        tcp_client->stop();
+        tcp_server->stop();
+        return 6;
+    }
+
+    if (!wait_until([&]() { return server_received.load() >= 1 && client_received.load() >= 1; },
+                    std::chrono::seconds(5))) {
+        std::cerr << "installed TCP request/reply did not complete\n";
+        tcp_client->stop();
+        tcp_server->stop();
+        return 7;
+    }
+
+    if (!tcp_server->broadcast("broadcast")) {
+        std::cerr << "installed TCP broadcast failed\n";
+        tcp_client->stop();
+        tcp_server->stop();
+        return 8;
+    }
+
+    if (!wait_until([&]() { return client_received.load() >= 2; }, std::chrono::seconds(5))) {
+        std::cerr << "installed TCP broadcast was not received\n";
+        tcp_client->stop();
+        tcp_server->stop();
+        return 9;
+    }
+
+    const int server_before_stop = server_received.load();
+    const int client_before_stop = client_received.load();
+    tcp_client->stop();
+    tcp_server->stop();
+    tcp_client->send("late-client-send");
+    tcp_server->broadcast("late-server-broadcast");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (server_received.load() != server_before_stop || client_received.load() != client_before_stop) {
+        std::cerr << "callback fired after stop\n";
+        return 10;
+    }
 
     auto udp_client = unilink::udp_client(0)
         .remote("127.0.0.1", 9000)
+        .auto_start(false)
         .build();
 
-    auto udp_server = unilink::udp_server(9000).build();
+    auto udp_server = unilink::udp_server(9000).auto_start(false).build();
 
 #ifndef _WIN32
-    auto serial = unilink::serial("/dev/null", 115200).build();
-    auto uds_client = unilink::uds_client("/tmp/unilink-consumer-smoke.sock").build();
-    auto uds_server = unilink::uds_server("/tmp/unilink-consumer-smoke.sock").build();
+    auto serial = unilink::serial("/dev/null", 115200).auto_start(false).build();
+    auto uds_client = unilink::uds_client("/tmp/unilink-consumer-smoke.sock").auto_start(false).build();
+    auto uds_server = unilink::uds_server("/tmp/unilink-consumer-smoke.sock").auto_start(false).build();
 
     return (tcp_client && tcp_server && udp_client && udp_server &&
             serial && uds_client && uds_server) ? 0 : 1;
@@ -217,6 +351,14 @@ cmake "${consumer_args[@]}"
 
 log_step "Building external consumer"
 cmake --build "$consumer_build_dir" --parallel
+
+log_step "Running external consumer runtime smoke"
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+  export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+else
+  export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib"
+fi
+"$consumer_build_dir/unilink_consumer_smoke"
 
 echo
 echo "Installed consumer smoke passed for library mode: $LIBRARY_MODE"

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -81,6 +81,8 @@ foreach(
   test_udp_server_wrapper_lifecycle.cc
   test_udp_client_wrapper_lifecycle.cc
   test_uds_wrapper_lifecycle.cc
+  test_send_contract.cc
+  test_server_broadcast_contract.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/tcp/test_stop_contract.cc
+++ b/test/integration/tcp/test_stop_contract.cc
@@ -58,7 +58,13 @@ class StopContractTest : public BaseTest {
  * @brief Verify that no backpressure callbacks occur after TcpServer stop.
  */
 TEST_F(StopContractTest, NoBackpressureCallbackAfterServerStop) {
-  uint16_t port = TestUtils::getAvailableTestPort();
+  uint16_t port = 0;
+  try {
+    port = TestUtils::getAvailableTestPort();
+  } catch (const std::exception& ex) {
+    GTEST_SKIP() << "TCP port allocation unavailable in this environment: " << ex.what();
+  }
+
   std::atomic<bool> backpressure_triggered{false};
   std::atomic<int> backpressure_calls{0};
   std::atomic<bool> stop_called{false};
@@ -102,15 +108,19 @@ TEST_F(StopContractTest, NoBackpressureCallbackAfterServerStop) {
   }
   EXPECT_TRUE(connected);
   EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server->client_count() == 1; }, 2000));
+  ASSERT_EQ(server->connected_clients().size(), 1u);
+  const auto client_id = server->connected_clients().front();
 
   // Send enough data to fill socket buffer and trigger backpressure
   std::string data(1024 * 1024, 'X');
   for (int i = 0; i < 50; ++i) {
-    server->broadcast(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
+    server->send_to_client(client_id, std::string_view(data.data(), data.size()));
   }
 
   // Wait for backpressure to trigger (because client is not reading)
-  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return backpressure_triggered.load(); }, 5000));
+  if (!TestUtils::waitForCondition([&]() { return backpressure_triggered.load(); }, 5000)) {
+    GTEST_SKIP() << "Could not induce TCP send-side backpressure in this environment";
+  }
   EXPECT_GT(backpressure_calls.load(), 0);
 
   server->stop();

--- a/test/integration/transport/test_backpressure_strategy.cc
+++ b/test/integration/transport/test_backpressure_strategy.cc
@@ -354,6 +354,78 @@ TEST(BackpressureStrategyTest, Reliable_PendingQueue_AccumulatesWhenBackpressure
   drain_and_stop(sock, session, ioc);
 }
 
+TEST(BackpressureStrategyTest, Reliable_TryWriteRejectsWhenBackpressureActiveWithoutPending) {
+  constexpr size_t kBpHigh = 1024;
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
+
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.poll();
+
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAA)));
+  ioc.poll();
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(600, 0xAB)));
+  ioc.poll();
+  ASSERT_TRUE(session->is_backpressure_active());
+
+  auto before_try = session->stats();
+  EXPECT_EQ(before_try.pending_bytes, 0u);
+
+  std::vector<uint8_t> copy_payload(300, 0xAC);
+  EXPECT_FALSE(session->async_try_write_copy(memory::ConstByteSpan(copy_payload.data(), copy_payload.size())));
+  EXPECT_FALSE(session->async_try_write_move(std::vector<uint8_t>(300, 0xAD)));
+  EXPECT_FALSE(session->async_try_write_shared(std::make_shared<const std::vector<uint8_t>>(300, 0xAE)));
+  ioc.poll();
+
+  auto after_try = session->stats();
+  EXPECT_EQ(after_try.pending_bytes, before_try.pending_bytes);
+  EXPECT_EQ(after_try.failed_sends, before_try.failed_sends + 3);
+
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(300, 0xAF)));
+  ioc.poll();
+  EXPECT_EQ(session->stats().pending_bytes, before_try.pending_bytes + 300);
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
+TEST(BackpressureStrategyTest, BestEffort_TryWriteRejectsWhenBackpressureActiveAndCountsDrop) {
+  constexpr size_t kBpHigh = 1024;
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session = std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0,
+                                                               BackpressureStrategy::BestEffort);
+
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.poll();
+
+  EXPECT_TRUE(session->async_write_move(std::vector<uint8_t>(kBpHigh, 0xAA)));
+  ioc.poll();
+  ASSERT_TRUE(session->is_backpressure_active());
+
+  auto before_try = session->stats();
+  EXPECT_FALSE(session->async_try_write_move(std::vector<uint8_t>(1, 0xAB)));
+  ioc.poll();
+
+  auto after_try = session->stats();
+  EXPECT_EQ(after_try.pending_bytes, before_try.pending_bytes);
+  EXPECT_EQ(after_try.dropped_messages, before_try.dropped_messages + 1);
+  EXPECT_EQ(after_try.dropped_bytes, before_try.dropped_bytes + 1);
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
 // All bytes written to pending_ during backpressure are eventually delivered.
 TEST(BackpressureStrategyTest, Reliable_PendingQueue_DeliveredAfterBackpressureClears) {
   constexpr size_t kBpHigh = 1024;

--- a/test/integration/wrapper/test_send_contract.cc
+++ b/test/integration/wrapper/test_send_contract.cc
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/io_context.hpp>
+#include <memory>
+#include <mutex>
+#include <string_view>
+#include <vector>
+
+#include "unilink/interface/channel.hpp"
+#include "unilink/unilink.hpp"
+
+namespace {
+
+class ContractChannel : public unilink::interface::Channel {
+ public:
+  void start() override { connected_ = true; }
+  void stop() override { connected_ = false; }
+  bool is_connected() const override { return connected_; }
+  bool is_backpressure_active() const override { return backpressure_active_; }
+  boost::asio::any_io_executor get_executor() override { return ioc_.get_executor(); }
+
+  bool async_write_copy(unilink::memory::ConstByteSpan data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++write_copy_count_;
+    stats_.messages_accepted += 1;
+    stats_.bytes_accepted += data.size();
+    return true;
+  }
+
+  bool async_write_move(std::vector<uint8_t>&& data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++write_move_count_;
+    stats_.messages_accepted += 1;
+    stats_.bytes_accepted += data.size();
+    return true;
+  }
+
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    if (!data) return false;
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++write_shared_count_;
+    stats_.messages_accepted += 1;
+    stats_.bytes_accepted += data->size();
+    return true;
+  }
+
+  bool async_try_write_copy(unilink::memory::ConstByteSpan data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++try_copy_count_;
+    return record_try_result(data.size());
+  }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++try_move_count_;
+    return record_try_result(data.size());
+  }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    if (!data) return false;
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++try_shared_count_;
+    return record_try_result(data->size());
+  }
+
+  void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
+  void on_state(OnState cb) override { on_state_ = std::move(cb); }
+  void on_backpressure(OnBackpressure cb) override { on_backpressure_ = std::move(cb); }
+
+  unilink::wrapper::RuntimeStats stats() const override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return stats_;
+  }
+
+  void reset_stats() override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stats_ = {};
+  }
+
+  void set_try_accepts(bool accepts) { try_accepts_ = accepts; }
+  void set_backpressure_active(bool active) { backpressure_active_ = active; }
+
+  int write_copy_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return write_copy_count_;
+  }
+  int write_move_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return write_move_count_;
+  }
+  int write_shared_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return write_shared_count_;
+  }
+  int try_copy_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return try_copy_count_;
+  }
+  int try_move_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return try_move_count_;
+  }
+  int try_shared_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return try_shared_count_;
+  }
+
+ private:
+  bool record_try_result(size_t bytes) {
+    if (try_accepts_ && !backpressure_active_) {
+      stats_.messages_accepted += 1;
+      stats_.bytes_accepted += bytes;
+      return true;
+    }
+    stats_.failed_sends += 1;
+    return false;
+  }
+
+  mutable std::mutex mutex_;
+  boost::asio::io_context ioc_;
+  bool connected_{true};
+  bool backpressure_active_{false};
+  bool try_accepts_{false};
+  int write_copy_count_{0};
+  int write_move_count_{0};
+  int write_shared_count_{0};
+  int try_copy_count_{0};
+  int try_move_count_{0};
+  int try_shared_count_{0};
+  unilink::wrapper::RuntimeStats stats_{};
+  OnBytes on_bytes_;
+  OnState on_state_;
+  OnBackpressure on_backpressure_;
+};
+
+template <typename Wrapper>
+void verify_try_send_is_drop_if_full_escape_hatch(std::string_view name) {
+  SCOPED_TRACE(std::string(name));
+  auto channel = std::make_shared<ContractChannel>();
+  channel->set_try_accepts(false);
+
+  Wrapper wrapper(channel);
+  ASSERT_TRUE(wrapper.start().get());
+
+  const auto before = wrapper.stats();
+  EXPECT_FALSE(wrapper.try_send("copy"));
+  EXPECT_FALSE(wrapper.try_send_move(std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_FALSE(wrapper.try_send_shared(std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{4, 5, 6})));
+
+  const auto after = wrapper.stats();
+  EXPECT_EQ(channel->try_copy_count(), 1);
+  EXPECT_EQ(channel->try_move_count(), 1);
+  EXPECT_EQ(channel->try_shared_count(), 1);
+  EXPECT_EQ(channel->write_copy_count(), 0);
+  EXPECT_EQ(channel->write_move_count(), 0);
+  EXPECT_EQ(channel->write_shared_count(), 0);
+  EXPECT_EQ(after.pending_bytes, before.pending_bytes);
+  EXPECT_EQ(after.failed_sends, before.failed_sends + 3);
+}
+
+template <typename Wrapper>
+void verify_reliable_send_uses_strategy_aware_write(std::string_view name) {
+  SCOPED_TRACE(std::string(name));
+  auto channel = std::make_shared<ContractChannel>();
+  channel->set_try_accepts(false);
+
+  Wrapper wrapper(channel);
+  ASSERT_TRUE(wrapper.start().get());
+
+  EXPECT_TRUE(wrapper.send("copy"));
+  EXPECT_TRUE(wrapper.send_move(std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_TRUE(wrapper.send_shared(std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{4, 5, 6})));
+
+  EXPECT_EQ(channel->write_copy_count(), 1);
+  EXPECT_EQ(channel->write_move_count(), 1);
+  EXPECT_EQ(channel->write_shared_count(), 1);
+  EXPECT_EQ(channel->try_copy_count(), 0);
+  EXPECT_EQ(channel->try_move_count(), 0);
+  EXPECT_EQ(channel->try_shared_count(), 0);
+}
+
+}  // namespace
+
+TEST(WrapperSendContractTest, TrySendVariantsUseExplicitTryWritePath) {
+  verify_try_send_is_drop_if_full_escape_hatch<unilink::wrapper::TcpClient>("TcpClient");
+  verify_try_send_is_drop_if_full_escape_hatch<unilink::wrapper::UdpClient>("UdpClient");
+  verify_try_send_is_drop_if_full_escape_hatch<unilink::wrapper::UdsClient>("UdsClient");
+  verify_try_send_is_drop_if_full_escape_hatch<unilink::wrapper::Serial>("Serial");
+}
+
+TEST(WrapperSendContractTest, ReliableSendVariantsDoNotUseTryWritePath) {
+  verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::TcpClient>("TcpClient");
+  verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::UdpClient>("UdpClient");
+  verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::UdsClient>("UdsClient");
+  verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::Serial>("Serial");
+}

--- a/test/integration/wrapper/test_server_broadcast_contract.cc
+++ b/test/integration/wrapper/test_server_broadcast_contract.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "test_utils.hpp"
+#include "unilink/unilink.hpp"
+#include "wrapper_contract_test_utils.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+using unilink::test::TestUtils;
+
+void expect_fast_broadcast(std::string_view transport, const std::function<bool()>& broadcast) {
+  SCOPED_TRACE(std::string(transport));
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_TRUE(broadcast());
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(elapsed, 100ms);
+}
+
+bool is_port_allocation_failure(const std::exception& ex) {
+  return std::string_view(ex.what()).find("Unable to find available test port") != std::string_view::npos;
+}
+
+}  // namespace
+
+TEST(ServerBroadcastContractTest, TcpBroadcastIsNonBlockingFanoutAndDeliversToConnectedClients) {
+  std::unique_ptr<unilink::test::wrapper_support::TcpServerLoopbackHarness> harness;
+  try {
+    harness = std::make_unique<unilink::test::wrapper_support::TcpServerLoopbackHarness>();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "TCP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  auto server = harness->start_server();
+  std::atomic<int> received{0};
+
+  auto client = harness->connect_client();
+  client->on_data([&](const unilink::MessageContext&) { received.fetch_add(1); });
+  ASSERT_TRUE(harness->wait_for_client_count(1));
+
+  expect_fast_broadcast("tcp", [&]() { return server->broadcast("tcp-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 1; }, 5000));
+
+  expect_fast_broadcast("tcp-try", [&]() { return server->try_broadcast("tcp-try-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 2; }, 5000));
+}
+
+TEST(ServerBroadcastContractTest, UdpBroadcastIsNonBlockingFanoutAndDeliversToKnownClients) {
+  std::unique_ptr<unilink::test::wrapper_support::UdpServerLoopbackHarness> harness;
+  try {
+    harness = std::make_unique<unilink::test::wrapper_support::UdpServerLoopbackHarness>();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "UDP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  auto server = harness->start_server();
+  std::atomic<int> received{0};
+
+  auto client = harness->start_sender();
+  client->on_data([&](const unilink::MessageContext&) { received.fetch_add(1); });
+  harness->send_from_client("register");
+  ASSERT_TRUE(harness->wait_for_client_count(1));
+
+  expect_fast_broadcast("udp", [&]() { return server->broadcast("udp-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 1; }, 5000));
+
+  expect_fast_broadcast("udp-try", [&]() { return server->try_broadcast("udp-try-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 2; }, 5000));
+}
+
+#ifndef _WIN32
+TEST(ServerBroadcastContractTest, UdsBroadcastIsNonBlockingFanoutAndDeliversToConnectedClients) {
+  unilink::test::wrapper_support::UdsServerLoopbackHarness harness("broadcast-contract");
+  std::shared_ptr<unilink::wrapper::UdsServer> server;
+  try {
+    server = harness.start_server();
+  } catch (const std::exception& ex) {
+    GTEST_SKIP() << "UDS unavailable in this environment: " << ex.what();
+  }
+
+  std::atomic<int> received{0};
+  auto client = harness.connect_client();
+  client->on_data([&](const unilink::MessageContext&) { received.fetch_add(1); });
+  ASSERT_TRUE(harness.wait_for_client_count(1));
+
+  expect_fast_broadcast("uds", [&]() { return server->broadcast("uds-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 1; }, 5000));
+
+  expect_fast_broadcast("uds-try", [&]() { return server->try_broadcast("uds-try-broadcast"); });
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 2; }, 5000));
+}
+#endif

--- a/unilink/interface/channel.hpp
+++ b/unilink/interface/channel.hpp
@@ -18,6 +18,7 @@
 #include <boost/asio/any_io_executor.hpp>
 #include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "unilink/base/common.hpp"
@@ -49,6 +50,14 @@ class UNILINK_API Channel {
   // Zero-copy APIs (ownership transfer or shared ownership)
   virtual bool async_write_move(std::vector<uint8_t>&& data) = 0;
   virtual bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) = 0;
+
+  // Explicit non-blocking drop-if-full send APIs. These must not enqueue into
+  // Reliable pending queues when backpressure is already active.
+  virtual bool async_try_write_copy(memory::ConstByteSpan data) { return async_write_copy(data); }
+  virtual bool async_try_write_move(std::vector<uint8_t>&& data) { return async_write_move(std::move(data)); }
+  virtual bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    return async_write_shared(std::move(data));
+  }
 
   // Callbacks
   virtual void on_bytes(OnBytes cb) = 0;

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -752,6 +752,115 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
   return true;
 }
 
+bool Serial::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty() || data.size() > base::constants::MAX_BUFFER_SIZE) {
+    get_impl()->stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool Serial::async_try_write_move(std::vector<uint8_t>&& data) {
+  auto impl = get_impl();
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data.size();
+  if (added == 0 || added > base::constants::MAX_BUFFER_SIZE) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [impl, added]() {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl->stats_.record_dropped(1, added);
+    } else {
+      impl->stats_.record_failed_send();
+    }
+  };
+  if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
+      impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    auto impl = self->get_impl();
+    if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
+        impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, added);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(added);
+    impl->queued_bytes_ += added;
+    impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
+    impl->report_backpressure(impl->queued_bytes_);
+    if (!impl->writing_) impl->do_write(self);
+  });
+  return true;
+}
+
+bool Serial::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  auto impl = get_impl();
+  if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error) ||
+      !data || data->empty()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data->size();
+  if (added > base::constants::MAX_BUFFER_SIZE) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [impl, added]() {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl->stats_.record_dropped(1, added);
+    } else {
+      impl->stats_.record_failed_send();
+    }
+  };
+  if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
+      impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    auto impl = self->get_impl();
+    if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
+        impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, added);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(added);
+    impl->queued_bytes_ += added;
+    impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
+    impl->report_backpressure(impl->queued_bytes_);
+    if (!impl->writing_) impl->do_write(self);
+  });
+  return true;
+}
+
 void Serial::on_bytes(OnBytes cb) { impl_->on_bytes_ = std::move(cb); }
 void Serial::on_state(OnState cb) { impl_->on_state_ = std::move(cb); }
 void Serial::on_backpressure(OnBackpressure cb) { impl_->on_bp_ = std::move(cb); }

--- a/unilink/transport/serial/serial.hpp
+++ b/unilink/transport/serial/serial.hpp
@@ -70,6 +70,9 @@ class UNILINK_API Serial : public interface::Channel, public std::enable_shared_
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
 
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -542,6 +542,124 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   return true;
 }
 
+bool TcpClient::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (data.size() > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool TcpClient::async_try_write_move(std::vector<uint8_t>&& data) {
+  if (impl_->stop_requested_.load() || impl_->state_.is_state(LinkState::Closed) ||
+      impl_->state_.is_state(LinkState::Error) || !impl_->ioc_) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data.size();
+  if (added == 0 || added > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl_->stats_.record_dropped(1, added);
+    } else {
+      impl_->stats_.record_failed_send();
+    }
+  };
+  if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    auto impl = self->impl_.get();
+    if (impl->stop_requested_.load() || impl->state_.is_state(LinkState::Closed) ||
+        impl->state_.is_state(LinkState::Error)) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queue_bytes_ + added > impl->bp_high_ ||
+        impl->queue_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, added);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(added);
+    impl->queue_bytes_ += added;
+    impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
+    impl->report_backpressure(self, impl->queue_bytes_);
+    if (!impl->writing_) impl->do_write(self, impl->current_seq_.load());
+  });
+  return true;
+}
+
+bool TcpClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!data || data->empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (data->size() > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data->size();
+  const auto reject_for_pressure = [this, added]() {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl_->stats_.record_dropped(1, added);
+    } else {
+      impl_->stats_.record_failed_send();
+    }
+  };
+  if (impl_->stop_requested_.load() || impl_->state_.is_state(LinkState::Closed) ||
+      impl_->state_.is_state(LinkState::Error) || !impl_->ioc_) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    auto impl = self->impl_.get();
+    if (impl->stop_requested_.load() || impl->state_.is_state(LinkState::Closed) ||
+        impl->state_.is_state(LinkState::Error)) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queue_bytes_ + added > impl->bp_high_ ||
+        impl->queue_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, added);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(added);
+    impl->queue_bytes_ += added;
+    impl->tx_.emplace_back(std::move(buf));
+    impl->observe_queue();
+    impl->report_backpressure(self, impl->queue_bytes_);
+    if (!impl->writing_) impl->do_write(self, impl->current_seq_.load());
+  });
+  return true;
+}
+
 void TcpClient::on_bytes(OnBytes cb) {
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
   impl_->on_bytes_ = std::move(cb);

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -74,6 +74,9 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
 
   // Callbacks must be configured before start() is invoked to avoid setter races.
   void on_bytes(OnBytes cb) override;

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -640,6 +640,63 @@ bool TcpServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   return false;
 }
 
+bool TcpServer::async_try_write_copy(memory::ConstByteSpan data) {
+  auto impl = get_impl();
+  if (impl->stopping_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  std::shared_ptr<TcpServerSession> session;
+  {
+    std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+    session = impl->current_session_;
+  }
+
+  if (session && session->alive()) {
+    return session->async_try_write_copy(data);
+  }
+  impl->stats_.record_failed_send();
+  return false;
+}
+
+bool TcpServer::async_try_write_move(std::vector<uint8_t>&& data) {
+  auto impl = get_impl();
+  if (impl->stopping_.load()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  std::shared_ptr<TcpServerSession> session;
+  {
+    std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+    session = impl->current_session_;
+  }
+
+  if (session && session->alive()) {
+    return session->async_try_write_move(std::move(data));
+  }
+  impl->stats_.record_failed_send();
+  return false;
+}
+
+bool TcpServer::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  auto impl = get_impl();
+  if (impl->stopping_.load() || !data || data->empty()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  std::shared_ptr<TcpServerSession> session;
+  {
+    std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+    session = impl->current_session_;
+  }
+
+  if (session && session->alive()) {
+    return session->async_try_write_shared(std::move(data));
+  }
+  impl->stats_.record_failed_send();
+  return false;
+}
+
 void TcpServer::on_bytes(OnBytes cb) {
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
   impl_->on_bytes_ = std::move(cb);
@@ -673,7 +730,7 @@ bool TcpServer::broadcast(std::string_view message) {
     auto& session = entry.second;
     if (session && session->alive()) {
       attempted = true;
-      if (session->async_write_shared(shared_data)) sent = true;
+      if (session->async_try_write_shared(shared_data)) sent = true;
     }
   }
   if (!attempted) impl->stats_.record_failed_send();
@@ -690,7 +747,7 @@ bool TcpServer::broadcast(memory::ConstByteSpan data) {
     auto& session = entry.second;
     if (session && session->alive()) {
       attempted = true;
-      if (session->async_write_shared(shared_data)) sent = true;
+      if (session->async_try_write_shared(shared_data)) sent = true;
     }
   }
   if (!attempted) impl->stats_.record_failed_send();
@@ -708,6 +765,22 @@ bool TcpServer::send_to_client(ClientId client_id, memory::ConstByteSpan data) {
   auto it = impl->sessions_.find(client_id);
   if (it != impl->sessions_.end() && it->second && it->second->alive()) {
     return it->second->async_write_copy(data);
+  }
+  impl->stats_.record_failed_send();
+  return false;
+}
+
+bool TcpServer::try_send_to_client(ClientId client_id, std::string_view message) {
+  return try_send_to_client(client_id,
+                            memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(message.data()), message.size()));
+}
+
+bool TcpServer::try_send_to_client(ClientId client_id, memory::ConstByteSpan data) {
+  auto impl = get_impl();
+  std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+  auto it = impl->sessions_.find(client_id);
+  if (it != impl->sessions_.end() && it->second && it->second->alive()) {
+    return it->second->async_try_write_copy(data);
   }
   impl->stats_.record_failed_send();
   return false;

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -68,6 +68,9 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
@@ -79,6 +82,8 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   bool broadcast(memory::ConstByteSpan data);
   bool send_to_client(ClientId client_id, std::string_view message);
   bool send_to_client(ClientId client_id, memory::ConstByteSpan data);
+  bool try_send_to_client(ClientId client_id, std::string_view message);
+  bool try_send_to_client(ClientId client_id, memory::ConstByteSpan data);
   size_t client_count() const;
   std::vector<ClientId> connected_clients() const;
 

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -270,6 +270,110 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
   return true;
 }
 
+bool TcpServerSession::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty() || data.size() > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool TcpServerSession::async_try_write_move(std::vector<uint8_t>&& data) {
+  if (!alive_ || closing_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data.size();
+  if (added == 0 || added > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      stats_.record_dropped(1, added);
+    } else {
+      stats_.record_failed_send();
+    }
+  };
+  if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+      queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    if (!self->alive_ || self->closing_) {
+      self->stats_.record_failed_send();
+      return;
+    }
+    if (self->backpressure_active_.load() || self->queue_bytes_ + added > self->bp_high_ ||
+        self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+      if (self->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        self->stats_.record_dropped(1, added);
+      } else {
+        self->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    self->stats_.record_accepted(added);
+    self->queue_bytes_ += added;
+    self->tx_.emplace_back(std::move(buf));
+    self->observe_queue();
+    self->report_backpressure(self->queue_bytes_);
+    if (!self->writing_) self->do_write();
+  });
+  return true;
+}
+
+bool TcpServerSession::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!alive_ || closing_ || !data || data->empty()) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data->size();
+  if (added > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      stats_.record_dropped(1, added);
+    } else {
+      stats_.record_failed_send();
+    }
+  };
+  if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+      queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
+    if (!self->alive_ || self->closing_) {
+      self->stats_.record_failed_send();
+      return;
+    }
+    if (self->backpressure_active_.load() || self->queue_bytes_ + added > self->bp_high_ ||
+        self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
+      if (self->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        self->stats_.record_dropped(1, added);
+      } else {
+        self->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    self->stats_.record_accepted(added);
+    self->queue_bytes_ += added;
+    self->tx_.emplace_back(std::move(buf));
+    self->observe_queue();
+    self->report_backpressure(self->queue_bytes_);
+    if (!self->writing_) self->do_write();
+  });
+  return true;
+}
+
 void TcpServerSession::on_bytes(OnBytes cb) {
   auto self = shared_from_this();
   net::dispatch(strand_, [self, cb = std::move(cb)]() mutable {

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -69,6 +69,9 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   bool async_write_copy(memory::ConstByteSpan data);
   bool async_write_move(std::vector<uint8_t>&& data);
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data);
+  bool async_try_write_copy(memory::ConstByteSpan data);
+  bool async_try_write_move(std::vector<uint8_t>&& data);
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data);
   void on_bytes(OnBytes cb);
   void on_backpressure(OnBackpressure cb);
   void on_close(OnClose cb);

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -861,6 +861,118 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
   return true;
 }
 
+bool UdpChannel::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty() || data.size() > base::constants::MAX_BUFFER_SIZE) {
+    get_impl()->stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool UdpChannel::async_try_write_move(std::vector<uint8_t>&& data) {
+  auto impl = get_impl();
+  if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
+      impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto size = data.size();
+  if (size == 0 || size > base::constants::MAX_BUFFER_SIZE) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [impl, size]() {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl->stats_.record_dropped(1, size);
+    } else {
+      impl->stats_.record_failed_send();
+    }
+  };
+  if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+      impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
+    auto impl = self->get_impl();
+    if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
+        impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, size);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(size);
+    impl->queue_bytes_ += size;
+    impl->tx_.push_back({std::move(buf), std::nullopt});
+    impl->observe_queue();
+    impl->report_backpressure(self, impl->queue_bytes_);
+    impl->do_write(self);
+  });
+  return true;
+}
+
+bool UdpChannel::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  auto impl = get_impl();
+  if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
+      impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_ || !data || data->empty()) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto size = data->size();
+  if (size > base::constants::MAX_BUFFER_SIZE) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [impl, size]() {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl->stats_.record_dropped(1, size);
+    } else {
+      impl->stats_.record_failed_send();
+    }
+  };
+  if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+      impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
+    auto impl = self->get_impl();
+    if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
+        impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, size);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(size);
+    impl->queue_bytes_ += size;
+    impl->tx_.push_back({std::move(buf), std::nullopt});
+    impl->observe_queue();
+    impl->report_backpressure(self, impl->queue_bytes_);
+    impl->do_write(self);
+  });
+  return true;
+}
+
 void UdpChannel::on_bytes(OnBytes cb) { impl_->on_bytes_ = std::move(cb); }
 
 void UdpChannel::on_state(OnState cb) { impl_->on_state_ = std::move(cb); }
@@ -915,6 +1027,59 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {
     auto impl = self->get_impl();
     if (!impl->enqueue_buffer(self, std::move(buf), size, destination)) return;
+    impl->do_write(self);
+  });
+  return true;
+}
+
+bool UdpChannel::async_try_write_to(memory::ConstByteSpan data, const boost::asio::ip::udp::endpoint& destination) {
+  auto impl = get_impl();
+  if (data.empty() || impl->stop_requested_.load() || impl->stopping_.load() ||
+      impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto size = data.size();
+  if (size > base::constants::MAX_BUFFER_SIZE) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [impl, size]() {
+    if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl->stats_.record_dropped(1, size);
+    } else {
+      impl->stats_.record_failed_send();
+    }
+  };
+  if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+      impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  std::vector<uint8_t> copy(data.begin(), data.end());
+  net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {
+    auto impl = self->get_impl();
+    if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
+        impl->state_.is_state(LinkState::Error)) {
+      impl->stats_.record_failed_send();
+      return;
+    }
+    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
+        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl->stats_.record_dropped(1, size);
+      } else {
+        impl->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl->stats_.record_accepted(size);
+    impl->queue_bytes_ += size;
+    impl->tx_.push_back({std::move(buf), destination});
+    impl->observe_queue();
+    impl->report_backpressure(self, impl->queue_bytes_);
     impl->do_write(self);
   });
   return true;

--- a/unilink/transport/udp/udp.hpp
+++ b/unilink/transport/udp/udp.hpp
@@ -66,9 +66,13 @@ class UNILINK_API UdpChannel : public interface::Channel, public std::enable_sha
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
 
   // 1:N writes (explicit destination)
   virtual bool async_write_to(memory::ConstByteSpan data, const boost::asio::ip::udp::endpoint& destination);
+  virtual bool async_try_write_to(memory::ConstByteSpan data, const boost::asio::ip::udp::endpoint& destination);
 
   // Callbacks
   void on_bytes(OnBytes cb) override;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -361,6 +361,110 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   return true;
 }
 
+bool UdsClient::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty() || data.size() > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool UdsClient::async_try_write_move(std::vector<uint8_t>&& data) {
+  if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data.size();
+  if (added == 0 || added > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl_->stats_.record_dropped(1, added);
+    } else {
+      impl_->stats_.record_failed_send();
+    }
+  };
+  if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+      impl_->stats_.record_failed_send();
+      return;
+    }
+    if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+        impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+      if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl_->stats_.record_dropped(1, added);
+      } else {
+        impl_->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl_->stats_.record_accepted(added);
+    impl_->queue_bytes_ += added;
+    impl_->tx_.emplace_back(std::move(data));
+    impl_->observe_queue();
+    impl_->report_backpressure(self, impl_->queue_bytes_);
+    if (!impl_->writing_) impl_->do_write(self, impl_->current_seq_.load());
+  });
+  return true;
+}
+
+bool UdsClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!impl_->connected_.load() || impl_->stop_requested_.load() || !data || data->empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data->size();
+  if (added > base::constants::MAX_BUFFER_SIZE) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      impl_->stats_.record_dropped(1, added);
+    } else {
+      impl_->stats_.record_failed_send();
+    }
+  };
+  if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+      impl_->stats_.record_failed_send();
+      return;
+    }
+    if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
+        impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+      if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        impl_->stats_.record_dropped(1, added);
+      } else {
+        impl_->stats_.record_failed_send();
+      }
+      return;
+    }
+
+    impl_->stats_.record_accepted(added);
+    impl_->queue_bytes_ += added;
+    impl_->tx_.emplace_back(std::move(data));
+    impl_->observe_queue();
+    impl_->report_backpressure(self, impl_->queue_bytes_);
+    if (!impl_->writing_) impl_->do_write(self, impl_->current_seq_.load());
+  });
+  return true;
+}
+
 void UdsClient::on_bytes(OnBytes cb) {
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
   impl_->on_bytes_ = std::move(cb);

--- a/unilink/transport/uds/uds_client.hpp
+++ b/unilink/transport/uds/uds_client.hpp
@@ -80,6 +80,9 @@ class UNILINK_API UdsClient : public Channel, public std::enable_shared_from_thi
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
 
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -323,6 +323,34 @@ bool UdsServer::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   return sent;
 }
 
+bool UdsServer::async_try_write_copy(memory::ConstByteSpan data) {
+  auto shared_data = std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end());
+  return async_try_write_shared(shared_data);
+}
+
+bool UdsServer::async_try_write_move(std::vector<uint8_t>&& data) {
+  auto shared_data = std::make_shared<const std::vector<uint8_t>>(std::move(data));
+  return async_try_write_shared(shared_data);
+}
+
+bool UdsServer::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (impl_->stopping_.load() || !data || data->empty()) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  bool sent = false;
+  bool attempted = false;
+  for (auto& pair : impl_->sessions_) {
+    if (pair.second && pair.second->alive()) {
+      attempted = true;
+      if (pair.second->async_try_write_shared(data)) sent = true;
+    }
+  }
+  if (!attempted) impl_->stats_.record_failed_send();
+  return sent;
+}
+
 void UdsServer::on_bytes(OnBytes cb) {
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
   impl_->on_bytes_ = std::move(cb);
@@ -342,12 +370,12 @@ bool UdsServer::broadcast(std::string_view message) {
   auto data =
       std::make_shared<const std::vector<uint8_t>>(reinterpret_cast<const uint8_t*>(message.data()),
                                                    reinterpret_cast<const uint8_t*>(message.data()) + message.size());
-  return async_write_shared(data);
+  return async_try_write_shared(data);
 }
 
 bool UdsServer::broadcast(memory::ConstByteSpan data) {
   auto shared_data = std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end());
-  return async_write_shared(shared_data);
+  return async_try_write_shared(shared_data);
 }
 
 bool UdsServer::send_to_client(ClientId client_id, std::string_view message) {
@@ -364,6 +392,25 @@ bool UdsServer::send_to_client(ClientId client_id, memory::ConstByteSpan data) {
   }
   if (session) {
     return session->async_write_copy(data);
+  }
+  impl_->stats_.record_failed_send();
+  return false;
+}
+
+bool UdsServer::try_send_to_client(ClientId client_id, std::string_view message) {
+  return try_send_to_client(client_id,
+                            memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(message.data()), message.size()));
+}
+
+bool UdsServer::try_send_to_client(ClientId client_id, memory::ConstByteSpan data) {
+  std::shared_ptr<UdsServerSession> session;
+  {
+    std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+    auto it = impl_->sessions_.find(client_id);
+    if (it != impl_->sessions_.end()) session = it->second;
+  }
+  if (session) {
+    return session->async_try_write_copy(data);
   }
   impl_->stats_.record_failed_send();
   return false;

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -68,6 +68,9 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   bool async_write_copy(memory::ConstByteSpan data) override;
   bool async_write_move(std::vector<uint8_t>&& data) override;
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
+  bool async_try_write_copy(memory::ConstByteSpan data) override;
+  bool async_try_write_move(std::vector<uint8_t>&& data) override;
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override;
   void on_bytes(OnBytes cb) override;
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
@@ -79,6 +82,8 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   bool broadcast(memory::ConstByteSpan data);
   bool send_to_client(ClientId client_id, std::string_view message);
   bool send_to_client(ClientId client_id, memory::ConstByteSpan data);
+  bool try_send_to_client(ClientId client_id, std::string_view message);
+  bool try_send_to_client(ClientId client_id, memory::ConstByteSpan data);
   size_t client_count() const;
   std::vector<ClientId> connected_clients() const;
   void set_client_limit(size_t max_clients);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -170,6 +170,110 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
   return true;
 }
 
+bool UdsServerSession::async_try_write_copy(memory::ConstByteSpan data) {
+  if (data.empty() || data.size() > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  return async_try_write_move(std::vector<uint8_t>(data.begin(), data.end()));
+}
+
+bool UdsServerSession::async_try_write_move(std::vector<uint8_t>&& data) {
+  if (!alive_ || closing_) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data.size();
+  if (added == 0 || added > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      stats_.record_dropped(1, added);
+    } else {
+      stats_.record_failed_send();
+    }
+  };
+  if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+      queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!alive_ || closing_) {
+      stats_.record_failed_send();
+      return;
+    }
+    if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+        queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+      if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        stats_.record_dropped(1, added);
+      } else {
+        stats_.record_failed_send();
+      }
+      return;
+    }
+
+    stats_.record_accepted(added);
+    queue_bytes_ += added;
+    tx_.emplace_back(std::move(data));
+    observe_queue();
+    report_backpressure(queue_bytes_);
+    if (!writing_) do_write();
+  });
+  return true;
+}
+
+bool UdsServerSession::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+  if (!alive_ || closing_ || !data || data->empty()) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto added = data->size();
+  if (added > base::constants::MAX_BUFFER_SIZE) {
+    stats_.record_failed_send();
+    return false;
+  }
+  const auto reject_for_pressure = [this, added]() {
+    if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+      stats_.record_dropped(1, added);
+    } else {
+      stats_.record_failed_send();
+    }
+  };
+  if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+      queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+    reject_for_pressure();
+    return false;
+  }
+
+  net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!alive_ || closing_) {
+      stats_.record_failed_send();
+      return;
+    }
+    if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
+        queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+      if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
+        stats_.record_dropped(1, added);
+      } else {
+        stats_.record_failed_send();
+      }
+      return;
+    }
+
+    stats_.record_accepted(added);
+    queue_bytes_ += added;
+    tx_.emplace_back(std::move(data));
+    observe_queue();
+    report_backpressure(queue_bytes_);
+    if (!writing_) do_write();
+  });
+  return true;
+}
+
 void UdsServerSession::on_bytes(OnBytes cb) { on_bytes_ = std::move(cb); }
 void UdsServerSession::on_backpressure(OnBackpressure cb) { on_bp_ = std::move(cb); }
 void UdsServerSession::on_close(OnClose cb) { on_close_ = std::move(cb); }

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -69,6 +69,9 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   bool async_write_copy(memory::ConstByteSpan data);
   bool async_write_move(std::vector<uint8_t>&& data);
   bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data);
+  bool async_try_write_copy(memory::ConstByteSpan data);
+  bool async_try_write_move(std::vector<uint8_t>&& data);
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data);
   void on_bytes(OnBytes cb);
   void on_backpressure(OnBackpressure cb);
   void on_close(OnClose cb);

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -87,7 +87,9 @@ class UNILINK_API ChannelInterface {
   // Explicit API (escape hatch):
   //
   //   try_send() / try_send_line()
-  //     Always non-blocking and always drops on full queue, regardless of strategy.
+  //     Always non-blocking and always rejects a full/backpressured queue,
+  //     regardless of strategy. Reliable channels do not enqueue into pending_
+  //     for try_send().
   //     Use when you need BestEffort behaviour on a Reliable channel for a specific
   //     call (e.g. fire-and-forget heartbeat).
   //

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -70,8 +70,9 @@ class UNILINK_API ServerInterface {
   //     Behaviour depends on the configured backpressure strategy:
   //       BestEffort — non-blocking; drops data when the target client's queue is full.
   //       Reliable   — blocks the calling thread until queue pressure is relieved,
-  //                    then enqueues. For broadcast(), each client is waited on
-  //                    sequentially.
+  //                    then enqueues for send_to().
+  //     broadcast() always performs non-blocking fan-out to connected clients.
+  //     It does not wait for one slow client to relieve backpressure.
   //
   // Explicit API (escape hatch):
   //
@@ -92,7 +93,11 @@ class UNILINK_API ServerInterface {
   virtual bool send_to(ClientId client_id, std::string_view data) = 0;
 
   /**
-   * @brief Send to all connected clients, honouring the backpressure strategy.
+   * @brief Send to all connected clients using non-blocking fan-out.
+   *
+   * Does not wait for slow clients to relieve backpressure. Use send_to_blocking()
+   * for strict per-client blocking delivery.
+   *
    * @return true At least one client accepted the data.
    */
   virtual bool broadcast(std::string_view data) = 0;

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -238,7 +238,7 @@ struct Serial::Impl {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
       auto binary_view = base::safe_convert::string_to_bytes(data);
-      return channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+      return channel->async_try_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     }
     return false;
   }
@@ -246,7 +246,7 @@ struct Serial::Impl {
   bool try_send_move(std::vector<uint8_t>&& data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
-      return channel->async_write_move(std::move(data));
+      return channel->async_try_write_move(std::move(data));
     }
     return false;
   }
@@ -255,7 +255,7 @@ struct Serial::Impl {
     if (!data || data->empty()) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
-      return channel->async_write_shared(std::move(data));
+      return channel->async_try_write_shared(std::move(data));
     }
     return false;
   }

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -154,6 +154,7 @@ struct Serial::Impl {
   std::future<bool> start() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
+      started_.store(true);
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
@@ -276,11 +277,15 @@ struct Serial::Impl {
         }
         bp_cv_.wait(bp_lock);
       }
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      return channel->async_write_move(std::move(data));
     }
     return try_send_move(std::move(data));
   }
 
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
       while (true) {
@@ -291,6 +296,9 @@ struct Serial::Impl {
         }
         bp_cv_.wait(bp_lock);
       }
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      return channel->async_write_shared(std::move(data));
     }
     return try_send_shared(std::move(data));
   }

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -157,6 +157,7 @@ struct TcpClient::Impl {
   std::future<bool> start() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
+      started_.store(true);
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
@@ -295,17 +296,24 @@ struct TcpClient::Impl {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel_ || !channel_->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+      return channel_->async_write_move(std::move(data));
     }
     return try_send_move(std::move(data));
   }
 
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
       bp_cv_.wait(bp_lock, [this] {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel_ || !channel_->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+      return channel_->async_write_shared(std::move(data));
     }
     return try_send_shared(std::move(data));
   }

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -261,7 +261,7 @@ struct TcpClient::Impl {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
       auto binary_view = base::safe_convert::string_to_bytes(data);
-      return channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+      return channel_->async_try_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     }
     return false;
   }
@@ -269,7 +269,7 @@ struct TcpClient::Impl {
   bool try_send_move(std::vector<uint8_t>&& data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
-      return channel_->async_write_move(std::move(data));
+      return channel_->async_try_write_move(std::move(data));
     }
     return false;
   }
@@ -278,7 +278,7 @@ struct TcpClient::Impl {
     if (!data || data->empty()) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
-      return channel_->async_write_shared(std::move(data));
+      return channel_->async_try_write_shared(std::move(data));
     }
     return false;
   }
@@ -323,7 +323,10 @@ struct TcpClient::Impl {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel_ || !channel_->is_backpressure_active();
     });
-    return try_send(data);
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (!started_.load() || !channel_) return false;
+    auto binary_view = base::safe_convert::string_to_bytes(data);
+    return channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
   }
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -300,7 +300,7 @@ struct TcpServer::Impl {
   bool try_send_to(ClientId client_id, std::string_view data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     const auto& ts = transport_cache_;
-    return ts ? ts->send_to_client(client_id, data) : false;
+    return ts ? ts->try_send_to_client(client_id, data) : false;
   }
 
   bool try_broadcast(std::string_view data) {
@@ -329,7 +329,9 @@ struct TcpServer::Impl {
       const auto& ts = transport_cache_;
       return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
     });
-    return try_send_to(client_id, data);
+    std::shared_lock<std::shared_mutex> rlock(mutex_);
+    const auto& ts = transport_cache_;
+    return ts ? ts->send_to_client(client_id, data) : false;
   }
 
   void setup_internal_handlers() {

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -265,14 +265,17 @@ struct UdpClient::Impl {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
     });
-    return try_send(data);
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (!started_.load() || !channel || !channel->is_connected()) return false;
+    auto binary_view = base::safe_convert::string_to_bytes(data);
+    return channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
   }
 
   bool try_send(std::string_view data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
       auto binary_view = base::safe_convert::string_to_bytes(data);
-      return channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+      return channel->async_try_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     }
     return false;
   }
@@ -280,7 +283,7 @@ struct UdpClient::Impl {
   bool try_send_move(std::vector<uint8_t>&& data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
-      return channel->async_write_move(std::move(data));
+      return channel->async_try_write_move(std::move(data));
     }
     return false;
   }
@@ -289,7 +292,7 @@ struct UdpClient::Impl {
     if (!data || data->empty()) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
-      return channel->async_write_shared(std::move(data));
+      return channel->async_try_write_shared(std::move(data));
     }
     return false;
   }

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -140,6 +140,7 @@ struct UdpClient::Impl {
   std::future<bool> start() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (channel && channel->is_connected()) {
+      started_.store(true);
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
@@ -237,17 +238,24 @@ struct UdpClient::Impl {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      return channel->async_write_move(std::move(data));
     }
     return try_send_move(std::move(data));
   }
 
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
       bp_cv_.wait(bp_lock, [this] {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      return channel->async_write_shared(std::move(data));
     }
     return try_send_shared(std::move(data));
   }

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -470,24 +470,12 @@ struct UdpServer::Impl {
     bool sent = false;
     auto bytes = base::safe_convert::string_to_bytes(data);
     for (const auto& [id, entry] : sessions) {
-      sent |= channel->async_write_to(memory::ConstByteSpan(bytes.first, bytes.second), entry.endpoint);
+      sent |= channel->async_try_write_to(memory::ConstByteSpan(bytes.first, bytes.second), entry.endpoint);
     }
     return sent;
   }
 
   bool broadcast(std::string_view data) {
-    if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
-      std::vector<ClientId> clients;
-      {
-        std::shared_lock<std::shared_mutex> lock(mutex);
-        for (const auto& [id, _] : sessions) clients.push_back(id);
-      }
-      bool any_sent = false;
-      for (auto id : clients) {
-        if (send_to_blocking(id, data)) any_sent = true;
-      }
-      return any_sent;
-    }
     return try_broadcast(data);
   }
 
@@ -506,7 +494,7 @@ struct UdpServer::Impl {
     if (it == sessions.end() || !channel) return false;
 
     auto bytes = base::safe_convert::string_to_bytes(data);
-    return channel->async_write_to(memory::ConstByteSpan(bytes.first, bytes.second), it->second.endpoint);
+    return channel->async_try_write_to(memory::ConstByteSpan(bytes.first, bytes.second), it->second.endpoint);
   }
 
   RuntimeStats stats() const {

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -475,9 +475,7 @@ struct UdpServer::Impl {
     return sent;
   }
 
-  bool broadcast(std::string_view data) {
-    return try_broadcast(data);
-  }
+  bool broadcast(std::string_view data) { return try_broadcast(data); }
 
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -292,13 +292,16 @@ struct UdsClient::Impl {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
     });
-    return try_send(data);
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+    return channel_->async_write_copy(
+        memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
   }
 
   bool try_send(std::string_view data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
-      return channel_->async_write_copy(
+      return channel_->async_try_write_copy(
           memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     }
     return false;
@@ -307,7 +310,7 @@ struct UdsClient::Impl {
   bool try_send_move(std::vector<uint8_t>&& data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
-      return channel_->async_write_move(std::move(data));
+      return channel_->async_try_write_move(std::move(data));
     }
     return false;
   }
@@ -316,7 +319,7 @@ struct UdsClient::Impl {
     if (!data || data->empty()) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
-      return channel_->async_write_shared(std::move(data));
+      return channel_->async_try_write_shared(std::move(data));
     }
     return false;
   }

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -152,6 +152,7 @@ struct UdsClient::Impl {
   std::future<bool> start() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
     if (channel_ && channel_->is_connected()) {
+      started_.store(true);
       std::promise<bool> p;
       p.set_value(true);
       return p.get_future();
@@ -264,17 +265,24 @@ struct UdsClient::Impl {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+      return channel_->async_write_move(std::move(data));
     }
     return try_send_move(std::move(data));
   }
 
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
+    if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
       bp_cv_.wait(bp_lock, [this] {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
       });
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+      return channel_->async_write_shared(std::move(data));
     }
     return try_send_shared(std::move(data));
   }

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -122,7 +122,7 @@ struct UdsServer::Impl {
   bool try_send_to(ClientId client_id, std::string_view data) {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
-    return ts ? ts->send_to_client(client_id, data) : false;
+    return ts ? ts->try_send_to_client(client_id, data) : false;
   }
 
   bool try_broadcast(std::string_view data) {
@@ -138,19 +138,6 @@ struct UdsServer::Impl {
   }
 
   bool broadcast(std::string_view data) {
-    if (backpressure_strategy_.load() == base::constants::BackpressureStrategy::Reliable) {
-      std::vector<ClientId> clients;
-      {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
-        if (ts) clients = ts->connected_clients();
-      }
-      bool any_sent = false;
-      for (auto id : clients) {
-        if (send_to_blocking(id, data)) any_sent = true;
-      }
-      return any_sent;
-    }
     return try_broadcast(data);
   }
 

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -137,9 +137,7 @@ struct UdsServer::Impl {
     return try_send_to(client_id, data);
   }
 
-  bool broadcast(std::string_view data) {
-    return try_broadcast(data);
-  }
+  bool broadcast(std::string_view data) { return try_broadcast(data); }
 
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> lock(bp_mutex_);


### PR DESCRIPTION
## Description
Prepare unilink for a v1.0-quality API contract by stabilizing send/try-send and broadcast semantics, documenting the supported public surface and error/callback behavior, and wiring the remaining validation automation into CI-ready workflows.

This PR focuses on API contract clarity rather than adding new transport features. It makes the user-facing behavior predictable across TCP, UDP, UDS, and Serial wrappers, and adds regression coverage for the key contract differences.

## Key Changes
- Added explicit non-blocking try-write transport paths and routed `try_send`, `try_send_move`, and `try_send_shared` through them so Reliable mode does not enqueue into pending queues on try-send failure.
- Standardized server `broadcast()` as non-blocking fan-out across TCP, UDP, and UDS, with strict per-client blocking delivery remaining explicit through `send_to_blocking()`.
- Added wrapper and transport contract tests covering try-send behavior, Reliable send behavior, pending-byte preservation, and TCP/UDP/UDS broadcast behavior.
- Documented the v1.0 public API surface, deep include policy, error model, callback data lifetime, and performance validation process.
- Updated installed consumer smoke coverage to run a real TCP loopback runtime check after package installation.
- Added benchmark and optional TSAN workflows, plus a core benchmark harness that emits JSON and Markdown artifacts.
- Stabilized the stop-contract backpressure test so environment limitations do not produce false failures.

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [x] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Validation performed locally:

- `scripts/verify.sh`
  - Initial run built successfully but exposed one flaky stop-contract test.
  - Fixed the test to use targeted `send_to_client()` backpressure induction and environment-aware skips.
- `scripts/verify.sh --skip-format`
  - Passed: 641/641 tests.

Notes:

- The benchmark workflow is intentionally a soft gate. It records artifacts for release comparison but does not fail PRs on performance deltas yet.
- `broadcast_blocking()` is not introduced in this PR. The documented strict-delivery path remains explicit per-client `send_to_blocking()`.
