### PR TITLE
feat: add idle timeout liveness policy

### DIFF
--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -25,6 +25,7 @@ User-facing APIs include:
 - `send_move(...)`, `try_send_move(...)`
 - `send_shared(...)`, `try_send_shared(...)`
 - TCP/UDP socket tuning builder options
+- TCP/UDP idle timeout builder options
 
 ## Supported but pre-1.0 unstable APIs
 

--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -47,6 +47,26 @@ sender.
 Use `RuntimeStats` to inspect accepted bytes, sent bytes, failed sends, drops,
 queued bytes, pending bytes, and backpressure state.
 
+## Liveness and idle timeout
+
+`idle_timeout(...)` is an application-level stale-session policy, not a
+heartbeat protocol.
+
+- `0ms` disables idle timeout.
+- TCP client idle timeout closes the current socket. By default it uses
+  `IdleTimeoutAction::Reconnect`, so the client follows the existing retry
+  interval, max retries, and reconnect policy. `IdleTimeoutAction::Close`
+  closes without reconnecting.
+- TCP server idle timeout closes only the idle client session. The server keeps
+  listening, and a peer that connects again is accepted as a new session.
+- UDP server idle timeout removes the virtual session and invokes
+  `on_disconnect(...)`. If the endpoint sends another datagram later, it is
+  discovered as a new virtual session.
+
+`keep_alive(true)` enables the operating system's TCP keepalive option. Its
+detection interval and failure behavior are OS-dependent and should not be used
+as the only mechanism for predictable stale-session cleanup.
+
 ## RuntimeStats send accounting
 
 Send counters distinguish rejected Reliable sends from intentional BestEffort

--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -279,7 +279,7 @@ TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutResetsOnInboundData) {
   std::atomic<size_t> received_bytes{0};
 
   client_ = unilink::tcp_client("127.0.0.1", test_port_)
-                .idle_timeout(150ms)
+                .idle_timeout(1000ms)
                 .idle_timeout_action(IdleTimeoutAction::Close)
                 .on_connect([&](const wrapper::ConnectionContext&) { connected++; })
                 .on_disconnect([&](const wrapper::ConnectionContext&) { disconnected++; })
@@ -292,8 +292,8 @@ TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutResetsOnInboundData) {
   ASSERT_TRUE(TestUtils::waitForCondition([&]() { return connected.load() == 1; }, 1000));
   ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() == 1; }, 1000));
 
-  for (int i = 1; i <= 4; ++i) {
-    std::this_thread::sleep_for(75ms);
+  for (int i = 1; i <= 6; ++i) {
+    std::this_thread::sleep_for(200ms);
     ASSERT_TRUE(server_->broadcast(payload));
     ASSERT_TRUE(TestUtils::waitForCondition(
         [&]() { return received_bytes.load() >= payload.size() * static_cast<size_t>(i); }, 1000));

--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -272,6 +272,36 @@ TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutCloseActionClosesWithoutReconne
   EXPECT_FALSE(client_->connected());
 }
 
+TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutResetsOnInboundData) {
+  constexpr std::string_view payload = "tick";
+  std::atomic<int> connected{0};
+  std::atomic<int> disconnected{0};
+  std::atomic<size_t> received_bytes{0};
+
+  client_ = unilink::tcp_client("127.0.0.1", test_port_)
+                .idle_timeout(150ms)
+                .idle_timeout_action(IdleTimeoutAction::Close)
+                .on_connect([&](const wrapper::ConnectionContext&) { connected++; })
+                .on_disconnect([&](const wrapper::ConnectionContext&) { disconnected++; })
+                .on_data([&](const wrapper::MessageContext& ctx) { received_bytes += ctx.data().size(); })
+                .on_error([](auto&&) {})
+                .build();
+
+  auto started = client_->start();
+  ASSERT_TRUE(started.get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return connected.load() == 1; }, 1000));
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() == 1; }, 1000));
+
+  for (int i = 1; i <= 4; ++i) {
+    std::this_thread::sleep_for(75ms);
+    ASSERT_TRUE(server_->broadcast(payload));
+    ASSERT_TRUE(TestUtils::waitForCondition(
+        [&]() { return received_bytes.load() >= payload.size() * static_cast<size_t>(i); }, 1000));
+    EXPECT_EQ(disconnected.load(), 0);
+    EXPECT_TRUE(client_->connected());
+  }
+}
+
 TEST(TcpClientWrapperContractTest, HandlerReplacementUsesLatestCallback) {
   auto fake_channel = std::make_shared<wrapper_support::FakeChannel>();
   wrapper::TcpClient client(fake_channel);

--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -36,6 +36,7 @@ namespace {
 
 using namespace unilink;
 using namespace unilink::test;
+using namespace std::chrono_literals;
 
 class ControlledChannel : public interface::Channel {
  public:
@@ -232,6 +233,43 @@ TEST_F(TcpClientWrapperLifecycleTest, SendMultipleMessages) {
   }
 
   EXPECT_TRUE(TestUtils::waitForCondition([&]() { return received.load() >= 5; }, 5000));
+}
+
+TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutReconnectsByDefault) {
+  std::atomic<int> connected{0};
+  client_ = unilink::tcp_client("127.0.0.1", test_port_)
+                .retry_interval(100ms)
+                .idle_timeout(100ms)
+                .on_connect([&](const wrapper::ConnectionContext&) { connected++; })
+                .on_data([](auto&&) {})
+                .on_error([](auto&&) {})
+                .build();
+
+  auto started = client_->start();
+  ASSERT_TRUE(started.get());
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return connected.load() >= 2; }, 3000));
+  EXPECT_TRUE(client_->connected());
+}
+
+TEST_F(TcpClientWrapperLifecycleTest, IdleTimeoutCloseActionClosesWithoutReconnect) {
+  std::atomic<int> connected{0};
+  std::atomic<int> disconnected{0};
+  client_ = unilink::tcp_client("127.0.0.1", test_port_)
+                .idle_timeout(100ms)
+                .idle_timeout_action(IdleTimeoutAction::Close)
+                .on_connect([&](const wrapper::ConnectionContext&) { connected++; })
+                .on_disconnect([&](const wrapper::ConnectionContext&) { disconnected++; })
+                .on_data([](auto&&) {})
+                .on_error([](auto&&) {})
+                .build();
+
+  auto started = client_->start();
+  ASSERT_TRUE(started.get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return connected.load() == 1; }, 1000));
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return disconnected.load() == 1; }, 3000));
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(connected.load(), 1);
+  EXPECT_FALSE(client_->connected());
 }
 
 TEST(TcpClientWrapperContractTest, HandlerReplacementUsesLatestCallback) {

--- a/test/integration/wrapper/test_udp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_udp_server_wrapper_lifecycle.cc
@@ -86,6 +86,32 @@ TEST(UdpServerWrapperLifecycleTest, SessionReaping) {
   server.stop();
 }
 
+TEST(UdpServerWrapperLifecycleTest, DefaultIdleTimeoutDisabledKeepsVirtualSession) {
+  auto port = TestUtils::getAvailableTestPort();
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = port;
+
+  wrapper::UdpServer server(cfg);
+  std::atomic<int> disconnects{0};
+  server.on_disconnect([&](const wrapper::ConnectionContext&) { disconnects++; });
+
+  auto started = server.start();
+  ASSERT_TRUE(started.get());
+
+  boost::asio::io_context ioc;
+  boost::asio::ip::udp::socket sock(ioc, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0));
+  sock.send_to(boost::asio::buffer("hello", 5),
+               boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), port));
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server.client_count() == 1; }, 1000));
+  std::this_thread::sleep_for(300ms);
+  EXPECT_EQ(disconnects.load(), 0);
+  EXPECT_EQ(server.client_count(), 1u);
+
+  server.stop();
+}
+
 TEST(UdpServerWrapperLifecycleTest, BatchAndClientLimitHandling) {
   auto port = TestUtils::getAvailableTestPort();
   config::UdpConfig cfg;

--- a/test/unit/builder/test_builder.cc
+++ b/test/unit/builder/test_builder.cc
@@ -130,6 +130,8 @@ TEST_F(BuilderTest, TcpClientBuilderAdvancedOptions) {
                     .retry_interval(25ms)
                     .max_retries(2)
                     .connection_timeout(50ms)
+                    .idle_timeout(75ms)
+                    .idle_timeout_action(IdleTimeoutAction::Close)
                     .tcp_no_delay(true)
                     .keep_alive(true)
                     .send_buffer_size(4 * 1024)

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -20,6 +20,12 @@
 #include <cstdint>
 
 namespace unilink {
+
+enum class IdleTimeoutAction {
+  Reconnect,
+  Close,
+};
+
 namespace base {
 
 // Network and I/O constants
@@ -72,10 +78,10 @@ constexpr unsigned MAX_CLEANUP_INTERVAL_MS = 1000;           // 1s maximum clean
 constexpr unsigned DEFAULT_HEALTH_CHECK_INTERVAL_MS = 1000;  // 1s health check interval
 
 // Connection and session constants
-constexpr size_t MAX_MAX_CONNECTIONS = 10000;      // Maximum allowed connections
-constexpr size_t DEFAULT_IDLE_TIMEOUT_MS = 30000;  // 30s default idle timeout
-constexpr size_t MIN_IDLE_TIMEOUT_MS = 1000;       // 1s minimum idle timeout
-constexpr size_t MAX_IDLE_TIMEOUT_MS = 300000;     // 5m maximum idle timeout
+constexpr size_t MAX_MAX_CONNECTIONS = 10000;   // Maximum allowed connections
+constexpr size_t DEFAULT_IDLE_TIMEOUT_MS = 0;   // Idle timeout disabled by default
+constexpr size_t MIN_IDLE_TIMEOUT_MS = 1;       // 1ms minimum idle timeout when enabled
+constexpr size_t MAX_IDLE_TIMEOUT_MS = 300000;  // 5m maximum idle timeout
 
 // Error handling constants
 constexpr size_t DEFAULT_MAX_RECENT_ERRORS = 1000;           // Default max recent errors to track

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -21,8 +21,16 @@
 
 namespace unilink {
 
+/**
+ * @brief Action taken by TCP clients when an enabled idle timeout expires.
+ *
+ * Idle timeout is disabled when the configured timeout is 0ms. This action is
+ * only consulted after a positive idle timeout has expired.
+ */
 enum class IdleTimeoutAction {
+  /// Close the stale socket and follow the existing reconnect policy.
   Reconnect,
+  /// Close the stale socket and leave the client closed.
   Close,
 };
 

--- a/unilink/builder/tcp_client_builder.cc
+++ b/unilink/builder/tcp_client_builder.cc
@@ -33,6 +33,8 @@ TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port
       retry_interval_(3000),
       max_retries_(-1),
       connection_timeout_(5000),
+      idle_timeout_(0),
+      idle_timeout_action_(IdleTimeoutAction::Reconnect),
       tcp_no_delay_(false),
       keep_alive_(false),
       send_buffer_size_(0),
@@ -64,6 +66,8 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   client->retry_interval(retry_interval_);
   client->max_retries(max_retries_);
   client->connection_timeout(connection_timeout_);
+  client->idle_timeout(idle_timeout_);
+  client->idle_timeout_action(idle_timeout_action_);
   client->tcp_no_delay(tcp_no_delay_);
   client->keep_alive(keep_alive_);
   client->send_buffer_size(send_buffer_size_);
@@ -110,6 +114,18 @@ TcpClientBuilder<State>& TcpClientBuilder<State>::max_retries(int max_retries) {
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::connection_timeout(std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
+  return *this;
+}
+
+template <uint32_t State>
+TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
+  idle_timeout_ = timeout;
+  return *this;
+}
+
+template <uint32_t State>
+TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout_action(IdleTimeoutAction action) {
+  idle_timeout_action_ = action;
   return *this;
 }
 

--- a/unilink/builder/tcp_client_builder.hpp
+++ b/unilink/builder/tcp_client_builder.hpp
@@ -54,6 +54,8 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
         retry_interval_(other.retry_interval_),
         max_retries_(other.max_retries_),
         connection_timeout_(other.connection_timeout_),
+        idle_timeout_(other.idle_timeout_),
+        idle_timeout_action_(other.idle_timeout_action_),
         tcp_no_delay_(other.tcp_no_delay_),
         keep_alive_(other.keep_alive_),
         send_buffer_size_(other.send_buffer_size_),
@@ -84,6 +86,8 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
   TcpClientBuilder<State>& retry_interval(std::chrono::milliseconds interval);
   TcpClientBuilder<State>& max_retries(int max_retries);
   TcpClientBuilder<State>& connection_timeout(std::chrono::milliseconds timeout);
+  TcpClientBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+  TcpClientBuilder<State>& idle_timeout_action(IdleTimeoutAction action);
   TcpClientBuilder<State>& independent_context(bool use_independent = true);
   TcpClientBuilder<State>& tcp_no_delay(bool enable = true);
   TcpClientBuilder<State>& keep_alive(bool enable = true);
@@ -102,6 +106,8 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
   std::chrono::milliseconds retry_interval_;
   int max_retries_;
   std::chrono::milliseconds connection_timeout_;
+  std::chrono::milliseconds idle_timeout_;
+  IdleTimeoutAction idle_timeout_action_;
   bool tcp_no_delay_;
   bool keep_alive_;
   size_t send_buffer_size_;

--- a/unilink/builder/tcp_client_builder.hpp
+++ b/unilink/builder/tcp_client_builder.hpp
@@ -86,7 +86,19 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
   TcpClientBuilder<State>& retry_interval(std::chrono::milliseconds interval);
   TcpClientBuilder<State>& max_retries(int max_retries);
   TcpClientBuilder<State>& connection_timeout(std::chrono::milliseconds timeout);
+  /**
+   * @brief Configure application-level idle timeout.
+   *
+   * A value of 0ms disables idle timeout. When enabled, inbound or outbound
+   * activity resets the timer.
+   */
   TcpClientBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+  /**
+   * @brief Configure what happens when an enabled idle timeout expires.
+   *
+   * The default is IdleTimeoutAction::Reconnect. This setting has no effect
+   * while idle_timeout is 0ms.
+   */
   TcpClientBuilder<State>& idle_timeout_action(IdleTimeoutAction action);
   TcpClientBuilder<State>& independent_context(bool use_independent = true);
   TcpClientBuilder<State>& tcp_no_delay(bool enable = true);

--- a/unilink/builder/tcp_server_builder.hpp
+++ b/unilink/builder/tcp_server_builder.hpp
@@ -97,6 +97,12 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
 
   // Backward compatibility methods
   TcpServerBuilder<State>& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
+  /**
+   * @brief Configure application-level idle timeout for accepted sessions.
+   *
+   * A value of 0ms disables idle timeout. When enabled, only the idle client
+   * session is closed; the server keeps listening for new connections.
+   */
   TcpServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
   [[deprecated("Use max_clients(1) instead")]]
   TcpServerBuilder<State>& single_client();

--- a/unilink/builder/udp_builder.hpp
+++ b/unilink/builder/udp_builder.hpp
@@ -173,6 +173,13 @@ class UNILINK_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer,
   UdpServerBuilder<State>& broadcast(bool enable = true);
   UdpServerBuilder<State>& reuse_address(bool enable = true);
   UdpServerBuilder<State>& independent_context(bool use_independent = true);
+  /**
+   * @brief Configure application-level idle timeout for virtual sessions.
+   *
+   * A value of 0ms disables idle timeout. When enabled, stale UDP virtual
+   * sessions are removed and a later datagram from the same endpoint creates a
+   * new virtual session.
+   */
   UdpServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
   UdpServerBuilder<State>& send_buffer_size(size_t bytes);
   UdpServerBuilder<State>& receive_buffer_size(size_t bytes);

--- a/unilink/config/tcp_client_config.hpp
+++ b/unilink/config/tcp_client_config.hpp
@@ -30,6 +30,8 @@ struct TcpClientConfig {
   uint16_t port = 9000;
   unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
   unsigned connection_timeout_ms = base::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
+  unsigned idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
+  IdleTimeoutAction idle_timeout_action = IdleTimeoutAction::Reconnect;
   int max_retries = base::constants::DEFAULT_MAX_RETRIES;
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -81,6 +81,7 @@ struct TcpClient::Impl {
   TcpClientConfig cfg_;
   net::steady_timer retry_timer_;
   net::steady_timer connect_timer_;
+  net::steady_timer idle_timer_;
   bool owns_ioc_ = true;
   std::atomic<bool> stop_requested_{false};
   std::atomic<bool> stopping_{false};
@@ -124,6 +125,7 @@ struct TcpClient::Impl {
         cfg_(cfg),
         retry_timer_(strand_),
         connect_timer_(strand_),
+        idle_timer_(strand_),
         owns_ioc_(!ioc_ptr),
         bp_strategy_(cfg.backpressure_strategy),
         bp_high_(cfg.backpressure_threshold) {
@@ -145,6 +147,7 @@ struct TcpClient::Impl {
   void start_read(std::shared_ptr<TcpClient> self, uint64_t seq);
   void do_write(std::shared_ptr<TcpClient> self, uint64_t seq);
   void handle_close(std::shared_ptr<TcpClient> self, uint64_t seq, const boost::system::error_code& ec = {});
+  void handle_idle_timeout(std::shared_ptr<TcpClient> self, uint64_t seq);
   void transition_to(LinkState next, const boost::system::error_code& ec = {});
   void perform_stop_cleanup();
   void reset_start_state();
@@ -157,6 +160,8 @@ struct TcpClient::Impl {
   void notify_state();
   void reset_io_objects();
   void apply_socket_options();
+  void reset_idle_timer(std::shared_ptr<TcpClient> self, uint64_t seq);
+  void cancel_idle_timer();
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
                     const boost::system::error_code& ec, std::string_view msg, bool retryable, uint32_t retry_count);
 };
@@ -671,6 +676,8 @@ void TcpClient::set_backpressure_strategy(base::constants::BackpressureStrategy 
 void TcpClient::set_retry_interval(unsigned interval_ms) { impl_->cfg_.retry_interval_ms = interval_ms; }
 void TcpClient::set_max_retries(int max_retries) { impl_->cfg_.max_retries = max_retries; }
 void TcpClient::set_connection_timeout(unsigned timeout_ms) { impl_->cfg_.connection_timeout_ms = timeout_ms; }
+void TcpClient::set_idle_timeout(unsigned timeout_ms) { impl_->cfg_.idle_timeout_ms = timeout_ms; }
+void TcpClient::set_idle_timeout_action(IdleTimeoutAction action) { impl_->cfg_.idle_timeout_action = action; }
 void TcpClient::set_reconnect_policy(ReconnectPolicy policy) {
   if (policy) {
     impl_->reconnect_policy_ = std::move(policy);
@@ -797,6 +804,7 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
                              fmt::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
           }
           self->impl_->start_read(self, seq);
+          self->impl_->reset_idle_timer(self, seq);
           net::post(self->impl_->strand_, [self, seq]() {
             self->impl_->writing_ = false;
             self->impl_->do_write(self, seq);
@@ -881,6 +889,9 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
     if (ec) {
       self->impl_->handle_close(self, seq, ec);
       return;
+    }
+    if (n > 0) {
+      self->impl_->reset_idle_timer(self, seq);
     }
     OnBytes on_bytes;
     {
@@ -974,6 +985,9 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
 
     self->impl_->current_write_buffer_.reset();
     self->impl_->stats_.record_sent(bytes_written);
+    if (bytes_written > 0) {
+      self->impl_->reset_idle_timer(self, seq);
+    }
     self->impl_->queue_bytes_ =
         (self->impl_->queue_bytes_ > queued_bytes) ? (self->impl_->queue_bytes_ - queued_bytes) : 0;
     self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
@@ -1014,12 +1028,44 @@ void TcpClient::Impl::handle_close(std::shared_ptr<TcpClient> self, uint64_t seq
   }
   connected_.store(false);
   writing_ = false;
+  cancel_idle_timer();
   connect_timer_.cancel();
   close_socket();
   if (stop_requested_.load() || stopping_.load() || state_.is_state(LinkState::Closed)) {
     transition_to(LinkState::Closed, ec);
     return;
   }
+  transition_to(LinkState::Connecting, ec);
+  schedule_retry(self, seq);
+}
+
+void TcpClient::Impl::handle_idle_timeout(std::shared_ptr<TcpClient> self, uint64_t seq) {
+  if (seq != current_seq_.load() || stop_requested_.load() || stopping_.load() || !connected_.load()) {
+    return;
+  }
+
+  const auto ec = make_error_code(boost::asio::error::timed_out);
+  const bool should_reconnect = cfg_.idle_timeout_action == IdleTimeoutAction::Reconnect;
+  const uint32_t current_attempts =
+      reconnect_policy_ ? reconnect_attempt_count_ : static_cast<uint32_t>(retry_attempts_);
+
+  UNILINK_LOG_WARNING("tcp_client", "idle_timeout",
+                      fmt::format("Idle timeout expired after {}ms; {}", cfg_.idle_timeout_ms,
+                                  should_reconnect ? "scheduling reconnect" : "closing connection"));
+  record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "idle_timeout", ec,
+               "Idle timeout expired", should_reconnect, current_attempts);
+
+  connected_.store(false);
+  writing_ = false;
+  cancel_idle_timer();
+  connect_timer_.cancel();
+  close_socket();
+
+  if (!should_reconnect) {
+    transition_to(LinkState::Closed, ec);
+    return;
+  }
+
   transition_to(LinkState::Connecting, ec);
   schedule_retry(self, seq);
 }
@@ -1137,6 +1183,7 @@ void TcpClient::Impl::perform_stop_cleanup() {
   try {
     retry_timer_.cancel();
     connect_timer_.cancel();
+    cancel_idle_timer();
     resolver_.cancel();
     boost::system::error_code ec_cancel;
     socket_.cancel(ec_cancel);
@@ -1240,6 +1287,7 @@ void TcpClient::Impl::reset_io_objects() {
     resolver_ = tcp::resolver(strand_);
     retry_timer_ = net::steady_timer(strand_);
     connect_timer_ = net::steady_timer(strand_);
+    idle_timer_ = net::steady_timer(strand_);
     tx_.clear();
     queue_bytes_ = 0;
     pending_.clear();
@@ -1257,6 +1305,28 @@ void TcpClient::Impl::reset_io_objects() {
     diagnostics::error_reporting::report_system_error("tcp_client", "reset_io_objects",
                                                       "Unknown error while resetting io objects");
   }
+}
+
+void TcpClient::Impl::reset_idle_timer(std::shared_ptr<TcpClient> self, uint64_t seq) {
+  if (cfg_.idle_timeout_ms == 0 || !connected_.load() || stop_requested_.load() || stopping_.load()) {
+    return;
+  }
+
+  idle_timer_.cancel();
+  idle_timer_.expires_after(std::chrono::milliseconds(cfg_.idle_timeout_ms));
+  idle_timer_.async_wait([self, seq](const boost::system::error_code& ec) {
+    if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) {
+      return;
+    }
+    if (!ec) {
+      self->impl_->handle_idle_timeout(self, seq);
+    }
+  });
+}
+
+void TcpClient::Impl::cancel_idle_timer() {
+  boost::system::error_code ignored;
+  idle_timer_.cancel(ignored);
 }
 
 }  // namespace transport

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -1324,10 +1324,7 @@ void TcpClient::Impl::reset_idle_timer(std::shared_ptr<TcpClient> self, uint64_t
   });
 }
 
-void TcpClient::Impl::cancel_idle_timer() {
-  boost::system::error_code ignored;
-  idle_timer_.cancel(ignored);
-}
+void TcpClient::Impl::cancel_idle_timer() { idle_timer_.cancel(); }
 
 }  // namespace transport
 }  // namespace unilink

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -90,6 +90,8 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   void set_retry_interval(unsigned interval_ms);
   void set_max_retries(int max_retries);
   void set_connection_timeout(unsigned timeout_ms);
+  void set_idle_timeout(unsigned timeout_ms);
+  void set_idle_timeout_action(IdleTimeoutAction action);
   void set_reconnect_policy(ReconnectPolicy policy);
 
  private:

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -76,6 +76,8 @@ struct TcpClient::Impl {
   std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   int max_retries_ = -1;
   std::chrono::milliseconds connection_timeout_{5000};
+  std::chrono::milliseconds idle_timeout_{0};
+  IdleTimeoutAction idle_timeout_action_{IdleTimeoutAction::Reconnect};
   size_t backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   base::constants::BackpressureStrategy backpressure_strategy_{base::constants::BackpressureStrategy::Reliable};
   bool tcp_no_delay_ = false;
@@ -178,6 +180,8 @@ struct TcpClient::Impl {
       config.retry_interval_ms = static_cast<unsigned int>(retry_interval_.count());
       config.max_retries = max_retries_;
       config.connection_timeout_ms = static_cast<unsigned>(connection_timeout_.count());
+      config.idle_timeout_ms = static_cast<unsigned>(idle_timeout_.count());
+      config.idle_timeout_action = idle_timeout_action_;
       config.backpressure_threshold = backpressure_threshold_;
       config.backpressure_strategy = backpressure_strategy_;
       config.tcp_no_delay = tcp_no_delay_;
@@ -616,6 +620,27 @@ TcpClient& TcpClient::connection_timeout(std::chrono::milliseconds t) {
   }
   return *this;
 }
+
+TcpClient& TcpClient::idle_timeout(std::chrono::milliseconds t) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->idle_timeout_ = t;
+  if (impl_->channel_) {
+    auto transport = std::dynamic_pointer_cast<transport::TcpClient>(impl_->channel_);
+    if (transport) transport->set_idle_timeout(static_cast<unsigned>(t.count()));
+  }
+  return *this;
+}
+
+TcpClient& TcpClient::idle_timeout_action(IdleTimeoutAction action) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->idle_timeout_action_ = action;
+  if (impl_->channel_) {
+    auto transport = std::dynamic_pointer_cast<transport::TcpClient>(impl_->channel_);
+    if (transport) transport->set_idle_timeout_action(action);
+  }
+  return *this;
+}
+
 TcpClient& TcpClient::manage_external_context(bool m) {
   impl_->manage_external_context_.store(m);
   return *this;

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -96,6 +96,8 @@ class UNILINK_API TcpClient : public ChannelInterface {
   TcpClient& retry_interval(std::chrono::milliseconds interval);
   TcpClient& max_retries(int max_retries);
   TcpClient& connection_timeout(std::chrono::milliseconds timeout);
+  TcpClient& idle_timeout(std::chrono::milliseconds timeout);
+  TcpClient& idle_timeout_action(IdleTimeoutAction action);
   TcpClient& backpressure_threshold(size_t threshold);
   TcpClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   TcpClient& tcp_no_delay(bool enable = true);

--- a/unilink/wrapper/tcp_client/tcp_client.hpp
+++ b/unilink/wrapper/tcp_client/tcp_client.hpp
@@ -96,7 +96,19 @@ class UNILINK_API TcpClient : public ChannelInterface {
   TcpClient& retry_interval(std::chrono::milliseconds interval);
   TcpClient& max_retries(int max_retries);
   TcpClient& connection_timeout(std::chrono::milliseconds timeout);
+  /**
+   * @brief Configure application-level idle timeout.
+   *
+   * A value of 0ms disables idle timeout. When enabled, inbound or outbound
+   * activity resets the timer.
+   */
   TcpClient& idle_timeout(std::chrono::milliseconds timeout);
+  /**
+   * @brief Configure what happens when an enabled idle timeout expires.
+   *
+   * The default is IdleTimeoutAction::Reconnect. This setting has no effect
+   * while idle_timeout is 0ms.
+   */
   TcpClient& idle_timeout_action(IdleTimeoutAction action);
   TcpClient& backpressure_threshold(size_t threshold);
   TcpClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -97,6 +97,12 @@ class UNILINK_API TcpServer : public ServerInterface {
   TcpServer& auto_start(bool manage = true) override;
   TcpServer& bind_address(const std::string& address);
   TcpServer& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
+  /**
+   * @brief Configure application-level idle timeout for accepted sessions.
+   *
+   * A value of 0ms disables idle timeout. When enabled, only the idle client
+   * session is closed; the server keeps listening for new connections.
+   */
   TcpServer& idle_timeout(std::chrono::milliseconds timeout);
   TcpServer& max_clients(size_t max);
   TcpServer& backpressure_threshold(size_t threshold);

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -83,7 +83,7 @@ struct UdpServer::Impl {
   ClientId next_client_id{1};
   std::unordered_map<boost::asio::ip::udp::endpoint, ClientId, UdpEndpointHash> endpoint_to_id;
   std::unordered_map<ClientId, SessionEntry> sessions;
-  std::chrono::milliseconds session_timeout{30000};  // Default 30s
+  std::chrono::milliseconds session_timeout{0};  // 0 = disabled
   std::unique_ptr<boost::asio::steady_timer> reaper_timer;
   std::atomic<bool> auto_start{false};
   std::atomic<bool> client_limit_enabled{false};
@@ -175,7 +175,7 @@ struct UdpServer::Impl {
   }
 
   void schedule_reaper() {
-    if (!started.load() || !reaper_timer) return;
+    if (!started.load() || !reaper_timer || session_timeout.count() <= 0) return;
 
     // Run reaper at interval proportional to timeout (min 100ms, max 5s)
     auto interval =
@@ -194,6 +194,8 @@ struct UdpServer::Impl {
   }
 
   void run_reaper() {
+    if (session_timeout.count() <= 0) return;
+
     std::vector<std::pair<ClientId, std::string>> to_remove_with_info;
     auto now = std::chrono::steady_clock::now();
 
@@ -394,7 +396,7 @@ struct UdpServer::Impl {
       });
     }
 
-    if (channel) {
+    if (channel && session_timeout.count() > 0) {
       reaper_timer = std::make_unique<boost::asio::steady_timer>(channel->get_executor());
       schedule_reaper();
     }
@@ -628,6 +630,17 @@ UdpServer& UdpServer::bind_address(const std::string& address) {
 UdpServer& UdpServer::idle_timeout(std::chrono::milliseconds timeout) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->session_timeout = timeout;
+  if (impl_->session_timeout.count() <= 0) {
+    if (impl_->reaper_timer) {
+      impl_->reaper_timer->cancel();
+      impl_->reaper_timer.reset();
+    }
+    return *this;
+  }
+  if (impl_->started.load() && impl_->channel && !impl_->reaper_timer) {
+    impl_->reaper_timer = std::make_unique<boost::asio::steady_timer>(impl_->channel->get_executor());
+    impl_->schedule_reaper();
+  }
   return *this;
 }
 

--- a/unilink/wrapper/udp/udp_server.hpp
+++ b/unilink/wrapper/udp/udp_server.hpp
@@ -88,6 +88,13 @@ class UNILINK_API UdpServer : public ServerInterface {
   // Configuration (Fluent API)
   UdpServer& auto_start(bool manage = true) override;
   UdpServer& bind_address(const std::string& address);
+  /**
+   * @brief Configure application-level idle timeout for virtual sessions.
+   *
+   * A value of 0ms disables idle timeout. When enabled, stale UDP virtual
+   * sessions are removed and a later datagram from the same endpoint creates a
+   * new virtual session.
+   */
   UdpServer& idle_timeout(std::chrono::milliseconds timeout);
   UdpServer& max_clients(size_t max);
   UdpServer& backpressure_threshold(size_t threshold);


### PR DESCRIPTION
## Description
Adds an application-level idle timeout policy for stale connection/session cleanup. TCP clients can now recover from idle timeouts through observable managed reconnects by default, while TCP/UDP server behavior remains session-oriented. UDP virtual sessions are now timeout-disabled by default unless users opt in.

## Key Changes
- Added `IdleTimeoutAction` with TCP client `idle_timeout(...)` and `idle_timeout_action(...)` APIs.
- Implemented TCP client idle timeout handling with default reconnect behavior and optional close-only behavior.
- Changed UDP server virtual session timeout default to `0ms` disabled and only schedules the reaper when enabled.
- Documented idle timeout semantics, TCP keepalive OS dependency, and server/session recovery behavior.
- Added builder and integration coverage for TCP client idle timeout and UDP server timeout defaults.

## Related Issues
- N/A

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Validation performed:
- `cmake -S . -B /tmp/unilink-idle-build -DCMAKE_BUILD_TYPE=Debug -DUNILINK_BUILD_TESTS=ON -DUNILINK_ENABLE_CONFIG=ON -DUNILINK_ENABLE_SANITIZERS=OFF -DUNILINK_ENABLE_TSAN=OFF`
- `cmake --build /tmp/unilink-idle-build --target run_unit_test_builder run_integration_test_tcp_client_wrapper_lifecycle run_integration_test_udp_server_wrapper_lifecycle -j2`
- `/tmp/unilink-idle-build/bin/run_unit_test_builder --gtest_filter=BuilderTest.TcpClientBuilderAdvancedOptions`
- `ctest --test-dir /tmp/unilink-idle-build -R "(IdleTimeoutReconnectsByDefault|IdleTimeoutCloseActionClosesWithoutReconnect|SessionReaping|DefaultIdleTimeoutDisabledKeepsVirtualSession)" --output-on-failure`

`build/verify` is currently configured with TSAN and failed during gtest discovery with `ThreadSanitizer: unexpected memory mapping`, so the focused validation used a non-TSAN debug build.