### PR TITLE
fix: bound the backpressure-clear wait in 6 more wrappers to prevent lost-wakeup hangs

### DIFF
--- a/test/integration/wrapper/test_send_contract.cc
+++ b/test/integration/wrapper/test_send_contract.cc
@@ -16,10 +16,14 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <boost/asio/io_context.hpp>
+#include <chrono>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include "unilink/interface/channel.hpp"
@@ -195,7 +199,60 @@ void verify_reliable_send_uses_strategy_aware_write(std::string_view name) {
   EXPECT_EQ(channel->try_shared_count(), 0);
 }
 
+// Regression test for jwsung91/unilink#431: the blocking Reliable-mode send
+// path used to wait on a condition variable unbounded. Since the transport
+// clears backpressure_active_ and calls notify_all() without holding the
+// wrapper's bp_mutex_, a notification can race a waiter that's mid-way
+// through checking the predicate and registering to wait, and get lost - an
+// unbounded wait() would then block forever (the same class of bug fixed
+// for UDP in #427/#428). Simulates a "lost" notification directly: the
+// channel's backpressure flips off with no on_backpressure()/notify_all()
+// call at all. A correct fix polls with a bounded timeout regardless of
+// notifications, so the blocked call must still return well within a few
+// poll intervals; the old unbounded wait() would hang this test forever.
+template <typename Wrapper>
+void verify_blocking_send_recovers_without_notify(std::string_view name) {
+  SCOPED_TRACE(std::string(name));
+  auto channel = std::make_shared<ContractChannel>();
+  channel->set_backpressure_active(true);
+
+  // Heap-allocated and captured by shared_ptr (not by reference) so that if
+  // this test fails - i.e. reproduces the #431 hang - the sender thread can
+  // be safely detached rather than joined, without leaving it referencing
+  // locals that are about to go out of scope. A permanently-stuck thread
+  // can't be joined without hanging the test binary itself.
+  auto wrapper = std::make_shared<Wrapper>(channel);
+  ASSERT_TRUE(wrapper->start().get());
+
+  auto sent_promise = std::make_shared<std::promise<bool>>();
+  auto sent_future = sent_promise->get_future();
+  std::thread sender([wrapper, sent_promise] { sent_promise->set_value(wrapper->send("blocked")); });
+
+  // Give the sender thread time to actually enter the wait loop before the
+  // "lost notification" state change below.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  channel->set_backpressure_active(false);  // no notify_all() - simulates a missed wakeup
+
+  bool recovered = sent_future.wait_for(std::chrono::milliseconds(500)) == std::future_status::ready;
+  if (recovered) {
+    sender.join();
+  } else {
+    sender.detach();
+  }
+  ASSERT_TRUE(recovered) << "blocking send did not recover from a missed backpressure notification within a "
+                            "bounded number of poll intervals";
+  EXPECT_TRUE(sent_future.get());
+}
+
 }  // namespace
+
+TEST(WrapperSendContractTest, BlockingSendRecoversWithoutBackpressureNotification) {
+  verify_blocking_send_recovers_without_notify<unilink::wrapper::TcpClient>("TcpClient");
+  verify_blocking_send_recovers_without_notify<unilink::wrapper::UdpClient>("UdpClient");
+  verify_blocking_send_recovers_without_notify<unilink::wrapper::UdsClient>("UdsClient");
+  verify_blocking_send_recovers_without_notify<unilink::wrapper::Serial>("Serial");
+}
 
 TEST(WrapperSendContractTest, TrySendVariantsUseExplicitTryWritePath) {
   verify_try_send_is_drop_if_full_escape_hatch<unilink::wrapper::TcpClient>("TcpClient");

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -267,17 +267,26 @@ struct Serial::Impl {
     return try_send(data);
   }
 
+  // channel->on_backpressure() calls bp_cv_.notify_all() from the transport's io_context
+  // thread without holding bp_mutex_ (backpressure_active_ is a plain atomic on the transport
+  // side, not guarded by bp_mutex_ at all). That makes a classic lost-wakeup race possible: a
+  // waiter can check the predicate, find it still blocking, and be in the process of
+  // registering to wait when the notify fires - in the rare case that race is lost, an
+  // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
+  // notify only costs a short delay rather than a permanent hang (see #427, #431).
+  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+    auto predicate = [this] {
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
+    };
+    while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+    }
+  }
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      while (true) {
-        {
-          std::shared_lock<std::shared_mutex> lock(mutex_);
-          if (!started_.load() || !channel || !channel->is_connected()) return false;
-          if (!channel->is_backpressure_active()) break;
-        }
-        bp_cv_.wait(bp_lock);
-      }
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_move(std::move(data));
@@ -289,14 +298,7 @@ struct Serial::Impl {
     if (!data || data->empty()) return false;
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      while (true) {
-        {
-          std::shared_lock<std::shared_mutex> lock(mutex_);
-          if (!started_.load() || !channel || !channel->is_connected()) return false;
-          if (!channel->is_backpressure_active()) break;
-        }
-        bp_cv_.wait(bp_lock);
-      }
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_shared(std::move(data));
@@ -313,15 +315,9 @@ struct Serial::Impl {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    while (true) {
-      {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        if (!started_.load() || !channel || !channel->is_connected()) return false;
-        if (!channel->is_backpressure_active()) break;
-      }
-      bp_cv_.wait(bp_lock);
-    }
+    wait_for_backpressure_clear(bp_lock);
     std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (!started_.load() || !channel || !channel->is_connected()) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
     channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
     return true;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -293,13 +293,26 @@ struct TcpClient::Impl {
     return try_send(data);
   }
 
+  // channel_->on_backpressure() calls bp_cv_.notify_all() from the transport's io_context
+  // thread without holding bp_mutex_ (backpressure_active_ is a plain atomic on the transport
+  // side, not guarded by bp_mutex_ at all). That makes a classic lost-wakeup race possible: a
+  // waiter can check the predicate, find it still blocking, and be in the process of
+  // registering to wait when the notify fires - in the rare case that race is lost, an
+  // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
+  // notify only costs a short delay rather than a permanent hang (see #427, #431).
+  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+    auto predicate = [this] {
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      return !started_.load() || !channel_ || !channel_->is_backpressure_active();
+    };
+    while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+    }
+  }
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      bp_cv_.wait(bp_lock, [this] {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        return !started_.load() || !channel_ || !channel_->is_backpressure_active();
-      });
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_move(std::move(data));
@@ -311,10 +324,7 @@ struct TcpClient::Impl {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      bp_cv_.wait(bp_lock, [this] {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        return !started_.load() || !channel_ || !channel_->is_backpressure_active();
-      });
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_shared(std::move(data));
@@ -331,10 +341,7 @@ struct TcpClient::Impl {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    bp_cv_.wait(bp_lock, [this] {
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      return !started_.load() || !channel_ || !channel_->is_backpressure_active();
-    });
+    wait_for_backpressure_clear(bp_lock);
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel_) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -322,13 +322,21 @@ struct TcpServer::Impl {
     return try_broadcast(data);
   }
 
+  // channel_->on_backpressure()/session-level backpressure callbacks call bp_cv_.notify_all()
+  // from the transport's io_context thread without holding bp_mutex_ - a classic lost-wakeup
+  // race is possible: a waiter can check the predicate, find it still blocking, and be in the
+  // process of registering to wait when the notify fires. Poll with a bounded timeout instead
+  // of an unbounded wait() so a missed notify only costs a short delay rather than a
+  // permanent hang (see #427, #431).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> lock(bp_mutex_);
-    bp_cv_.wait(lock, [this, client_id]() {
+    auto predicate = [this, client_id]() {
       std::shared_lock<std::shared_mutex> rlock(mutex_);
       const auto& ts = transport_cache_;
       return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
-    });
+    };
+    while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+    }
     std::shared_lock<std::shared_mutex> rlock(mutex_);
     const auto& ts = transport_cache_;
     return ts ? ts->send_to_client(client_id, data) : false;

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -479,12 +479,21 @@ struct UdpServer::Impl {
 
   bool broadcast(std::string_view data) { return try_broadcast(data); }
 
+  // channel->on_backpressure() calls bp_cv_.notify_all() from the transport's io_context
+  // thread without holding bp_mutex_ (backpressure_active_ is a plain atomic on the transport
+  // side, not guarded by bp_mutex_ at all). That makes a classic lost-wakeup race possible: a
+  // waiter can check the predicate, find it still blocking, and be in the process of
+  // registering to wait when the notify fires - in the rare case that race is lost, an
+  // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
+  // notify only costs a short delay rather than a permanent hang (see #427, #431).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    bp_cv_.wait(bp_lock, [this] {
+    auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex);
       return !started.load() || !channel || !channel->is_backpressure_active();
-    });
+    };
+    while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+    }
     return try_send_to(client_id, data);
   }
 

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -258,13 +258,26 @@ struct UdsClient::Impl {
     return try_send(data);
   }
 
+  // channel_->on_backpressure() calls bp_cv_.notify_all() from the transport's io_context
+  // thread without holding bp_mutex_ (backpressure_active_ is a plain atomic on the transport
+  // side, not guarded by bp_mutex_ at all). That makes a classic lost-wakeup race possible: a
+  // waiter can check the predicate, find it still blocking, and be in the process of
+  // registering to wait when the notify fires - in the rare case that race is lost, an
+  // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
+  // notify only costs a short delay rather than a permanent hang (see #427, #431).
+  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+    auto predicate = [this] {
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
+    };
+    while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+    }
+  }
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      bp_cv_.wait(bp_lock, [this] {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
-      });
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_move(std::move(data));
@@ -276,10 +289,7 @@ struct UdsClient::Impl {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      bp_cv_.wait(bp_lock, [this] {
-        std::shared_lock<std::shared_mutex> lock(mutex_);
-        return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
-      });
+      wait_for_backpressure_clear(bp_lock);
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_shared(std::move(data));
@@ -296,10 +306,7 @@ struct UdsClient::Impl {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    bp_cv_.wait(bp_lock, [this] {
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
-    });
+    wait_for_backpressure_clear(bp_lock);
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
     return channel_->async_write_copy(

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -139,13 +139,21 @@ struct UdsServer::Impl {
 
   bool broadcast(std::string_view data) { return try_broadcast(data); }
 
+  // channel_->on_backpressure()/session-level backpressure callbacks call bp_cv_.notify_all()
+  // from the transport's io_context thread without holding bp_mutex_ - a classic lost-wakeup
+  // race is possible: a waiter can check the predicate, find it still blocking, and be in the
+  // process of registering to wait when the notify fires. Poll with a bounded timeout instead
+  // of an unbounded wait() so a missed notify only costs a short delay rather than a
+  // permanent hang (see #427, #431).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> lock(bp_mutex_);
-    bp_cv_.wait(lock, [this, client_id]() {
+    auto predicate = [this, client_id]() {
       std::shared_lock<std::shared_mutex> rlock(mutex_);
       auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
       return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
-    });
+    };
+    while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+    }
     std::shared_lock<std::shared_mutex> rlock(mutex_);
     auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
     return ts ? ts->send_to_client(client_id, data) : false;


### PR DESCRIPTION
## Description
Fixes #431. `wrapper/udp/udp.cc` already had the correct fix from #427/#428: since the transport clears `backpressure_active_` and calls `bp_cv_.notify_all()` from its io_context thread without holding `bp_mutex_`, a notification can race a waiter that's mid-way through checking the predicate and registering to wait, and get lost. An unbounded `bp_cv_.wait()` would then block forever. The same unbounded-wait pattern was still present, unfixed, in six other places.

## Key Changes
- `wrapper/tcp_client/tcp_client.cc` (3 call sites, one shared predicate), `wrapper/uds_client/uds_client.cc` (same shape) — collapsed into a private `wait_for_backpressure_clear()` helper using bounded `wait_for(50ms, predicate)` in a loop.
- `wrapper/serial/serial.cc` — this one was structurally different: a manual `while(true) { check; if ok break; bp_cv_.wait(bp_lock); }` loop with **no predicate argument at all**, the most primitive/riskiest form. Refactored to the same bounded-polling style as the others. Also fixed a latent secondary bug found in the process: `send_blocking` had no post-wait `!started_/!channel/!is_connected()` guard before writing, unlike `send_move`/`send_shared` — a null-deref risk if the channel became null while waiting. Added the guard to match.
- `wrapper/tcp_server/tcp_server.cc`, `wrapper/uds_server/uds_server.cc`, `wrapper/udp/udp_server.cc` — one `send_to_blocking()` call site each, same bounded-polling fix applied inline.

## Related Issues
- Fixes #431

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Added a regression test (`test/integration/wrapper/test_send_contract.cc`) covering the four client wrappers (`TcpClient`, `UdpClient`, `UdsClient`, `Serial`) via the existing injectable `ContractChannel` test double: start a blocking Reliable-mode send while backpressure is active, then clear it on the channel *without* ever calling `on_backpressure()`/`notify_all()`, simulating a permanently lost wakeup. Verified to hang without the fix and pass with it (the test itself uses a bounded `wait_for` + safe thread-detach rather than a bare `join()`, so a real regression fails loudly instead of hanging the test binary).

**Testing gap, disclosed honestly**: the three server wrappers' `send_to_blocking()` route through `dynamic_pointer_cast<transport::XServer>` to check per-client backpressure state, which the simple injectable-channel double can't satisfy (it isn't a real `transport::TcpServer`/`UdsServer`/`UdpServer`). The identical polling pattern was applied to all three, verified to compile and not regress any of the existing 670+ tests, but wasn't independently covered by a new targeted regression test here.