### PR TITLE
ci: scope security scans to project sources

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "CodeQL config"
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - "build/**"
+  - "build-*/**"
+  - "**/_deps/**"
+  - "vcpkg/**"
+  - "**/vcpkg/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        queries: security-and-quality
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Install dependencies
       uses: ./.github/actions/apt-install

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,6 +56,7 @@ jobs:
       with:
         scan-type: 'fs'
         scan-ref: '.'
+        skip-dirs: 'build,build-deps,vcpkg,.git'
         format: 'sarif'
         output: 'trivy-results.sarif'
 


### PR DESCRIPTION
## Description
Scope GitHub security scanning to project-owned sources so CodeQL and Trivy do not report vendored dependency or generated build artifacts as repository alerts.

## Key Changes
- Add a CodeQL configuration that keeps `security-and-quality` queries while ignoring `build/**`, `build-*/**`, `**/_deps/**`, and `vcpkg/**` paths.
- Update the CodeQL workflow to use the shared configuration file.
- Configure the Trivy filesystem scan to skip build outputs, the local vcpkg checkout, and `.git` metadata.

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Validation performed:
- Parsed `.github/workflows/codeql.yml`, `.github/workflows/security.yml`, and `.github/codeql/codeql-config.yml` with Ruby YAML loading.
- Confirmed open CodeQL alerts with `critical`, `high`, or `medium` security severity are now zero after dismissing obsolete third-party/generated-code alerts.

`./scripts/verify.sh` was not run because this PR only changes GitHub Actions security scan configuration.