### PR TITLE
test: harden try-write and broadcast contracts

### DIFF
--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -31,6 +31,12 @@ must not later be rejected only because queue pressure changed before the
 transport strand processed the enqueue. A concurrent `stop()` or close can still
 cancel already accepted asynchronous work.
 
+`try_send*` rejects payloads that would exceed the current non-blocking queue
+threshold. A payload may be rejected even if it is below `MAX_BUFFER_SIZE` when
+it is larger than the current backpressure high-water budget. Use `send()` or
+`send_blocking()` when Reliable enqueue semantics are required for large
+payloads.
+
 `send_blocking(...)` waits until queue pressure is relieved, then enqueues using
 the normal strategy-aware write path. It returns `false` if the channel stops
 while waiting or cannot accept the write. It can block indefinitely while the

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -83,6 +83,7 @@ foreach(
   test_uds_wrapper_lifecycle.cc
   test_send_contract.cc
   test_server_broadcast_contract.cc
+  test_server_broadcast_slow_consumer_contract.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 
@@ -124,6 +125,7 @@ foreach(
   transport_uds_error_test.cc
   test_tcp_client_lifecycle.cc
   test_backpressure_strategy.cc
+  test_try_write_contract.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/transport/test_try_write_contract.cc
+++ b/test/integration/transport/test_try_write_contract.cc
@@ -179,8 +179,7 @@ void expect_reliable_try_write_rejects_without_pending(Transport& transport, siz
 
   EXPECT_FALSE(transport.async_try_write_copy(memory::ConstByteSpan(copy_payload.data(), copy_payload.size())));
   EXPECT_FALSE(transport.async_try_write_move(std::vector<uint8_t>(payload_size, 0xA2)));
-  EXPECT_FALSE(
-      transport.async_try_write_shared(std::make_shared<const std::vector<uint8_t>>(payload_size, 0xA3)));
+  EXPECT_FALSE(transport.async_try_write_shared(std::make_shared<const std::vector<uint8_t>>(payload_size, 0xA3)));
 
   auto after = transport.stats();
   EXPECT_EQ(after.pending_bytes, before.pending_bytes);
@@ -202,8 +201,8 @@ void expect_best_effort_try_write_counts_drop(Transport& transport, size_t paylo
 }
 
 template <typename Transport>
-void expect_try_write_true_return_remains_accepted(Transport& transport, net::io_context& ioc,
-                                                   size_t normal_size = 900, size_t try_size = 200) {
+void expect_try_write_true_return_remains_accepted(Transport& transport, net::io_context& ioc, size_t normal_size = 900,
+                                                   size_t try_size = 200) {
   ASSERT_TRUE(transport.async_write_move(std::vector<uint8_t>(normal_size, 0xC1)));
   ASSERT_TRUE(transport.async_try_write_move(std::vector<uint8_t>(try_size, 0xC2)));
 
@@ -306,8 +305,7 @@ config::SerialConfig serial_config(BackpressureStrategy strategy) {
   return cfg;
 }
 
-std::shared_ptr<Serial> started_serial(net::io_context& ioc, StallingSerialPort** port,
-                                       BackpressureStrategy strategy) {
+std::shared_ptr<Serial> started_serial(net::io_context& ioc, StallingSerialPort** port, BackpressureStrategy strategy) {
   auto fake = std::make_unique<StallingSerialPort>(ioc);
   *port = fake.get();
   auto serial = Serial::create(serial_config(strategy), std::move(fake), ioc);

--- a/test/integration/transport/test_try_write_contract.cc
+++ b/test/integration/transport/test_try_write_contract.cc
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "unilink/base/constants.hpp"
+#include "unilink/config/serial_config.hpp"
+#include "unilink/config/tcp_client_config.hpp"
+#include "unilink/config/udp_config.hpp"
+#include "unilink/config/uds_config.hpp"
+#include "unilink/interface/iserial_port.hpp"
+#include "unilink/interface/iuds_socket.hpp"
+#include "unilink/memory/safe_span.hpp"
+#include "unilink/transport/serial/serial.hpp"
+#include "unilink/transport/tcp_client/tcp_client.hpp"
+#include "unilink/transport/udp/udp.hpp"
+#include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/transport/uds/uds_server_session.hpp"
+
+using namespace unilink;
+using namespace unilink::base::constants;
+using namespace unilink::transport;
+using namespace std::chrono_literals;
+namespace net = boost::asio;
+using uds = net::local::stream_protocol;
+
+namespace {
+
+constexpr size_t kBpHigh = MIN_BACKPRESSURE_THRESHOLD;
+
+void poll_for(net::io_context& ioc, const std::function<bool()>& done) {
+  for (int i = 0; i < 32 && !done(); ++i) {
+    ioc.restart();
+    ioc.poll();
+  }
+}
+
+class StallingUdsSocket : public interface::UdsSocketInterface {
+ public:
+  struct WriteEntry {
+    size_t size;
+    std::function<void(const boost::system::error_code&, std::size_t)> handler;
+  };
+
+  explicit StallingUdsSocket(net::io_context& ioc) : ioc_(ioc) {}
+
+  void async_read_some(const net::mutable_buffer&,
+                       std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    read_handler_ = std::move(handler);
+  }
+
+  void async_write(const net::const_buffer& buffer,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    writes_.push_back({buffer.size(), std::move(handler)});
+  }
+
+  void async_connect(const uds::endpoint&, std::function<void(const boost::system::error_code&)> handler) override {
+    net::post(ioc_, [handler = std::move(handler)]() mutable { handler({}); });
+  }
+
+  void shutdown(uds::socket::shutdown_type, boost::system::error_code& ec) override { ec.clear(); }
+
+  void close(boost::system::error_code& ec) override {
+    ec.clear();
+    if (read_handler_) {
+      auto handler = std::move(read_handler_);
+      net::post(ioc_, [handler = std::move(handler)]() mutable {
+        handler(make_error_code(net::error::operation_aborted), 0);
+      });
+    }
+  }
+
+  uds::endpoint remote_endpoint(boost::system::error_code& ec) const override {
+    ec.clear();
+    return uds::endpoint("/tmp/unilink-test-peer");
+  }
+
+  bool complete_one(boost::system::error_code ec = {}) {
+    if (writes_.empty()) return false;
+    auto entry = std::move(writes_.front());
+    writes_.pop_front();
+    net::post(ioc_, [handler = std::move(entry.handler), ec, n = entry.size]() mutable { handler(ec, n); });
+    return true;
+  }
+
+  size_t pending_write_count() const { return writes_.size(); }
+
+ private:
+  net::io_context& ioc_;
+  std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
+  std::deque<WriteEntry> writes_;
+};
+
+class StallingSerialPort : public interface::SerialPortInterface {
+ public:
+  struct WriteEntry {
+    size_t size;
+    std::function<void(const boost::system::error_code&, std::size_t)> handler;
+  };
+
+  explicit StallingSerialPort(net::io_context& ioc) : ioc_(ioc) {}
+
+  void open(const std::string&, boost::system::error_code& ec) override {
+    open_ = true;
+    ec.clear();
+  }
+  bool is_open() const override { return open_; }
+  void close(boost::system::error_code& ec) override {
+    open_ = false;
+    ec.clear();
+    if (read_handler_) {
+      auto handler = std::move(read_handler_);
+      net::post(ioc_, [handler = std::move(handler)]() mutable {
+        handler(make_error_code(net::error::operation_aborted), 0);
+      });
+    }
+  }
+
+  void set_option(const net::serial_port_base::baud_rate&, boost::system::error_code& ec) override { ec.clear(); }
+  void set_option(const net::serial_port_base::character_size&, boost::system::error_code& ec) override { ec.clear(); }
+  void set_option(const net::serial_port_base::stop_bits&, boost::system::error_code& ec) override { ec.clear(); }
+  void set_option(const net::serial_port_base::parity&, boost::system::error_code& ec) override { ec.clear(); }
+  void set_option(const net::serial_port_base::flow_control&, boost::system::error_code& ec) override { ec.clear(); }
+
+  void async_read_some(const net::mutable_buffer&,
+                       std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    read_handler_ = std::move(handler);
+  }
+
+  void async_write(const net::const_buffer& buffer,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    writes_.push_back({buffer.size(), std::move(handler)});
+  }
+
+  bool complete_one(boost::system::error_code ec = {}) {
+    if (writes_.empty()) return false;
+    auto entry = std::move(writes_.front());
+    writes_.pop_front();
+    net::post(ioc_, [handler = std::move(entry.handler), ec, n = entry.size]() mutable { handler(ec, n); });
+    return true;
+  }
+
+  size_t pending_write_count() const { return writes_.size(); }
+
+ private:
+  net::io_context& ioc_;
+  bool open_{false};
+  std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
+  std::deque<WriteEntry> writes_;
+};
+
+template <typename Transport>
+void expect_reliable_try_write_rejects_without_pending(Transport& transport, size_t payload_size = 1) {
+  auto before = transport.stats();
+  std::vector<uint8_t> copy_payload(payload_size, 0xA1);
+
+  EXPECT_FALSE(transport.async_try_write_copy(memory::ConstByteSpan(copy_payload.data(), copy_payload.size())));
+  EXPECT_FALSE(transport.async_try_write_move(std::vector<uint8_t>(payload_size, 0xA2)));
+  EXPECT_FALSE(
+      transport.async_try_write_shared(std::make_shared<const std::vector<uint8_t>>(payload_size, 0xA3)));
+
+  auto after = transport.stats();
+  EXPECT_EQ(after.pending_bytes, before.pending_bytes);
+  EXPECT_EQ(after.failed_sends, before.failed_sends + 3);
+  EXPECT_EQ(after.dropped_messages, before.dropped_messages);
+  EXPECT_EQ(after.dropped_bytes, before.dropped_bytes);
+}
+
+template <typename Transport>
+void expect_best_effort_try_write_counts_drop(Transport& transport, size_t payload_size = 1) {
+  auto before = transport.stats();
+
+  EXPECT_FALSE(transport.async_try_write_move(std::vector<uint8_t>(payload_size, 0xB1)));
+
+  auto after = transport.stats();
+  EXPECT_EQ(after.pending_bytes, before.pending_bytes);
+  EXPECT_EQ(after.dropped_messages, before.dropped_messages + 1);
+  EXPECT_EQ(after.dropped_bytes, before.dropped_bytes + payload_size);
+}
+
+template <typename Transport>
+void expect_try_write_true_return_remains_accepted(Transport& transport, net::io_context& ioc,
+                                                   size_t normal_size = 900, size_t try_size = 200) {
+  ASSERT_TRUE(transport.async_write_move(std::vector<uint8_t>(normal_size, 0xC1)));
+  ASSERT_TRUE(transport.async_try_write_move(std::vector<uint8_t>(try_size, 0xC2)));
+
+  auto reserved = transport.stats();
+  EXPECT_EQ(reserved.failed_sends, 0u);
+  EXPECT_EQ(reserved.dropped_messages, 0u);
+  EXPECT_EQ(reserved.messages_accepted, 2u);
+  EXPECT_EQ(reserved.bytes_accepted, normal_size + try_size);
+
+  ioc.restart();
+  ioc.poll();
+
+  auto after = transport.stats();
+  EXPECT_EQ(after.failed_sends, 0u);
+  EXPECT_EQ(after.dropped_messages, 0u);
+  EXPECT_EQ(after.messages_accepted, 2u);
+  EXPECT_EQ(after.bytes_accepted, normal_size + try_size);
+}
+
+config::TcpClientConfig tcp_client_config(BackpressureStrategy strategy) {
+  config::TcpClientConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = 9;
+  cfg.retry_interval_ms = MIN_RETRY_INTERVAL_MS;
+  cfg.connection_timeout_ms = MIN_CONNECTION_TIMEOUT_MS;
+  cfg.backpressure_threshold = kBpHigh;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+std::shared_ptr<TcpClient> started_tcp_client(net::io_context& ioc, BackpressureStrategy strategy) {
+  auto client = TcpClient::create(tcp_client_config(strategy), ioc);
+  client->on_backpressure([](size_t) {});
+  client->start();
+  ioc.restart();
+  ioc.poll_one();
+  return client;
+}
+
+config::UdpConfig udp_config(BackpressureStrategy strategy) {
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = 0;
+  cfg.remote_address = "127.0.0.1";
+  cfg.remote_port = 9;
+  cfg.backpressure_threshold = kBpHigh;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+std::shared_ptr<UdpChannel> started_udp_channel(net::io_context& ioc, BackpressureStrategy strategy) {
+  auto channel = UdpChannel::create(udp_config(strategy), ioc);
+  channel->on_backpressure([](size_t) {});
+  channel->start();
+  ioc.restart();
+  ioc.poll();
+  return channel;
+}
+
+config::UdsClientConfig uds_client_config(BackpressureStrategy strategy) {
+  config::UdsClientConfig cfg;
+  cfg.socket_path = "/tmp/unilink-try-write-contract.sock";
+  cfg.retry_interval_ms = MIN_RETRY_INTERVAL_MS;
+  cfg.backpressure_threshold = kBpHigh;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+std::shared_ptr<UdsClient> started_uds_client(net::io_context& ioc, StallingUdsSocket** socket,
+                                              BackpressureStrategy strategy) {
+  auto fake = std::make_unique<StallingUdsSocket>(ioc);
+  *socket = fake.get();
+  auto client = UdsClient::create(uds_client_config(strategy), std::move(fake), ioc);
+  client->on_backpressure([](size_t) {});
+  client->start();
+  poll_for(ioc, [&] { return client->is_connected(); });
+  EXPECT_TRUE(client->is_connected());
+  return client;
+}
+
+std::shared_ptr<UdsServerSession> started_uds_server_session(net::io_context& ioc, StallingUdsSocket** socket,
+                                                             BackpressureStrategy strategy) {
+  auto fake = std::make_unique<StallingUdsSocket>(ioc);
+  *socket = fake.get();
+  auto session = std::make_shared<UdsServerSession>(ioc, std::move(fake), kBpHigh, 0, strategy);
+  session->on_backpressure([](size_t) {});
+  session->start();
+  ioc.restart();
+  ioc.poll();
+  EXPECT_TRUE(session->alive());
+  return session;
+}
+
+config::SerialConfig serial_config(BackpressureStrategy strategy) {
+  config::SerialConfig cfg;
+  cfg.device = "/dev/unilink-test";
+  cfg.retry_interval_ms = MIN_RETRY_INTERVAL_MS;
+  cfg.backpressure_threshold = kBpHigh;
+  cfg.backpressure_strategy = strategy;
+  return cfg;
+}
+
+std::shared_ptr<Serial> started_serial(net::io_context& ioc, StallingSerialPort** port,
+                                       BackpressureStrategy strategy) {
+  auto fake = std::make_unique<StallingSerialPort>(ioc);
+  *port = fake.get();
+  auto serial = Serial::create(serial_config(strategy), std::move(fake), ioc);
+  serial->on_backpressure([](size_t) {});
+  serial->start();
+  poll_for(ioc, [&] { return serial->is_connected(); });
+  EXPECT_TRUE(serial->is_connected());
+  return serial;
+}
+
+template <typename Transport>
+void activate_backpressure(Transport& transport, net::io_context& ioc) {
+  ASSERT_TRUE(transport.async_write_move(std::vector<uint8_t>(kBpHigh, 0xD1)));
+  poll_for(ioc, [&] { return transport.is_backpressure_active(); });
+  ASSERT_TRUE(transport.is_backpressure_active());
+}
+
+void stop_uds_client(std::shared_ptr<UdsClient>& client, StallingUdsSocket* socket, net::io_context& ioc) {
+  client->stop();
+  ioc.restart();
+  ioc.poll();
+  while (socket && socket->pending_write_count() > 0) {
+    socket->complete_one(make_error_code(net::error::operation_aborted));
+    ioc.restart();
+    ioc.poll();
+  }
+  client.reset();
+}
+
+void stop_uds_session(std::shared_ptr<UdsServerSession>& session, StallingUdsSocket* socket, net::io_context& ioc) {
+  session->stop();
+  ioc.restart();
+  ioc.poll();
+  while (socket && socket->pending_write_count() > 0) {
+    socket->complete_one(make_error_code(net::error::operation_aborted));
+    ioc.restart();
+    ioc.poll();
+  }
+  session.reset();
+}
+
+void stop_serial(std::shared_ptr<Serial>& serial, StallingSerialPort* port, net::io_context& ioc) {
+  serial->stop();
+  ioc.restart();
+  ioc.poll();
+  while (port && port->pending_write_count() > 0) {
+    port->complete_one(make_error_code(net::error::operation_aborted));
+    ioc.restart();
+    ioc.poll();
+  }
+  serial.reset();
+}
+
+}  // namespace
+
+TEST(TryWriteTransportContractTest, TcpClientReliableTryWriteRejectsWithoutPending) {
+  net::io_context ioc;
+  auto client = started_tcp_client(ioc, BackpressureStrategy::Reliable);
+  activate_backpressure(*client, ioc);
+
+  expect_reliable_try_write_rejects_without_pending(*client);
+
+  client->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdpReliableTryWriteRejectsWithoutPending) {
+  net::io_context ioc;
+  auto channel = started_udp_channel(ioc, BackpressureStrategy::Reliable);
+  ASSERT_TRUE(channel->async_try_write_move(std::vector<uint8_t>(kBpHigh, 0xD1)));
+
+  expect_reliable_try_write_rejects_without_pending(*channel);
+
+  channel->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdsClientReliableTryWriteRejectsWithoutPending) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto client = started_uds_client(ioc, &socket, BackpressureStrategy::Reliable);
+  activate_backpressure(*client, ioc);
+
+  expect_reliable_try_write_rejects_without_pending(*client);
+
+  stop_uds_client(client, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, UdsServerSessionReliableTryWriteRejectsWithoutPending) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto session = started_uds_server_session(ioc, &socket, BackpressureStrategy::Reliable);
+  activate_backpressure(*session, ioc);
+
+  expect_reliable_try_write_rejects_without_pending(*session);
+
+  stop_uds_session(session, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, SerialReliableTryWriteRejectsWithoutPending) {
+  net::io_context ioc;
+  StallingSerialPort* port = nullptr;
+  auto serial = started_serial(ioc, &port, BackpressureStrategy::Reliable);
+  activate_backpressure(*serial, ioc);
+
+  expect_reliable_try_write_rejects_without_pending(*serial);
+
+  stop_serial(serial, port, ioc);
+}
+
+TEST(TryWriteTransportContractTest, TcpClientBestEffortTryWriteCountsDrop) {
+  net::io_context ioc;
+  auto client = started_tcp_client(ioc, BackpressureStrategy::BestEffort);
+  activate_backpressure(*client, ioc);
+
+  expect_best_effort_try_write_counts_drop(*client);
+
+  client->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdpBestEffortTryWriteCountsDrop) {
+  net::io_context ioc;
+  auto channel = started_udp_channel(ioc, BackpressureStrategy::BestEffort);
+  ASSERT_TRUE(channel->async_try_write_move(std::vector<uint8_t>(kBpHigh, 0xD1)));
+
+  expect_best_effort_try_write_counts_drop(*channel);
+
+  channel->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdsClientBestEffortTryWriteCountsDrop) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto client = started_uds_client(ioc, &socket, BackpressureStrategy::BestEffort);
+  activate_backpressure(*client, ioc);
+
+  expect_best_effort_try_write_counts_drop(*client);
+
+  stop_uds_client(client, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, UdsServerSessionBestEffortTryWriteCountsDrop) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto session = started_uds_server_session(ioc, &socket, BackpressureStrategy::BestEffort);
+  activate_backpressure(*session, ioc);
+
+  expect_best_effort_try_write_counts_drop(*session);
+
+  stop_uds_session(session, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, SerialBestEffortTryWriteCountsDrop) {
+  net::io_context ioc;
+  StallingSerialPort* port = nullptr;
+  auto serial = started_serial(ioc, &port, BackpressureStrategy::BestEffort);
+  activate_backpressure(*serial, ioc);
+
+  expect_best_effort_try_write_counts_drop(*serial);
+
+  stop_serial(serial, port, ioc);
+}
+
+TEST(TryWriteTransportContractTest, TcpClientTryWriteTrueReturnRemainsAccepted) {
+  net::io_context ioc;
+  auto client = started_tcp_client(ioc, BackpressureStrategy::Reliable);
+
+  expect_try_write_true_return_remains_accepted(*client, ioc);
+
+  client->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdpTryWriteTrueReturnRemainsAccepted) {
+  net::io_context ioc;
+  auto channel = started_udp_channel(ioc, BackpressureStrategy::Reliable);
+
+  expect_try_write_true_return_remains_accepted(*channel, ioc);
+
+  channel->stop();
+}
+
+TEST(TryWriteTransportContractTest, UdsClientTryWriteTrueReturnRemainsAccepted) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto client = started_uds_client(ioc, &socket, BackpressureStrategy::Reliable);
+
+  expect_try_write_true_return_remains_accepted(*client, ioc);
+
+  stop_uds_client(client, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, UdsServerSessionTryWriteTrueReturnRemainsAccepted) {
+  net::io_context ioc;
+  StallingUdsSocket* socket = nullptr;
+  auto session = started_uds_server_session(ioc, &socket, BackpressureStrategy::Reliable);
+
+  expect_try_write_true_return_remains_accepted(*session, ioc);
+
+  stop_uds_session(session, socket, ioc);
+}
+
+TEST(TryWriteTransportContractTest, SerialTryWriteTrueReturnRemainsAccepted) {
+  net::io_context ioc;
+  StallingSerialPort* port = nullptr;
+  auto serial = started_serial(ioc, &port, BackpressureStrategy::Reliable);
+
+  expect_try_write_true_return_remains_accepted(*serial, ioc);
+
+  stop_serial(serial, port, ioc);
+}

--- a/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
+++ b/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "test_utils.hpp"
+#include "unilink/base/constants.hpp"
+#include "unilink/unilink.hpp"
+
+namespace {
+
+using namespace std::chrono_literals;
+using unilink::test::TestUtils;
+namespace net = boost::asio;
+using tcp = net::ip::tcp;
+using udp = net::ip::udp;
+using uds = net::local::stream_protocol;
+
+constexpr size_t kThreshold = unilink::base::constants::MIN_BACKPRESSURE_THRESHOLD;
+
+bool is_port_allocation_failure(const std::exception& ex) {
+  return std::string_view(ex.what()).find("Unable to find available test port") != std::string_view::npos;
+}
+
+void expect_fast(std::string_view label, const std::function<bool()>& fn) {
+  SCOPED_TRACE(std::string(label));
+  const auto start = std::chrono::steady_clock::now();
+  EXPECT_TRUE(fn());
+  EXPECT_LT(std::chrono::steady_clock::now() - start, 100ms);
+}
+
+bool call_fast(std::string_view label, const std::function<bool()>& fn) {
+  SCOPED_TRACE(std::string(label));
+  const auto start = std::chrono::steady_clock::now();
+  const bool result = fn();
+  EXPECT_LT(std::chrono::steady_clock::now() - start, 100ms);
+  return result;
+}
+
+template <typename Server>
+void expect_observable_broadcast_stats(const Server& server) {
+  const auto stats = server.stats();
+  EXPECT_GT(stats.messages_accepted, 0u);
+  EXPECT_GT(stats.bytes_accepted, 0u);
+}
+
+}  // namespace
+
+TEST(ServerBroadcastSlowConsumerContractTest, TcpBroadcastDoesNotBlockOnSingleSlowClient) {
+  uint16_t port = 0;
+  try {
+    port = TestUtils::getAvailableTestPort();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "TCP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  auto server = std::make_shared<unilink::wrapper::TcpServer>(port);
+  server->backpressure_threshold(kThreshold).send_buffer_size(kThreshold);
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  std::atomic<size_t> healthy_bytes{0};
+  auto healthy = std::make_shared<unilink::wrapper::TcpClient>("127.0.0.1", port);
+  healthy->on_data([&](const unilink::MessageContext& msg) { healthy_bytes.fetch_add(msg.data().size()); });
+  ASSERT_TRUE(healthy->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return healthy->connected(); }, 5000));
+
+  net::io_context slow_ioc;
+  tcp::socket slow_socket(slow_ioc);
+  slow_socket.connect(tcp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  slow_socket.set_option(net::socket_base::receive_buffer_size(static_cast<int>(kThreshold)));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
+
+  const std::string payload(kThreshold, 't');
+  int accepted = 0;
+  for (int i = 0; i < 128; ++i) {
+    if (call_fast("tcp-broadcast", [&] { return server->broadcast(payload); })) {
+      ++accepted;
+    }
+  }
+
+  EXPECT_GT(accepted, 0);
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return healthy_bytes.load() > 0; }, 5000));
+  expect_observable_broadcast_stats(*server);
+
+  boost::system::error_code ec;
+  slow_socket.close(ec);
+  healthy->stop();
+  server->stop();
+}
+
+TEST(ServerBroadcastSlowConsumerContractTest, TcpBroadcastContinuesDeliveringToHealthyClient) {
+  uint16_t port = 0;
+  try {
+    port = TestUtils::getAvailableTestPort();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "TCP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  auto server = std::make_shared<unilink::wrapper::TcpServer>(port);
+  server->backpressure_threshold(kThreshold);
+  ASSERT_TRUE(server->start().get());
+
+  std::atomic<int> healthy_callbacks{0};
+  auto healthy = std::make_shared<unilink::wrapper::TcpClient>("127.0.0.1", port);
+  healthy->on_data([&](const unilink::MessageContext&) { healthy_callbacks.fetch_add(1); });
+  ASSERT_TRUE(healthy->start().get());
+
+  net::io_context slow_ioc;
+  tcp::socket slow_socket(slow_ioc);
+  slow_socket.connect(tcp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
+
+  for (int i = 0; i < 16; ++i) {
+    expect_fast("tcp-healthy", [&] { return server->broadcast("healthy-tcp"); });
+    ASSERT_TRUE(TestUtils::waitForCondition([&] { return healthy_callbacks.load() > i; }, 5000));
+  }
+
+  expect_observable_broadcast_stats(*server);
+
+  boost::system::error_code ec;
+  slow_socket.close(ec);
+  healthy->stop();
+  server->stop();
+}
+
+TEST(ServerBroadcastSlowConsumerContractTest, UdpBroadcastDoesNotBlockOnSlowVirtualClient) {
+  uint16_t port = 0;
+  try {
+    port = TestUtils::getAvailableTestPort();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "UDP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  unilink::config::UdpConfig server_cfg;
+  server_cfg.bind_address = "127.0.0.1";
+  server_cfg.local_port = port;
+  server_cfg.backpressure_threshold = kThreshold;
+
+  auto server = std::make_shared<unilink::wrapper::UdpServer>(server_cfg);
+  ASSERT_TRUE(server->start().get());
+
+  unilink::config::UdpConfig healthy_cfg;
+  healthy_cfg.bind_address = "127.0.0.1";
+  healthy_cfg.local_port = 0;
+  healthy_cfg.remote_address = "127.0.0.1";
+  healthy_cfg.remote_port = port;
+  auto healthy = std::make_shared<unilink::wrapper::UdpClient>(healthy_cfg);
+
+  std::atomic<int> healthy_callbacks{0};
+  healthy->on_data([&](const unilink::MessageContext&) { healthy_callbacks.fetch_add(1); });
+  ASSERT_TRUE(healthy->start().get());
+  healthy->send("register-healthy");
+
+  net::io_context slow_ioc;
+  udp::socket slow_socket(slow_ioc, udp::endpoint(net::ip::make_address("127.0.0.1"), 0));
+  const udp::endpoint server_ep(net::ip::make_address("127.0.0.1"), port);
+  slow_socket.send_to(net::buffer("register-slow", 13), server_ep);
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
+
+  for (int i = 0; i < 32; ++i) {
+    expect_fast("udp-broadcast", [&] { return server->broadcast("healthy-udp"); });
+  }
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return healthy_callbacks.load() > 0; }, 5000));
+  expect_observable_broadcast_stats(*server);
+
+  boost::system::error_code ec;
+  slow_socket.close(ec);
+  healthy->stop();
+  server->stop();
+}
+
+#ifndef _WIN32
+TEST(ServerBroadcastSlowConsumerContractTest, UdsBroadcastDoesNotBlockOnSingleSlowClient) {
+  auto socket_path = TestUtils::makeUniqueUdsSocketPath("slow-broadcast-contract").string();
+  TestUtils::removeFileIfExists(socket_path);
+
+  auto server = std::make_shared<unilink::wrapper::UdsServer>(socket_path);
+  server->backpressure_threshold(kThreshold);
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  std::atomic<int> healthy_callbacks{0};
+  auto healthy = std::make_shared<unilink::wrapper::UdsClient>(socket_path);
+  healthy->on_data([&](const unilink::MessageContext&) { healthy_callbacks.fetch_add(1); });
+  ASSERT_TRUE(healthy->start().get());
+
+  net::io_context slow_ioc;
+  uds::socket slow_socket(slow_ioc);
+  slow_socket.connect(uds::endpoint(socket_path));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
+
+  for (int i = 0; i < 32; ++i) {
+    expect_fast("uds-broadcast", [&] { return server->broadcast("healthy-uds"); });
+  }
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return healthy_callbacks.load() > 0; }, 5000));
+  expect_observable_broadcast_stats(*server);
+
+  boost::system::error_code ec;
+  slow_socket.close(ec);
+  healthy->stop();
+  server->stop();
+  TestUtils::removeFileIfExists(socket_path);
+}
+#endif

--- a/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
+++ b/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
@@ -16,8 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/asio.hpp>
 #include <atomic>
+#include <boost/asio.hpp>
 #include <chrono>
 #include <exception>
 #include <functional>

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -90,11 +90,17 @@ class UNILINK_API ChannelInterface {
   //     Always non-blocking and always rejects a full/backpressured queue,
   //     regardless of strategy. Reliable channels do not enqueue into pending_
   //     for try_send().
+  //     Rejects payloads that would exceed the current non-blocking queue
+  //     threshold; payloads below MAX_BUFFER_SIZE can still be rejected when
+  //     they exceed the current backpressure high-water budget.
   //     Use when you need BestEffort behaviour on a Reliable channel for a specific
   //     call (e.g. fire-and-forget heartbeat).
   //
   //   send_blocking() / send_line_blocking()
   //     Always blocks until queue pressure is relieved, regardless of strategy.
+  //     This call may block indefinitely while the channel remains active and
+  //     backpressure does not clear. stop() from another thread is expected to
+  //     unblock waiting senders.
 
   /**
    * @brief Enqueue data for transmission, honouring the backpressure strategy.
@@ -118,6 +124,9 @@ class UNILINK_API ChannelInterface {
    *
    * Ignores the configured strategy — always blocks. Prefer send() unless you need
    * to override BestEffort behaviour for a specific call.
+   * This call may block indefinitely while the channel remains active and
+   * backpressure does not clear. stop() from another thread is expected to unblock
+   * waiting senders.
    *
    * @return true Data was accepted. @return false Channel stopped while waiting.
    */
@@ -125,6 +134,11 @@ class UNILINK_API ChannelInterface {
 
   /**
    * @brief Blocking variant of send_line(). Always blocks regardless of strategy.
+   *
+   * This call may block indefinitely while the channel remains active and
+   * backpressure does not clear. stop() from another thread is expected to unblock
+   * waiting senders.
+   *
    * @return true Data was accepted. @return false Channel stopped while waiting.
    */
   virtual bool send_line_blocking(std::string_view line) = 0;
@@ -133,6 +147,10 @@ class UNILINK_API ChannelInterface {
    * @brief Non-blocking send that always drops on a full queue, ignoring strategy.
    *
    * Use as an escape hatch when you need drop-on-full behaviour on a Reliable channel.
+   * Rejects payloads that would exceed the current non-blocking queue threshold.
+   * A payload may be rejected even if it is below MAX_BUFFER_SIZE when it is larger
+   * than the current backpressure high-water budget. Use send() or send_blocking()
+   * when Reliable enqueue semantics are required for large payloads.
    *
    * @return true Data was accepted. @return false Dropped (not connected or queue full).
    */
@@ -140,6 +158,9 @@ class UNILINK_API ChannelInterface {
 
   /**
    * @brief Non-blocking send_line that always drops on a full queue, ignoring strategy.
+   *
+   * Uses the same non-blocking queue threshold policy as try_send().
+   *
    * @return true Data was accepted. @return false Dropped.
    */
   virtual bool try_send_line(std::string_view line) = 0;
@@ -159,6 +180,8 @@ class UNILINK_API ChannelInterface {
    *
    * Always returns without waiting for backpressure. The moved-from vector is consumed
    * regardless of the return value.
+   * Rejects payloads that would exceed the current non-blocking queue threshold,
+   * even below MAX_BUFFER_SIZE when they exceed the current high-water budget.
    *
    * @return true Data was accepted. @return false Data was dropped or rejected.
    */
@@ -177,6 +200,8 @@ class UNILINK_API ChannelInterface {
    * @brief Non-blocking shared-buffer send.
    *
    * The shared buffer must be non-null and non-empty.
+   * Rejects payloads that would exceed the current non-blocking queue threshold,
+   * even below MAX_BUFFER_SIZE when they exceed the current high-water budget.
    *
    * @return true Data was accepted. @return false Data was dropped or rejected.
    */

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -78,9 +78,15 @@ class UNILINK_API ServerInterface {
   //
   //   try_send_to() / try_broadcast()
   //     Always non-blocking and always drops on full queue, regardless of strategy.
+  //     Rejects payloads that would exceed the current non-blocking queue
+  //     threshold; payloads below MAX_BUFFER_SIZE can still be rejected when
+  //     they exceed the current backpressure high-water budget.
   //
   //   send_to_blocking()
   //     Always blocks until queue pressure is relieved, regardless of strategy.
+  //     This call may block indefinitely while the server remains active and
+  //     backpressure does not clear. stop() from another thread is expected to
+  //     unblock waiting senders.
 
   /**
    * @brief Send to a specific client, honouring the backpressure strategy.
@@ -104,6 +110,11 @@ class UNILINK_API ServerInterface {
 
   /**
    * @brief Block until queue pressure is relieved, then send to a client. Ignores strategy.
+   *
+   * This call may block indefinitely while the server remains active and
+   * backpressure does not clear. stop() from another thread is expected to unblock
+   * waiting senders.
+   *
    * @return true Data was accepted. @return false Server stopped while waiting.
    */
   virtual bool send_to_blocking(ClientId client_id, std::string_view data) = 0;
@@ -112,6 +123,11 @@ class UNILINK_API ServerInterface {
    * @brief Non-blocking send_to that always drops on a full queue, ignoring strategy.
    *
    * Use as an escape hatch when you need drop-on-full behaviour on a Reliable channel.
+   * Rejects payloads that would exceed the current non-blocking queue threshold.
+   * A payload may be rejected even if it is below MAX_BUFFER_SIZE when it is larger
+   * than the current backpressure high-water budget. Use send_to() or
+   * send_to_blocking() when Reliable enqueue semantics are required for large
+   * payloads.
    *
    * @return true Data was accepted. @return false Dropped or client not found.
    */
@@ -119,6 +135,9 @@ class UNILINK_API ServerInterface {
 
   /**
    * @brief Non-blocking broadcast that always drops on full queues, ignoring strategy.
+   *
+   * Uses the same non-blocking queue threshold policy as try_send_to().
+   *
    * @return true At least one client accepted the data.
    */
   virtual bool try_broadcast(std::string_view data) = 0;


### PR DESCRIPTION
## Summary

- Add direct transport try-write contract coverage for TcpClient, UdpChannel, UdsClient, UdsServerSession, and Serial.
- Add slow-consumer broadcast contract coverage for TCP, UDP, and UDS wrapper servers.
- Document try_send high-water threshold rejection and mirror send_blocking indefinite-block warnings in public interfaces.

## Impact

This locks down the v1.0 send/try_send/broadcast behavior so Reliable try-write rejects do not enter pending queues, BestEffort rejects account as drops, true try-write returns remain accepted, and slow consumers do not block broadcast fanout to healthy clients.

## Validation

- `cmake -S . -B build-local -G "Unix Makefiles" -DUNILINK_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-local --parallel 2`
- `ctest --test-dir build-local --output-on-failure -R "TryWrite|SlowConsumer"`
- `ctest --test-dir build-local --output-on-failure -R "WrapperSendContractTest|ServerBroadcastContractTest|BackpressureStrategyTest"`
- `ctest --test-dir build-local --output-on-failure --parallel 2` (661/661 passed)

Note: `cmake --preset dev-linux-x64` was not available locally because the repo-local vcpkg toolchain and Ninja were missing in this workspace.