### PR TITLE
fix: establish single-source-of-truth defaults across all builder options

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -53,6 +53,7 @@ foreach(
   test_tcp_flood.cc
   test_tcp_abort.cc
   test_tcp_cancel.cc
+  test_tcp_nodelay_default.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/tcp/test_tcp_nodelay_default.cc
+++ b/test/integration/tcp/test_tcp_nodelay_default.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+#include "test_utils.hpp"
+#include "unilink/unilink.hpp"
+
+using namespace unilink;
+using namespace unilink::test;
+
+// unilink::tcp_client()/tcp_server() go through three separate layers that
+// each used to carry their own tcp_no_delay default (config struct, wrapper
+// impl, and the fluent builder that actually constructs those wrappers). A
+// prior fix updated the first two but missed the builder layer, so real
+// callers going through the public tcp_client()/tcp_server() factory
+// functions never actually got TCP_NODELAY enabled. This test exercises that
+// exact public path with no explicit .tcp_no_delay() call and a payload
+// large enough to span multiple MSS segments in production.
+//
+// NOTE: this only checks data-integrity of the round trip, not latency. The
+// Nagle/delayed-ACK stall this bug caused (~40-48ms, observed on a Jetson
+// benchmark) depends on the loopback interface's MTU/MSS and didn't
+// reproduce locally on this dev machine (its loopback MTU is 65536, large
+// enough that this payload doesn't get split the same way). No unit test
+// here can substitute for re-running the real benchmark on the original
+// hardware to confirm the latency symptom is actually gone.
+TEST(TcpNoDelayDefaultTest, LargePayloadRoundTripSucceedsByDefault) {
+  uint16_t test_port = TestUtils::getAvailableTestPort();
+
+  auto server = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_NE(server, nullptr);
+
+  std::atomic<ClientId> server_client_id{0};
+  server->on_connect([&](const wrapper::ConnectionContext& ctx) { server_client_id = ctx.client_id(); });
+  server->on_data([&](const wrapper::MessageContext& ctx) { server->send_to(server_client_id.load(), ctx.data()); });
+  ASSERT_TRUE(server->start().get());
+
+  std::atomic<bool> client_connected{false};
+  std::mutex received_mutex;
+  std::string received;
+
+  auto client = unilink::tcp_client("127.0.0.1", test_port)
+                    .on_connect([&](const wrapper::ConnectionContext&) { client_connected = true; })
+                    .on_data([&](const wrapper::MessageContext& ctx) {
+                      std::lock_guard<std::mutex> lock(received_mutex);
+                      received.append(ctx.data());
+                    })
+                    .on_error([](auto&&) {})
+                    .build();
+  ASSERT_NE(client, nullptr);
+  client->start();
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return client_connected.load(); }, 2000))
+      << "Client failed to connect within 2 seconds";
+
+  // Larger than a typical MSS (~1448B) on a real NIC, matching the payload
+  // size that reproduced the production stall.
+  const std::string payload(8192, 'A');
+
+  ASSERT_TRUE(client->send(payload));
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&]() {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        return received.size() >= payload.size();
+      },
+      2000))
+      << "Echoed payload was not fully received within 2 seconds";
+
+  {
+    std::lock_guard<std::mutex> lock(received_mutex);
+    EXPECT_EQ(received, payload);
+  }
+
+  client->stop();
+  server->stop();
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -86,7 +86,7 @@ endforeach()
 
 # Builder tests (separate executables)
 foreach(test_file test_builder.cc test_udp_builder_options.cc
-                  test_uds_builder_options.cc
+                  test_uds_builder_options.cc test_builder_option_wiring.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
   unilink_add_unit_gtest(

--- a/test/unit/builder/test_builder_option_wiring.cc
+++ b/test/unit/builder/test_builder_option_wiring.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "unilink/config/serial_config.hpp"
+#include "unilink/unilink.hpp"
+#include "unilink/wrapper/serial/serial.hpp"
+
+using namespace unilink;
+using namespace std::chrono_literals;
+
+// unilink::serial()'s builder used to silently drop explicit char_size()/
+// stop_bits()/reopen_on_error() calls: it captured them into its own fields
+// but build() never forwarded them to the constructed wrapper::Serial at
+// all (unlike parity()/flow_control(), which were correctly wired). This
+// fixture is a declared friend of wrapper::Serial (see the forward
+// declaration and friend statement in unilink/wrapper/serial/serial.hpp) so
+// it can read back the config actually produced via the public
+// unilink::serial() factory, the same path real callers use.
+class SerialBuilderConfigTest : public ::testing::Test {
+ protected:
+  static config::SerialConfig BuildConfig(std::unique_ptr<wrapper::Serial>& out) { return out->build_config(); }
+};
+
+TEST_F(SerialBuilderConfigTest, ExplicitOptionsArePropagatedToTheWrapper) {
+  auto serial = unilink::serial("/dev/ttyUSB0", 115200)
+                    .char_size(7)
+                    .stop_bits(2)
+                    .reopen_on_error(false)
+                    .retry_interval(500ms)
+                    .on_data([](auto&&) {})
+                    .on_error([](auto&&) {})
+                    .build();
+  ASSERT_NE(serial, nullptr);
+
+  auto cfg = BuildConfig(serial);
+  EXPECT_EQ(cfg.char_size, 7u);
+  EXPECT_EQ(cfg.stop_bits, 2u);
+  EXPECT_FALSE(cfg.reopen_on_error);
+  EXPECT_EQ(cfg.retry_interval_ms, 500u);
+}
+
+TEST_F(SerialBuilderConfigTest, UnsetOptionsFallBackToConfigDefaultsNotBuilderDefaults) {
+  // No .char_size()/.stop_bits()/.reopen_on_error()/.retry_interval() calls:
+  // the resulting config must match config::SerialConfig{}'s own defaults,
+  // not some separately-hardcoded value inside the builder.
+  auto serial = unilink::serial("/dev/ttyUSB0", 115200).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_NE(serial, nullptr);
+
+  config::SerialConfig expected;
+  auto cfg = BuildConfig(serial);
+  EXPECT_EQ(cfg.char_size, expected.char_size);
+  EXPECT_EQ(cfg.stop_bits, expected.stop_bits);
+  EXPECT_EQ(cfg.reopen_on_error, expected.reopen_on_error);
+  EXPECT_EQ(cfg.retry_interval_ms, expected.retry_interval_ms);
+}

--- a/unilink/builder/serial_builder.cc
+++ b/unilink/builder/serial_builder.cc
@@ -20,6 +20,7 @@
 #include <boost/asio/io_context.hpp>
 #include <cctype>
 
+#include "unilink/base/constants.hpp"
 #include "unilink/builder/auto_initializer.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
 
@@ -32,7 +33,7 @@ SerialBuilder<State>::SerialBuilder(const std::string& device, uint32_t baud_rat
       baud_rate_(baud_rate),
       auto_start_(false),
       independent_context_(false),
-      retry_interval_ms_(3000),
+      retry_interval_ms_(base::constants::DEFAULT_RETRY_INTERVAL_MS),
       char_size_(8),
       stop_bits_(1),
       parity_(config::SerialConfig::Parity::None),
@@ -61,22 +62,30 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   if (this->on_error_) serial->on_error(this->on_error_);
   if (this->on_backpressure_) serial->on_backpressure(this->on_backpressure_);
 
+  if (char_size_set_) serial->data_bits(static_cast<int>(char_size_));
+  if (stop_bits_set_) serial->stop_bits(static_cast<int>(stop_bits_));
+
   // Note: wrapper::Serial setters use strings for enum types
-  std::string p_str = "none";
-  if (parity_ == config::SerialConfig::Parity::Even)
-    p_str = "even";
-  else if (parity_ == config::SerialConfig::Parity::Odd)
-    p_str = "odd";
-  serial->parity(p_str);
+  if (parity_set_) {
+    std::string p_str = "none";
+    if (parity_ == config::SerialConfig::Parity::Even)
+      p_str = "even";
+    else if (parity_ == config::SerialConfig::Parity::Odd)
+      p_str = "odd";
+    serial->parity(p_str);
+  }
 
-  std::string f_str = "none";
-  if (flow_ == config::SerialConfig::Flow::Software)
-    f_str = "software";
-  else if (flow_ == config::SerialConfig::Flow::Hardware)
-    f_str = "hardware";
-  serial->flow_control(f_str);
+  if (flow_set_) {
+    std::string f_str = "none";
+    if (flow_ == config::SerialConfig::Flow::Software)
+      f_str = "software";
+    else if (flow_ == config::SerialConfig::Flow::Hardware)
+      f_str = "hardware";
+    serial->flow_control(f_str);
+  }
 
-  serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
+  if (reopen_on_error_set_) serial->reopen_on_error(reopen_on_error_);
+  if (retry_interval_set_) serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
 
   if (this->bp_strategy_set_) serial->backpressure_strategy(this->bp_strategy_);
   serial->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -107,18 +116,21 @@ SerialBuilder<State>& SerialBuilder<State>::auto_start(bool auto_start) {
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::char_size(unsigned int size) {
   char_size_ = size;
+  char_size_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::stop_bits(unsigned int bits) {
   stop_bits_ = bits;
+  stop_bits_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::parity(config::SerialConfig::Parity p) {
   parity_ = p;
+  parity_set_ = true;
   return *this;
 }
 
@@ -135,12 +147,14 @@ SerialBuilder<State>& SerialBuilder<State>::parity(const std::string& p) {
   } else {
     parity_ = config::SerialConfig::Parity::None;
   }
+  parity_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::flow_control(config::SerialConfig::Flow f) {
   flow_ = f;
+  flow_set_ = true;
   return *this;
 }
 
@@ -157,18 +171,21 @@ SerialBuilder<State>& SerialBuilder<State>::flow_control(const std::string& f) {
   } else {
     flow_ = config::SerialConfig::Flow::None;
   }
+  flow_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::reopen_on_error(bool enable) {
   reopen_on_error_ = enable;
+  reopen_on_error_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ms_ = static_cast<uint32_t>(interval.count());
+  retry_interval_set_ = true;
   return *this;
 }
 

--- a/unilink/builder/serial_builder.hpp
+++ b/unilink/builder/serial_builder.hpp
@@ -51,11 +51,17 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
         retry_interval_ms_(other.retry_interval_ms_),
+        retry_interval_set_(other.retry_interval_set_),
         char_size_(other.char_size_),
+        char_size_set_(other.char_size_set_),
         stop_bits_(other.stop_bits_),
+        stop_bits_set_(other.stop_bits_set_),
         parity_(other.parity_),
+        parity_set_(other.parity_set_),
         flow_(other.flow_),
-        reopen_on_error_(other.reopen_on_error_) {
+        flow_set_(other.flow_set_),
+        reopen_on_error_(other.reopen_on_error_),
+        reopen_on_error_set_(other.reopen_on_error_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -99,11 +105,17 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
   bool independent_context_;
 
   uint32_t retry_interval_ms_;
+  bool retry_interval_set_{false};
   unsigned int char_size_;
+  bool char_size_set_{false};
   unsigned int stop_bits_;
+  bool stop_bits_set_{false};
   config::SerialConfig::Parity parity_;
+  bool parity_set_{false};
   config::SerialConfig::Flow flow_;
+  bool flow_set_{false};
   bool reopen_on_error_;
+  bool reopen_on_error_set_{false};
 };
 
 using SerialBuilderDefault = SerialBuilder<BuilderState::None>;

--- a/unilink/builder/tcp_client_builder.cc
+++ b/unilink/builder/tcp_client_builder.cc
@@ -35,7 +35,7 @@ TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port
       connection_timeout_(5000),
       idle_timeout_(0),
       idle_timeout_action_(IdleTimeoutAction::Reconnect),
-      tcp_no_delay_(false),
+      tcp_no_delay_(true),
       keep_alive_(false),
       send_buffer_size_(0),
       receive_buffer_size_(0) {

--- a/unilink/builder/tcp_client_builder.cc
+++ b/unilink/builder/tcp_client_builder.cc
@@ -18,6 +18,7 @@
 
 #include <boost/asio/io_context.hpp>
 
+#include "unilink/base/constants.hpp"
 #include "unilink/builder/auto_initializer.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
 
@@ -30,9 +31,9 @@ TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port
       port_(port),
       auto_start_(false),
       independent_context_(false),
-      retry_interval_(3000),
-      max_retries_(-1),
-      connection_timeout_(5000),
+      retry_interval_(base::constants::DEFAULT_RETRY_INTERVAL_MS),
+      max_retries_(base::constants::DEFAULT_MAX_RETRIES),
+      connection_timeout_(base::constants::DEFAULT_CONNECTION_TIMEOUT_MS),
       idle_timeout_(0),
       idle_timeout_action_(IdleTimeoutAction::Reconnect),
       tcp_no_delay_(true),
@@ -63,15 +64,15 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   if (this->on_error_) client->on_error(this->on_error_);
   if (this->on_backpressure_) client->on_backpressure(this->on_backpressure_);
 
-  client->retry_interval(retry_interval_);
-  client->max_retries(max_retries_);
-  client->connection_timeout(connection_timeout_);
-  client->idle_timeout(idle_timeout_);
-  client->idle_timeout_action(idle_timeout_action_);
-  client->tcp_no_delay(tcp_no_delay_);
-  client->keep_alive(keep_alive_);
-  client->send_buffer_size(send_buffer_size_);
-  client->receive_buffer_size(receive_buffer_size_);
+  if (retry_interval_set_) client->retry_interval(retry_interval_);
+  if (max_retries_set_) client->max_retries(max_retries_);
+  if (connection_timeout_set_) client->connection_timeout(connection_timeout_);
+  if (idle_timeout_set_) client->idle_timeout(idle_timeout_);
+  if (idle_timeout_action_set_) client->idle_timeout_action(idle_timeout_action_);
+  if (tcp_no_delay_set_) client->tcp_no_delay(tcp_no_delay_);
+  if (keep_alive_set_) client->keep_alive(keep_alive_);
+  if (send_buffer_size_set_) client->send_buffer_size(send_buffer_size_);
+  if (receive_buffer_size_set_) client->receive_buffer_size(receive_buffer_size_);
 
   if (this->bp_strategy_set_) client->backpressure_strategy(this->bp_strategy_);
   client->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -102,30 +103,35 @@ TcpClientBuilder<State>& TcpClientBuilder<State>::auto_start(bool auto_start) {
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ = interval;
+  retry_interval_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::max_retries(int max_retries) {
   max_retries_ = max_retries;
+  max_retries_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::connection_timeout(std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
+  connection_timeout_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
+  idle_timeout_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout_action(IdleTimeoutAction action) {
   idle_timeout_action_ = action;
+  idle_timeout_action_set_ = true;
   return *this;
 }
 
@@ -138,24 +144,28 @@ TcpClientBuilder<State>& TcpClientBuilder<State>::independent_context(bool use_i
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::tcp_no_delay(bool enable) {
   tcp_no_delay_ = enable;
+  tcp_no_delay_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::keep_alive(bool enable) {
   keep_alive_ = enable;
+  keep_alive_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
+  send_buffer_size_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
+  receive_buffer_size_set_ = true;
   return *this;
 }
 

--- a/unilink/builder/tcp_client_builder.hpp
+++ b/unilink/builder/tcp_client_builder.hpp
@@ -52,14 +52,23 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
         retry_interval_(other.retry_interval_),
+        retry_interval_set_(other.retry_interval_set_),
         max_retries_(other.max_retries_),
+        max_retries_set_(other.max_retries_set_),
         connection_timeout_(other.connection_timeout_),
+        connection_timeout_set_(other.connection_timeout_set_),
         idle_timeout_(other.idle_timeout_),
+        idle_timeout_set_(other.idle_timeout_set_),
         idle_timeout_action_(other.idle_timeout_action_),
+        idle_timeout_action_set_(other.idle_timeout_action_set_),
         tcp_no_delay_(other.tcp_no_delay_),
+        tcp_no_delay_set_(other.tcp_no_delay_set_),
         keep_alive_(other.keep_alive_),
+        keep_alive_set_(other.keep_alive_set_),
         send_buffer_size_(other.send_buffer_size_),
-        receive_buffer_size_(other.receive_buffer_size_) {
+        send_buffer_size_set_(other.send_buffer_size_set_),
+        receive_buffer_size_(other.receive_buffer_size_),
+        receive_buffer_size_set_(other.receive_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -116,14 +125,23 @@ class UNILINK_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient,
   bool independent_context_;
 
   std::chrono::milliseconds retry_interval_;
+  bool retry_interval_set_{false};
   int max_retries_;
+  bool max_retries_set_{false};
   std::chrono::milliseconds connection_timeout_;
+  bool connection_timeout_set_{false};
   std::chrono::milliseconds idle_timeout_;
+  bool idle_timeout_set_{false};
   IdleTimeoutAction idle_timeout_action_;
+  bool idle_timeout_action_set_{false};
   bool tcp_no_delay_;
+  bool tcp_no_delay_set_{false};
   bool keep_alive_;
+  bool keep_alive_set_{false};
   size_t send_buffer_size_;
+  bool send_buffer_size_set_{false};
   size_t receive_buffer_size_;
+  bool receive_buffer_size_set_{false};
 };
 
 using TcpClientBuilderDefault = TcpClientBuilder<BuilderState::None>;

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -37,7 +37,7 @@ TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
       port_retry_interval_ms_(1000),
       idle_timeout_(0),
       idle_timeout_set_(false),
-      tcp_no_delay_(false),
+      tcp_no_delay_(true),
       keep_alive_(false),
       send_buffer_size_(0),
       receive_buffer_size_(0) {

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -33,7 +33,7 @@ TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
       max_clients_(0),
       client_limit_enabled_(false),
       port_retry_enabled_(false),
-      max_port_retries_(10),
+      max_port_retries_(3),
       port_retry_interval_ms_(1000),
       idle_timeout_(0),
       idle_timeout_set_(false),
@@ -68,14 +68,16 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
     server->max_clients(max_clients_);
   }
 
-  server->bind_address(bind_address_);
-  server->port_retry(port_retry_enabled_, static_cast<int>(max_port_retries_),
-                     static_cast<int>(port_retry_interval_ms_));
+  if (bind_address_set_) server->bind_address(bind_address_);
+  if (port_retry_enabled_set_ || max_port_retries_set_ || port_retry_interval_set_) {
+    server->port_retry(port_retry_enabled_, static_cast<int>(max_port_retries_),
+                       static_cast<int>(port_retry_interval_ms_));
+  }
   if (idle_timeout_set_) server->idle_timeout(idle_timeout_);
-  server->tcp_no_delay(tcp_no_delay_);
-  server->keep_alive(keep_alive_);
-  server->send_buffer_size(send_buffer_size_);
-  server->receive_buffer_size(receive_buffer_size_);
+  if (tcp_no_delay_set_) server->tcp_no_delay(tcp_no_delay_);
+  if (keep_alive_set_) server->keep_alive(keep_alive_);
+  if (send_buffer_size_set_) server->send_buffer_size(send_buffer_size_);
+  if (receive_buffer_size_set_) server->receive_buffer_size(receive_buffer_size_);
 
   if (this->bp_strategy_set_) server->backpressure_strategy(this->bp_strategy_);
   server->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -106,6 +108,7 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::auto_start(bool auto_start) {
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::bind_address(const std::string& address) {
   bind_address_ = address;
+  bind_address_set_ = true;
   return *this;
 }
 
@@ -125,42 +128,49 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::max_clients(uint32_t max_clien
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::enable_port_retry(bool enable) {
   port_retry_enabled_ = enable;
+  port_retry_enabled_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::max_port_retries(uint32_t max_retries) {
   max_port_retries_ = max_retries;
+  max_port_retries_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::port_retry_interval(std::chrono::milliseconds interval) {
   port_retry_interval_ms_ = static_cast<uint32_t>(interval.count());
+  port_retry_interval_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::tcp_no_delay(bool enable) {
   tcp_no_delay_ = enable;
+  tcp_no_delay_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::keep_alive(bool enable) {
   keep_alive_ = enable;
+  keep_alive_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
+  send_buffer_size_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
+  receive_buffer_size_set_ = true;
   return *this;
 }
 
@@ -168,8 +178,11 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::receive_buffer_size(size_t byt
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::port_retry(bool enable, int max_retries, int retry_interval_ms) {
   port_retry_enabled_ = enable;
+  port_retry_enabled_set_ = true;
   max_port_retries_ = static_cast<uint32_t>(max_retries);
+  max_port_retries_set_ = true;
   port_retry_interval_ms_ = static_cast<uint32_t>(retry_interval_ms);
+  port_retry_interval_set_ = true;
   return *this;
 }
 

--- a/unilink/builder/tcp_server_builder.hpp
+++ b/unilink/builder/tcp_server_builder.hpp
@@ -49,19 +49,27 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
   TcpServerBuilder(TcpServerBuilder<OtherState>&& other) noexcept
       : port_(other.port_),
         bind_address_(std::move(other.bind_address_)),
+        bind_address_set_(other.bind_address_set_),
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
         max_clients_(other.max_clients_),
         client_limit_enabled_(other.client_limit_enabled_),
         port_retry_enabled_(other.port_retry_enabled_),
+        port_retry_enabled_set_(other.port_retry_enabled_set_),
         max_port_retries_(other.max_port_retries_),
+        max_port_retries_set_(other.max_port_retries_set_),
         port_retry_interval_ms_(other.port_retry_interval_ms_),
+        port_retry_interval_set_(other.port_retry_interval_set_),
         idle_timeout_(other.idle_timeout_),
         idle_timeout_set_(other.idle_timeout_set_),
         tcp_no_delay_(other.tcp_no_delay_),
+        tcp_no_delay_set_(other.tcp_no_delay_set_),
         keep_alive_(other.keep_alive_),
+        keep_alive_set_(other.keep_alive_set_),
         send_buffer_size_(other.send_buffer_size_),
-        receive_buffer_size_(other.receive_buffer_size_) {
+        send_buffer_size_set_(other.send_buffer_size_set_),
+        receive_buffer_size_(other.receive_buffer_size_),
+        receive_buffer_size_set_(other.receive_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -115,6 +123,7 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
 
   uint16_t port_;
   std::string bind_address_;
+  bool bind_address_set_{false};
   bool auto_start_;
   bool independent_context_;
 
@@ -122,14 +131,21 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
   bool client_limit_enabled_;
 
   bool port_retry_enabled_;
+  bool port_retry_enabled_set_{false};
   uint32_t max_port_retries_;
+  bool max_port_retries_set_{false};
   uint32_t port_retry_interval_ms_;
+  bool port_retry_interval_set_{false};
   std::chrono::milliseconds idle_timeout_;
   bool idle_timeout_set_;
   bool tcp_no_delay_;
+  bool tcp_no_delay_set_{false};
   bool keep_alive_;
+  bool keep_alive_set_{false};
   size_t send_buffer_size_;
+  bool send_buffer_size_set_{false};
   size_t receive_buffer_size_;
+  bool receive_buffer_size_set_{false};
 };
 
 using TcpServerBuilderDefault = TcpServerBuilder<BuilderState::None>;

--- a/unilink/builder/uds_builder.cc
+++ b/unilink/builder/uds_builder.cc
@@ -18,6 +18,7 @@
 
 #include <boost/asio/io_context.hpp>
 
+#include "unilink/base/constants.hpp"
 #include "unilink/builder/auto_initializer.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
 
@@ -31,9 +32,9 @@ UdsClientBuilder<State>::UdsClientBuilder(const std::string& socket_path)
     : socket_path_(socket_path),
       auto_start_(false),
       independent_context_(false),
-      retry_interval_(3000),
-      max_retries_(-1),
-      connection_timeout_(5000) {
+      retry_interval_(base::constants::DEFAULT_RETRY_INTERVAL_MS),
+      max_retries_(base::constants::DEFAULT_MAX_RETRIES),
+      connection_timeout_(base::constants::DEFAULT_CONNECTION_TIMEOUT_MS) {
   if (socket_path.empty()) throw diagnostics::BuilderException("Socket path cannot be empty");
 
   // Ensure background IO service is running
@@ -57,9 +58,9 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
   if (this->on_error_) client->on_error(this->on_error_);
   if (this->on_backpressure_) client->on_backpressure(this->on_backpressure_);
 
-  client->retry_interval(retry_interval_);
-  client->max_retries(max_retries_);
-  client->connection_timeout(connection_timeout_);
+  if (retry_interval_set_) client->retry_interval(retry_interval_);
+  if (max_retries_set_) client->max_retries(max_retries_);
+  if (connection_timeout_set_) client->connection_timeout(connection_timeout_);
 
   if (this->bp_strategy_set_) client->backpressure_strategy(this->bp_strategy_);
   client->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -90,18 +91,21 @@ UdsClientBuilder<State>& UdsClientBuilder<State>::auto_start(bool auto_start) {
 template <uint32_t State>
 UdsClientBuilder<State>& UdsClientBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ = interval;
+  retry_interval_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 UdsClientBuilder<State>& UdsClientBuilder<State>::max_retries(int max_retries) {
   max_retries_ = max_retries;
+  max_retries_set_ = true;
   return *this;
 }
 
 template <uint32_t State>
 UdsClientBuilder<State>& UdsClientBuilder<State>::connection_timeout(std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
+  connection_timeout_set_ = true;
   return *this;
 }
 

--- a/unilink/builder/uds_builder.hpp
+++ b/unilink/builder/uds_builder.hpp
@@ -53,8 +53,11 @@ class UNILINK_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient,
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
         retry_interval_(other.retry_interval_),
+        retry_interval_set_(other.retry_interval_set_),
         max_retries_(other.max_retries_),
-        connection_timeout_(other.connection_timeout_) {
+        max_retries_set_(other.max_retries_set_),
+        connection_timeout_(other.connection_timeout_),
+        connection_timeout_set_(other.connection_timeout_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -91,8 +94,11 @@ class UNILINK_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient,
   bool independent_context_;
 
   std::chrono::milliseconds retry_interval_;
+  bool retry_interval_set_{false};
   int max_retries_;
+  bool max_retries_set_{false};
   std::chrono::milliseconds connection_timeout_;
+  bool connection_timeout_set_{false};
 };
 
 using UdsClientBuilderDefault = UdsClientBuilder<BuilderState::None>;

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -86,6 +86,7 @@ struct Serial::Impl {
   int stop_bits = 1;
   std::string parity = "none";
   std::string flow_control = "none";
+  bool reopen_on_error = true;
   std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
@@ -501,6 +502,7 @@ struct Serial::Impl {
       config.flow = config::SerialConfig::Flow::None;
 
     config.retry_interval_ms = static_cast<unsigned int>(retry_interval.count());
+    config.reopen_on_error = reopen_on_error;
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
     return config;
@@ -615,6 +617,11 @@ Serial& Serial::parity(const std::string& p) {
 Serial& Serial::flow_control(const std::string& f) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->flow_control = f;
+  return *this;
+}
+Serial& Serial::reopen_on_error(bool enable) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->reopen_on_error = enable;
   return *this;
 }
 Serial& Serial::retry_interval(std::chrono::milliseconds i) {

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -35,6 +35,10 @@ class io_context;
 }
 }  // namespace boost
 
+// Forward declaration so Serial can grant it test-only access to
+// build_config() (see the friend declaration below).
+class SerialBuilderConfigTest;
+
 namespace unilink {
 namespace interface {
 class Channel;
@@ -96,6 +100,7 @@ class UNILINK_API Serial : public ChannelInterface {
   Serial& stop_bits(int stop_bits);
   Serial& parity(const std::string& parity);
   Serial& flow_control(const std::string& flow_control);
+  Serial& reopen_on_error(bool enable);
   Serial& retry_interval(std::chrono::milliseconds interval);
   Serial& backpressure_threshold(size_t threshold);
   Serial& backpressure_strategy(base::constants::BackpressureStrategy strategy);
@@ -105,6 +110,7 @@ class UNILINK_API Serial : public ChannelInterface {
 
  protected:
   // Exposed for testing only — not part of the public API.
+  friend class ::SerialBuilderConfigTest;
   config::SerialConfig build_config() const;
 
  private:


### PR DESCRIPTION
## Description
This started as a narrow fix (builder-layer `tcp_no_delay` default), but re-running the official benchmark against the merged commit (`04398bd5d`) still showed the ~44ms TCP stall, which led to finding a systemic anti-pattern: builder constructors hard-code their own default for an option, and `build()` calls the wrapper setter unconditionally — silently overriding whatever the config struct/wrapper impl actually default to. The user asked for a full audit and fix rather than patching options one at a time.

An exhaustive audit (every setter on every builder: TCP client/server, UDP client/server, Serial, UDS client/server) found, beyond `tcp_no_delay`:

- `TcpClientBuilder` / `UdsClientBuilder` / `SerialBuilder`: `retry_interval_` defaulted to `3000ms` in the builder vs `1000ms` in config/wrapper.
- `TcpServerBuilder`: `max_port_retries_` defaulted to `10` vs `3`.
- **More severe**, in `SerialBuilder`: `char_size()`/`stop_bits()`/`reopen_on_error()` were captured into builder fields but `build()` never forwarded them to the wrapper *at all* — explicit user configuration was silently dropped, not just a wrong default. `wrapper::Serial` also had no `reopen_on_error` setter at all, so this option was previously impossible to control through any path.
- UDP builders were exempt: their wrappers hold a single `config::UdpConfig` directly with no duplicated fields, so there's no second place for a default to drift (confirmed zero mismatches).

## Key Changes
- Added a `reopen_on_error(bool)` setter to `wrapper::Serial` (`unilink/wrapper/serial/serial.hpp`/`.cc`) so this option can actually be controlled, and wired it into `build_config_locked()`.
- Applied the guard-flag pattern already used correctly elsewhere in this codebase (`backpressure_strategy`/`threshold`, server `idle_timeout`, `max_clients`) to every remaining unconditionally-applied option in `TcpClientBuilder`, `TcpServerBuilder`, `UdsClientBuilder`, and `SerialBuilder`: each option now has a companion `<field>_set_` flag, and `build()` only calls the wrapper setter if the caller explicitly configured it. This makes the builder's own hardcoded default irrelevant by construction — the wrapper/config default (the actual source of truth) applies untouched unless overridden, so this bug class can't silently reappear the way it did for `tcp_no_delay`.
- Also wired `SerialBuilder::build()` to actually call `data_bits()`/`stop_bits()`/`reopen_on_error()` on the built wrapper, which it previously never did.
- Fixed the two additional wrong hardcoded values (`retry_interval_` → `1000`, `max_port_retries_` → `3`) for clarity, even though the guard makes them moot when unset.

## Related Issues
- Follow-up to #426

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass (670/670).
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
`test/unit/builder/test_builder_option_wiring.cc` covers the most severe case (Serial's dropped options) via a test-only friend accessor into `wrapper::Serial::build_config()` — verified to fail without the fix and pass with it. The TCP/UDS `retry_interval`/`max_port_retries` fixes are covered by the full regression suite plus direct code review; a dedicated timing-based behavioral test for those was out of scope for this pass.

**Still pending real-hardware re-verification**: this branch is queued for another Jetson benchmark run (same process used for #426/#428) before merge, to confirm the TCP latency fix actually holds now that all three layers agree.