### PR TITLE
feat: add shared backpressure/enqueue state machine header (#434 step 1/6)

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -190,6 +190,13 @@ unilink_add_unit_gtest(
   "unit_transport_reconnect_stable" 30
 )
 
+# Shared backpressure state machine (#434) - isolated, no sockets/io_context
+unilink_add_unit_gtest(
+  run_unit_test_bp_state_machine
+  ${CMAKE_CURRENT_SOURCE_DIR}/transport/test_bp_state_machine.cc
+  "unit_transport_backpressure_fast" 30
+)
+
 # New error handling tests
 unilink_add_unit_gtest(
   run_unit_test_tcp_abort

--- a/test/unit/transport/test_bp_state_machine.cc
+++ b/test/unit/transport/test_bp_state_machine.cc
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <deque>
+#include <variant>
+#include <vector>
+
+#include "unilink/transport/base/bp_state_machine.hpp"
+
+using namespace unilink::transport::queue_util;
+using unilink::base::constants::BackpressureStrategy;
+using unilink::interface::Channel;
+
+namespace {
+
+// maybe_flush_for_keep_latest() (reused by decide_enqueue() for BestEffort
+// trimming) visits each deque element via std::visit, so elements must
+// actually be a std::variant - a single-alternative one is enough here,
+// matching how TCP/UDS/Serial transports store tx_ as deque<BufferVariant>
+// directly (UDP's deque<TxItem{BufferVariant, destination}> is the one
+// exception, handled separately when UDP migrates to this header).
+using TestBuffer = std::variant<std::vector<uint8_t>>;
+
+// Isolated fixture: no sockets, no io_context.
+struct FakeQueues {
+  std::deque<TestBuffer> tx;
+  std::deque<TestBuffer> pending;
+  std::atomic<size_t> queue_bytes{0};
+  std::atomic<size_t> pending_bytes{0};
+  std::atomic<bool> backpressure_active{false};
+  unilink::diagnostics::RuntimeStatsCounters stats;
+
+  BackpressureFields fields(BackpressureStrategy strategy, size_t bp_high = 100, size_t bp_low = 50,
+                            size_t bp_limit = 400) {
+    return BackpressureFields{queue_bytes, pending_bytes, backpressure_active, bp_high, bp_low, bp_limit, strategy};
+  }
+};
+
+}  // namespace
+
+TEST(BpStateMachineTest, ReliableRoutesToPendingOnceBackpressureActive) {
+  FakeQueues q;
+  q.backpressure_active.store(true);
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  DropAccounting dropped;
+
+  auto decision = decide_enqueue(f, 10, q.tx, dropped);
+
+  EXPECT_EQ(decision, EnqueueDecision::Pending);
+  EXPECT_FALSE(dropped.any());
+}
+
+TEST(BpStateMachineTest, ReliableRejectsWhenPendingWouldExceedLimit) {
+  FakeQueues q;
+  q.backpressure_active.store(true);
+  q.queue_bytes.store(300);
+  q.pending_bytes.store(90);
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  DropAccounting dropped;
+
+  // queue_bytes(300) + pending_bytes(90) + added(20) = 410 > bp_limit(400)
+  auto decision = decide_enqueue(f, 20, q.tx, dropped);
+
+  EXPECT_EQ(decision, EnqueueDecision::Rejected);
+}
+
+TEST(BpStateMachineTest, ReliableIsImmediateWhenBackpressureNotActive) {
+  FakeQueues q;
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  DropAccounting dropped;
+
+  auto decision = decide_enqueue(f, 10, q.tx, dropped);
+
+  EXPECT_EQ(decision, EnqueueDecision::Immediate);
+  EXPECT_FALSE(dropped.any());
+}
+
+TEST(BpStateMachineTest, BestEffortTrimsOldestEntriesToFitNewBuffer) {
+  FakeQueues q;
+  q.tx.push_back(std::vector<uint8_t>(40, 0));
+  q.tx.push_back(std::vector<uint8_t>(40, 0));
+  q.queue_bytes.store(80);
+  auto f = q.fields(BackpressureStrategy::BestEffort);  // bp_high = 100
+  DropAccounting dropped;
+
+  // queue_bytes(80) + added(30) = 110 > bp_high(100): must trim.
+  auto decision = decide_enqueue(f, 30, q.tx, dropped);
+
+  EXPECT_EQ(decision, EnqueueDecision::Immediate);
+  EXPECT_TRUE(dropped.any());
+  EXPECT_EQ(dropped.messages, 1u);  // dropping the oldest 40-byte entry brings us to 40+30=70 <= 100
+  EXPECT_EQ(q.tx.size(), 1u);
+}
+
+TEST(BpStateMachineTest, BestEffortDropsEverythingWhenNewBufferAloneExceedsHigh) {
+  FakeQueues q;
+  q.tx.push_back(std::vector<uint8_t>(10, 0));
+  q.queue_bytes.store(10);
+  auto f = q.fields(BackpressureStrategy::BestEffort);  // bp_high = 100
+  DropAccounting dropped;
+
+  auto decision = decide_enqueue(f, 150, q.tx, dropped);  // added alone >= bp_high
+
+  EXPECT_EQ(decision, EnqueueDecision::Immediate);
+  EXPECT_EQ(dropped.messages, 1u);
+  EXPECT_TRUE(q.tx.empty());
+  EXPECT_EQ(q.queue_bytes.load(), 0u);
+}
+
+TEST(BpStateMachineTest, ReportBackpressureFiresOnWhenCrossingHighWatermark) {
+  FakeQueues q;
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  Channel::OnBackpressure on_bp;
+  int fired_with = -1;
+  on_bp = [&](size_t queued) { fired_with = static_cast<int>(queued); };
+  bool kicked = false;
+
+  report_backpressure(f, /*queued_bytes=*/120, on_bp, q.stats, [&]() -> size_t { return 0; }, [&]() { kicked = true; });
+
+  EXPECT_TRUE(q.backpressure_active.load());
+  EXPECT_EQ(fired_with, 120);
+  EXPECT_FALSE(kicked);  // ON transition never kicks a write
+}
+
+TEST(BpStateMachineTest, ReportBackpressureDoesNothingBetweenLowAndHigh) {
+  FakeQueues q;
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  Channel::OnBackpressure on_bp;
+  bool fired = false;
+  on_bp = [&](size_t) { fired = true; };
+
+  report_backpressure(f, /*queued_bytes=*/75, on_bp, q.stats, [&]() -> size_t { return 0; }, [&]() {});
+
+  EXPECT_FALSE(q.backpressure_active.load());
+  EXPECT_FALSE(fired);
+}
+
+TEST(BpStateMachineTest, ReportBackpressureFlushesPendingAndKicksWriteOnOffTransition) {
+  FakeQueues q;
+  q.backpressure_active.store(true);
+  q.queue_bytes.store(40);
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  Channel::OnBackpressure on_bp;
+  std::vector<int> fired;
+  on_bp = [&](size_t queued) { fired.push_back(static_cast<int>(queued)); };
+  bool kicked = false;
+  bool flushed = false;
+
+  report_backpressure(
+      f, /*queued_bytes=*/40, on_bp, q.stats,
+      [&]() -> size_t {
+        flushed = true;
+        return 15;  // pretend 15 bytes moved from pending_ into tx_
+      },
+      [&]() { kicked = true; });
+
+  EXPECT_TRUE(flushed);
+  EXPECT_FALSE(q.backpressure_active.load());  // stays off: 40 + 15 = 55 < bp_high(100)
+  EXPECT_EQ(q.queue_bytes.load(), 55u);        // fetch_add applied the flushed bytes onto the existing 40
+  ASSERT_EQ(fired.size(), 1u);
+  EXPECT_EQ(fired[0], 40);  // OFF fired with the pre-flush queued_bytes, not the post-flush total
+  EXPECT_TRUE(kicked);
+}
+
+TEST(BpStateMachineTest, ReportBackpressureReArmsImmediatelyIfPostFlushStillHigh) {
+  FakeQueues q;
+  q.backpressure_active.store(true);
+  q.queue_bytes.store(40);
+  auto f = q.fields(BackpressureStrategy::Reliable);  // bp_high = 100
+  Channel::OnBackpressure on_bp;
+  std::vector<int> fired;
+  on_bp = [&](size_t queued) { fired.push_back(static_cast<int>(queued)); };
+
+  report_backpressure(
+      f, /*queued_bytes=*/40, on_bp, q.stats, [&]() -> size_t { return 90; },  // 40 + 90 = 130 >= bp_high(100)
+      [&]() {});
+
+  EXPECT_TRUE(q.backpressure_active.load());  // re-armed
+  ASSERT_EQ(fired.size(), 2u);
+  EXPECT_EQ(fired[0], 40);   // OFF with pre-flush size
+  EXPECT_EQ(fired[1], 130);  // immediately re-fired ON with the post-flush size
+}
+
+TEST(BpStateMachineTest, DrainClearsQueuesAndFiresOnceIfBackpressureWasActive) {
+  FakeQueues q;
+  q.backpressure_active.store(true);
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  Channel::OnBackpressure on_bp;
+  int fire_count = 0;
+  int last_value = -1;
+  on_bp = [&](size_t queued) {
+    ++fire_count;
+    last_value = static_cast<int>(queued);
+  };
+  bool cleared = false;
+
+  drain_and_clear_backpressure(f, on_bp, [&]() { cleared = true; });
+
+  EXPECT_TRUE(cleared);
+  EXPECT_FALSE(q.backpressure_active.load());
+  EXPECT_EQ(fire_count, 1);
+  EXPECT_EQ(last_value, 0);
+}
+
+TEST(BpStateMachineTest, DrainIsNoOpIfBackpressureWasNotActive) {
+  FakeQueues q;
+  auto f = q.fields(BackpressureStrategy::Reliable);
+  Channel::OnBackpressure on_bp;
+  bool fired = false;
+  on_bp = [&](size_t) { fired = true; };
+  bool cleared = false;
+
+  drain_and_clear_backpressure(f, on_bp, [&]() { cleared = true; });
+
+  EXPECT_TRUE(cleared);  // clear_queues always runs regardless of whether bp was active
+  EXPECT_FALSE(fired);   // but on_bp only fires if there was something to clear
+}

--- a/unilink/transport/base/bp_state_machine.hpp
+++ b/unilink/transport/base/bp_state_machine.hpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+
+#include "unilink/base/constants.hpp"
+#include "unilink/diagnostics/runtime_stats_counter.hpp"
+#include "unilink/interface/channel.hpp"
+#include "unilink/transport/base/bp_utils.hpp"
+
+// Shared "pre-check -> route to tx/pending -> report backpressure -> drain on
+// terminate" state machine, factored out of ~6 independently-maintained
+// per-transport copies (jwsung91/unilink#434). Deliberately non-owning/
+// ref-based rather than template-owning the queues themselves: buffer
+// element types genuinely differ across transports (UDP's TxItem carries a
+// destination endpoint that stream transports have no analogue for), so
+// this header only decides what a transport's own enqueue/write-completion
+// code should do, and calls back into transport-supplied hooks for the
+// pieces that must stay transport-specific (moving a buffer element from
+// pending_ into tx_, kicking off a write).
+namespace unilink {
+namespace transport {
+namespace queue_util {
+
+// The subset of a transport's Impl state this state machine needs to read
+// and mutate. All fields are references into the transport's own members -
+// this struct never owns anything and is cheap to construct per call.
+struct BackpressureFields {
+  std::atomic<size_t>& queue_bytes;
+  std::atomic<size_t>& pending_bytes;
+  std::atomic<bool>& backpressure_active;
+  size_t bp_high;
+  size_t bp_low;
+  size_t bp_limit;
+  ::unilink::base::constants::BackpressureStrategy strategy;
+};
+
+enum class EnqueueDecision {
+  Immediate,  // push the buffer onto tx_ and proceed to write it now
+  Pending,    // Reliable + backpressure already active: route to pending_ instead
+  Rejected,   // over bp_limit_ even after BestEffort trimming; caller must drop it
+};
+
+// Decides how a new buffer of `added` bytes should be routed, mirroring the
+// branch structure every transport's enqueue function hand-copied. Does NOT
+// push `added` into any queue itself - the caller pushes its own
+// buffer/destination element into tx_ or pending_ based on the returned
+// decision, and is responsible for incrementing the corresponding byte
+// counter (queue_bytes/pending_bytes) to match. For BestEffort, trims `tx`
+// via the existing maybe_flush_for_keep_latest() before returning
+// Immediate, recording anything dropped into `dropped_out`.
+template <typename Deque>
+inline EnqueueDecision decide_enqueue(BackpressureFields& f, size_t added, Deque& tx, DropAccounting& dropped_out) {
+  using Strategy = ::unilink::base::constants::BackpressureStrategy;
+
+  if (f.strategy == Strategy::Reliable && f.backpressure_active.load(std::memory_order_relaxed)) {
+    if (f.queue_bytes.load(std::memory_order_relaxed) + f.pending_bytes.load(std::memory_order_relaxed) + added >
+        f.bp_limit) {
+      return EnqueueDecision::Rejected;
+    }
+    return EnqueueDecision::Pending;
+  }
+
+  if (f.strategy == Strategy::BestEffort && (f.backpressure_active.load(std::memory_order_relaxed) ||
+                                             f.queue_bytes.load(std::memory_order_relaxed) + added > f.bp_high)) {
+    dropped_out = maybe_flush_for_keep_latest(f.strategy, added, f.bp_high, tx, f.queue_bytes, f.backpressure_active);
+  }
+
+  if (f.queue_bytes.load(std::memory_order_relaxed) + added > f.bp_limit) {
+    return EnqueueDecision::Rejected;
+  }
+  return EnqueueDecision::Immediate;
+}
+
+// Runs the ON / OFF-with-reflush / re-ARM state machine and fires on_bp
+// accordingly, mirroring UdpChannel::report_backpressure() (the
+// best-behaved existing copy). `flush_pending_into_tx` is called exactly
+// once, only on the OFF transition, and must move every element out of the
+// transport's own pending_ deque into tx_ (preserving whatever
+// transport-specific fields those elements carry) and return the number of
+// bytes moved; `kick_write` is called if the OFF transition leaves anything
+// in tx_ and nothing is currently being written.
+template <typename FlushFn, typename KickFn>
+inline void report_backpressure(BackpressureFields& f, size_t queued_bytes, interface::Channel::OnBackpressure& on_bp,
+                                diagnostics::RuntimeStatsCounters& stats, FlushFn&& flush_pending_into_tx,
+                                KickFn&& kick_write) {
+  if (!f.backpressure_active.load(std::memory_order_relaxed) && queued_bytes >= f.bp_high) {
+    f.backpressure_active.store(true, std::memory_order_relaxed);
+    stats.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (...) {
+      }
+    }
+    return;
+  }
+
+  if (f.backpressure_active.load(std::memory_order_relaxed) && queued_bytes <= f.bp_low) {
+    const size_t moved = flush_pending_into_tx();
+    f.queue_bytes.fetch_add(moved, std::memory_order_relaxed);
+    f.backpressure_active.store(false, std::memory_order_relaxed);
+    stats.record_backpressure_event();
+    if (on_bp) {
+      try {
+        on_bp(queued_bytes);
+      } catch (...) {
+      }  // fire OFF with pre-flush queue size, matching every existing copy
+    }
+
+    const size_t post_flush = f.queue_bytes.load(std::memory_order_relaxed);
+    if (post_flush >= f.bp_high) {
+      f.backpressure_active.store(true, std::memory_order_relaxed);
+      stats.record_backpressure_event();
+      if (on_bp) {
+        try {
+          on_bp(post_flush);
+        } catch (...) {
+        }
+      }
+    }
+    kick_write();
+  }
+}
+
+// Drops all queued and pending writes and clears backpressure, firing on_bp
+// once (with a final queued-bytes value of 0) if it was active - and doing
+// nothing at all if it wasn't. This is the *terminal* drain path (stop/error),
+// deliberately distinct from report_backpressure()'s normal-operation flush:
+// report_backpressure() moves pending_ back into tx_ and can immediately
+// re-arm backpressure_active_, which would strand a Reliable-mode sender
+// blocked on a condition variable forever once nothing will ever call
+// do_write() again (jwsung91/unilink#427, #452). `clear_queues` must clear
+// every transport-specific queue (tx_, pending_, and their byte counters).
+template <typename ClearFn>
+inline void drain_and_clear_backpressure(BackpressureFields& f, interface::Channel::OnBackpressure& on_bp,
+                                         ClearFn&& clear_queues) {
+  clear_queues();
+  const bool had_backpressure = f.backpressure_active.load(std::memory_order_relaxed);
+  f.backpressure_active.store(false, std::memory_order_relaxed);
+  if (!had_backpressure) return;
+  if (on_bp) {
+    try {
+      on_bp(0);
+    } catch (...) {
+    }
+  }
+}
+
+}  // namespace queue_util
+}  // namespace transport
+}  // namespace unilink


### PR DESCRIPTION
## Summary
Part of #434 (step 1 of the 6-step migration plan posted on that issue). The "pre-check capacity -> route to tx/pending -> report backpressure -> drain on terminate" state machine is currently hand-copied across ~6 transports (TCP/UDS client, TCP/UDS server sessions, UDP, Serial). A queue-drain/backpressure bug fixed in one (as happened for UDP in #427/#428) has no guarantee of being fixed in the others, because there's no shared implementation to fix once — this was a structural risk factor called out alongside the #452 lost-wakeup bug (already fixed independently).

Adds `unilink/transport/base/bp_state_machine.hpp`, extending `bp_utils.hpp` with three ref-based (non-owning) functions modeled on `UdpChannel`'s existing implementation (the best-behaved of the six copies):
- `decide_enqueue()` — routes a new buffer to Immediate/Pending/Rejected, reusing the existing BestEffort trim logic.
- `report_backpressure()` — the ON / OFF-with-reflush / re-ARM state machine, via caller-supplied hooks for the two things that must stay transport-specific (moving `pending_` into `tx_`, kicking off a write).
- `drain_and_clear_backpressure()` — the terminal-path drain, generalizing `UdpChannel::drain_queue_and_clear_backpressure()` (from #427/#428).

Deliberately non-owning/ref-based rather than template-owning the queues: buffer element types genuinely differ (UDP's `TxItem` carries a destination endpoint that stream transports have no analogue for).

**No transport has been migrated to use this yet — this PR is purely additive**, per the plan's recommendation that each migration land as its own commit/PR for independent review. Follow-ups (#434 steps 2-6): UDP → TCP/UDS server sessions → TCP client → UDS client → Serial.

## Test plan
- [x] `./scripts/verify.sh` passes (671 tests, +11 new)
- [x] New isolated unit tests (`test/unit/transport/test_bp_state_machine.cc`, no sockets/io_context) cover: Reliable pending-routing, BestEffort trim (partial + full-drop), the ON/OFF/re-arm sequence, and drain-fires-once-if-active/no-op-if-not

🤖 Generated with [Claude Code](https://claude.com/claude-code)