### PR TITLE
refactor: migrate UDP transport to the shared bp_state_machine.hpp (#434 step 2/6)

### DIFF
--- a/unilink/transport/base/bp_state_machine.hpp
+++ b/unilink/transport/base/bp_state_machine.hpp
@@ -64,9 +64,13 @@ enum class EnqueueDecision {
 // decision, and is responsible for incrementing the corresponding byte
 // counter (queue_bytes/pending_bytes) to match. For BestEffort, trims `tx`
 // via the existing maybe_flush_for_keep_latest() before returning
-// Immediate, recording anything dropped into `dropped_out`.
-template <typename Deque>
-inline EnqueueDecision decide_enqueue(BackpressureFields& f, size_t added, Deque& tx, DropAccounting& dropped_out) {
+// Immediate, recording anything dropped into `dropped_out`. `project`
+// defaults to identity (tx's elements are the BufferVariant directly);
+// UDP's tx_ holds TxItem{BufferVariant, destination} instead and supplies a
+// projection extracting `.buffer`.
+template <typename Deque, typename Project = IdentityProjection>
+inline EnqueueDecision decide_enqueue(BackpressureFields& f, size_t added, Deque& tx, DropAccounting& dropped_out,
+                                      Project project = Project{}) {
   using Strategy = ::unilink::base::constants::BackpressureStrategy;
 
   if (f.strategy == Strategy::Reliable && f.backpressure_active.load(std::memory_order_relaxed)) {
@@ -79,7 +83,8 @@ inline EnqueueDecision decide_enqueue(BackpressureFields& f, size_t added, Deque
 
   if (f.strategy == Strategy::BestEffort && (f.backpressure_active.load(std::memory_order_relaxed) ||
                                              f.queue_bytes.load(std::memory_order_relaxed) + added > f.bp_high)) {
-    dropped_out = maybe_flush_for_keep_latest(f.strategy, added, f.bp_high, tx, f.queue_bytes, f.backpressure_active);
+    dropped_out =
+        maybe_flush_for_keep_latest(f.strategy, added, f.bp_high, tx, f.queue_bytes, f.backpressure_active, project);
   }
 
   if (f.queue_bytes.load(std::memory_order_relaxed) + added > f.bp_limit) {

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -73,25 +73,39 @@ inline size_t variant_buffer_size(const T& buf) {
   }
 }
 
-// BestEffort queue-trimming shared by all stream transports (TCP client/server, UDS client/server).
+// Identity projection: the default for maybe_flush_for_keep_latest()'s `project`
+// parameter below, used as-is by transports whose tx_ deque holds the
+// BufferVariant directly. UDP's tx_ holds TxItem{BufferVariant, destination}
+// instead, and supplies a projection extracting `.buffer` so this same
+// trimming logic can still visit the variant inside.
+struct IdentityProjection {
+  template <typename T>
+  constexpr T& operator()(T& x) const {
+    return x;
+  }
+};
+
+// BestEffort queue-trimming shared by all stream transports (TCP client/server, UDS client/server)
+// and, via a projection, UDP.
 // Must be called on the strand immediately before enqueueing a new buffer of `added` bytes.
 //
 // No-op for Reliable strategy.
 // For BestEffort:
 //   added >= bp_high  →  drop entire tx_ (full keep-latest replacement).
 //   otherwise         →  pop oldest tx_ entries until queue_bytes + added <= bp_high.
-template <typename Deque>
+template <typename Deque, typename Project = IdentityProjection>
 inline DropAccounting maybe_flush_for_keep_latest(::unilink::base::constants::BackpressureStrategy bp_strategy,
                                                   size_t added, size_t bp_high, Deque& tx,
                                                   std::atomic<size_t>& queue_bytes,
-                                                  const std::atomic<bool>& backpressure_active) {
+                                                  const std::atomic<bool>& backpressure_active,
+                                                  Project project = Project{}) {
   DropAccounting dropped;
   if (bp_strategy != ::unilink::base::constants::BackpressureStrategy::BestEffort) return dropped;
 
   if (added >= bp_high) {
     size_t removed_bytes = 0;
-    for (const auto& buf : tx) {
-      removed_bytes += std::visit([](const auto& b) { return variant_buffer_size(b); }, buf);
+    for (auto& buf : tx) {
+      removed_bytes += std::visit([](const auto& b) { return variant_buffer_size(b); }, project(buf));
     }
     dropped.messages = tx.size();
     dropped.bytes = removed_bytes;
@@ -106,7 +120,7 @@ inline DropAccounting maybe_flush_for_keep_latest(::unilink::base::constants::Ba
     while (!tx.empty()) {
       const size_t qb = queue_bytes.load(std::memory_order_relaxed);
       if (qb + added <= bp_high) break;
-      const size_t oldest = std::visit([](const auto& b) { return variant_buffer_size(b); }, tx.front());
+      const size_t oldest = std::visit([](const auto& b) { return variant_buffer_size(b); }, project(tx.front()));
       queue_bytes.store(qb > oldest ? qb - oldest : 0, std::memory_order_relaxed);
       tx.pop_front();
       ++dropped.messages;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -39,6 +39,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/memory/memory_pool.hpp"
+#include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
 
 namespace unilink {
@@ -322,6 +323,16 @@ struct UdpChannel::Impl {
     start_receive(self);
   }
 
+  queue_util::BackpressureFields bp_fields() {
+    return queue_util::BackpressureFields{queue_bytes_,
+                                          pending_bytes_,
+                                          backpressure_active_,
+                                          bp_high_,
+                                          bp_low_,
+                                          bp_limit_,
+                                          bp_strategy_.load(std::memory_order_relaxed)};
+  }
+
   // Drops all queued (tx_) and pending (pending_, reliable-mode overflow) writes and clears
   // backpressure, notifying any waiter directly. Mirrors perform_stop_cleanup()'s approach
   // rather than calling report_backpressure(), because report_backpressure() flushes pending_
@@ -329,25 +340,18 @@ struct UdpChannel::Impl {
   // which would leave a Reliable-mode sender blocked in send_blocking()'s bp_cv_ wait forever
   // since nothing will ever call do_write() again once the channel has stopped/errored (#427).
   void drain_queue_and_clear_backpressure() {
-    tx_.clear();
-    queue_bytes_ = 0;
-    pending_.clear();
-    pending_bytes_ = 0;
-    const bool had_backpressure = backpressure_active_;
-    backpressure_active_ = false;
-    if (had_backpressure) {
-      OnBackpressure on_bp;
-      {
-        std::lock_guard<std::mutex> lock(callback_mtx_);
-        on_bp = on_bp_;
-      }
-      if (on_bp) {
-        try {
-          on_bp(queue_bytes_);
-        } catch (...) {
-        }
-      }
+    OnBackpressure on_bp;
+    {
+      std::lock_guard<std::mutex> lock(callback_mtx_);
+      on_bp = on_bp_;
     }
+    auto f = bp_fields();
+    queue_util::drain_and_clear_backpressure(f, on_bp, [&]() {
+      tx_.clear();
+      queue_bytes_ = 0;
+      pending_.clear();
+      pending_bytes_ = 0;
+    });
   }
 
   void do_write(std::shared_ptr<UdpChannel> self) {
@@ -476,48 +480,24 @@ struct UdpChannel::Impl {
       on_bp = on_bp_;
     }
 
-    if (!backpressure_active_ && queued_bytes >= bp_high_) {
-      backpressure_active_ = true;
-      stats_.record_backpressure_event();
-      if (on_bp) {
-        try {
-          on_bp(queued_bytes);
-        } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_backpressure", fmt::format("Exception in backpressure callback: {}", e.what()));
-        } catch (...) {
-          UNILINK_LOG_ERROR("udp", "on_backpressure", "Unknown exception in backpressure callback");
-        }
-      }
-    } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-      // Flush pending_ → tx_
-      const size_t moved = pending_bytes_.exchange(0);
-      queue_bytes_ += moved;
-      while (!pending_.empty()) {
-        tx_.emplace_back(std::move(pending_.front()));
-        pending_.pop_front();
-      }
-      observe_queue();
-      backpressure_active_ = false;
-      stats_.record_backpressure_event();
-      if (on_bp) {
-        try {
-          on_bp(queued_bytes);
-        } catch (...) {
-        }  // fire OFF with pre-flush queue size
-      }
-      // If post-flush queue is still high, fire ON again
-      if (queue_bytes_ >= bp_high_) {
-        backpressure_active_ = true;
-        stats_.record_backpressure_event();
-        if (on_bp) {
-          try {
-            on_bp(queue_bytes_);
-          } catch (...) {
+    auto f = bp_fields();
+    queue_util::report_backpressure(
+        f, queued_bytes, on_bp, stats_,
+        [&]() -> size_t {
+          // Flush pending_ → tx_
+          const size_t moved = pending_bytes_.exchange(0);
+          while (!pending_.empty()) {
+            tx_.emplace_back(std::move(pending_.front()));
+            pending_.pop_front();
           }
-        }
-      }
-      if (!writing_) do_write(self);
-    }
+          return moved;
+        },
+        [&]() {
+          // Post-flush sample: queue_bytes_ has already been updated by the
+          // time this kick runs, unlike the flush hook above (#434).
+          observe_queue();
+          if (!writing_) do_write(self);
+        });
   }
 
   void observe_queue() {
@@ -531,54 +511,36 @@ struct UdpChannel::Impl {
       return false;
     }
 
-    // Reliable: route to pending_ when backpressure is active
-    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
-      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
-        UNILINK_LOG_ERROR("udp", "write",
-                          fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + pending_bytes_ + size));
-        return false;
-      }
+    auto f = bp_fields();
+    queue_util::DropAccounting dropped;
+    // TxItem carries a destination endpoint alongside the BufferVariant that
+    // decide_enqueue()'s BestEffort trim needs to visit - project onto
+    // `.buffer` rather than the item itself (#434).
+    auto decision =
+        queue_util::decide_enqueue(f, size, tx_, dropped, [](TxItem& item) -> BufferVariant& { return item.buffer; });
+    if (dropped.any()) {
+      stats_.record_dropped(dropped.messages, dropped.bytes);
+    }
+
+    if (decision == queue_util::EnqueueDecision::Rejected) {
+      UNILINK_LOG_ERROR("udp", "write",
+                        fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + pending_bytes_ + size));
+      // Always reporting here (rather than only for the non-Reliable-pending
+      // rejection path, as the pre-#434 code did) is a no-op in practice for
+      // the Reliable+pending case: queued_bytes is already >= bp_high_ or
+      // this rejection couldn't have happened, so report_backpressure()'s
+      // OFF-transition check (<= bp_low_) can't fire here either way.
+      report_backpressure(self, queue_bytes_ + size);
+      return false;
+    }
+
+    if (decision == queue_util::EnqueueDecision::Pending) {
       pending_bytes_ += size;
       pending_.push_back({std::move(buffer), dest});
       observe_queue();
       return true;
     }
 
-    if (bp_strategy_ == base::constants::BackpressureStrategy::BestEffort &&
-        (backpressure_active_ || queue_bytes_ + size > bp_high_)) {
-      size_t dropped_messages = 0;
-      size_t dropped_bytes = 0;
-      if (size >= bp_high_) {
-        // Compute bytes to remove from tx_ (note: in-flight datagram already popped from tx_)
-        size_t removed_bytes = 0;
-        for (const auto& item : tx_) {
-          removed_bytes += std::visit([](const auto& b) { return queue_util::variant_buffer_size(b); }, item.buffer);
-        }
-        dropped_messages = tx_.size();
-        dropped_bytes = removed_bytes;
-        tx_.clear();
-        queue_bytes_ = (queue_bytes_ > removed_bytes) ? (queue_bytes_ - removed_bytes) : 0;
-      } else {
-        while (!tx_.empty() && (queue_bytes_ + size > bp_high_)) {
-          auto& oldest = tx_.front();
-          size_t oldest_size =
-              std::visit([](const auto& buf) { return queue_util::variant_buffer_size(buf); }, oldest.buffer);
-          queue_bytes_ = (queue_bytes_ > oldest_size) ? (queue_bytes_ - oldest_size) : 0;
-          tx_.pop_front();
-          ++dropped_messages;
-          dropped_bytes += oldest_size;
-        }
-      }
-      if (dropped_messages > 0 || dropped_bytes > 0) {
-        stats_.record_dropped(dropped_messages, dropped_bytes);
-      }
-    }
-
-    if (queue_bytes_ + size > bp_limit_) {
-      UNILINK_LOG_ERROR("udp", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + size));
-      report_backpressure(self, queue_bytes_ + size);
-      return false;
-    }
     queue_bytes_ += size;
     tx_.push_back({std::move(buffer), dest});
     observe_queue();
@@ -622,26 +584,19 @@ struct UdpChannel::Impl {
   void perform_stop_cleanup() {
     try {
       close_socket();
-      tx_.clear();
-      queue_bytes_ = 0;
-      pending_.clear();
-      pending_bytes_ = 0;
       writing_ = false;
-      const bool had_backpressure = backpressure_active_;
-      backpressure_active_ = false;
-      if (had_backpressure) {
-        OnBackpressure on_bp;
-        {
-          std::lock_guard<std::mutex> lock(callback_mtx_);
-          on_bp = on_bp_;
-        }
-        if (on_bp) {
-          try {
-            on_bp(queue_bytes_);
-          } catch (...) {
-          }
-        }
+      OnBackpressure on_bp;
+      {
+        std::lock_guard<std::mutex> lock(callback_mtx_);
+        on_bp = on_bp_;
       }
+      auto f = bp_fields();
+      queue_util::drain_and_clear_backpressure(f, on_bp, [&]() {
+        tx_.clear();
+        queue_bytes_ = 0;
+        pending_.clear();
+        pending_bytes_ = 0;
+      });
       connected_.store(false);
       opened_.store(false);
       if (owns_ioc_ && work_guard_) {


### PR DESCRIPTION
## Summary
Part of #434 (step 2 of 6, stacked on #462 since it depends on that header). Migrates `UdpChannel::enqueue_buffer()`/`report_backpressure()`/`drain_queue_and_clear_backpressure()`/`perform_stop_cleanup()` to the shared `bp_state_machine.hpp` state machine, removing UDP's own hand-copied (if best-behaved) implementation.

Adds projection support to `bp_utils.hpp`'s `maybe_flush_for_keep_latest()` (forwarded through `decide_enqueue()`) to handle the one genuinely necessary difference the design plan called out: UDP's `tx_`/`pending_` hold `TxItem{BufferVariant, destination}`, not the `BufferVariant` directly like every other transport. The trim logic now takes an optional projection (defaulting to identity, so the other five transports are unaffected) to visit the variant inside the wrapper. `perform_stop_cleanup()` also stopped duplicating the same clear+notify logic inline (already-noted drift, even within this one file).

Normalizes one accidental inconsistency in the process: `enqueue_buffer()`'s Reliable-pending-overflow rejection didn't call `report_backpressure()` while its BestEffort/tx_-overflow rejection did; both paths do now (a no-op in practice for the pending case, since backpressure is already active/high whenever that rejection can trigger).

## Test plan
- [x] `./scripts/verify.sh` passes unchanged (671 tests) — critically, the existing #427/#428 UDP backpressure regression tests (the canary for this exact bug class) stay green through the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)