### PR TITLE
feat: add shared wrapper-side error-context builder (#445 step 3/7)

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -123,9 +123,10 @@ unilink_add_unit_gtest(
 )
 
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
-foreach(test_file
-        test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
-        test_runtime_stats.cc test_send_buffer_apis.cc
+foreach(
+  test_file
+  test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
+  test_runtime_stats.cc test_send_buffer_apis.cc test_error_context_builder.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/wrapper/test_error_context_builder.cc
+++ b/test/unit/wrapper/test_error_context_builder.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/wrapper/error_context_builder.hpp"
+
+using namespace unilink;
+using namespace unilink::wrapper;
+using namespace unilink::diagnostics;
+
+namespace {
+
+// Minimal fake exercising only what build_error_context() touches
+// (last_error_info()); every other pure virtual is a trivial stub.
+class FakeChannel : public interface::Channel {
+ public:
+  void start() override {}
+  void stop() override {}
+  bool is_connected() const override { return false; }
+  bool is_backpressure_active() const override { return false; }
+  boost::asio::any_io_executor get_executor() override { return {}; }
+  bool async_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  bool async_try_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_try_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  void on_bytes(OnBytes) override {}
+  void on_state(OnState) override {}
+  void on_backpressure(OnBackpressure) override {}
+
+  std::optional<ErrorInfo> last_error_info() const override { return error_; }
+
+  std::optional<ErrorInfo> error_;
+};
+
+}  // namespace
+
+TEST(ErrorContextBuilderTest, FallsBackToGenericMessageWhenNoDetailAvailable) {
+  FakeChannel channel;  // error_ stays nullopt, matching an unmigrated transport
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::IoError);
+  EXPECT_EQ(ctx.message(), "Connection error");
+  EXPECT_FALSE(ctx.client_id().has_value());
+}
+
+TEST(ErrorContextBuilderTest, UsesDetailedInfoWhenAvailable) {
+  FakeChannel channel;
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "connect",
+                             "Connection refused", boost::asio::error::connection_refused, true);
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::ConnectionRefused);
+  EXPECT_EQ(ctx.message(), "Connection refused");
+}
+
+TEST(ErrorContextBuilderTest, ThreadsClientIdThroughBothPaths) {
+  FakeChannel channel;
+
+  auto fallback_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(fallback_ctx.client_id().has_value());
+  EXPECT_EQ(*fallback_ctx.client_id(), 7u);
+
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "read", "Read failed");
+  auto detailed_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(detailed_ctx.client_id().has_value());
+  EXPECT_EQ(*detailed_ctx.client_id(), 7u);
+}

--- a/unilink/wrapper/error_context_builder.hpp
+++ b/unilink/wrapper/error_context_builder.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "unilink/diagnostics/error_mapping.hpp"
+#include "unilink/interface/channel.hpp"
+#include "unilink/wrapper/context.hpp"
+
+// Shared replacement for the per-wrapper dynamic_pointer_cast<TcpClient>/
+// <UdsClient> special-casing (previously the only two transports whose
+// wrapper could report a detailed ErrorContext) and every other wrapper's
+// independent hardcoded generic-string fallback (jwsung91/unilink#445).
+// Works uniformly now that interface::Channel::last_error_info() is
+// virtual - no cast to a concrete transport type needed.
+namespace unilink {
+namespace wrapper {
+namespace detail {
+
+inline ErrorContext build_error_context(const interface::Channel& channel, std::string_view fallback_message,
+                                        std::optional<ClientId> client_id = std::nullopt) {
+  if (auto info = channel.last_error_info()) {
+    return diagnostics::to_error_context(*info, client_id);
+  }
+  return ErrorContext(ErrorCode::IoError, fallback_message, client_id);
+}
+
+}  // namespace detail
+}  // namespace wrapper
+}  // namespace unilink


### PR DESCRIPTION
## Summary
Part of #445 (step 3 of 7, stacked on #469). Adds `unilink/wrapper/error_context_builder.hpp`: `wrapper::detail::build_error_context(channel, fallback_message, client_id)` replaces the pattern of `dynamic_pointer_cast<TcpClient>`/`<UdsClient>` (the only two transports a wrapper could previously reach a detailed error from) plus every other wrapper's independent hardcoded generic-string fallback (`"Connection error"` / `"Server error"` — confirmed by grepping every wrapper, only those two strings exist across all seven).

No cast needed anymore since `interface::Channel::last_error_info()` is now virtual (#469): the helper just calls it directly on the base `Channel` reference. Falls back to the given message only when `last_error_info()` returns `nullopt` (i.e. the underlying transport hasn't been wired up to `ErrorInfoHolder` yet, or genuinely has no detail for this particular error path).

Purely additive — no wrapper migrated to use it yet (step 6 of this plan does that once every transport is wired up in step 5).

## Test plan
- [x] `./scripts/verify.sh` passes (682 tests, +3 new)
- [x] New unit test (`test/unit/wrapper/test_error_context_builder.cc`) uses a minimal `FakeChannel` stub to cover: generic fallback when no detail is available, detailed `ErrorCode`/message mapping when it is, and `client_id` threading through both paths (needed for server wrappers' per-session errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)