### PR TITLE
fix: retry UDS server accept() on transient errors instead of stopping forever

### DIFF
--- a/test/unit/transport/transport_uds_server.cc
+++ b/test/unit/transport/transport_uds_server.cc
@@ -125,3 +125,43 @@ TEST_F(TransportUdsServerTest, BindFailure) {
   EXPECT_FALSE(server->is_connected());
   EXPECT_TRUE(has_error);
 }
+
+// Regression test for jwsung91/unilink#453: a transient accept() failure
+// (e.g. EMFILE) used to be logged and silently swallowed, permanently
+// stopping the server from ever accepting again. It must now surface an
+// Error state transition and keep retrying do_accept().
+TEST_F(TransportUdsServerTest, AcceptFailureRetriesAndKeepsAccepting) {
+  EXPECT_CALL(*mock_acceptor, open(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, bind(_, _)).WillOnce(Return());
+  EXPECT_CALL(*mock_acceptor, listen(_, _)).WillOnce(Return());
+
+  bool retried = false;
+  EXPECT_CALL(*mock_acceptor, async_accept(_))
+      .WillOnce(Invoke(
+          [this](std::function<void(const boost::system::error_code&, net::local::stream_protocol::socket)> handler) {
+            handler(make_error_code(boost::asio::error::no_descriptors), net::local::stream_protocol::socket(ioc));
+          }))
+      .WillOnce(Invoke(
+          [&retried](std::function<void(const boost::system::error_code&, net::local::stream_protocol::socket)>) {
+            // Second call proves do_accept() was invoked again after the failure
+            // instead of the server silently giving up forever.
+            retried = true;
+          }));
+
+  std::atomic<bool> has_error{false};
+  server->on_state([&has_error](base::LinkState state) {
+    if (state == base::LinkState::Error) {
+      has_error = true;
+    }
+  });
+
+  server->start();
+
+  for (int i = 0; i < 50 && !(has_error && retried); ++i) {
+    ioc.poll();
+    TestUtils::waitFor(10);
+  }
+
+  EXPECT_TRUE(has_error);
+  EXPECT_TRUE(retried);
+}

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -566,9 +566,25 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
       auto* impl = self->impl_.get();
       impl->do_accept(self);
     } else {
+      auto* impl = self->impl_.get();
+      if (impl->stopping_.load()) return;
+
       // Log only real errors, not operation_aborted
       if (ec != boost::asio::error::operation_aborted) {
         UNILINK_LOG_ERROR("uds_server", "accept", fmt::format("Accept failed: {}", ec.message()));
+        impl->state_.set_state(base::LinkState::Error);
+        impl->notify_state();
+      }
+
+      if (!impl->stopping_.load()) {
+        auto timer = std::make_shared<net::steady_timer>(*impl->ioc_);
+        timer->expires_after(std::chrono::milliseconds(100));
+        timer->async_wait([self, timer](const boost::system::error_code&) {
+          auto* retry_impl = self->impl_.get();
+          if (!retry_impl->stopping_.load()) {
+            retry_impl->do_accept(self);
+          }
+        });
       }
     }
   });


### PR DESCRIPTION
## Description
Fixes #453. `UdsServer::Impl::do_accept()` logged and returned on any accept() error other than `operation_aborted`, with no retry and no state/`on_error` signal — unlike `TcpServer::do_accept()`, which surfaces `LinkState::Error` and retries via a 100ms backoff timer. A single transient error (fd exhaustion, momentary resource pressure) permanently disabled a UDS server's ability to accept new connections, indistinguishable from "server fine, nobody's connecting."

## Key Changes
- `unilink/transport/uds/uds_server.cc`: mirror `TcpServer::do_accept()` — transition to `LinkState::Error` + `notify_state()` on error, then keep retrying `do_accept()` via a 100ms timer unless the server is stopping.
- `test/unit/transport/transport_uds_server.cc`: new regression test using the existing `MockUdsAcceptor`, injecting one accept failure followed by a successful retry attempt. Verified to fail without the fix (server never calls `async_accept` again) and pass with it.

## Related Issues
- Fixes #453 (found during the design-plan pass for #445)

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] My changes follow the project's coding style and conventions.