### PR TITLE
version: v0.8.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.2
+  VERSION 0.8.3
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Description
Version checkpoint covering everything merged since v0.8.2:

- #426 — fix: default TCP_NODELAY to true (partial fix, config/wrapper layers)
- #428 — fix: clear UDP backpressure queue on write error to prevent deadlock
- #429 — fix: establish single-source-of-truth defaults across all builder options (completes the TCP_NODELAY fix at the builder layer; CONFIRMED on Jetson, ~44ms→~200-500us for TCP payloads >=4096B)
- #430 — fix: derive pkg-config Libs.private from the real link dependency list
- #455 — fix: retry UDS server accept() on transient errors instead of stopping forever
- #456 — fix: clear backpressure on server session disconnect to prevent lost-wakeup hang
- #457 — fix: reset Serial/UdpClient wrapper channel on stop() to unblock restart
- #458 — fix: bound the backpressure-clear wait in 6 more wrappers to prevent lost-wakeup hangs

## Behavior changes worth flagging
A few of these are real, user-visible behavior changes rather than pure bug fixes:
- TCP client/UDS client/Serial `retry_interval` default is now actually 1000ms (previously 3000ms via the builder layer, despite config saying 1000ms since v0.8.2's predecessor).
- TCP server `max_port_retries` default is now actually 3 (previously 10 via the builder layer).
- Serial and UdpClient wrappers can now be `stop()`ped and `start()`ed again without hanging.

## Type of Change
- [x] **Version bump**

## Checklist
- [x] `CMakeLists.txt` project version updated (0.8.2 → 0.8.3).
- [x] `./scripts/verify.sh` passes.