### PR TITLE
refactor: migrate TCP/UDS server sessions to the shared bp_state_machine.hpp (#434 step 3/6)

### DIFF
--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -105,31 +105,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
         if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
         const auto added = buf.size();
-
-        // Reliable: route to pending_ when backpressure is active
-        if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-            self->backpressure_active_.load()) {
-          if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-            UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-            return;
-          }
-          self->pending_bytes_ += added;
-          self->pending_.emplace_back(std::move(buf));
-          self->observe_queue();
-          return;
-        }
-
-        self->maybe_flush_for_keep_latest(added);
-        if (self->queue_bytes_ + added > self->bp_limit_) {
-          UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-          self->report_backpressure(self->queue_bytes_ + added);
-          return;
-        }
-        self->queue_bytes_ += added;
-        self->tx_.emplace_back(std::move(buf));
-        self->observe_queue();
-        self->report_backpressure(self->queue_bytes_);
-        if (!self->writing_) self->do_write();
+        self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
       });
       return true;
     }
@@ -146,30 +122,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   net::post(strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
     if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
     const auto added = buf.size();
-
-    // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
-      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-        return;
-      }
-      self->pending_bytes_ += added;
-      self->pending_.emplace_back(std::move(buf));
-      self->observe_queue();
-      return;
-    }
-
-    self->maybe_flush_for_keep_latest(added);
-    if (self->queue_bytes_ + added > self->bp_limit_) {
-      UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-      self->report_backpressure(self->queue_bytes_ + added);
-      return;
-    }
-    self->queue_bytes_ += added;
-    self->tx_.emplace_back(std::move(buf));
-    self->observe_queue();
-    self->report_backpressure(self->queue_bytes_);
-    if (!self->writing_) self->do_write();
+    self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
   });
   return true;
 }
@@ -196,30 +149,7 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
-
-    // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
-      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-        return;
-      }
-      self->pending_bytes_ += added;
-      self->pending_.emplace_back(std::move(buf));
-      self->observe_queue();
-      return;
-    }
-
-    self->maybe_flush_for_keep_latest(added);
-    if (self->queue_bytes_ + added > self->bp_limit_) {
-      UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-      self->report_backpressure(self->queue_bytes_ + added);
-      return;
-    }
-    self->queue_bytes_ += added;
-    self->tx_.emplace_back(std::move(buf));
-    self->observe_queue();
-    self->report_backpressure(self->queue_bytes_);
-    if (!self->writing_) self->do_write();
+    self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
   });
   return true;
 }
@@ -242,30 +172,7 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) return;
-
-    // Reliable: route to pending_ when backpressure is active
-    if (self->bp_strategy_ == base::constants::BackpressureStrategy::Reliable && self->backpressure_active_.load()) {
-      if (self->queue_bytes_ + self->pending_bytes_ + added > self->bp_limit_) {
-        UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-        return;
-      }
-      self->pending_bytes_ += added;
-      self->pending_.emplace_back(std::move(buf));
-      self->observe_queue();
-      return;
-    }
-
-    self->maybe_flush_for_keep_latest(added);
-    if (self->queue_bytes_ + added > self->bp_limit_) {
-      UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
-      self->report_backpressure(self->queue_bytes_ + added);
-      return;
-    }
-    self->queue_bytes_ += added;
-    self->tx_.emplace_back(std::move(buf));
-    self->observe_queue();
-    self->report_backpressure(self->queue_bytes_);
-    if (!self->writing_) self->do_write();
+    self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
   });
   return true;
 }
@@ -519,22 +426,19 @@ void TcpServerSession::do_close() {
   socket_->close(ec);
 
   // Drain queued/pending writes and unconditionally clear backpressure,
-  // notifying any waiter directly - mirrors UdpChannel's
-  // drain_queue_and_clear_backpressure(). Must run before on_bp_ is cleared
-  // below: otherwise a Reliable-mode caller blocked in send_to_blocking()
-  // for this client would never be woken up when the client disconnects via
-  // a read error or idle timeout (jwsung91/unilink#452).
-  tx_.clear();
-  queue_bytes_ = 0;
-  pending_.clear();
-  pending_bytes_ = 0;
-  const bool had_backpressure = backpressure_active_;
-  backpressure_active_ = false;
-  if (had_backpressure && on_bp_) {
-    try {
-      on_bp_(queue_bytes_);
-    } catch (...) {
-    }
+  // notifying any waiter directly - shares UdpChannel's terminal-drain
+  // helper (#434). Must run before on_bp_ is cleared below: otherwise a
+  // Reliable-mode caller blocked in send_to_blocking() for this client
+  // would never be woken up when the client disconnects via a read error
+  // or idle timeout (jwsung91/unilink#452).
+  {
+    auto f = bp_fields();
+    queue_util::drain_and_clear_backpressure(f, on_bp_, [&]() {
+      tx_.clear();
+      queue_bytes_ = 0;
+      pending_.clear();
+      pending_bytes_ = 0;
+    });
   }
 
   // Clear all callbacks to prevent any further invocations
@@ -554,10 +458,33 @@ void TcpServerSession::do_close() {
   }
 }
 
-void TcpServerSession::maybe_flush_for_keep_latest(size_t added) {
-  const auto dropped =
-      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+queue_util::BackpressureFields TcpServerSession::bp_fields() {
+  return queue_util::BackpressureFields{queue_bytes_, pending_bytes_, backpressure_active_, bp_high_,
+                                        bp_low_,      bp_limit_,      bp_strategy_};
+}
+
+void TcpServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) {
+  auto f = bp_fields();
+  queue_util::DropAccounting dropped;
+  auto decision = queue_util::decide_enqueue(f, added, tx_, dropped);
   if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
+
+  if (decision == queue_util::EnqueueDecision::Rejected) {
+    UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+    report_backpressure(queue_bytes_ + added);
+    return;
+  }
+  if (decision == queue_util::EnqueueDecision::Pending) {
+    pending_bytes_ += added;
+    pending_.emplace_back(std::move(buf));
+    observe_queue();
+    return;
+  }
+  queue_bytes_ += added;
+  tx_.emplace_back(std::move(buf));
+  observe_queue();
+  report_backpressure(queue_bytes_);
+  if (!writing_) do_write();
 }
 
 void TcpServerSession::observe_queue() {
@@ -567,49 +494,21 @@ void TcpServerSession::observe_queue() {
 void TcpServerSession::report_backpressure(size_t queued_bytes) {
   if (closing_ || !alive_) return;
   observe_queue();
-  if (!backpressure_active_ && queued_bytes >= bp_high_) {
-    backpressure_active_ = true;
-    stats_.record_backpressure_event();
-    if (on_bp_) {
-      try {
-        on_bp_(queued_bytes);
-      } catch (const std::exception& e) {
-        UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure",
-                          "Exception in backpressure callback: " + std::string(e.what()));
-      } catch (...) {
-        UNILINK_LOG_ERROR("tcp_server_session", "on_backpressure", "Unknown exception in backpressure callback");
-      }
-    }
-  } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    // Flush pending_ → tx_
-    const size_t moved = pending_bytes_.exchange(0);
-    queue_bytes_ += moved;
-    while (!pending_.empty()) {
-      tx_.emplace_back(std::move(pending_.front()));
-      pending_.pop_front();
-    }
-    observe_queue();
-    backpressure_active_ = false;
-    stats_.record_backpressure_event();
-    if (on_bp_) {
-      try {
-        on_bp_(queued_bytes);
-      } catch (...) {
-      }  // fire OFF with pre-flush queue size
-    }
-    // If post-flush queue is still high, fire ON again
-    if (queue_bytes_ >= bp_high_) {
-      backpressure_active_ = true;
-      stats_.record_backpressure_event();
-      if (on_bp_) {
-        try {
-          on_bp_(queue_bytes_);
-        } catch (...) {
+  auto f = bp_fields();
+  queue_util::report_backpressure(
+      f, queued_bytes, on_bp_, stats_,
+      [&]() -> size_t {
+        const size_t moved = pending_bytes_.exchange(0);
+        while (!pending_.empty()) {
+          tx_.emplace_back(std::move(pending_.front()));
+          pending_.pop_front();
         }
-      }
-    }
-    if (!writing_) do_write();
-  }
+        return moved;
+      },
+      [&]() {
+        observe_queue();
+        if (!writing_) do_write();
+      });
 }
 
 void TcpServerSession::reset_idle_timer() {

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -37,6 +37,7 @@
 #include "unilink/interface/itcp_socket.hpp"
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/memory/safe_span.hpp"
+#include "unilink/transport/base/bp_state_machine.hpp"
 
 namespace unilink {
 namespace transport {
@@ -86,10 +87,12 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   void start_read();
   void do_write();
   void do_close();
-  void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(size_t queued_bytes);
   void reset_idle_timer();
   void observe_queue();
+  // Shared decide_enqueue()/route dispatch used by all 3 async_write_* variants (#434).
+  void route_enqueued_buffer(BufferVariant&& buf, size_t added);
+  queue_util::BackpressureFields bp_fields();
 
  private:
   net::io_context& ioc_;

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -99,31 +99,7 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data.size();
-
-    // Reliable: route to pending_ when backpressure is active
-    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
-      if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
-        UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
-        return;
-      }
-      pending_bytes_ += added;
-      pending_.emplace_back(std::move(data));
-      observe_queue();
-      return;
-    }
-
-    maybe_flush_for_keep_latest(added);
-    if (queue_bytes_ + added > bp_limit_) {
-      UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
-      report_backpressure(queue_bytes_ + added);
-      return;
-    }
-
-    queue_bytes_ += added;
-    tx_.emplace_back(std::move(data));
-    observe_queue();
-    report_backpressure(queue_bytes_);
-    if (!writing_) do_write();
+    route_enqueued_buffer(BufferVariant{std::move(data)}, added);
   });
   return true;
 }
@@ -141,31 +117,7 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
     if (!alive_) return;
     size_t added = data->size();
-
-    // Reliable: route to pending_ when backpressure is active
-    if (bp_strategy_ == base::constants::BackpressureStrategy::Reliable && backpressure_active_.load()) {
-      if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
-        UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
-        return;
-      }
-      pending_bytes_ += added;
-      pending_.emplace_back(std::move(data));
-      observe_queue();
-      return;
-    }
-
-    maybe_flush_for_keep_latest(added);
-    if (queue_bytes_ + added > bp_limit_) {
-      UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
-      report_backpressure(queue_bytes_ + added);
-      return;
-    }
-
-    queue_bytes_ += added;
-    tx_.emplace_back(std::move(data));
-    observe_queue();
-    report_backpressure(queue_bytes_);
-    if (!writing_) do_write();
+    route_enqueued_buffer(BufferVariant{std::move(data)}, added);
   });
   return true;
 }
@@ -355,24 +307,21 @@ void UdsServerSession::do_close() {
   socket_->close(ec);
 
   // Drain queued/pending writes and unconditionally clear backpressure,
-  // notifying any waiter directly - mirrors UdpChannel's
-  // drain_queue_and_clear_backpressure(). Must run before on_bp_ is cleared
-  // below: otherwise a Reliable-mode caller blocked in send_to_blocking()
-  // for this client would never be woken up when the client disconnects via
-  // a read error or idle timeout (jwsung91/unilink#452).
-  tx_.clear();
-  current_write_buffer_ = std::nullopt;
-  queue_bytes_ = 0;
-  pending_.clear();
-  pending_bytes_ = 0;
+  // notifying any waiter directly - shares UdpChannel's terminal-drain
+  // helper (#434). Must run before on_bp_ is cleared below: otherwise a
+  // Reliable-mode caller blocked in send_to_blocking() for this client
+  // would never be woken up when the client disconnects via a read error
+  // or idle timeout (jwsung91/unilink#452).
   writing_ = false;
-  const bool had_backpressure = backpressure_active_;
-  backpressure_active_ = false;
-  if (had_backpressure && on_bp_) {
-    try {
-      on_bp_(queue_bytes_);
-    } catch (...) {
-    }
+  {
+    auto f = bp_fields();
+    queue_util::drain_and_clear_backpressure(f, on_bp_, [&]() {
+      tx_.clear();
+      current_write_buffer_ = std::nullopt;
+      queue_bytes_ = 0;
+      pending_.clear();
+      pending_bytes_ = 0;
+    });
   }
 
   on_bytes_ = nullptr;
@@ -386,10 +335,33 @@ void UdsServerSession::do_close() {
   }
 }
 
-void UdsServerSession::maybe_flush_for_keep_latest(size_t added) {
-  const auto dropped =
-      queue_util::maybe_flush_for_keep_latest(bp_strategy_, added, bp_high_, tx_, queue_bytes_, backpressure_active_);
+queue_util::BackpressureFields UdsServerSession::bp_fields() {
+  return queue_util::BackpressureFields{queue_bytes_, pending_bytes_, backpressure_active_, bp_high_,
+                                        bp_low_,      bp_limit_,      bp_strategy_};
+}
+
+void UdsServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) {
+  auto f = bp_fields();
+  queue_util::DropAccounting dropped;
+  auto decision = queue_util::decide_enqueue(f, added, tx_, dropped);
   if (dropped.any()) stats_.record_dropped(dropped.messages, dropped.bytes);
+
+  if (decision == queue_util::EnqueueDecision::Rejected) {
+    UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
+    report_backpressure(queue_bytes_ + added);
+    return;
+  }
+  if (decision == queue_util::EnqueueDecision::Pending) {
+    pending_bytes_ += added;
+    pending_.emplace_back(std::move(buf));
+    observe_queue();
+    return;
+  }
+  queue_bytes_ += added;
+  tx_.emplace_back(std::move(buf));
+  observe_queue();
+  report_backpressure(queue_bytes_);
+  if (!writing_) do_write();
 }
 
 void UdsServerSession::observe_queue() {
@@ -399,46 +371,21 @@ void UdsServerSession::observe_queue() {
 void UdsServerSession::report_backpressure(size_t queued_bytes) {
   if (closing_ || !alive_) return;
   observe_queue();
-
-  if (!backpressure_active_ && queued_bytes >= bp_high_) {
-    backpressure_active_ = true;
-    stats_.record_backpressure_event();
-    if (on_bp_) {
-      try {
-        on_bp_(queued_bytes);
-      } catch (...) {
-      }
-    }
-  } else if (backpressure_active_ && queued_bytes <= bp_low_) {
-    // Flush pending_ → tx_
-    const size_t moved = pending_bytes_.exchange(0);
-    queue_bytes_ += moved;
-    while (!pending_.empty()) {
-      tx_.emplace_back(std::move(pending_.front()));
-      pending_.pop_front();
-    }
-    observe_queue();
-    backpressure_active_ = false;
-    stats_.record_backpressure_event();
-    if (on_bp_) {
-      try {
-        on_bp_(queued_bytes);
-      } catch (...) {
-      }  // fire OFF with pre-flush queue size
-    }
-    // If post-flush queue is still high, fire ON again
-    if (queue_bytes_ >= bp_high_) {
-      backpressure_active_ = true;
-      stats_.record_backpressure_event();
-      if (on_bp_) {
-        try {
-          on_bp_(queue_bytes_);
-        } catch (...) {
+  auto f = bp_fields();
+  queue_util::report_backpressure(
+      f, queued_bytes, on_bp_, stats_,
+      [&]() -> size_t {
+        const size_t moved = pending_bytes_.exchange(0);
+        while (!pending_.empty()) {
+          tx_.emplace_back(std::move(pending_.front()));
+          pending_.pop_front();
         }
-      }
-    }
-    if (!writing_) do_write();
-  }
+        return moved;
+      },
+      [&]() {
+        observe_queue();
+        if (!writing_) do_write();
+      });
 }
 
 void UdsServerSession::reset_idle_timer() {

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -37,6 +37,7 @@
 #include "unilink/interface/iuds_socket.hpp"
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/memory/safe_span.hpp"
+#include "unilink/transport/base/bp_state_machine.hpp"
 
 namespace unilink {
 namespace transport {
@@ -85,8 +86,10 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   void start_read();
   void do_write();
   void do_close();
-  void maybe_flush_for_keep_latest(size_t added);
   void report_backpressure(size_t queued_bytes);
+  // Shared decide_enqueue()/route dispatch used by both async_write_* variants (#434).
+  void route_enqueued_buffer(BufferVariant&& buf, size_t added);
+  queue_util::BackpressureFields bp_fields();
   void reset_idle_timer();
   void observe_queue();
 


### PR DESCRIPTION
## Summary
Part of #434 (step 3 of 6, stacked on #463 → #462). Migrates `TcpServerSession` and `UdsServerSession`'s 3-4 duplicated write-variant copies (`async_write_copy/move/shared`), plus `report_backpressure()` and `do_close()`'s drain logic, to the shared state machine — both sessions had the identical (4|3)+2 hand-copied shape.

Both sessions' `tx_`/`pending_` deques already hold the `BufferVariant` directly (unlike UDP's `TxItem` wrapper), so no projection is needed here — the default identity projection from #463 applies as-is.

`do_close()`'s drain-and-clear-backpressure logic now calls the shared `drain_and_clear_backpressure()` instead of its own inline copy — this was the exact code path fixed for #452 (client disconnects while a `send_to_blocking()` caller is blocked on backpressure). Folding it into the shared implementation means future backpressure bugs only need fixing once across all six transports instead of independently in each.

## Test plan
- [x] `./scripts/verify.sh` passes unchanged (671 tests)
- [x] No new regression test needed — PR #456's `BackpressureClearsOnDisconnectWhileActive` tests (one per session type) already cover exactly the scenario the design plan calls for here and stay green through this migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)