### PR TITLE
feat: wire ErrorInfoHolder into TcpServer/UdsServer/UdpChannel/Serial (#445 step 5/7)

### DIFF
--- a/test/integration/transport/transport_tcp_server.cc
+++ b/test/integration/transport/transport_tcp_server.cc
@@ -440,6 +440,9 @@ TEST_F(TransportTcpServerTest, InjectedAcceptorOpenFailureMovesToError) {
   ioc.run_for(std::chrono::milliseconds(50));
 
   EXPECT_TRUE(error_seen.load());
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(server_->last_error_info().has_value());
+  EXPECT_EQ(server_->last_error_info()->component, "tcp_server");
 
   server_->stop();
   server_.reset();

--- a/test/unit/transport/test_udp_error.cc
+++ b/test/unit/transport/test_udp_error.cc
@@ -67,6 +67,10 @@ TEST(TransportUdpErrorTest, SendOversizedPacket) {
 
   EXPECT_TRUE(error_occurred.load()) << "Sending >65535 bytes via UDP should trigger Error state";
 
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(channel->last_error_info().has_value());
+  EXPECT_EQ(channel->last_error_info()->component, "udp");
+
   channel->stop();
 }
 

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -238,6 +238,9 @@ TEST(TransportSerialTest, OpenAndConfigureFailuresMoveToError) {
     ioc.run_for(30ms);
 
     EXPECT_TRUE(error_seen.load());
+    // #445: last_error_info() should now report detail for this transport too.
+    ASSERT_TRUE(serial->last_error_info().has_value());
+    EXPECT_EQ(serial->last_error_info()->component, "serial");
     serial->stop();
     ioc.restart();
     ioc.run_for(5ms);

--- a/test/unit/transport/transport_uds_server.cc
+++ b/test/unit/transport/transport_uds_server.cc
@@ -124,6 +124,9 @@ TEST_F(TransportUdsServerTest, BindFailure) {
 
   EXPECT_FALSE(server->is_connected());
   EXPECT_TRUE(has_error);
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(server->last_error_info().has_value());
+  EXPECT_EQ(server->last_error_info()->component, "uds_server");
 }
 
 // Regression test for jwsung91/unilink#453: a transient accept() failure

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/serial/boost_serial_port.hpp"
 
 namespace unilink {
@@ -106,6 +107,8 @@ struct Serial::Impl {
 
   std::atomic<bool> opened_{false};
   ThreadSafeLinkState state_{LinkState::Idle};
+
+  ErrorInfoHolder error_info_holder_{"serial"};
 
   void observe_queue() {
     stats_.observe_queue(queued_bytes_.load(std::memory_order_relaxed) +
@@ -313,8 +316,12 @@ struct Serial::Impl {
             try {
               on_bytes(memory::ConstByteSpan(impl->rx_.data(), n));
             } catch (const std::exception& e) {
-              UNILINK_LOG_ERROR("serial", "on_bytes", fmt::format("Exception in callback: {}", e.what()));
+              std::string msg = fmt::format("Exception in callback: {}", e.what());
+              UNILINK_LOG_ERROR("serial", "on_bytes", msg);
               if (impl->cfg_.stop_on_callback_exception) {
+                impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                      diagnostics::ErrorCategory::COMMUNICATION, "on_bytes", {}, msg,
+                                                      false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
                 impl->state_.set_state(LinkState::Error);
@@ -325,6 +332,9 @@ struct Serial::Impl {
               return;
             } catch (...) {
               if (impl->cfg_.stop_on_callback_exception) {
+                impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                      diagnostics::ErrorCategory::COMMUNICATION, "on_bytes", {},
+                                                      "Unknown exception in callback", false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
                 impl->state_.set_state(LinkState::Error);
@@ -433,6 +443,8 @@ struct Serial::Impl {
     diagnostics::error_reporting::report_connection_error("serial", where, ec, retryable);
 
     UNILINK_LOG_ERROR("serial", where, fmt::format("Error: {}", ec.message()));
+    error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, where, ec,
+                                    ec.message(), retryable, 0);
 
     if (cfg_.reopen_on_error) {
       opened_.store(false);
@@ -613,6 +625,10 @@ void Serial::reset_stats() {
   auto impl = get_impl();
   impl->stats_.reset(impl->queued_bytes_.load(std::memory_order_relaxed) +
                      impl->pending_bytes_.load(std::memory_order_relaxed));
+}
+
+std::optional<diagnostics::ErrorInfo> Serial::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
 }
 
 boost::asio::any_io_executor Serial::get_executor() { return impl_->strand_; }

--- a/unilink/transport/serial/serial.hpp
+++ b/unilink/transport/serial/serial.hpp
@@ -17,11 +17,13 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/serial_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -65,6 +67,7 @@ class UNILINK_API Serial : public interface::Channel, public std::enable_shared_
   bool is_backpressure_active() const override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
   boost::asio::any_io_executor get_executor() override;
 
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -33,6 +33,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/itcp_acceptor.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/tcp_server/boost_tcp_acceptor.hpp"
 #include "unilink/transport/tcp_server/tcp_server_session.hpp"
 
@@ -72,6 +73,8 @@ struct TcpServer::Impl {
   bool paused_accept_ = false;
 
   std::shared_ptr<TcpServerSession> current_session_;
+
+  ErrorInfoHolder error_info_holder_{"tcp_server"};
 
   explicit Impl(const config::TcpServerConfig& cfg)
       : owns_ioc_(false),
@@ -182,8 +185,10 @@ struct TcpServer::Impl {
 
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("tcp_server", "bind",
-                        fmt::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message()));
+      std::string msg = fmt::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message());
+      UNILINK_LOG_ERROR("tcp_server", "bind", msg);
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION, "bind",
+                                      ec, msg, false, static_cast<uint32_t>(retry_count));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -192,7 +197,10 @@ struct TcpServer::Impl {
     if (!acceptor_->is_open()) {
       acceptor_->open(address.is_v6() ? tcp::v6() : tcp::v4(), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("tcp_server", "open", fmt::format("Failed to open acceptor: {}", ec.message()));
+        std::string msg = fmt::format("Failed to open acceptor: {}", ec.message());
+        UNILINK_LOG_ERROR("tcp_server", "open", msg);
+        error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open", ec,
+                                        msg, false, static_cast<uint32_t>(retry_count));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -214,7 +222,10 @@ struct TcpServer::Impl {
         });
         return;
       } else {
-        UNILINK_LOG_ERROR("tcp_server", "bind", fmt::format("Failed to bind to port {}: {}", cfg_.port, ec.message()));
+        std::string msg = fmt::format("Failed to bind to port {}: {}", cfg_.port, ec.message());
+        UNILINK_LOG_ERROR("tcp_server", "bind", msg);
+        error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "bind",
+                                        ec, msg, false, static_cast<uint32_t>(retry_count));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -223,8 +234,10 @@ struct TcpServer::Impl {
 
     acceptor_->listen(boost::asio::socket_base::max_listen_connections, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("tcp_server", "listen",
-                        fmt::format("Failed to listen on port {}: {}", cfg_.port, ec.message()));
+      std::string msg = fmt::format("Failed to listen on port {}: {}", cfg_.port, ec.message());
+      UNILINK_LOG_ERROR("tcp_server", "listen", msg);
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "listen",
+                                      ec, msg, false, static_cast<uint32_t>(retry_count));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -245,6 +258,9 @@ struct TcpServer::Impl {
       }
       if (ec) {
         if (ec != boost::asio::error::operation_aborted) {
+          accept_impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                       diagnostics::ErrorCategory::CONNECTION, "accept", ec,
+                                                       fmt::format("Accept failed: {}", ec.message()), true, 0);
           accept_impl->state_.set_state(base::LinkState::Error);
           accept_impl->notify_state();
         }
@@ -501,6 +517,8 @@ void TcpServer::start() {
   }
 
   if (!impl->acceptor_) {
+    impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "start",
+                                          {}, "No acceptor available", false, 0);
     impl->state_.set_state(base::LinkState::Error);
     impl->notify_state();
     return;
@@ -590,6 +608,10 @@ void TcpServer::reset_stats() {
   for (const auto& entry : impl->sessions_) {
     if (entry.second) entry.second->reset_stats();
   }
+}
+
+std::optional<diagnostics::ErrorInfo> TcpServer::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
 }
 
 bool TcpServer::async_write_copy(memory::ConstByteSpan data) {

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/tcp_server_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -76,6 +78,7 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   void on_backpressure(OnBackpressure cb) override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Multi-client support
   bool broadcast(std::string_view message);

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 
 namespace unilink {
 namespace transport {
@@ -106,6 +107,8 @@ struct UdpChannel::Impl {
   OnState on_state_;
   OnBackpressure on_bp_;
 
+  ErrorInfoHolder error_info_holder_{"udp"};
+
   explicit Impl(const config::UdpConfig& config)
       : owned_ioc_(std::make_unique<net::io_context>()),
         ioc_(owned_ioc_.get()),
@@ -168,24 +171,27 @@ struct UdpChannel::Impl {
     boost::system::error_code ec;
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Invalid bind address: {}", cfg_.bind_address));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Invalid bind address: {}", cfg_.bind_address);
+      UNILINK_LOG_ERROR("udp", "bind", msg);
+      transition_to(LinkState::Error, ec, "bind", msg);
       return;
     }
 
     local_endpoint_ = udp::endpoint(address, cfg_.local_port);
     socket_.open(local_endpoint_.protocol(), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "open", fmt::format("Socket open failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Socket open failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "open", msg);
+      transition_to(LinkState::Error, ec, "open", msg);
       return;
     }
 
     if (cfg_.reuse_address) {
       socket_.set_option(net::socket_base::reuse_address(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set reuse_address: {}", ec.message()));
-        transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Failed to set reuse_address: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "open", msg);
+        transition_to(LinkState::Error, ec, "open", msg);
         return;
       }
     }
@@ -193,16 +199,18 @@ struct UdpChannel::Impl {
     if (cfg_.enable_broadcast) {
       socket_.set_option(net::socket_base::broadcast(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set broadcast: {}", ec.message()));
-        transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Failed to set broadcast: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "open", msg);
+        transition_to(LinkState::Error, ec, "open", msg);
         return;
       }
     }
 
     socket_.bind(local_endpoint_, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Bind failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Bind failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "bind", msg);
+      transition_to(LinkState::Error, ec, "bind", msg);
       return;
     }
 
@@ -258,13 +266,14 @@ struct UdpChannel::Impl {
 
     if (ec == boost::asio::error::message_size || bytes >= rx_.size()) {
       UNILINK_LOG_ERROR("udp", "receive", "Datagram truncated (buffer too small)");
-      transition_to(LinkState::Error, ec);
+      transition_to(LinkState::Error, ec, "receive", "Datagram truncated (buffer too small)");
       return;
     }
 
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "receive", fmt::format("Receive failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Receive failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "receive", msg);
+      transition_to(LinkState::Error, ec, "receive", msg);
       return;
     }
 
@@ -287,15 +296,16 @@ struct UdpChannel::Impl {
         try {
           on_bytes(memory::ConstByteSpan(rx_.data(), bytes));
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes", fmt::format("Exception in bytes callback: {}", e.what()));
+          std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
+          UNILINK_LOG_ERROR("udp", "on_bytes", msg);
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes", msg);
             return;
           }
         } catch (...) {
           UNILINK_LOG_ERROR("udp", "on_bytes", "Unknown exception in bytes callback");
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes", "Unknown exception in bytes callback");
             return;
           }
         }
@@ -305,15 +315,16 @@ struct UdpChannel::Impl {
         try {
           on_bytes_from(memory::ConstByteSpan(rx_.data(), bytes), recv_endpoint_);
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes_from", fmt::format("Exception in bytes callback: {}", e.what()));
+          std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
+          UNILINK_LOG_ERROR("udp", "on_bytes_from", msg);
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes_from", msg);
             return;
           }
         } catch (...) {
           UNILINK_LOG_ERROR("udp", "on_bytes_from", "Unknown exception in bytes callback");
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes_from", "Unknown exception in bytes callback");
             return;
           }
         }
@@ -406,8 +417,9 @@ struct UdpChannel::Impl {
       }
 
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "write", fmt::format("Send failed: {}", ec.message()));
-        impl->transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Send failed: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "write", msg);
+        impl->transition_to(LinkState::Error, ec, "write", msg);
         impl->writing_ = false;
         // do_write() will never run again to reach the "already in Error" cleanup above, so
         // drain everything and clear backpressure here directly.
@@ -558,7 +570,8 @@ struct UdpChannel::Impl {
     remote_endpoint_ = udp::endpoint(addr, *cfg_.remote_port);
   }
 
-  void transition_to(LinkState target, const boost::system::error_code& ec = {}) {
+  void transition_to(LinkState target, const boost::system::error_code& ec = {}, std::string_view operation = {},
+                     std::string_view msg = {}) {
     if (ec == net::error::operation_aborted) {
       return;
     }
@@ -567,6 +580,11 @@ struct UdpChannel::Impl {
     if ((current == LinkState::Closed || current == LinkState::Error) &&
         (target == LinkState::Closed || target == LinkState::Error)) {
       return;
+    }
+
+    if (target == LinkState::Error) {
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, operation,
+                                      ec, msg.empty() ? std::string_view(ec.message()) : msg, static_cast<bool>(ec), 0);
     }
 
     if (target == LinkState::Closed || target == LinkState::Error) {
@@ -747,6 +765,10 @@ void UdpChannel::reset_stats() {
                      impl->pending_bytes_.load(std::memory_order_relaxed));
 }
 
+std::optional<diagnostics::ErrorInfo> UdpChannel::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
+}
+
 bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   auto impl = get_impl();
   if (data.empty()) {
@@ -823,7 +845,7 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
 
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
-    impl->transition_to(LinkState::Error);
+    impl->transition_to(LinkState::Error, {}, "write", "Queue limit exceeded by single write");
     impl->stats_.record_failed_send();
     return false;
   }
@@ -863,7 +885,7 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
   auto size = data->size();
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
-    impl->transition_to(LinkState::Error);
+    impl->transition_to(LinkState::Error, {}, "write", "Queue limit exceeded by single write");
     impl->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/udp/udp.hpp
+++ b/unilink/transport/udp/udp.hpp
@@ -24,6 +24,7 @@
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/udp_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -61,6 +62,7 @@ class UNILINK_API UdpChannel : public interface::Channel, public std::enable_sha
   bool is_backpressure_active() const override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // 1:1 writes (using configured remote_endpoint_)
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -35,6 +35,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/iuds_acceptor.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/uds/boost_uds_acceptor.hpp"
 #include "unilink/transport/uds/uds_server_session.hpp"
 
@@ -68,6 +69,8 @@ struct UdsServer::Impl {
 
   mutable std::mutex sessions_mutex_;
   std::unordered_map<ClientId, std::shared_ptr<UdsServerSession>> sessions_;
+
+  ErrorInfoHolder error_info_holder_{"uds_server"};
 
   Impl(const config::UdsServerConfig& cfg, net::io_context* ioc_ptr)
       : owned_ioc_(ioc_ptr ? nullptr : std::make_unique<net::io_context>()),
@@ -222,6 +225,8 @@ void UdsServer::start() {
 
   if (!impl_->cfg_.is_valid()) {
     UNILINK_LOG_ERROR("uds_server", "start", "Invalid UDS server configuration or socket path");
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
+                                           "start", {}, "Invalid UDS server configuration or socket path", false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -233,7 +238,10 @@ void UdsServer::start() {
   boost::system::error_code ec;
   impl_->acceptor_->open(uds(), ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to open acceptor: {}", ec.message()));
+    std::string msg = fmt::format("Failed to open acceptor: {}", ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open",
+                                           ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -243,7 +251,11 @@ void UdsServer::start() {
   try {
     endpoint = uds::endpoint(impl_->cfg_.socket_path);
   } catch (const std::exception& e) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Invalid UDS endpoint: {}", e.what()));
+    std::string msg = fmt::format("Invalid UDS endpoint: {}", e.what());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
+                                           "start", make_error_code(boost::system::errc::filename_too_long), msg, false,
+                                           0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -251,8 +263,10 @@ void UdsServer::start() {
 
   impl_->acceptor_->bind(endpoint, ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start",
-                      fmt::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message()));
+    std::string msg = fmt::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "bind", ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -260,7 +274,10 @@ void UdsServer::start() {
 
   impl_->acceptor_->listen(net::socket_base::max_listen_connections, ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to listen: {}", ec.message()));
+    std::string msg = fmt::format("Failed to listen: {}", ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "listen", ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -333,6 +350,10 @@ void UdsServer::reset_stats() {
   for (const auto& pair : impl_->sessions_) {
     if (pair.second) pair.second->reset_stats();
   }
+}
+
+std::optional<diagnostics::ErrorInfo> UdsServer::last_error_info() const {
+  return impl_->error_info_holder_.last_error_info();
 }
 
 bool UdsServer::async_write_copy(memory::ConstByteSpan data) {
@@ -571,7 +592,10 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
 
       // Log only real errors, not operation_aborted
       if (ec != boost::asio::error::operation_aborted) {
-        UNILINK_LOG_ERROR("uds_server", "accept", fmt::format("Accept failed: {}", ec.message()));
+        std::string msg = fmt::format("Accept failed: {}", ec.message());
+        UNILINK_LOG_ERROR("uds_server", "accept", msg);
+        impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                              "accept", ec, msg, true, 0);
         impl->state_.set_state(base::LinkState::Error);
         impl->notify_state();
       }

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/uds_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -76,6 +78,7 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   void on_backpressure(OnBackpressure cb) override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Multi-client support
   bool broadcast(std::string_view message);


### PR DESCRIPTION
## Summary
Part of #445 (step 5 of 7, stacked on #471 → #470 → #469). Every transport now implements `last_error_info()` with real detail, not just the `std::nullopt` default from `interface::Channel` — before this, only `TcpClient`/`UdsClient` had any detailed-error mechanism at all, so a wrapper's `on_error` handler for the other five transports could only ever report a fixed generic string regardless of what actually went wrong. Additive only: existing state transitions, retry logic, and log messages are all unchanged, this just also records what's already being logged into the same `ErrorInfoHolder` used by `TcpClient`/`UdsClient`.

- **TcpServer**: added `record_error()` at all 5 error sites in `attempt_port_binding()`/`do_accept()`/`start()` (invalid bind address, open failure, bind failure, listen failure, accept failure, missing acceptor).
- **UdsServer**: added `record_error()` at all 5 error sites in `start()`/`do_accept()` (invalid config, open failure, invalid endpoint, bind failure, listen failure, accept failure) — same call sites #453 already made non-silent.
- **UdpChannel**: extended the existing centralized `transition_to()` helper with optional operation/message parameters (every `LinkState::Error` call site already had a `UNILINK_LOG_ERROR` immediately before it with the exact same operation/message, so this was a single-function change plus updating each of the 14 call sites to pass through what they were already logging).
- **Serial**: added `record_error()` inside the existing centralized `handle_error()` helper (covers 8 of 10 error sites), plus the 2 sites that bypass it entirely when `stop_on_callback_exception=true` (previously transitioned to Error with no detail recorded at all).

## Test plan
- [x] `./scripts/verify.sh` passes (683 tests)
- [x] Extended one existing regression test per transport with a `last_error_info()` assertion, proving the wiring end-to-end rather than just that it compiles: `test_udp_error.cc` (`SendOversizedPacket`), `transport_serial.cc` (`OpenAndConfigureFailuresMoveToError`), `transport_uds_server.cc` (`BindFailure`), and the integration-level `transport_tcp_server.cc` (`InjectedAcceptorOpenFailureMovesToError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)