### PR TITLE
refactor: use the shared error-context builder in all 7 wrappers (#445 step 6/7)

### DIFF
--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -33,6 +33,7 @@
 #include "unilink/base/constants.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/serial/serial.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -446,7 +447,8 @@ struct Serial::Impl {
             disconnect_handler_snapshot(ConnectionContext(0));
           }
           if (error_handler_snapshot) {
-            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+            error_handler_snapshot(channel ? detail::build_error_context(*channel, "Connection error")
+                                           : ErrorContext(ErrorCode::IoError, "Connection error"));
           }
           break;
         }

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -33,6 +33,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_client/tcp_client.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -439,16 +440,8 @@ struct TcpClient::Impl {
         if (state == base::LinkState::Closed && disconnect_handler) {
           disconnect_handler(ConnectionContext(0));
         } else if (state == base::LinkState::Error && error_handler) {
-          bool handled = false;
-          if (auto transport = std::dynamic_pointer_cast<transport::TcpClient>(channel_snapshot)) {
-            if (auto info = transport->last_error_info()) {
-              error_handler(diagnostics::to_error_context(*info));
-              handled = true;
-            }
-          }
-          if (!handled) {
-            error_handler(ErrorContext(ErrorCode::IoError, "Connection error"));
-          }
+          error_handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                         : ErrorContext(ErrorCode::IoError, "Connection error"));
         }
       }
     });

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/config/tcp_server_config.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_server/tcp_server.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -469,7 +470,8 @@ struct TcpServer::Impl {
           }
         }
         if (handler) {
-          handler(ErrorContext(ErrorCode::IoError, "Server error"));
+          handler(channel_ ? detail::build_error_context(*channel_, "Server error")
+                           : ErrorContext(ErrorCode::IoError, "Server error"));
         }
       }
     });

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -36,6 +36,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -432,7 +433,7 @@ struct UdpClient::Impl {
             disconnect_handler_snapshot(ConnectionContext(0));
           }
           if (error_handler_snapshot) {
-            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+            error_handler_snapshot(detail::build_error_context(*channel, "Connection error"));
           }
           break;
         }

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -353,7 +354,8 @@ struct UdpServer::Impl {
       }
 
       if (error_handler_copy) {
-        error_handler_copy(ErrorContext(ErrorCode::IoError, "Server error"));
+        error_handler_copy(channel ? detail::build_error_context(*channel, "Server error")
+                                   : ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
   }

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -34,6 +34,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -386,16 +387,8 @@ struct UdsClient::Impl {
           channel_snapshot = channel_;
         }
         if (handler) {
-          bool handled = false;
-          if (auto transport = std::dynamic_pointer_cast<transport::UdsClient>(channel_snapshot)) {
-            if (auto info = transport->last_error_info()) {
-              handler(diagnostics::to_error_context(*info));
-              handled = true;
-            }
-          }
-          if (!handled) {
-            handler(ErrorContext(ErrorCode::IoError, "Connection error"));
-          }
+          handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                   : ErrorContext(ErrorCode::IoError, "Connection error"));
         }
       } else if (state == base::LinkState::Closed || state == base::LinkState::Idle) {
         ConnectionHandler handler;

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -13,6 +13,7 @@
 #include "unilink/framer/line_framer.hpp"
 #include "unilink/framer/packet_framer.hpp"
 #include "unilink/transport/uds/uds_server.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -369,7 +370,8 @@ struct UdsServer::Impl {
           }
         }
         if (handler) {
-          handler(ErrorContext(ErrorCode::IoError, "Server error"));
+          handler(server_ ? detail::build_error_context(*server_, "Server error")
+                          : ErrorContext(ErrorCode::IoError, "Server error"));
         }
       }
     });


### PR DESCRIPTION
## Summary
Part of #445 (step 6 of 7, stacked on #472 → #471 → #470 → #469). Every wrapper's `on_error` handler now goes through `wrapper::detail::build_error_context()` (added in #470) instead of either a hardcoded generic `ErrorContext` (5 wrappers) or a `dynamic_pointer_cast<TcpClient>`/`<UdsClient>` special case that was the only way any wrapper could previously surface real error detail (the other 2). Now that every transport implements `last_error_info()` with real content (#472), all 7 wrappers report equally detailed errors uniformly, and the special-casing in `TcpClient`/`UdsClient`'s wrappers is gone.

Falls back to the same generic `ErrorContext` string as before only in the narrow case where the wrapper's channel reference is itself null (should not happen in practice, but preserves the exact prior behavior for that edge case rather than silently dropping the error callback).

Behavior-preserving for `TcpClient`/`UdsClient` (same detail, reached through one shared helper instead of duplicated inline casts); the other 5 wrappers (`TcpServer`, `UdsServer`, `UdpChannel` x2, `Serial`) go from a fixed generic string to real detail for the first time.

## Test plan
- [x] `./scripts/verify.sh` passes (683 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)