### PR TITLE
fix: reset Serial/UdpClient wrapper channel on stop() to unblock restart

### DIFF
--- a/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
@@ -312,5 +312,36 @@ TEST(UdpClientWrapperLifecycleTest, StopWithoutStart) {
   client.stop();
 }
 
+// Regression test for jwsung91/unilink#444: Impl::stop() used to null the
+// channel's callbacks (including on_state, which is what fulfills the
+// start() future) without releasing the channel object itself. Since
+// start()'s `if (!channel)` guard is the only place that re-runs
+// setup_internal_handlers(), a restarted channel's handlers stayed null
+// forever, and the second start()'s future never resolved. Uses wait_for()
+// with a bounded timeout rather than a bare get(), so this test fails
+// loudly instead of hanging the suite if the fix regresses.
+TEST(UdpClientWrapperLifecycleTest, RestartAfterStopResolvesFutureAndReinstallsHandlers) {
+  config::UdpConfig cfg;
+  cfg.local_port = 0;
+  wrapper::UdpClient client(cfg);
+
+  std::atomic<int> connect_count{0};
+  client.on_connect([&](const wrapper::ConnectionContext&) { connect_count++; });
+
+  auto first = client.start();
+  ASSERT_EQ(first.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_TRUE(first.get());
+  EXPECT_EQ(connect_count.load(), 1);
+
+  client.stop();
+
+  auto second = client.start();
+  ASSERT_EQ(second.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+  EXPECT_TRUE(second.get());
+  EXPECT_EQ(connect_count.load(), 2);
+
+  client.stop();
+}
+
 }  // namespace test
 }  // namespace unilink

--- a/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
+++ b/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
@@ -231,6 +231,34 @@ TEST_F(SerialWrapperLifecycleTest, ConfigurationSetters) {
   serial->stop();
 }
 
+// Regression test for jwsung91/unilink#444: Impl::stop() used to null the
+// channel's callbacks (including on_state, which is what fulfills the
+// start() future) without releasing the channel object itself. Since
+// start()'s `if (!channel)` guard is the only place that re-runs
+// setup_internal_handlers(), a restarted channel's handlers stayed null
+// forever, and the second start()'s future never resolved. Uses wait_for()
+// with a bounded timeout rather than a bare get(), so this test fails
+// loudly instead of hanging the suite if the fix regresses.
+TEST_F(SerialWrapperLifecycleTest, RestartAfterStopResolvesFutureAndReinstallsHandlers) {
+  auto serial = std::make_shared<wrapper::Serial>(device_, 9600);
+  // Fail fast instead of retrying forever: /dev/null (or NUL) doesn't
+  // support the serial ioctls, so open() always fails here - the point of
+  // this test is that the future resolves at all (worse-finding #1 from
+  // #444: it used to hang), not that the device actually connects.
+  serial->reopen_on_error(false);
+  serial->on_error([](const wrapper::ErrorContext&) {});
+
+  auto first = serial->start();
+  ASSERT_EQ(first.wait_for(1s), std::future_status::ready);
+
+  serial->stop();
+
+  auto second = serial->start();
+  ASSERT_EQ(second.wait_for(1s), std::future_status::ready);
+
+  serial->stop();
+}
+
 TEST_F(SerialWrapperLifecycleTest, AutoManageStartsInjectedTransport) {
   boost::asio::io_context ioc;
 

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -91,10 +91,18 @@ struct Serial::Impl {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
 
+  // False only for the dependency-injected-channel constructor below, where
+  // the caller owns the channel's identity and lifecycle (e.g. tests
+  // injecting a fake channel) - stop() must not discard and factory-rebuild
+  // a channel it didn't create itself.
+  bool factory_managed_channel_ = true;
+
   Impl(const std::string& dev, uint32_t baud) : device(dev), baud_rate(baud) {}
   Impl(const std::string& dev, uint32_t baud, std::shared_ptr<boost::asio::io_context> ioc)
       : device(dev), baud_rate(baud), external_ioc(std::move(ioc)), use_external_context(external_ioc != nullptr) {}
-  explicit Impl(std::shared_ptr<interface::Channel> ch) : channel(std::move(ch)) { setup_internal_handlers(); }
+  explicit Impl(std::shared_ptr<interface::Channel> ch) : channel(std::move(ch)), factory_managed_channel_(false) {
+    setup_internal_handlers();
+  }
 
   ~Impl() {
     try {
@@ -211,9 +219,21 @@ struct Serial::Impl {
     if (channel) {
       channel->on_bytes(nullptr);
       channel->on_state(nullptr);
+      channel->on_backpressure(nullptr);
       lock.unlock();
       channel->stop();
       lock.lock();
+      if (factory_managed_channel_) {
+        // Fully release the channel rather than reusing it: start()'s
+        // `if (!channel)` guard is what re-runs setup_internal_handlers() and
+        // rebuilds config from the (possibly changed) staged fields. Reusing
+        // a stopped channel left every handler nulled forever - including
+        // the one that fulfills the start() future - so a restart would
+        // hang (jwsung91/unilink#444). Injected channels (factory_managed_
+        // channel_ == false) are exempt: the caller owns that channel's
+        // identity, so we must not discard and factory-rebuild it.
+        channel.reset();
+      }
     }
 
     if (work_guard_) {

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -76,10 +76,18 @@ struct UdpClient::Impl {
   std::atomic<bool> started_{false};
   std::shared_ptr<bool> alive_marker{std::make_shared<bool>(true)};
 
+  // False only for the dependency-injected-channel constructor below, where
+  // the caller owns the channel's identity and lifecycle (e.g. tests
+  // injecting a fake channel) - stop() must not discard and factory-rebuild
+  // a channel it didn't create itself.
+  bool factory_managed_channel_ = true;
+
   explicit Impl(const config::UdpConfig& config) : cfg(config) {}
   Impl(const config::UdpConfig& config, std::shared_ptr<boost::asio::io_context> ioc)
       : cfg(config), external_ioc(std::move(ioc)), use_external_context(external_ioc != nullptr) {}
-  explicit Impl(std::shared_ptr<interface::Channel> ch) : channel(std::move(ch)) { setup_internal_handlers(); }
+  explicit Impl(std::shared_ptr<interface::Channel> ch) : channel(std::move(ch)), factory_managed_channel_(false) {
+    setup_internal_handlers();
+  }
 
   ~Impl() {
     try {
@@ -160,10 +168,6 @@ struct UdpClient::Impl {
     }
     started_.store(true);
 
-    if (channel && !batch_timer_) {
-      batch_timer_ = std::make_unique<boost::asio::steady_timer>(channel->get_executor());
-    }
-
     lock.unlock();
     channel->start();
     if (use_external_context && manage_external_context && !external_thread.joinable()) {
@@ -197,9 +201,21 @@ struct UdpClient::Impl {
     if (channel) {
       channel->on_bytes(nullptr);
       channel->on_state(nullptr);
+      channel->on_backpressure(nullptr);
       lock.unlock();
       channel->stop();
       lock.lock();
+      if (factory_managed_channel_) {
+        // Fully release the channel rather than reusing it: start()'s
+        // `if (!channel)` guard is what re-runs setup_internal_handlers() and
+        // rebuilds config from the (possibly changed) staged fields. Reusing
+        // a stopped channel left every handler nulled forever - including
+        // the one that fulfills the start() future - so a restart would
+        // hang (jwsung91/unilink#444). Injected channels (factory_managed_
+        // channel_ == false) are exempt: the caller owns that channel's
+        // identity, so we must not discard and factory-rebuild it.
+        channel.reset();
+      }
     }
 
     if (work_guard) {


### PR DESCRIPTION
## Description
Fixes #444. `wrapper::Serial::Impl::stop()` and `wrapper::UdpClient::Impl::stop()` nulled `on_bytes`/`on_state` but kept the channel object alive, and `start()`'s `if (!channel)` guard is the only place that re-runs `setup_internal_handlers()`. So after `stop()`, every handler stayed null forever — including the `on_state` handler that fulfills the `start()` future — meaning a second `start().get()` **hung indefinitely** (worse than the originally-reported "callbacks silently dropped": confirmed via the design-plan pass that this also affects `UdpClient`, not just Serial). Config setters called while stopped were also silently frozen at their first-start values, since `build_config_locked()`/`cfg` is likewise only consulted inside that same guard.

## Key Changes
- `unilink/wrapper/serial/serial.cc`, `unilink/wrapper/udp/udp.cc`: fully release the channel in `stop()` so the next `start()` rebuilds it via the factory, matching the pattern `TcpClient`/`TcpServer`/`UdsClient`/`UdsServer` already use correctly.
- Guarded behind a new `factory_managed_channel_` flag (`false` only for the dependency-injected-channel constructor, where the caller owns the channel's identity/lifecycle) so existing tests that inject a fake channel for a single start/stop cycle are unaffected.
- `test/unit/wrapper/test_serial_wrapper_lifecycle.cc`, `test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc`: new regression tests — start, stop, start again, assert the second future resolves within a bounded timeout (never a bare `.get()`, so a regression fails loudly instead of hanging the suite) and `on_connect` fires again. Verified to fail (timeout) without the fix and pass with it.

## Related Issues
- Fixes #444 (scope expanded during the design-plan pass: also affects `UdpClient`, and the failure mode is a hang, not just dropped callbacks — issue title updated accordingly)

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Confirmed all existing dependency-injection-based tests (`InjectedChannelCoversHandlersAndSendVariants`, etc.) still pass unchanged, since `factory_managed_channel_` keeps their channel alive across `stop()` as before.