### PR TITLE
ci: deploy Pages via actions/deploy-pages instead of a legacy branch push

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -202,9 +202,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download coverage report
         uses: actions/download-artifact@v8
@@ -335,11 +338,50 @@ jobs:
           EOF
           echo "✅ Custom index page created with coverage: ${COVERAGE}"
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      # API docs (Doxygen) live in a separate repo (unilink-lab/unilink-docs)
+      # since docs generation moved out of this one. GitHub's native
+      # actions/deploy-pages can only publish to the Pages site of the repo
+      # the workflow is running in, so unilink-docs can't deploy here itself
+      # (no supported cross-repo path) - this job checks unilink-docs out as
+      # a source dependency instead and generates docs from *this* exact
+      # commit, then combines them with the coverage report into one
+      # artifact before the single deploy-pages call below.
+      - name: Checkout unilink-docs
+        uses: actions/checkout@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build-coverage/coverage_html
-          publish_branch: gh-pages
-          destination_dir: coverage
-          keep_files: true
+          repository: unilink-lab/unilink-docs
+          path: docs-src
+
+      - name: Checkout unilink core for docs generation
+        uses: actions/checkout@v7
+        with:
+          path: docs-src/external/unilink
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Generate API reference
+        working-directory: docs-src
+        run: ./scripts/generate_docs.sh
+
+      - name: Assemble Pages site
+        run: |
+          set -euo pipefail
+          mkdir -p site
+          cp -r docs-src/build/doxygen/html/. site/
+          mkdir -p site/coverage
+          cp -r build-coverage/coverage_html/. site/coverage/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
The `gh-pages` branch's "legacy" Pages build has been failing ("Page build failed", no further detail) on every recent push, unrelated to content - switching to GitHub's native Actions-based Pages deployment sidesteps the legacy build pipeline entirely.

`deploy-coverage` now assembles a single combined site (API docs + coverage report) and publishes it with `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages`, replacing the `peaceiris/actions-gh-pages` branch push. API docs are generated *here* (checking out `unilink-lab/unilink-docs` as a source dependency, mirroring what that repo's own `doxygen.yml` already does in reverse) rather than in `unilink-docs`'s own CI, because `actions/deploy-pages` can only publish to the Pages site of the repo the workflow runs in - there's no supported way for one repo's Actions run to deploy to another repo's Pages site. This keeps generating docs from the exact commit being tested rather than a separately-triggered, potentially-stale `unilink-docs` run.

**Requires switching this repo's Pages source from "Deploy from a branch" to "GitHub Actions" in Settings > Pages before this job's deploy step can succeed** (done out-of-band via the API, not part of this diff). Once that's done, the `gh-pages` branch stops being read by Pages at all; a follow-up will remove the now-unused deploy step and cross-repo deploy key added to `unilink-docs` for the (superseded) branch-push approach.

## Test plan
- [x] `coverage.yml`'s YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Merge and confirm the resulting push-to-main run's `deploy-coverage` job succeeds and https://jwsung91.github.io/unilink/ serves both fresh API docs and the coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)