### PR TITLE
fix: default TCP_NODELAY to true to avoid Nagle/delayed-ACK latency spikes

### DIFF
--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -271,7 +271,7 @@ TEST_F(ConfigTest, TcpClientConfigDirectValidation) {
 
 TEST(SocketTuningConfigTest, SocketBufferConfigValidationAndClamping) {
   TcpClientConfig tcp_client;
-  EXPECT_FALSE(tcp_client.tcp_no_delay);
+  EXPECT_TRUE(tcp_client.tcp_no_delay);
   EXPECT_FALSE(tcp_client.keep_alive);
   EXPECT_EQ(tcp_client.send_buffer_size, 0u);
   EXPECT_EQ(tcp_client.receive_buffer_size, 0u);

--- a/unilink/config/tcp_client_config.hpp
+++ b/unilink/config/tcp_client_config.hpp
@@ -36,7 +36,7 @@ struct TcpClientConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  bool tcp_no_delay = false;
+  bool tcp_no_delay = true;
   bool keep_alive = false;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -39,7 +39,7 @@ struct TcpServerConfig {
   int port_retry_interval_ms = 1000;  // Retry interval in milliseconds
 
   int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
-  bool tcp_no_delay = false;
+  bool tcp_no_delay = true;
   bool keep_alive = false;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -80,7 +80,7 @@ struct TcpClient::Impl {
   IdleTimeoutAction idle_timeout_action_{IdleTimeoutAction::Reconnect};
   size_t backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   base::constants::BackpressureStrategy backpressure_strategy_{base::constants::BackpressureStrategy::Reliable};
-  bool tcp_no_delay_ = false;
+  bool tcp_no_delay_ = true;
   bool keep_alive_ = false;
   size_t send_buffer_size_ = 0;
   size_t receive_buffer_size_ = 0;

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -65,7 +65,7 @@ struct TcpServer::Impl {
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
-  std::atomic<bool> tcp_no_delay_{false};
+  std::atomic<bool> tcp_no_delay_{true};
   std::atomic<bool> keep_alive_{false};
   std::atomic<size_t> send_buffer_size_{0};
   std::atomic<size_t> receive_buffer_size_{0};


### PR DESCRIPTION
## Description
Benchmarking `unilink` v0.8.2 on TCP (unilink-benchmarks, Jetson Orin Nano Super) showed round-trip latency jumping to a consistent ~44ms for payloads >= 4096 bytes on every iteration (10000/10000), while UDS stayed sub-millisecond at the same sizes. Root cause: `tcp_no_delay` defaulted to `false`, so Nagle's algorithm was active; the trailing partial-MSS segment of each large write then stalls waiting for the peer's delayed ACK (~40ms on Linux), which lines up exactly with the observed spike. Flipping the default to `true` removes the stall and brings TCP latency behavior in line with UDS (which has no Nagle equivalent). Callers who want Nagle-style batching for chatty small-write bulk transfer can still opt back in via `.tcp_no_delay(false)`.

## Key Changes
- Default `tcp_no_delay` to `true` in `TcpClientConfig` / `TcpServerConfig` (`unilink/config/tcp_client_config.hpp`, `unilink/config/tcp_server_config.hpp`).
- Default `tcp_no_delay_` to `true` in the `TcpClient` / `TcpServer` wrapper builder implementations (`unilink/wrapper/tcp_client/tcp_client.cc`, `unilink/wrapper/tcp_server/tcp_server.cc`), since the builders carry their own default independent of the config struct.
- Update `SocketTuningConfigTest.SocketBufferConfigValidationAndClamping` to expect the new default.

## Related Issues
- Fixes #

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [x] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Benchmark data backing this change: https://github.com/unilink-lab/unilink-benchmarks/releases/tag/benchmark-unilink-v0.8.2-jetson-orin-nano-super (see Latency Summary table — TCP payload >= 4096B rows).