### PR TITLE
fix: derive pkg-config Libs.private from the real link dependency list

### DIFF
--- a/cmake/UnilinkDependencies.cmake
+++ b/cmake/UnilinkDependencies.cmake
@@ -235,14 +235,29 @@ elseif(TARGET spdlog)
   set(_UNILINK_SPDLOG_BUILD_TARGET spdlog)
 endif()
 
+# System libraries a pkg-config consumer linking against unilink_static must
+# also pass to its linker. Built up alongside the corresponding
+# target_link_libraries(unilink_dependencies ...) calls below so the two never
+# drift apart the way they previously did (the .pc file used to hardcode its own
+# separate, incomplete copy of this list — see UnilinkPackaging.cmake).
+set(UNILINK_PKGCONFIG_LIBS_PRIVATE "")
+
 # Link common dependencies
 target_link_libraries(unilink_dependencies INTERFACE Threads::Threads)
+if(NOT WIN32)
+  list(APPEND UNILINK_PKGCONFIG_LIBS_PRIVATE "-lpthread")
+endif()
 if(_UNILINK_SPDLOG_BUILD_TARGET)
   target_link_libraries(
     unilink_dependencies
     INTERFACE $<BUILD_INTERFACE:${_UNILINK_SPDLOG_BUILD_TARGET}>
               $<INSTALL_INTERFACE:unilink_spdlog_proxy>
   )
+  if(UNILINK_SPDLOG_BUNDLED)
+    # A FetchContent-built spdlog is always a real compiled static library (not
+    # header-only), so static consumers need it explicitly.
+    list(APPEND UNILINK_PKGCONFIG_LIBS_PRIVATE "-lspdlog")
+  endif()
 endif()
 if(UNILINK_LINK_BOOST_SYSTEM)
   target_link_libraries(
@@ -250,6 +265,7 @@ if(UNILINK_LINK_BOOST_SYSTEM)
     INTERFACE $<BUILD_INTERFACE:Boost::system>
               $<INSTALL_INTERFACE:unilink_boost_system_proxy>
   )
+  list(APPEND UNILINK_PKGCONFIG_LIBS_PRIVATE "-lboost_system")
   if(TARGET Boost::asio)
     target_link_libraries(
       unilink_dependencies
@@ -271,6 +287,9 @@ elseif(UNILINK_BOOST_INCLUDE_DIR)
 endif()
 if(WIN32)
   target_link_libraries(unilink_dependencies INTERFACE ws2_32 mswsock iphlpapi)
+  list(APPEND UNILINK_PKGCONFIG_LIBS_PRIVATE "-lws2_32" "-lmswsock"
+       "-liphlpapi"
+  )
 endif()
 
 # Add include directories

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -193,11 +193,12 @@ if(UNILINK_ENABLE_INSTALL)
   if(UNILINK_ENABLE_PKGCONFIG)
     set(PKGCONFIG_REQUIRES "")
     set(PKGCONFIG_REQUIRES_PRIVATE "")
-    if(WIN32)
-      set(PKGCONFIG_LIBS_PRIVATE "-lboost_system")
-    else()
-      set(PKGCONFIG_LIBS_PRIVATE "-lboost_system -lpthread")
-    endif()
+    # Derived from UNILINK_PKGCONFIG_LIBS_PRIVATE (built up in
+    # UnilinkDependencies.cmake alongside the real
+    # target_link_libraries(unilink_dependencies ...) calls) instead of a
+    # separately hardcoded list, so this can no longer silently drift out of
+    # sync with what unilink_static actually links against.
+    list(JOIN UNILINK_PKGCONFIG_LIBS_PRIVATE " " PKGCONFIG_LIBS_PRIVATE)
     set(PKGCONFIG_CFLAGS "")
 
     configure_file(


### PR DESCRIPTION
## Description
A vcpkg reviewer (via an automated GPT-5.5 pre-review comment) flagged that the installed `unilink.pc` advertises only `-lboost_system` on Windows, missing the `ws2_32`/`mswsock`/`iphlpapi` system libraries `unilink_static` actually requires for Boost.Asio networking — causing a pkg-config example on Windows to fail to link with unresolved Winsock symbols.

Root cause: the same anti-pattern as #429's builder-defaults issue — two independently maintained copies of "what does `unilink_static` link against":
- the correct one: the `unilink_dependencies` INTERFACE target in `UnilinkDependencies.cmake` (already correctly consumed by CMake `find_package()` consumers via the exported target)
- a manually hardcoded, stale one: `UnilinkPackaging.cmake`'s `PKGCONFIG_LIBS_PRIVATE`, consumed only by pkg-config text-file consumers

## Key Changes
- Introduced a single `UNILINK_PKGCONFIG_LIBS_PRIVATE` list in `UnilinkDependencies.cmake`, appended to at each corresponding `target_link_libraries(unilink_dependencies ...)` call site (threads, spdlog, boost::system, Windows sockets), instead of a second hand-maintained list elsewhere.
- `UnilinkPackaging.cmake` now just `list(JOIN ...)`s this into the `.pc` file rather than re-deriving its own copy, so the two can't drift apart again.
- This also surfaced and fixes a related gap: a FetchContent-bundled spdlog (a real compiled static library, not header-only) was never listed at all, which would cause the same class of link failure for static pkg-config consumers on **any** platform when spdlog isn't found as a system package.

## Related Issues
- Reported via vcpkg PR review (GPT-5.5 automated observation)
- Same underlying pattern as jwsung91/unilink#429

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass (670/670).
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Verified locally (Linux, system spdlog found): generated `unilink.pc` now contains `Libs.private: -lpthread -lboost_system`, unchanged from before for this configuration (expected, since those two were already correct here). The Windows-specific `ws2_32`/`mswsock`/`iphlpapi` and bundled-spdlog cases can't be exercised on this dev machine, but the same list-building code path is used across all platforms/configurations, so there's no separate untested path for Windows specifically anymore.