### PR TITLE
refactor: migrate TcpClient/UdsClient onto the shared ErrorInfoHolder (#445 step 4/7)

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -123,9 +123,10 @@ unilink_add_unit_gtest(
 )
 
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
-foreach(test_file
-        test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
-        test_runtime_stats.cc test_send_buffer_apis.cc
+foreach(
+  test_file
+  test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
+  test_runtime_stats.cc test_send_buffer_apis.cc test_error_context_builder.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -197,6 +197,13 @@ unilink_add_unit_gtest(
   "unit_transport_backpressure_fast" 30
 )
 
+# Shared error-info holder (#445) - isolated, no sockets/io_context
+unilink_add_unit_gtest(
+  run_unit_test_error_info_holder
+  ${CMAKE_CURRENT_SOURCE_DIR}/transport/test_error_info_holder.cc
+  "unit_transport_fast" 30
+)
+
 # New error handling tests
 unilink_add_unit_gtest(
   run_unit_test_tcp_abort

--- a/test/unit/transport/test_error_info_holder.cc
+++ b/test/unit/transport/test_error_info_holder.cc
@@ -18,7 +18,7 @@
 
 #include "unilink/transport/base/error_info_holder.hpp"
 
-using namespace unilink::transport::base;
+using namespace unilink::transport;
 using namespace unilink::diagnostics;
 
 TEST(ErrorInfoHolderTest, StartsWithNoError) {

--- a/test/unit/transport/test_error_info_holder.cc
+++ b/test/unit/transport/test_error_info_holder.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/transport/base/error_info_holder.hpp"
+
+using namespace unilink::transport::base;
+using namespace unilink::diagnostics;
+
+TEST(ErrorInfoHolderTest, StartsWithNoError) {
+  ErrorInfoHolder holder("test_component");
+  EXPECT_FALSE(holder.last_error_info().has_value());
+}
+
+TEST(ErrorInfoHolderTest, RecordErrorPopulatesAllFields) {
+  ErrorInfoHolder holder("test_component");
+  boost::system::error_code ec = make_error_code(boost::system::errc::connection_refused);
+
+  holder.record_error(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "connect", ec, "Connection refused",
+                      /*retryable=*/true, /*retry_count=*/3);
+
+  auto info = holder.last_error_info();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->level, ErrorLevel::ERROR);
+  EXPECT_EQ(info->category, ErrorCategory::CONNECTION);
+  EXPECT_EQ(info->component, "test_component");
+  EXPECT_EQ(info->operation, "connect");
+  EXPECT_EQ(info->message, "Connection refused");
+  EXPECT_EQ(info->boost_error, ec);
+  EXPECT_TRUE(info->retryable);
+  EXPECT_EQ(info->retry_count, 3u);
+}
+
+TEST(ErrorInfoHolderTest, SubsequentRecordOverwritesPrevious) {
+  ErrorInfoHolder holder("test_component");
+  holder.record_error(ErrorLevel::WARNING, ErrorCategory::CONFIGURATION, "first", {}, "first error", false, 0);
+  holder.record_error(ErrorLevel::CRITICAL, ErrorCategory::SYSTEM, "second", {}, "second error", true, 5);
+
+  auto info = holder.last_error_info();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->operation, "second");
+  EXPECT_EQ(info->message, "second error");
+  EXPECT_EQ(info->retry_count, 5u);
+}

--- a/test/unit/transport/transport_uds_client.cc
+++ b/test/unit/transport/transport_uds_client.cc
@@ -145,6 +145,30 @@ TEST_F(TransportUdsClientTest, ConnectionFailure) {
   EXPECT_TRUE(has_error);
 }
 
+// Regression test for jwsung91/unilink#445: record_error()'s retry_count
+// parameter used to be silently discarded here (an unnamed uint32_t
+// parameter in the pre-ErrorInfoHolder implementation), so
+// last_error_info()->retry_count always reported 0 regardless of how many
+// reconnect attempts had actually happened - unlike TcpClient's equivalent,
+// which always set it correctly. Asserts it's now propagated end-to-end
+// through the shared ErrorInfoHolder.
+TEST_F(TransportUdsClientTest, RepeatedConnectionFailuresRecordIncreasingRetryCount) {
+  cfg.retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+  cfg.max_retries = -1;
+  EXPECT_CALL(*mock_socket, async_connect(_, _))
+      .WillRepeatedly(Invoke([this](const net::local::stream_protocol::endpoint&,
+                                    std::function<void(const boost::system::error_code&)> handler) {
+        net::post(ioc, [handler]() { handler(make_error_code(boost::asio::error::connection_refused)); });
+      }));
+
+  client->start();
+  ioc.restart();
+  ioc.run_for(std::chrono::milliseconds(1500));
+
+  ASSERT_TRUE(client->last_error_info().has_value());
+  EXPECT_GT(client->last_error_info()->retry_count, 0u);
+}
+
 TEST_F(TransportUdsClientTest, WriteData) {
   // Setup successful connection first
   std::cout << "WriteData: setting up async_connect mock" << std::endl;

--- a/test/unit/wrapper/test_error_context_builder.cc
+++ b/test/unit/wrapper/test_error_context_builder.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/wrapper/error_context_builder.hpp"
+
+using namespace unilink;
+using namespace unilink::wrapper;
+using namespace unilink::diagnostics;
+
+namespace {
+
+// Minimal fake exercising only what build_error_context() touches
+// (last_error_info()); every other pure virtual is a trivial stub.
+class FakeChannel : public interface::Channel {
+ public:
+  void start() override {}
+  void stop() override {}
+  bool is_connected() const override { return false; }
+  bool is_backpressure_active() const override { return false; }
+  boost::asio::any_io_executor get_executor() override { return {}; }
+  bool async_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  bool async_try_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_try_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  void on_bytes(OnBytes) override {}
+  void on_state(OnState) override {}
+  void on_backpressure(OnBackpressure) override {}
+
+  std::optional<ErrorInfo> last_error_info() const override { return error_; }
+
+  std::optional<ErrorInfo> error_;
+};
+
+}  // namespace
+
+TEST(ErrorContextBuilderTest, FallsBackToGenericMessageWhenNoDetailAvailable) {
+  FakeChannel channel;  // error_ stays nullopt, matching an unmigrated transport
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::IoError);
+  EXPECT_EQ(ctx.message(), "Connection error");
+  EXPECT_FALSE(ctx.client_id().has_value());
+}
+
+TEST(ErrorContextBuilderTest, UsesDetailedInfoWhenAvailable) {
+  FakeChannel channel;
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "connect",
+                             "Connection refused", boost::asio::error::connection_refused, true);
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::ConnectionRefused);
+  EXPECT_EQ(ctx.message(), "Connection refused");
+}
+
+TEST(ErrorContextBuilderTest, ThreadsClientIdThroughBothPaths) {
+  FakeChannel channel;
+
+  auto fallback_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(fallback_ctx.client_id().has_value());
+  EXPECT_EQ(*fallback_ctx.client_id(), 7u);
+
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "read", "Read failed");
+  auto detailed_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(detailed_ctx.client_id().has_value());
+  EXPECT_EQ(*detailed_ctx.client_id(), 7u);
+}

--- a/unilink/interface/channel.hpp
+++ b/unilink/interface/channel.hpp
@@ -18,11 +18,13 @@
 #include <boost/asio/any_io_executor.hpp>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "unilink/base/common.hpp"
 #include "unilink/base/visibility.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/memory/safe_span.hpp"
 #include "unilink/wrapper/runtime_stats.hpp"
 
@@ -42,6 +44,13 @@ class UNILINK_API Channel {
   virtual bool is_backpressure_active() const = 0;
   virtual wrapper::RuntimeStats stats() const { return {}; }
   virtual void reset_stats() {}
+
+  // Most recent error recorded by this channel, if any. Default no-op
+  // override (std::nullopt) so any transport not yet wired up to the
+  // shared ErrorInfoHolder plumbing (#445) just reports "no detail
+  // available" instead of failing to compile or requiring a stub
+  // override everywhere.
+  virtual std::optional<diagnostics::ErrorInfo> last_error_info() const { return std::nullopt; }
 
   virtual boost::asio::any_io_executor get_executor() = 0;
 

--- a/unilink/transport/base/error_info_holder.hpp
+++ b/unilink/transport/base/error_info_holder.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <boost/system/error_code.hpp>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "unilink/diagnostics/error_types.hpp"
+
+// Extracted from what used to be identical, independently-maintained
+// record_error()/last_error_info_ logic in TcpClient::Impl and
+// UdsClient::Impl (jwsung91/unilink#445), now shared so every transport can
+// implement interface::Channel::last_error_info() the same way instead of
+// only two of seven having any detailed-error mechanism at all.
+namespace unilink {
+namespace transport {
+namespace base {
+
+class ErrorInfoHolder {
+ public:
+  explicit ErrorInfoHolder(std::string component) : component_(std::move(component)) {}
+
+  void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
+                    const boost::system::error_code& ec, std::string_view msg, bool retryable, uint32_t retry_count) {
+    diagnostics::ErrorInfo info(lvl, cat, component_, operation, msg, ec, retryable);
+    info.retry_count = retry_count;
+    std::lock_guard<std::mutex> lock(mtx_);
+    last_error_info_ = std::move(info);
+  }
+
+  std::optional<diagnostics::ErrorInfo> last_error_info() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return last_error_info_;
+  }
+
+ private:
+  std::string component_;
+  mutable std::mutex mtx_;
+  std::optional<diagnostics::ErrorInfo> last_error_info_;
+};
+
+}  // namespace base
+}  // namespace transport
+}  // namespace unilink

--- a/unilink/transport/base/error_info_holder.hpp
+++ b/unilink/transport/base/error_info_holder.hpp
@@ -32,7 +32,6 @@
 // only two of seven having any detailed-error mechanism at all.
 namespace unilink {
 namespace transport {
-namespace base {
 
 class ErrorInfoHolder {
  public:
@@ -57,6 +56,5 @@ class ErrorInfoHolder {
   std::optional<diagnostics::ErrorInfo> last_error_info_;
 };
 
-}  // namespace base
 }  // namespace transport
 }  // namespace unilink

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -54,6 +54,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/tcp_client/detail/reconnect_decider.hpp"
 
 namespace unilink {
@@ -125,8 +126,7 @@ struct TcpClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"tcp_client"};
 
   Impl(const TcpClientConfig& cfg, net::io_context* ioc_ptr)
       : owned_ioc_(ioc_ptr ? nullptr : std::make_shared<net::io_context>()),
@@ -205,8 +205,7 @@ TcpClient::TcpClient(TcpClient&&) noexcept = default;
 TcpClient& TcpClient::operator=(TcpClient&&) noexcept = default;
 
 std::optional<diagnostics::ErrorInfo> TcpClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void TcpClient::start() {
@@ -730,11 +729,7 @@ void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t s
     return;
   }
 
-  std::optional<diagnostics::ErrorInfo> last_err;
-  {
-    std::lock_guard<std::mutex> lock(last_err_mtx_);
-    last_err = last_error_info_;
-  }
+  std::optional<diagnostics::ErrorInfo> last_err = error_info_holder_.last_error_info();
 
   if (!last_err) {
     last_err = diagnostics::ErrorInfo(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
@@ -1215,10 +1210,7 @@ void TcpClient::Impl::notify_state() {
 void TcpClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
                                    std::string_view msg, bool retryable, uint32_t retry_count) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  diagnostics::ErrorInfo info(lvl, cat, "tcp_client", operation, msg, ec, retryable);
-  info.retry_count = retry_count;
-  last_error_info_ = info;
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 void TcpClient::Impl::reset_io_objects() {

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -85,7 +85,7 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Dynamic configuration methods. Thread-safe; take effect for the next
   // reconnect/idle-timeout decision, not retroactively for one already in

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
 #include "unilink/transport/uds/detail/reconnect_decider.hpp"
 
@@ -100,8 +101,7 @@ struct UdsClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"uds_client"};
 
   Impl(const UdsClientConfig& cfg, net::io_context* ioc_ptr,
        std::unique_ptr<interface::UdsSocketInterface> socket = nullptr)
@@ -458,8 +458,7 @@ void UdsClient::set_reconnect_policy(ReconnectPolicy policy) {
 }
 
 std::optional<diagnostics::ErrorInfo> UdsClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void UdsClient::Impl::do_connect(std::shared_ptr<UdsClient> self, uint64_t seq) {
@@ -769,9 +768,8 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
 
 void UdsClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
-                                   std::string_view msg, bool retryable, uint32_t) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  last_error_info_ = diagnostics::ErrorInfo(lvl, cat, "uds_client", operation, msg, ec, retryable);
+                                   std::string_view msg, bool retryable, uint32_t retry_count) {
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 }  // namespace transport

--- a/unilink/transport/uds/uds_client.hpp
+++ b/unilink/transport/uds/uds_client.hpp
@@ -88,7 +88,7 @@ class UNILINK_API UdsClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   void set_backpressure_strategy(base::constants::BackpressureStrategy strategy);
   void set_retry_interval(unsigned interval_ms);

--- a/unilink/wrapper/error_context_builder.hpp
+++ b/unilink/wrapper/error_context_builder.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "unilink/diagnostics/error_mapping.hpp"
+#include "unilink/interface/channel.hpp"
+#include "unilink/wrapper/context.hpp"
+
+// Shared replacement for the per-wrapper dynamic_pointer_cast<TcpClient>/
+// <UdsClient> special-casing (previously the only two transports whose
+// wrapper could report a detailed ErrorContext) and every other wrapper's
+// independent hardcoded generic-string fallback (jwsung91/unilink#445).
+// Works uniformly now that interface::Channel::last_error_info() is
+// virtual - no cast to a concrete transport type needed.
+namespace unilink {
+namespace wrapper {
+namespace detail {
+
+inline ErrorContext build_error_context(const interface::Channel& channel, std::string_view fallback_message,
+                                        std::optional<ClientId> client_id = std::nullopt) {
+  if (auto info = channel.last_error_info()) {
+    return diagnostics::to_error_context(*info, client_id);
+  }
+  return ErrorContext(ErrorCode::IoError, fallback_message, client_id);
+}
+
+}  // namespace detail
+}  // namespace wrapper
+}  // namespace unilink


### PR DESCRIPTION
## Summary
Part of #445 (step 4 of 7, stacked on #470 → #469). Both transports' `record_error()`/`last_error_info()` now delegate to the `ErrorInfoHolder` extracted in #469, instead of each independently holding its own mutex + `std::optional<ErrorInfo>`. Behavior-neutral for `TcpClient` — same locking, same fields set.

`UdsClient` gets an actual behavior fix in the process: its `record_error()` took a `retry_count` parameter but the name was omitted (`uint32_t` with no identifier), so it was silently discarded and `last_error_info()->retry_count` always reported 0 regardless of how many reconnect attempts had actually happened — unlike `TcpClient`'s version, which always set it correctly. Routing both through the same `ErrorInfoHolder::record_error()` makes this class of independent drift structurally impossible going forward.

Both `last_error_info()` overrides are now marked `override` against `interface::Channel`'s virtual.

## Test plan
- [x] `./scripts/verify.sh` passes (683 tests, +1 new)
- [x] New regression test (`RepeatedConnectionFailuresRecordIncreasingRetryCount`) drives several real reconnect cycles against a mocked socket and asserts `retry_count` ends up > 0 — fails against the pre-fix implementation and passes now, proving the fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)