### PR TITLE
ci: limit codeql to security queries

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,7 +1,7 @@
 name: "CodeQL config"
 
 queries:
-  - uses: security-and-quality
+  - uses: security-extended
 
 paths-ignore:
   - "build/**"


### PR DESCRIPTION
## Description
Limit the CodeQL workflow to security-focused queries so repository security alerts are not populated with maintainability and reliability findings from vendored or generated C++ dependencies.

The previous configuration used `security-and-quality`, which includes `security-extended` plus maintainability and reliability queries. After the workflow ran on `main`, the remaining open alerts were all `security_severity_level: none` quality findings, mostly under `vcpkg/**` and `build/_deps/**`.

## Key Changes
- Change the CodeQL query suite from `security-and-quality` to `security-extended`.
- Keep the existing path ignore configuration for build output, vcpkg, and generated dependency directories.

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Validation performed:
- Parsed `.github/codeql/codeql-config.yml` and `.github/workflows/codeql.yml` with Ruby YAML loading.
- Confirmed the current open CodeQL alerts have no `critical`, `high`, or `medium` security severity.

`./scripts/verify.sh` was not run because this PR only changes GitHub Actions CodeQL configuration.