### PR TITLE
fix: harden try-send queue acceptance

### DIFF
--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -25,14 +25,48 @@ After `stop()` returns, no further callbacks should fire.
 `try_send(...)`, `try_send_move(...)`, and `try_send_shared(...)` are always
 non-blocking. They return `false` when the channel is stopped, disconnected,
 backpressured, or full. Reliable `try_send*` calls do not enqueue into pending
-queues.
+queues. A `true` return means the payload was accepted or reserved for send
+queue insertion according to the pressure state observed by the transport. It
+must not later be rejected only because queue pressure changed before the
+transport strand processed the enqueue. A concurrent `stop()` or close can still
+cancel already accepted asynchronous work.
 
 `send_blocking(...)` waits until queue pressure is relieved, then enqueues using
 the normal strategy-aware write path. It returns `false` if the channel stops
-while waiting or cannot accept the write.
+while waiting or cannot accept the write. It can block indefinitely while the
+channel remains active and pressure does not clear. Use `try_send(...)` for
+producer loops, or call `stop()` from another thread to unblock a blocking
+sender.
 
 Use `RuntimeStats` to inspect accepted bytes, sent bytes, failed sends, drops,
 queued bytes, pending bytes, and backpressure state.
+
+## RuntimeStats send accounting
+
+Send counters distinguish rejected Reliable sends from intentional BestEffort
+drops.
+
+- `send*` or `try_send*` rejected because the channel is stopped, disconnected,
+  closed, in error, or the payload is invalid: `failed_sends` increases.
+- Reliable `try_send*` rejected because the queue is backpressured or full:
+  `failed_sends` increases and `pending_bytes` must not increase.
+- BestEffort `try_send*` rejected because the queue is backpressured or full:
+  `dropped_messages` and `dropped_bytes` increase and `pending_bytes` must not
+  increase.
+- Reliable `send*` accepted while backpressure is active may enter the Reliable
+  pending queue. `pending_bytes` reflects those bytes until pressure clears and
+  the transport flushes them into the active send queue.
+- `messages_accepted` and `bytes_accepted` increase when a payload is accepted
+  or reserved for asynchronous queue insertion. A later lifecycle cancellation
+  after acceptance is reported as a failed send when the transport can observe
+  it.
+
+`broadcast(...)` and `try_broadcast(...)` are non-blocking fanout operations.
+They return success when at least one recipient accepts the payload. Recipients
+that are stopped, disconnected, full, or backpressured are reflected in the
+corresponding per-transport `RuntimeStats` counters: Reliable fanout rejects
+increase `failed_sends`, while BestEffort fanout drops increase
+`dropped_messages` and `dropped_bytes`.
 
 ## Async runtime errors
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -46,6 +46,7 @@ CI, CPack, and consumer smoke workflows live here.
 - [ ] Latest relevant benchmark result is preserved in `unilink-benchmarks`.
 - [ ] Latest benchmark artifact or `unilink-benchmarks` result is linked from the release notes.
 - [ ] `.github/workflows/benchmark.yml` was run manually or by the latest nightly schedule.
+- [ ] Contract-changing PRs link CI, Consumer Smoke, Benchmark, and TSAN run results in the PR or release notes.
 - [ ] Installed consumer runtime smoke passed for the release candidate package.
 - [ ] Optional TSAN workflow was reviewed or run for concurrency-sensitive changes.
 - [ ] Benchmark result links were checked.

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -161,6 +161,7 @@ int main(int argc, char** argv) {
   }
 
   std::atomic<uint64_t> server_received{0};
+  std::atomic<uint64_t> server_received_bytes{0};
   std::atomic<uint64_t> client_received{0};
   std::shared_ptr<unilink::TcpServer> server;
 
@@ -168,6 +169,7 @@ int main(int argc, char** argv) {
                .auto_start(false)
                .on_data([&](const unilink::MessageContext& ctx) {
                  server_received.fetch_add(1, std::memory_order_relaxed);
+                 server_received_bytes.fetch_add(ctx.data().size(), std::memory_order_relaxed);
                  if (server) server->send_to(ctx.client_id(), "ack");
                })
                .on_error([](const unilink::ErrorContext&) {})
@@ -207,12 +209,13 @@ int main(int argc, char** argv) {
   for (size_t payload_size : {size_t{64}, size_t{1024}, size_t{16 * 1024}, size_t{64 * 1024}, size_t{1024 * 1024}}) {
     const int iterations = payload_size >= 1024 * 1024 ? 4 : (payload_size >= 64 * 1024 ? 16 : 100);
     const std::string payload(payload_size, 'x');
-    const auto target = server_received.load(std::memory_order_relaxed) + static_cast<uint64_t>(iterations);
+    const auto target = server_received_bytes.load(std::memory_order_relaxed) +
+                        static_cast<uint64_t>(payload_size * iterations);
     const auto start = Clock::now();
     for (int i = 0; i < iterations; ++i) {
       if (!client->send(payload)) return 8;
     }
-    if (!wait_until([&]() { return server_received.load(std::memory_order_relaxed) >= target; },
+    if (!wait_until([&]() { return server_received_bytes.load(std::memory_order_relaxed) >= target; },
                     std::chrono::seconds(10))) {
       return 9;
     }

--- a/test/integration/transport/test_backpressure_strategy.cc
+++ b/test/integration/transport/test_backpressure_strategy.cc
@@ -426,6 +426,43 @@ TEST(BackpressureStrategyTest, BestEffort_TryWriteRejectsWhenBackpressureActiveA
   drain_and_stop(sock, session, ioc);
 }
 
+TEST(BackpressureStrategyTest, TryWritePressureRaceTrueReturnRemainsAccepted) {
+  constexpr size_t kBpHigh = 1024;
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
+
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.poll();
+
+  ASSERT_TRUE(session->async_write_move(std::vector<uint8_t>(900, 0xAA)));
+  ASSERT_TRUE(session->async_try_write_move(std::vector<uint8_t>(200, 0xAB)));
+
+  auto reserved = session->stats();
+  EXPECT_EQ(reserved.pending_bytes, 0u);
+  EXPECT_EQ(reserved.failed_sends, 0u);
+  EXPECT_EQ(reserved.messages_accepted, 2u);
+
+  ioc.poll();
+
+  auto accepted = session->stats();
+  EXPECT_TRUE(session->is_backpressure_active());
+  EXPECT_EQ(accepted.pending_bytes, 0u);
+  EXPECT_EQ(accepted.failed_sends, 0u);
+  EXPECT_EQ(accepted.dropped_messages, 0u);
+  EXPECT_EQ(accepted.messages_accepted, 2u);
+  EXPECT_EQ(accepted.bytes_accepted, 1100u);
+  EXPECT_EQ(accepted.queued_bytes, 1100u);
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+}
+
 // All bytes written to pending_ during backpressure are eventually delivered.
 TEST(BackpressureStrategyTest, Reliable_PendingQueue_DeliveredAfterBackpressureClears) {
   constexpr size_t kBpHigh = 1024;

--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -65,6 +65,14 @@ class ControlledChannel : public interface::Channel {
     return async_write_copy(memory::ConstByteSpan(data->data(), data->size()));
   }
 
+  bool async_try_write_copy(memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
 
   void on_state(OnState cb) override { on_state_ = std::move(cb); }

--- a/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
@@ -63,6 +63,14 @@ class ControlledUdpChannel : public interface::Channel {
     return async_write_copy(memory::ConstByteSpan(data->data(), data->size()));
   }
 
+  bool async_try_write_copy(memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
 
   void on_state(OnState cb) override { on_state_ = std::move(cb); }

--- a/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
@@ -71,6 +71,14 @@ class ControlledUdsChannel : public interface::Channel {
     return async_write_copy(memory::ConstByteSpan(data->data(), data->size()));
   }
 
+  bool async_try_write_copy(memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
 
   void on_state(OnState cb) override { on_state_ = std::move(cb); }

--- a/test/unit/wrapper/test_runtime_stats.cc
+++ b/test/unit/wrapper/test_runtime_stats.cc
@@ -57,6 +57,14 @@ class StatsChannel : public unilink::interface::Channel {
     return data ? async_write_copy(unilink::memory::ConstByteSpan(data->data(), data->size())) : false;
   }
 
+  bool async_try_write_copy(unilink::memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
   void on_state(OnState cb) override { on_state_ = std::move(cb); }
   void on_backpressure(OnBackpressure cb) override { on_backpressure_ = std::move(cb); }

--- a/test/unit/wrapper/test_send_buffer_apis.cc
+++ b/test/unit/wrapper/test_send_buffer_apis.cc
@@ -65,6 +65,14 @@ class CountingChannel : public unilink::interface::Channel {
     return write_result_ && data && !data->empty();
   }
 
+  bool async_try_write_copy(unilink::memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
   void on_state(OnState cb) override { on_state_ = std::move(cb); }
   void on_backpressure(OnBackpressure cb) override { on_backpressure_ = std::move(cb); }

--- a/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
+++ b/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
@@ -125,6 +125,14 @@ class ControlledChannel : public interface::Channel {
     return async_write_copy(memory::ConstByteSpan(data->data(), data->size()));
   }
 
+  bool async_try_write_copy(memory::ConstByteSpan data) override { return async_write_copy(data); }
+
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
 
   void on_state(OnState cb) override { on_state_ = std::move(cb); }

--- a/test/utils/wrapper_contract_test_utils.hpp
+++ b/test/utils/wrapper_contract_test_utils.hpp
@@ -53,6 +53,12 @@ class FakeChannel : public interface::Channel {
     return true;
   }
 
+  bool async_try_write_copy(memory::ConstByteSpan data) override { return async_write_copy(data); }
+  bool async_try_write_move(std::vector<uint8_t>&& data) override { return async_write_move(std::move(data)); }
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) override {
+    return async_write_shared(std::move(data));
+  }
+
   bool is_backpressure_active() const override { return false; }
 
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }

--- a/unilink/interface/channel.hpp
+++ b/unilink/interface/channel.hpp
@@ -53,11 +53,9 @@ class UNILINK_API Channel {
 
   // Explicit non-blocking drop-if-full send APIs. These must not enqueue into
   // Reliable pending queues when backpressure is already active.
-  virtual bool async_try_write_copy(memory::ConstByteSpan data) { return async_write_copy(data); }
-  virtual bool async_try_write_move(std::vector<uint8_t>&& data) { return async_write_move(std::move(data)); }
-  virtual bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
-    return async_write_shared(std::move(data));
-  }
+  virtual bool async_try_write_copy(memory::ConstByteSpan data) = 0;
+  virtual bool async_try_write_move(std::vector<uint8_t>&& data) = 0;
+  virtual bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> data) = 0;
 
   // Callbacks
   virtual void on_bytes(OnBytes cb) = 0;

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -36,6 +36,32 @@ struct DropAccounting {
   bool any() const { return messages > 0 || bytes > 0; }
 };
 
+inline bool try_reserve_write_bytes(std::atomic<size_t>& queue_bytes, const std::atomic<size_t>& pending_bytes,
+                                    const std::atomic<bool>& backpressure_active, size_t bytes, size_t bp_high,
+                                    size_t bp_limit) {
+  if (bytes == 0 || bytes > bp_limit || backpressure_active.load(std::memory_order_relaxed)) return false;
+
+  size_t current = queue_bytes.load(std::memory_order_relaxed);
+  for (;;) {
+    const size_t pending = pending_bytes.load(std::memory_order_relaxed);
+    if (current > bp_high || bytes > bp_high - current) return false;
+    if (current > bp_limit || pending > bp_limit - current || bytes > bp_limit - current - pending) return false;
+
+    if (queue_bytes.compare_exchange_weak(current, current + bytes, std::memory_order_acq_rel,
+                                          std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+}
+
+inline void release_reserved_write_bytes(std::atomic<size_t>& queue_bytes, size_t bytes) {
+  size_t current = queue_bytes.load(std::memory_order_relaxed);
+  for (;;) {
+    const size_t next = current > bytes ? current - bytes : 0;
+    if (queue_bytes.compare_exchange_weak(current, next, std::memory_order_acq_rel, std::memory_order_relaxed)) return;
+  }
+}
+
 // Returns the byte size of a buffer held in a transport BufferVariant alternative.
 // shared_ptr<const vector<uint8_t>> goes through ->size(); everything else via .size().
 template <typename T>

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -783,25 +783,21 @@ bool Serial::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->backpressure_active_, added,
+                                           impl->bp_high_, impl->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl->stats_.record_accepted(added);
 
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
     if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_write_bytes(impl->queued_bytes_, added);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
-        impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, added);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(added);
-    impl->queued_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
     impl->observe_queue();
     impl->report_backpressure(impl->queued_bytes_);
@@ -834,25 +830,21 @@ bool Serial::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->backpressure_active_, added,
+                                           impl->bp_high_, impl->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl->stats_.record_accepted(added);
 
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->get_impl();
     if (impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) || impl->state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_write_bytes(impl->queued_bytes_, added);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queued_bytes_ + added > impl->bp_high_ ||
-        impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, added);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(added);
-    impl->queued_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
     impl->observe_queue();
     impl->report_backpressure(impl->queued_bytes_);

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -577,26 +577,22 @@ bool TcpClient::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->backpressure_active_,
+                                           added, impl_->bp_high_, impl_->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl_->stats_.record_accepted(added);
 
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->impl_.get();
     if (impl->stop_requested_.load() || impl->state_.is_state(LinkState::Closed) ||
         impl->state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_write_bytes(impl->queue_bytes_, added);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queue_bytes_ + added > impl->bp_high_ ||
-        impl->queue_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, added);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(added);
-    impl->queue_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
     impl->observe_queue();
     impl->report_backpressure(self, impl->queue_bytes_);
@@ -632,26 +628,22 @@ bool TcpClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->backpressure_active_,
+                                           added, impl_->bp_high_, impl_->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl_->stats_.record_accepted(added);
 
   net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     auto impl = self->impl_.get();
     if (impl->stop_requested_.load() || impl->state_.is_state(LinkState::Closed) ||
         impl->state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_write_bytes(impl->queue_bytes_, added);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queue_bytes_ + added > impl->bp_high_ ||
-        impl->queue_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, added);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(added);
-    impl->queue_bytes_ += added;
     impl->tx_.emplace_back(std::move(buf));
     impl->observe_queue();
     impl->report_backpressure(self, impl->queue_bytes_);

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -300,24 +300,20 @@ bool TcpServerSession::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(queue_bytes_, pending_bytes_, backpressure_active_, added, bp_high_,
+                                           bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  stats_.record_accepted(added);
 
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) {
+      queue_util::release_reserved_write_bytes(self->queue_bytes_, added);
       self->stats_.record_failed_send();
       return;
     }
-    if (self->backpressure_active_.load() || self->queue_bytes_ + added > self->bp_high_ ||
-        self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-      if (self->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        self->stats_.record_dropped(1, added);
-      } else {
-        self->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    self->stats_.record_accepted(added);
-    self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
     self->observe_queue();
     self->report_backpressure(self->queue_bytes_);
@@ -348,24 +344,20 @@ bool TcpServerSession::async_try_write_shared(std::shared_ptr<const std::vector<
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(queue_bytes_, pending_bytes_, backpressure_active_, added, bp_high_,
+                                           bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  stats_.record_accepted(added);
 
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) {
+      queue_util::release_reserved_write_bytes(self->queue_bytes_, added);
       self->stats_.record_failed_send();
       return;
     }
-    if (self->backpressure_active_.load() || self->queue_bytes_ + added > self->bp_high_ ||
-        self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-      if (self->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        self->stats_.record_dropped(1, added);
-      } else {
-        self->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    self->stats_.record_accepted(added);
-    self->queue_bytes_ += added;
     self->tx_.emplace_back(std::move(buf));
     self->observe_queue();
     self->report_backpressure(self->queue_bytes_);

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -893,26 +893,22 @@ bool UdpChannel::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->backpressure_active_, size,
+                                           impl->bp_high_, impl->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl->stats_.record_accepted(size);
 
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
     if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
         impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_) {
+      queue_util::release_reserved_write_bytes(impl->queue_bytes_, size);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
-        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, size);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(size);
-    impl->queue_bytes_ += size;
     impl->tx_.push_back({std::move(buf), std::nullopt});
     impl->observe_queue();
     impl->report_backpressure(self, impl->queue_bytes_);
@@ -945,26 +941,22 @@ bool UdpChannel::async_try_write_shared(std::shared_ptr<const std::vector<uint8_
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->backpressure_active_, size,
+                                           impl->bp_high_, impl->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl->stats_.record_accepted(size);
 
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(data), size]() mutable {
     auto impl = self->get_impl();
     if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
         impl->state_.is_state(LinkState::Error) || !impl->remote_endpoint_) {
+      queue_util::release_reserved_write_bytes(impl->queue_bytes_, size);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
-        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, size);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(size);
-    impl->queue_bytes_ += size;
     impl->tx_.push_back({std::move(buf), std::nullopt});
     impl->observe_queue();
     impl->report_backpressure(self, impl->queue_bytes_);
@@ -1056,27 +1048,23 @@ bool UdpChannel::async_try_write_to(memory::ConstByteSpan data, const boost::asi
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->backpressure_active_, size,
+                                           impl->bp_high_, impl->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
 
   std::vector<uint8_t> copy(data.begin(), data.end());
+  impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {
     auto impl = self->get_impl();
     if (impl->stop_requested_.load() || impl->stopping_.load() || impl->state_.is_state(LinkState::Closed) ||
         impl->state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_write_bytes(impl->queue_bytes_, size);
       impl->stats_.record_failed_send();
       return;
     }
-    if (impl->backpressure_active_.load() || impl->queue_bytes_ + size > impl->bp_high_ ||
-        impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
-      if (impl->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl->stats_.record_dropped(1, size);
-      } else {
-        impl->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl->stats_.record_accepted(size);
-    impl->queue_bytes_ += size;
     impl->tx_.push_back({std::move(buf), destination});
     impl->observe_queue();
     impl->report_backpressure(self, impl->queue_bytes_);

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -391,24 +391,20 @@ bool UdsClient::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->backpressure_active_,
+                                           added, impl_->bp_high_, impl_->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl_->stats_.record_accepted(added);
 
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+      queue_util::release_reserved_write_bytes(impl_->queue_bytes_, added);
       impl_->stats_.record_failed_send();
       return;
     }
-    if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
-        impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
-      if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl_->stats_.record_dropped(1, added);
-      } else {
-        impl_->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl_->stats_.record_accepted(added);
-    impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
     impl_->observe_queue();
     impl_->report_backpressure(self, impl_->queue_bytes_);
@@ -439,24 +435,20 @@ bool UdsClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->backpressure_active_,
+                                           added, impl_->bp_high_, impl_->bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  impl_->stats_.record_accepted(added);
 
   net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+      queue_util::release_reserved_write_bytes(impl_->queue_bytes_, added);
       impl_->stats_.record_failed_send();
       return;
     }
-    if (impl_->backpressure_active_.load() || impl_->queue_bytes_ + added > impl_->bp_high_ ||
-        impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
-      if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        impl_->stats_.record_dropped(1, added);
-      } else {
-        impl_->stats_.record_failed_send();
-      }
-      return;
-    }
 
-    impl_->stats_.record_accepted(added);
-    impl_->queue_bytes_ += added;
     impl_->tx_.emplace_back(std::move(data));
     impl_->observe_queue();
     impl_->report_backpressure(self, impl_->queue_bytes_);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -200,24 +200,20 @@ bool UdsServerSession::async_try_write_move(std::vector<uint8_t>&& data) {
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(queue_bytes_, pending_bytes_, backpressure_active_, added, bp_high_,
+                                           bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  stats_.record_accepted(added);
 
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!alive_ || closing_) {
+      queue_util::release_reserved_write_bytes(queue_bytes_, added);
       stats_.record_failed_send();
       return;
     }
-    if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
-        queue_bytes_ + pending_bytes_ + added > bp_limit_) {
-      if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        stats_.record_dropped(1, added);
-      } else {
-        stats_.record_failed_send();
-      }
-      return;
-    }
 
-    stats_.record_accepted(added);
-    queue_bytes_ += added;
     tx_.emplace_back(std::move(data));
     observe_queue();
     report_backpressure(queue_bytes_);
@@ -248,24 +244,20 @@ bool UdsServerSession::async_try_write_shared(std::shared_ptr<const std::vector<
     reject_for_pressure();
     return false;
   }
+  if (!queue_util::try_reserve_write_bytes(queue_bytes_, pending_bytes_, backpressure_active_, added, bp_high_,
+                                           bp_limit_)) {
+    reject_for_pressure();
+    return false;
+  }
+  stats_.record_accepted(added);
 
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!alive_ || closing_) {
+      queue_util::release_reserved_write_bytes(queue_bytes_, added);
       stats_.record_failed_send();
       return;
     }
-    if (backpressure_active_.load() || queue_bytes_ + added > bp_high_ ||
-        queue_bytes_ + pending_bytes_ + added > bp_limit_) {
-      if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort) {
-        stats_.record_dropped(1, added);
-      } else {
-        stats_.record_failed_send();
-      }
-      return;
-    }
 
-    stats_.record_accepted(added);
-    queue_bytes_ += added;
     tx_.emplace_back(std::move(data));
     observe_queue();
     report_backpressure(queue_bytes_);


### PR DESCRIPTION
## Description

Hardens the v1.0 `try_send` contract so a `true` return means the payload has been accepted or reserved for queue insertion, instead of being only a scheduled enqueue attempt that can later be rejected because pressure changed. This also removes the unsafe `interface::Channel` try-write fallback that could silently route new transports into the Reliable pending queue.

## Key Changes

- Make `interface::Channel::async_try_write_copy`, `async_try_write_move`, and `async_try_write_shared` pure virtual.
- Add queue-byte reservation helpers and use them across TCP client/session, UDP, Serial, UDS client, and UDS server session try-write paths.
- Remove pressure-only rejection from posted try-write lambdas after a successful reservation; lifecycle stop/close cancellation still releases the reservation and records failure.
- Add a pressure-race regression test that verifies a `true` try-write return remains accepted even if pressure changes before strand execution.
- Update wrapper/test fake channels to implement explicit try-write methods after the interface contract change.
- Document RuntimeStats send accounting, broadcast partial-failure accounting, `try_send` acceptance semantics, and `send_blocking()` indefinite wait behavior.
- Stabilize benchmark smoke throughput accounting by tracking TCP stream bytes instead of callback count.

## Related Issues

- N/A

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [x] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Validation performed:

- `cmake --build build-local --parallel 2`
- `ctest --test-dir build-local --output-on-failure -R "WrapperSendContract|ServerBroadcastContract|BackpressureStrategy|TryWritePressureRace" -j 2`
- `ctest --test-dir build-local --output-on-failure -R "RuntimeStats|SendBufferApis|SerialWrapperLifecycle" -j 2`
- `ctest --test-dir build-local --output-on-failure --parallel 2` (642/642 passed)
- `scripts/verify_installed_consumer.sh --library-mode shared --build-dir build/consumer-shared --install-prefix build/install-shared --consumer-dir build/consumer-app-shared` (passed outside sandbox; sandbox TCP port reservation failed)
- `scripts/verify_installed_consumer.sh --library-mode static --build-dir build/consumer-static --install-prefix build/install-static --consumer-dir build/consumer-app-static` (passed outside sandbox; sandbox TCP port reservation failed)
- `bash scripts/run_benchmarks.sh --cmake-prefix "$PWD/build/install-shared" --output-json benchmark-result.json --output-summary benchmark-summary.md` (passed outside sandbox; sandbox TCP port reservation failed)

The requested `dev-linux-x64` preset could not configure in this checkout because `vcpkg/scripts/buildsystems/vcpkg.cmake` is absent, so validation used the existing `build-local` tree.