### PR TITLE
fix: clear backpressure on server session disconnect to prevent lost-wakeup hang

### DIFF
--- a/test/unit/transport/transport_tcp_server_session.cc
+++ b/test/unit/transport/transport_tcp_server_session.cc
@@ -35,6 +35,28 @@ namespace {
 namespace net = boost::asio;
 using tcp = net::ip::tcp;
 
+// Unlike FakeTcpSocket, whose async_write always auto-completes immediately,
+// this stub withholds the write completion indefinitely - modeling a real
+// client that has stopped reading, so the outstanding write never finishes
+// on its own. This is required to reproduce jwsung91/unilink#452: without
+// it, the fake socket's own auto-completion would drain the queue through
+// the normal (already-correct) path, masking whether do_close() itself
+// clears backpressure on disconnect.
+class HangingWriteSocket : public FakeTcpSocket {
+ public:
+  explicit HangingWriteSocket(net::io_context& ioc) : FakeTcpSocket(ioc) {}
+
+  void async_write(const net::const_buffer&,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    write_handler_ = std::move(handler);
+  }
+
+  bool has_write_handler() const { return !!write_handler_; }
+
+ private:
+  std::function<void(const boost::system::error_code&, std::size_t)> write_handler_;
+};
+
 }  // namespace
 
 TEST(TransportTcpServerSessionTest, QueueLimitDropsMessage) {
@@ -170,6 +192,51 @@ TEST(TransportTcpServerSessionTest, BackpressureReliefAfterDrain) {
   ASSERT_GE(events.size(), 2u);
   EXPECT_GE(events.front(), bp_threshold);
   EXPECT_LE(events.back(), bp_threshold / 2);
+}
+
+// Regression test for jwsung91/unilink#452: if a client disconnects (read
+// error) while backpressure is active for its session, do_close() must
+// unconditionally clear it and fire on_backpressure - otherwise a caller
+// blocked in send_to_blocking() for this client would never wake up, since
+// nothing else will ever call report_backpressure() again once the session
+// is gone.
+TEST(TransportTcpServerSessionTest, BackpressureClearsOnDisconnectWhileActive) {
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+  size_t bp_threshold = 1024;
+
+  // HangingWriteSocket never completes a write on its own, modeling a client
+  // that has stopped reading - the only way backpressure can ever clear is
+  // via do_close()'s drain, not via a write eventually finishing.
+  auto socket = std::make_unique<HangingWriteSocket>(ioc);
+  auto* socket_raw = socket.get();
+  auto session = std::make_shared<TcpServerSession>(ioc, std::move(socket), bp_threshold);
+
+  std::vector<size_t> events;
+  session->on_backpressure([&](size_t queued) { events.push_back(queued); });
+
+  session->start();
+  while (!socket_raw->has_handler()) {
+    ioc.run_for(std::chrono::milliseconds(1));
+  }
+
+  std::vector<uint8_t> payload(bp_threshold * 2, 0xEE);
+  ASSERT_TRUE(session->async_write_copy(memory::ConstByteSpan(payload.data(), payload.size())));
+  ioc.run_for(50ms);
+
+  ASSERT_GE(events.size(), 1u);
+  EXPECT_GE(events.back(), bp_threshold);
+  ASSERT_TRUE(socket_raw->has_write_handler());  // write is stuck in-flight, never completed
+
+  // Simulate an abrupt disconnect (client gone) while the write is still
+  // stuck and backpressure is still active. Nothing but do_close() itself
+  // can ever clear it now.
+  socket_raw->emit_read(0, boost::asio::error::eof);
+  ioc.restart();
+  ioc.run_for(50ms);
+
+  EXPECT_EQ(events.back(), 0u);
+  EXPECT_FALSE(session->alive());
 }
 
 TEST(TransportTcpServerSessionTest, OnBytesExceptionClosesSession) {

--- a/test/unit/transport/transport_uds_session_lifecycle.cc
+++ b/test/unit/transport/transport_uds_session_lifecycle.cc
@@ -172,6 +172,54 @@ TEST_F(UdsServerSessionLifecycleTest, SharedWritePendingFlushesAfterBackpressure
   ioc.run();
 }
 
+// Regression test for jwsung91/unilink#452: if a client disconnects (read
+// error) while backpressure is active for its session, do_close() must
+// unconditionally clear it and fire on_backpressure - otherwise a caller
+// blocked in send_to_blocking() for this client would never wake up, since
+// nothing else will ever call report_backpressure() again once the session
+// is gone. Uses a held (never-completing) write handler to model a client
+// that has stopped reading, so nothing but do_close() can ever clear
+// backpressure here.
+TEST_F(UdsServerSessionLifecycleTest, BackpressureClearsOnDisconnectWhileActive) {
+  auto mock_socket = std::make_unique<unilink::test::mocks::MockUdsSocket>();
+  std::function<void(const boost::system::error_code&, std::size_t)> read_handler;
+
+  EXPECT_CALL(*mock_socket, async_read_some(_, _))
+      .WillOnce(Invoke([&](const boost::asio::mutable_buffer&,
+                           std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+        read_handler = std::move(handler);
+      }));
+  EXPECT_CALL(*mock_socket, async_write(_, _))
+      .WillOnce(Invoke(
+          [](const boost::asio::const_buffer&, std::function<void(const boost::system::error_code&, std::size_t)>) {
+            // Never invoke: the write is permanently stuck in-flight.
+          }));
+  EXPECT_CALL(*mock_socket, close(_)).Times(1);
+
+  auto session = std::make_shared<UdsServerSession>(ioc, std::move(mock_socket), 1024, 0);
+  std::vector<size_t> events;
+  session->on_backpressure([&](size_t queued) { events.push_back(queued); });
+  session->start();
+
+  std::vector<uint8_t> payload(2048, 'p');
+  ASSERT_TRUE(session->async_write_copy(memory::ConstByteSpan(payload.data(), payload.size())));
+  ioc.run_for(10ms);
+
+  ASSERT_GE(events.size(), 1u);
+  EXPECT_GE(events.back(), 1024u);
+  EXPECT_TRUE(session->is_backpressure_active());
+  ASSERT_TRUE(read_handler);
+
+  // Simulate an abrupt disconnect (client gone) while the write is still
+  // stuck and backpressure is still active.
+  read_handler(make_error_code(boost::asio::error::eof), 0);
+  ioc.restart();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(events.back(), 0u);
+  EXPECT_FALSE(session->alive());
+}
+
 TEST_F(UdsServerSessionLifecycleTest, SharedWriteRejectsNullAndClosedSession) {
   auto mock_socket = std::make_unique<unilink::test::mocks::MockUdsSocket>();
   EXPECT_CALL(*mock_socket, close(_)).Times(1);

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -513,22 +513,35 @@ void TcpServerSession::do_close() {
   // Safely invoke on_close callback
   auto close_cb = std::move(on_close_);
 
-  // Clear all callbacks to prevent any further invocations
-  on_bytes_ = nullptr;
-  on_bp_ = nullptr;
-  on_close_ = nullptr;
-  idle_timer_.cancel();
-
   UNILINK_LOG_INFO("tcp_server_session", "disconnect", "Client disconnected");
   boost::system::error_code ec;
   socket_->shutdown(tcp::socket::shutdown_both, ec);
   socket_->close(ec);
 
-  // Release memory immediately
+  // Drain queued/pending writes and unconditionally clear backpressure,
+  // notifying any waiter directly - mirrors UdpChannel's
+  // drain_queue_and_clear_backpressure(). Must run before on_bp_ is cleared
+  // below: otherwise a Reliable-mode caller blocked in send_to_blocking()
+  // for this client would never be woken up when the client disconnects via
+  // a read error or idle timeout (jwsung91/unilink#452).
   tx_.clear();
   queue_bytes_ = 0;
   pending_.clear();
   pending_bytes_ = 0;
+  const bool had_backpressure = backpressure_active_;
+  backpressure_active_ = false;
+  if (had_backpressure && on_bp_) {
+    try {
+      on_bp_(queue_bytes_);
+    } catch (...) {
+    }
+  }
+
+  // Clear all callbacks to prevent any further invocations
+  on_bytes_ = nullptr;
+  on_bp_ = nullptr;
+  on_close_ = nullptr;
+  idle_timer_.cancel();
 
   if (close_cb) {
     try {

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -327,17 +327,34 @@ void UdsServerSession::do_close() {
   if (!closing_.exchange(true) && !alive_) return;
   alive_ = false;
   auto close_cb = std::move(on_close_);
-  on_bytes_ = nullptr;
-  on_bp_ = nullptr;
-  on_close_ = nullptr;
+
+  boost::system::error_code ec;
+  socket_->close(ec);
+
+  // Drain queued/pending writes and unconditionally clear backpressure,
+  // notifying any waiter directly - mirrors UdpChannel's
+  // drain_queue_and_clear_backpressure(). Must run before on_bp_ is cleared
+  // below: otherwise a Reliable-mode caller blocked in send_to_blocking()
+  // for this client would never be woken up when the client disconnects via
+  // a read error or idle timeout (jwsung91/unilink#452).
   tx_.clear();
   current_write_buffer_ = std::nullopt;
   queue_bytes_ = 0;
   pending_.clear();
   pending_bytes_ = 0;
   writing_ = false;
-  boost::system::error_code ec;
-  socket_->close(ec);
+  const bool had_backpressure = backpressure_active_;
+  backpressure_active_ = false;
+  if (had_backpressure && on_bp_) {
+    try {
+      on_bp_(queue_bytes_);
+    } catch (...) {
+    }
+  }
+
+  on_bytes_ = nullptr;
+  on_bp_ = nullptr;
+  on_close_ = nullptr;
   if (close_cb) {
     try {
       close_cb();


### PR DESCRIPTION
## Description
Fixes #452. `TcpServerSession::do_close()` and `UdsServerSession::do_close()` cleared their `tx_`/`pending_` queues on session termination (read error or idle timeout) but never cleared `backpressure_active_` or fired `on_bp_`. A thread blocked in the wrapper's `send_to_blocking(client_id, ...)` for that specific client could wait forever: the predicate (`!is_backpressure_active(client_id)`) does eventually become true once the session is erased, but nothing ever calls `bp_cv_.notify_all()` to make the blocked waiter re-check it — the same lost-wakeup class fixed for UDP in #427/#428, in server-session code that fix never touched.

## Key Changes
- `unilink/transport/tcp_server/tcp_server_session.cc`, `unilink/transport/uds/uds_server_session.cc`: `do_close()` now mirrors `UdpChannel::drain_queue_and_clear_backpressure()` — drains the queues and unconditionally clears + notifies backpressure before the callbacks are nulled. Both the read-error and idle-timeout termination paths converge on `do_close()`, so this covers both.
- `test/unit/transport/transport_tcp_server_session.cc`, `test/unit/transport/transport_uds_session_lifecycle.cc`: new regression tests using a socket double that holds the write completion indefinitely (modeling a client that has stopped reading, so nothing but `do_close()` can ever clear backpressure), then injects a read error while backpressure is active. Verified to fail without the fix and pass with it.

## Related Issues
- Fixes #452 (found during the design-plan pass for #434)

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Also confirmed the whole-server `stop()` path is unaffected: the wrapper's own `stop()` already calls `bp_cv_.notify_all()` directly and flips `started_` before tearing anything down, which independently unblocks any `send_to_blocking` caller regardless of per-session backpressure state.