### PR TITLE
fix: UDP remote-address validation timing, TcpServer exception type (#445 step 7/7, final)

### DIFF
--- a/test/integration/transport/transport_tcp_server.cc
+++ b/test/integration/transport/transport_tcp_server.cc
@@ -440,6 +440,9 @@ TEST_F(TransportTcpServerTest, InjectedAcceptorOpenFailureMovesToError) {
   ioc.run_for(std::chrono::milliseconds(50));
 
   EXPECT_TRUE(error_seen.load());
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(server_->last_error_info().has_value());
+  EXPECT_EQ(server_->last_error_info()->component, "tcp_server");
 
   server_->stop();
   server_.reset();

--- a/test/integration/transport/transport_tcp_server.cc
+++ b/test/integration/transport/transport_tcp_server.cc
@@ -27,6 +27,7 @@
 #include "test_constants.hpp"
 #include "test_utils.hpp"
 #include "unilink/config/tcp_server_config.hpp"
+#include "unilink/diagnostics/exceptions.hpp"
 #include "unilink/interface/itcp_acceptor.hpp"
 #include "unilink/memory/safe_span.hpp"
 #include "unilink/transport/tcp_server/tcp_server.hpp"
@@ -400,7 +401,9 @@ TEST_F(TransportTcpServerTest, InjectedNullAcceptorThrows) {
   config::TcpServerConfig cfg;
   cfg.port = TestUtils::getAvailableTestPort();
 
-  EXPECT_THROW((void)TcpServer::create(cfg, nullptr, ioc), std::runtime_error);
+  // #445: construction-time configuration errors use diagnostics::BuilderException
+  // uniformly, matching every other transport's builder-validation exception type.
+  EXPECT_THROW((void)TcpServer::create(cfg, nullptr, ioc), diagnostics::BuilderException);
 }
 
 TEST_F(TransportTcpServerTest, InvalidBindAddressMovesToErrorAndSwallowsStateException) {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -123,9 +123,10 @@ unilink_add_unit_gtest(
 )
 
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
-foreach(test_file
-        test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
-        test_runtime_stats.cc test_send_buffer_apis.cc
+foreach(
+  test_file
+  test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
+  test_runtime_stats.cc test_send_buffer_apis.cc test_error_context_builder.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -197,6 +197,13 @@ unilink_add_unit_gtest(
   "unit_transport_backpressure_fast" 30
 )
 
+# Shared error-info holder (#445) - isolated, no sockets/io_context
+unilink_add_unit_gtest(
+  run_unit_test_error_info_holder
+  ${CMAKE_CURRENT_SOURCE_DIR}/transport/test_error_info_holder.cc
+  "unit_transport_fast" 30
+)
+
 # New error handling tests
 unilink_add_unit_gtest(
   run_unit_test_tcp_abort

--- a/test/unit/builder/test_udp_builder_options.cc
+++ b/test/unit/builder/test_udp_builder_options.cc
@@ -52,6 +52,15 @@ TEST(UdpBuilderOptionsTest, UdpClientBuilderSetters) {
   ASSERT_NE(udp, nullptr);
 }
 
+// #445: remote-address format is a pure-input error, detectable synchronously
+// with no I/O and always the caller's fault - it should throw as soon as
+// remote_endpoint()/remote() is called, not be deferred until build() time
+// constructs the underlying transport.
+TEST(UdpBuilderOptionsTest, InvalidRemoteAddressThrowsImmediately) {
+  builder::UdpClientBuilder builder(0);
+  EXPECT_THROW(builder.remote_endpoint("not-an-address", 1234), diagnostics::BuilderException);
+}
+
 TEST(UdpBuilderOptionsTest, UdpServerBuilderSetters) {
   auto server = builder::UdpServerBuilder(0)
                     .auto_start(false)

--- a/test/unit/transport/test_error_info_holder.cc
+++ b/test/unit/transport/test_error_info_holder.cc
@@ -18,7 +18,7 @@
 
 #include "unilink/transport/base/error_info_holder.hpp"
 
-using namespace unilink::transport::base;
+using namespace unilink::transport;
 using namespace unilink::diagnostics;
 
 TEST(ErrorInfoHolderTest, StartsWithNoError) {

--- a/test/unit/transport/test_error_info_holder.cc
+++ b/test/unit/transport/test_error_info_holder.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/transport/base/error_info_holder.hpp"
+
+using namespace unilink::transport::base;
+using namespace unilink::diagnostics;
+
+TEST(ErrorInfoHolderTest, StartsWithNoError) {
+  ErrorInfoHolder holder("test_component");
+  EXPECT_FALSE(holder.last_error_info().has_value());
+}
+
+TEST(ErrorInfoHolderTest, RecordErrorPopulatesAllFields) {
+  ErrorInfoHolder holder("test_component");
+  boost::system::error_code ec = make_error_code(boost::system::errc::connection_refused);
+
+  holder.record_error(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "connect", ec, "Connection refused",
+                      /*retryable=*/true, /*retry_count=*/3);
+
+  auto info = holder.last_error_info();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->level, ErrorLevel::ERROR);
+  EXPECT_EQ(info->category, ErrorCategory::CONNECTION);
+  EXPECT_EQ(info->component, "test_component");
+  EXPECT_EQ(info->operation, "connect");
+  EXPECT_EQ(info->message, "Connection refused");
+  EXPECT_EQ(info->boost_error, ec);
+  EXPECT_TRUE(info->retryable);
+  EXPECT_EQ(info->retry_count, 3u);
+}
+
+TEST(ErrorInfoHolderTest, SubsequentRecordOverwritesPrevious) {
+  ErrorInfoHolder holder("test_component");
+  holder.record_error(ErrorLevel::WARNING, ErrorCategory::CONFIGURATION, "first", {}, "first error", false, 0);
+  holder.record_error(ErrorLevel::CRITICAL, ErrorCategory::SYSTEM, "second", {}, "second error", true, 5);
+
+  auto info = holder.last_error_info();
+  ASSERT_TRUE(info.has_value());
+  EXPECT_EQ(info->operation, "second");
+  EXPECT_EQ(info->message, "second error");
+  EXPECT_EQ(info->retry_count, 5u);
+}

--- a/test/unit/transport/test_udp_error.cc
+++ b/test/unit/transport/test_udp_error.cc
@@ -67,6 +67,10 @@ TEST(TransportUdpErrorTest, SendOversizedPacket) {
 
   EXPECT_TRUE(error_occurred.load()) << "Sending >65535 bytes via UDP should trigger Error state";
 
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(channel->last_error_info().has_value());
+  EXPECT_EQ(channel->last_error_info()->component, "udp");
+
   channel->stop();
 }
 

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -238,6 +238,9 @@ TEST(TransportSerialTest, OpenAndConfigureFailuresMoveToError) {
     ioc.run_for(30ms);
 
     EXPECT_TRUE(error_seen.load());
+    // #445: last_error_info() should now report detail for this transport too.
+    ASSERT_TRUE(serial->last_error_info().has_value());
+    EXPECT_EQ(serial->last_error_info()->component, "serial");
     serial->stop();
     ioc.restart();
     ioc.run_for(5ms);

--- a/test/unit/transport/transport_uds_client.cc
+++ b/test/unit/transport/transport_uds_client.cc
@@ -145,6 +145,30 @@ TEST_F(TransportUdsClientTest, ConnectionFailure) {
   EXPECT_TRUE(has_error);
 }
 
+// Regression test for jwsung91/unilink#445: record_error()'s retry_count
+// parameter used to be silently discarded here (an unnamed uint32_t
+// parameter in the pre-ErrorInfoHolder implementation), so
+// last_error_info()->retry_count always reported 0 regardless of how many
+// reconnect attempts had actually happened - unlike TcpClient's equivalent,
+// which always set it correctly. Asserts it's now propagated end-to-end
+// through the shared ErrorInfoHolder.
+TEST_F(TransportUdsClientTest, RepeatedConnectionFailuresRecordIncreasingRetryCount) {
+  cfg.retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+  cfg.max_retries = -1;
+  EXPECT_CALL(*mock_socket, async_connect(_, _))
+      .WillRepeatedly(Invoke([this](const net::local::stream_protocol::endpoint&,
+                                    std::function<void(const boost::system::error_code&)> handler) {
+        net::post(ioc, [handler]() { handler(make_error_code(boost::asio::error::connection_refused)); });
+      }));
+
+  client->start();
+  ioc.restart();
+  ioc.run_for(std::chrono::milliseconds(1500));
+
+  ASSERT_TRUE(client->last_error_info().has_value());
+  EXPECT_GT(client->last_error_info()->retry_count, 0u);
+}
+
 TEST_F(TransportUdsClientTest, WriteData) {
   // Setup successful connection first
   std::cout << "WriteData: setting up async_connect mock" << std::endl;

--- a/test/unit/transport/transport_uds_server.cc
+++ b/test/unit/transport/transport_uds_server.cc
@@ -124,6 +124,9 @@ TEST_F(TransportUdsServerTest, BindFailure) {
 
   EXPECT_FALSE(server->is_connected());
   EXPECT_TRUE(has_error);
+  // #445: last_error_info() should now report detail for this transport too.
+  ASSERT_TRUE(server->last_error_info().has_value());
+  EXPECT_EQ(server->last_error_info()->component, "uds_server");
 }
 
 // Regression test for jwsung91/unilink#453: a transient accept() failure

--- a/test/unit/wrapper/test_error_context_builder.cc
+++ b/test/unit/wrapper/test_error_context_builder.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "unilink/wrapper/error_context_builder.hpp"
+
+using namespace unilink;
+using namespace unilink::wrapper;
+using namespace unilink::diagnostics;
+
+namespace {
+
+// Minimal fake exercising only what build_error_context() touches
+// (last_error_info()); every other pure virtual is a trivial stub.
+class FakeChannel : public interface::Channel {
+ public:
+  void start() override {}
+  void stop() override {}
+  bool is_connected() const override { return false; }
+  bool is_backpressure_active() const override { return false; }
+  boost::asio::any_io_executor get_executor() override { return {}; }
+  bool async_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  bool async_try_write_copy(memory::ConstByteSpan) override { return false; }
+  bool async_try_write_move(std::vector<uint8_t>&&) override { return false; }
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return false; }
+  void on_bytes(OnBytes) override {}
+  void on_state(OnState) override {}
+  void on_backpressure(OnBackpressure) override {}
+
+  std::optional<ErrorInfo> last_error_info() const override { return error_; }
+
+  std::optional<ErrorInfo> error_;
+};
+
+}  // namespace
+
+TEST(ErrorContextBuilderTest, FallsBackToGenericMessageWhenNoDetailAvailable) {
+  FakeChannel channel;  // error_ stays nullopt, matching an unmigrated transport
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::IoError);
+  EXPECT_EQ(ctx.message(), "Connection error");
+  EXPECT_FALSE(ctx.client_id().has_value());
+}
+
+TEST(ErrorContextBuilderTest, UsesDetailedInfoWhenAvailable) {
+  FakeChannel channel;
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "connect",
+                             "Connection refused", boost::asio::error::connection_refused, true);
+
+  auto ctx = wrapper::detail::build_error_context(channel, "Connection error");
+
+  EXPECT_EQ(ctx.code(), ErrorCode::ConnectionRefused);
+  EXPECT_EQ(ctx.message(), "Connection refused");
+}
+
+TEST(ErrorContextBuilderTest, ThreadsClientIdThroughBothPaths) {
+  FakeChannel channel;
+
+  auto fallback_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(fallback_ctx.client_id().has_value());
+  EXPECT_EQ(*fallback_ctx.client_id(), 7u);
+
+  channel.error_ = ErrorInfo(ErrorLevel::ERROR, ErrorCategory::CONNECTION, "test_component", "read", "Read failed");
+  auto detailed_ctx = wrapper::detail::build_error_context(channel, "Server error", ClientId{7});
+  ASSERT_TRUE(detailed_ctx.client_id().has_value());
+  EXPECT_EQ(*detailed_ctx.client_id(), 7u);
+}

--- a/unilink/builder/udp_builder.cc
+++ b/unilink/builder/udp_builder.cc
@@ -17,6 +17,7 @@
 #include "unilink/builder/udp_builder.hpp"
 
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/address.hpp>
 
 #include "unilink/builder/auto_initializer.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
@@ -112,6 +113,11 @@ UdpClientBuilder<State>& UdpClientBuilder<State>::bind_address(const std::string
 
 template <uint32_t State>
 UdpClientBuilder<State>& UdpClientBuilder<State>::remote_endpoint(const std::string& host, uint16_t port) {
+  boost::system::error_code ec;
+  boost::asio::ip::make_address(host, ec);
+  if (ec) {
+    throw diagnostics::BuilderException("Invalid remote address: " + host, "udp");
+  }
   remote_host_ = host;
   remote_port_ = port;
   return *this;

--- a/unilink/interface/channel.hpp
+++ b/unilink/interface/channel.hpp
@@ -18,11 +18,13 @@
 #include <boost/asio/any_io_executor.hpp>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
 #include "unilink/base/common.hpp"
 #include "unilink/base/visibility.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/memory/safe_span.hpp"
 #include "unilink/wrapper/runtime_stats.hpp"
 
@@ -42,6 +44,13 @@ class UNILINK_API Channel {
   virtual bool is_backpressure_active() const = 0;
   virtual wrapper::RuntimeStats stats() const { return {}; }
   virtual void reset_stats() {}
+
+  // Most recent error recorded by this channel, if any. Default no-op
+  // override (std::nullopt) so any transport not yet wired up to the
+  // shared ErrorInfoHolder plumbing (#445) just reports "no detail
+  // available" instead of failing to compile or requiring a stub
+  // override everywhere.
+  virtual std::optional<diagnostics::ErrorInfo> last_error_info() const { return std::nullopt; }
 
   virtual boost::asio::any_io_executor get_executor() = 0;
 

--- a/unilink/transport/base/error_info_holder.hpp
+++ b/unilink/transport/base/error_info_holder.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <boost/system/error_code.hpp>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "unilink/diagnostics/error_types.hpp"
+
+// Extracted from what used to be identical, independently-maintained
+// record_error()/last_error_info_ logic in TcpClient::Impl and
+// UdsClient::Impl (jwsung91/unilink#445), now shared so every transport can
+// implement interface::Channel::last_error_info() the same way instead of
+// only two of seven having any detailed-error mechanism at all.
+namespace unilink {
+namespace transport {
+namespace base {
+
+class ErrorInfoHolder {
+ public:
+  explicit ErrorInfoHolder(std::string component) : component_(std::move(component)) {}
+
+  void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
+                    const boost::system::error_code& ec, std::string_view msg, bool retryable, uint32_t retry_count) {
+    diagnostics::ErrorInfo info(lvl, cat, component_, operation, msg, ec, retryable);
+    info.retry_count = retry_count;
+    std::lock_guard<std::mutex> lock(mtx_);
+    last_error_info_ = std::move(info);
+  }
+
+  std::optional<diagnostics::ErrorInfo> last_error_info() const {
+    std::lock_guard<std::mutex> lock(mtx_);
+    return last_error_info_;
+  }
+
+ private:
+  std::string component_;
+  mutable std::mutex mtx_;
+  std::optional<diagnostics::ErrorInfo> last_error_info_;
+};
+
+}  // namespace base
+}  // namespace transport
+}  // namespace unilink

--- a/unilink/transport/base/error_info_holder.hpp
+++ b/unilink/transport/base/error_info_holder.hpp
@@ -32,7 +32,6 @@
 // only two of seven having any detailed-error mechanism at all.
 namespace unilink {
 namespace transport {
-namespace base {
 
 class ErrorInfoHolder {
  public:
@@ -57,6 +56,5 @@ class ErrorInfoHolder {
   std::optional<diagnostics::ErrorInfo> last_error_info_;
 };
 
-}  // namespace base
 }  // namespace transport
 }  // namespace unilink

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/serial/boost_serial_port.hpp"
 
 namespace unilink {
@@ -106,6 +107,8 @@ struct Serial::Impl {
 
   std::atomic<bool> opened_{false};
   ThreadSafeLinkState state_{LinkState::Idle};
+
+  ErrorInfoHolder error_info_holder_{"serial"};
 
   void observe_queue() {
     stats_.observe_queue(queued_bytes_.load(std::memory_order_relaxed) +
@@ -313,8 +316,12 @@ struct Serial::Impl {
             try {
               on_bytes(memory::ConstByteSpan(impl->rx_.data(), n));
             } catch (const std::exception& e) {
-              UNILINK_LOG_ERROR("serial", "on_bytes", fmt::format("Exception in callback: {}", e.what()));
+              std::string msg = fmt::format("Exception in callback: {}", e.what());
+              UNILINK_LOG_ERROR("serial", "on_bytes", msg);
               if (impl->cfg_.stop_on_callback_exception) {
+                impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                      diagnostics::ErrorCategory::COMMUNICATION, "on_bytes", {}, msg,
+                                                      false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
                 impl->state_.set_state(LinkState::Error);
@@ -325,6 +332,9 @@ struct Serial::Impl {
               return;
             } catch (...) {
               if (impl->cfg_.stop_on_callback_exception) {
+                impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                      diagnostics::ErrorCategory::COMMUNICATION, "on_bytes", {},
+                                                      "Unknown exception in callback", false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
                 impl->state_.set_state(LinkState::Error);
@@ -433,6 +443,8 @@ struct Serial::Impl {
     diagnostics::error_reporting::report_connection_error("serial", where, ec, retryable);
 
     UNILINK_LOG_ERROR("serial", where, fmt::format("Error: {}", ec.message()));
+    error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, where, ec,
+                                    ec.message(), retryable, 0);
 
     if (cfg_.reopen_on_error) {
       opened_.store(false);
@@ -613,6 +625,10 @@ void Serial::reset_stats() {
   auto impl = get_impl();
   impl->stats_.reset(impl->queued_bytes_.load(std::memory_order_relaxed) +
                      impl->pending_bytes_.load(std::memory_order_relaxed));
+}
+
+std::optional<diagnostics::ErrorInfo> Serial::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
 }
 
 boost::asio::any_io_executor Serial::get_executor() { return impl_->strand_; }

--- a/unilink/transport/serial/serial.hpp
+++ b/unilink/transport/serial/serial.hpp
@@ -17,11 +17,13 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/serial_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -65,6 +67,7 @@ class UNILINK_API Serial : public interface::Channel, public std::enable_shared_
   bool is_backpressure_active() const override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
   boost::asio::any_io_executor get_executor() override;
 
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -54,6 +54,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/tcp_client/detail/reconnect_decider.hpp"
 
 namespace unilink {
@@ -125,8 +126,7 @@ struct TcpClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"tcp_client"};
 
   Impl(const TcpClientConfig& cfg, net::io_context* ioc_ptr)
       : owned_ioc_(ioc_ptr ? nullptr : std::make_shared<net::io_context>()),
@@ -205,8 +205,7 @@ TcpClient::TcpClient(TcpClient&&) noexcept = default;
 TcpClient& TcpClient::operator=(TcpClient&&) noexcept = default;
 
 std::optional<diagnostics::ErrorInfo> TcpClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void TcpClient::start() {
@@ -730,11 +729,7 @@ void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t s
     return;
   }
 
-  std::optional<diagnostics::ErrorInfo> last_err;
-  {
-    std::lock_guard<std::mutex> lock(last_err_mtx_);
-    last_err = last_error_info_;
-  }
+  std::optional<diagnostics::ErrorInfo> last_err = error_info_holder_.last_error_info();
 
   if (!last_err) {
     last_err = diagnostics::ErrorInfo(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
@@ -1215,10 +1210,7 @@ void TcpClient::Impl::notify_state() {
 void TcpClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
                                    std::string_view msg, bool retryable, uint32_t retry_count) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  diagnostics::ErrorInfo info(lvl, cat, "tcp_client", operation, msg, ec, retryable);
-  info.retry_count = retry_count;
-  last_error_info_ = info;
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 void TcpClient::Impl::reset_io_objects() {

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -85,7 +85,7 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Dynamic configuration methods. Thread-safe; take effect for the next
   // reconnect/idle-timeout decision, not retroactively for one already in

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -33,6 +33,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/itcp_acceptor.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/tcp_server/boost_tcp_acceptor.hpp"
 #include "unilink/transport/tcp_server/tcp_server_session.hpp"
 
@@ -72,6 +73,8 @@ struct TcpServer::Impl {
   bool paused_accept_ = false;
 
   std::shared_ptr<TcpServerSession> current_session_;
+
+  ErrorInfoHolder error_info_holder_{"tcp_server"};
 
   explicit Impl(const config::TcpServerConfig& cfg)
       : owns_ioc_(false),
@@ -182,8 +185,10 @@ struct TcpServer::Impl {
 
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("tcp_server", "bind",
-                        fmt::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message()));
+      std::string msg = fmt::format("Invalid bind address: {}, {}", cfg_.bind_address, ec.message());
+      UNILINK_LOG_ERROR("tcp_server", "bind", msg);
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION, "bind",
+                                      ec, msg, false, static_cast<uint32_t>(retry_count));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -192,7 +197,10 @@ struct TcpServer::Impl {
     if (!acceptor_->is_open()) {
       acceptor_->open(address.is_v6() ? tcp::v6() : tcp::v4(), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("tcp_server", "open", fmt::format("Failed to open acceptor: {}", ec.message()));
+        std::string msg = fmt::format("Failed to open acceptor: {}", ec.message());
+        UNILINK_LOG_ERROR("tcp_server", "open", msg);
+        error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open", ec,
+                                        msg, false, static_cast<uint32_t>(retry_count));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -214,7 +222,10 @@ struct TcpServer::Impl {
         });
         return;
       } else {
-        UNILINK_LOG_ERROR("tcp_server", "bind", fmt::format("Failed to bind to port {}: {}", cfg_.port, ec.message()));
+        std::string msg = fmt::format("Failed to bind to port {}: {}", cfg_.port, ec.message());
+        UNILINK_LOG_ERROR("tcp_server", "bind", msg);
+        error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "bind",
+                                        ec, msg, false, static_cast<uint32_t>(retry_count));
         state_.set_state(base::LinkState::Error);
         notify_state();
         return;
@@ -223,8 +234,10 @@ struct TcpServer::Impl {
 
     acceptor_->listen(boost::asio::socket_base::max_listen_connections, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("tcp_server", "listen",
-                        fmt::format("Failed to listen on port {}: {}", cfg_.port, ec.message()));
+      std::string msg = fmt::format("Failed to listen on port {}: {}", cfg_.port, ec.message());
+      UNILINK_LOG_ERROR("tcp_server", "listen", msg);
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "listen",
+                                      ec, msg, false, static_cast<uint32_t>(retry_count));
       state_.set_state(base::LinkState::Error);
       notify_state();
       return;
@@ -245,6 +258,9 @@ struct TcpServer::Impl {
       }
       if (ec) {
         if (ec != boost::asio::error::operation_aborted) {
+          accept_impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
+                                                       diagnostics::ErrorCategory::CONNECTION, "accept", ec,
+                                                       fmt::format("Accept failed: {}", ec.message()), true, 0);
           accept_impl->state_.set_state(base::LinkState::Error);
           accept_impl->notify_state();
         }
@@ -501,6 +517,8 @@ void TcpServer::start() {
   }
 
   if (!impl->acceptor_) {
+    impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "start",
+                                          {}, "No acceptor available", false, 0);
     impl->state_.set_state(base::LinkState::Error);
     impl->notify_state();
     return;
@@ -590,6 +608,10 @@ void TcpServer::reset_stats() {
   for (const auto& entry : impl->sessions_) {
     if (entry.second) entry.second->reset_stats();
   }
+}
+
+std::optional<diagnostics::ErrorInfo> TcpServer::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
 }
 
 bool TcpServer::async_write_copy(memory::ConstByteSpan data) {

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -30,6 +30,7 @@
 
 #include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
+#include "unilink/diagnostics/exceptions.hpp"
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/itcp_acceptor.hpp"
@@ -86,7 +87,7 @@ struct TcpServer::Impl {
     try {
       acceptor_ = std::make_unique<BoostTcpAcceptor>(ioc_);
     } catch (const std::exception& e) {
-      throw std::runtime_error("Failed to create TCP acceptor: " + std::string(e.what()));
+      throw diagnostics::BuilderException("Failed to create TCP acceptor: " + std::string(e.what()), "tcp_server");
     }
     cfg_.validate_and_clamp();
     max_clients_ = cfg_.max_connections > 0 ? static_cast<size_t>(cfg_.max_connections) : 0;
@@ -103,7 +104,7 @@ struct TcpServer::Impl {
         max_clients_(cfg.max_connections > 0 ? static_cast<size_t>(cfg.max_connections) : 0),
         client_limit_enabled_(cfg.max_connections > 0) {
     if (!acceptor_) {
-      throw std::runtime_error("Failed to create TCP acceptor");
+      throw diagnostics::BuilderException("Failed to create TCP acceptor", "tcp_server");
     }
     cfg_.validate_and_clamp();
     max_clients_ = cfg_.max_connections > 0 ? static_cast<size_t>(cfg_.max_connections) : 0;

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/tcp_server_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -76,6 +78,7 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   void on_backpressure(OnBackpressure cb) override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Multi-client support
   bool broadcast(std::string_view message);

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 
 namespace unilink {
 namespace transport {
@@ -106,6 +107,8 @@ struct UdpChannel::Impl {
   OnState on_state_;
   OnBackpressure on_bp_;
 
+  ErrorInfoHolder error_info_holder_{"udp"};
+
   explicit Impl(const config::UdpConfig& config)
       : owned_ioc_(std::make_unique<net::io_context>()),
         ioc_(owned_ioc_.get()),
@@ -168,24 +171,27 @@ struct UdpChannel::Impl {
     boost::system::error_code ec;
     auto address = net::ip::make_address(cfg_.bind_address, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Invalid bind address: {}", cfg_.bind_address));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Invalid bind address: {}", cfg_.bind_address);
+      UNILINK_LOG_ERROR("udp", "bind", msg);
+      transition_to(LinkState::Error, ec, "bind", msg);
       return;
     }
 
     local_endpoint_ = udp::endpoint(address, cfg_.local_port);
     socket_.open(local_endpoint_.protocol(), ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "open", fmt::format("Socket open failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Socket open failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "open", msg);
+      transition_to(LinkState::Error, ec, "open", msg);
       return;
     }
 
     if (cfg_.reuse_address) {
       socket_.set_option(net::socket_base::reuse_address(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set reuse_address: {}", ec.message()));
-        transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Failed to set reuse_address: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "open", msg);
+        transition_to(LinkState::Error, ec, "open", msg);
         return;
       }
     }
@@ -193,16 +199,18 @@ struct UdpChannel::Impl {
     if (cfg_.enable_broadcast) {
       socket_.set_option(net::socket_base::broadcast(true), ec);
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "open", fmt::format("Failed to set broadcast: {}", ec.message()));
-        transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Failed to set broadcast: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "open", msg);
+        transition_to(LinkState::Error, ec, "open", msg);
         return;
       }
     }
 
     socket_.bind(local_endpoint_, ec);
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "bind", fmt::format("Bind failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Bind failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "bind", msg);
+      transition_to(LinkState::Error, ec, "bind", msg);
       return;
     }
 
@@ -258,13 +266,14 @@ struct UdpChannel::Impl {
 
     if (ec == boost::asio::error::message_size || bytes >= rx_.size()) {
       UNILINK_LOG_ERROR("udp", "receive", "Datagram truncated (buffer too small)");
-      transition_to(LinkState::Error, ec);
+      transition_to(LinkState::Error, ec, "receive", "Datagram truncated (buffer too small)");
       return;
     }
 
     if (ec) {
-      UNILINK_LOG_ERROR("udp", "receive", fmt::format("Receive failed: {}", ec.message()));
-      transition_to(LinkState::Error, ec);
+      std::string msg = fmt::format("Receive failed: {}", ec.message());
+      UNILINK_LOG_ERROR("udp", "receive", msg);
+      transition_to(LinkState::Error, ec, "receive", msg);
       return;
     }
 
@@ -287,15 +296,16 @@ struct UdpChannel::Impl {
         try {
           on_bytes(memory::ConstByteSpan(rx_.data(), bytes));
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes", fmt::format("Exception in bytes callback: {}", e.what()));
+          std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
+          UNILINK_LOG_ERROR("udp", "on_bytes", msg);
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes", msg);
             return;
           }
         } catch (...) {
           UNILINK_LOG_ERROR("udp", "on_bytes", "Unknown exception in bytes callback");
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes", "Unknown exception in bytes callback");
             return;
           }
         }
@@ -305,15 +315,16 @@ struct UdpChannel::Impl {
         try {
           on_bytes_from(memory::ConstByteSpan(rx_.data(), bytes), recv_endpoint_);
         } catch (const std::exception& e) {
-          UNILINK_LOG_ERROR("udp", "on_bytes_from", fmt::format("Exception in bytes callback: {}", e.what()));
+          std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
+          UNILINK_LOG_ERROR("udp", "on_bytes_from", msg);
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes_from", msg);
             return;
           }
         } catch (...) {
           UNILINK_LOG_ERROR("udp", "on_bytes_from", "Unknown exception in bytes callback");
           if (cfg_.stop_on_callback_exception) {
-            transition_to(LinkState::Error);
+            transition_to(LinkState::Error, {}, "on_bytes_from", "Unknown exception in bytes callback");
             return;
           }
         }
@@ -406,8 +417,9 @@ struct UdpChannel::Impl {
       }
 
       if (ec) {
-        UNILINK_LOG_ERROR("udp", "write", fmt::format("Send failed: {}", ec.message()));
-        impl->transition_to(LinkState::Error, ec);
+        std::string msg = fmt::format("Send failed: {}", ec.message());
+        UNILINK_LOG_ERROR("udp", "write", msg);
+        impl->transition_to(LinkState::Error, ec, "write", msg);
         impl->writing_ = false;
         // do_write() will never run again to reach the "already in Error" cleanup above, so
         // drain everything and clear backpressure here directly.
@@ -558,7 +570,8 @@ struct UdpChannel::Impl {
     remote_endpoint_ = udp::endpoint(addr, *cfg_.remote_port);
   }
 
-  void transition_to(LinkState target, const boost::system::error_code& ec = {}) {
+  void transition_to(LinkState target, const boost::system::error_code& ec = {}, std::string_view operation = {},
+                     std::string_view msg = {}) {
     if (ec == net::error::operation_aborted) {
       return;
     }
@@ -567,6 +580,11 @@ struct UdpChannel::Impl {
     if ((current == LinkState::Closed || current == LinkState::Error) &&
         (target == LinkState::Closed || target == LinkState::Error)) {
       return;
+    }
+
+    if (target == LinkState::Error) {
+      error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, operation,
+                                      ec, msg.empty() ? std::string_view(ec.message()) : msg, static_cast<bool>(ec), 0);
     }
 
     if (target == LinkState::Closed || target == LinkState::Error) {
@@ -747,6 +765,10 @@ void UdpChannel::reset_stats() {
                      impl->pending_bytes_.load(std::memory_order_relaxed));
 }
 
+std::optional<diagnostics::ErrorInfo> UdpChannel::last_error_info() const {
+  return get_impl()->error_info_holder_.last_error_info();
+}
+
 bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   auto impl = get_impl();
   if (data.empty()) {
@@ -823,7 +845,7 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
 
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
-    impl->transition_to(LinkState::Error);
+    impl->transition_to(LinkState::Error, {}, "write", "Queue limit exceeded by single write");
     impl->stats_.record_failed_send();
     return false;
   }
@@ -863,7 +885,7 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
   auto size = data->size();
   if (size > impl->bp_limit_) {
     UNILINK_LOG_ERROR("udp", "write", "Queue limit exceeded by single write");
-    impl->transition_to(LinkState::Error);
+    impl->transition_to(LinkState::Error, {}, "write", "Queue limit exceeded by single write");
     impl->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/udp/udp.hpp
+++ b/unilink/transport/udp/udp.hpp
@@ -24,6 +24,7 @@
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/udp_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -61,6 +62,7 @@ class UNILINK_API UdpChannel : public interface::Channel, public std::enable_sha
   bool is_backpressure_active() const override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // 1:1 writes (using configured remote_endpoint_)
   bool async_write_copy(memory::ConstByteSpan data) override;

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
 #include "unilink/transport/uds/detail/reconnect_decider.hpp"
 
@@ -100,8 +101,7 @@ struct UdsClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"uds_client"};
 
   Impl(const UdsClientConfig& cfg, net::io_context* ioc_ptr,
        std::unique_ptr<interface::UdsSocketInterface> socket = nullptr)
@@ -458,8 +458,7 @@ void UdsClient::set_reconnect_policy(ReconnectPolicy policy) {
 }
 
 std::optional<diagnostics::ErrorInfo> UdsClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void UdsClient::Impl::do_connect(std::shared_ptr<UdsClient> self, uint64_t seq) {
@@ -769,9 +768,8 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
 
 void UdsClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
-                                   std::string_view msg, bool retryable, uint32_t) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  last_error_info_ = diagnostics::ErrorInfo(lvl, cat, "uds_client", operation, msg, ec, retryable);
+                                   std::string_view msg, bool retryable, uint32_t retry_count) {
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 }  // namespace transport

--- a/unilink/transport/uds/uds_client.hpp
+++ b/unilink/transport/uds/uds_client.hpp
@@ -88,7 +88,7 @@ class UNILINK_API UdsClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   void set_backpressure_strategy(base::constants::BackpressureStrategy strategy);
   void set_retry_interval(unsigned interval_ms);

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -35,6 +35,7 @@
 #include "unilink/diagnostics/logger.hpp"
 #include "unilink/diagnostics/runtime_stats_counter.hpp"
 #include "unilink/interface/iuds_acceptor.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/uds/boost_uds_acceptor.hpp"
 #include "unilink/transport/uds/uds_server_session.hpp"
 
@@ -68,6 +69,8 @@ struct UdsServer::Impl {
 
   mutable std::mutex sessions_mutex_;
   std::unordered_map<ClientId, std::shared_ptr<UdsServerSession>> sessions_;
+
+  ErrorInfoHolder error_info_holder_{"uds_server"};
 
   Impl(const config::UdsServerConfig& cfg, net::io_context* ioc_ptr)
       : owned_ioc_(ioc_ptr ? nullptr : std::make_unique<net::io_context>()),
@@ -222,6 +225,8 @@ void UdsServer::start() {
 
   if (!impl_->cfg_.is_valid()) {
     UNILINK_LOG_ERROR("uds_server", "start", "Invalid UDS server configuration or socket path");
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
+                                           "start", {}, "Invalid UDS server configuration or socket path", false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -233,7 +238,10 @@ void UdsServer::start() {
   boost::system::error_code ec;
   impl_->acceptor_->open(uds(), ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to open acceptor: {}", ec.message()));
+    std::string msg = fmt::format("Failed to open acceptor: {}", ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open",
+                                           ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -243,7 +251,11 @@ void UdsServer::start() {
   try {
     endpoint = uds::endpoint(impl_->cfg_.socket_path);
   } catch (const std::exception& e) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Invalid UDS endpoint: {}", e.what()));
+    std::string msg = fmt::format("Invalid UDS endpoint: {}", e.what());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
+                                           "start", make_error_code(boost::system::errc::filename_too_long), msg, false,
+                                           0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -251,8 +263,10 @@ void UdsServer::start() {
 
   impl_->acceptor_->bind(endpoint, ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start",
-                      fmt::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message()));
+    std::string msg = fmt::format("Failed to bind to {}: {}", impl_->cfg_.socket_path, ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "bind", ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -260,7 +274,10 @@ void UdsServer::start() {
 
   impl_->acceptor_->listen(net::socket_base::max_listen_connections, ec);
   if (ec) {
-    UNILINK_LOG_ERROR("uds_server", "start", fmt::format("Failed to listen: {}", ec.message()));
+    std::string msg = fmt::format("Failed to listen: {}", ec.message());
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "listen", ec, msg, false, 0);
     impl_->state_.set_state(base::LinkState::Error);
     impl_->notify_state();
     return;
@@ -333,6 +350,10 @@ void UdsServer::reset_stats() {
   for (const auto& pair : impl_->sessions_) {
     if (pair.second) pair.second->reset_stats();
   }
+}
+
+std::optional<diagnostics::ErrorInfo> UdsServer::last_error_info() const {
+  return impl_->error_info_holder_.last_error_info();
 }
 
 bool UdsServer::async_write_copy(memory::ConstByteSpan data) {
@@ -571,7 +592,10 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
 
       // Log only real errors, not operation_aborted
       if (ec != boost::asio::error::operation_aborted) {
-        UNILINK_LOG_ERROR("uds_server", "accept", fmt::format("Accept failed: {}", ec.message()));
+        std::string msg = fmt::format("Accept failed: {}", ec.message());
+        UNILINK_LOG_ERROR("uds_server", "accept", msg);
+        impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                              "accept", ec, msg, true, 0);
         impl->state_.set_state(base::LinkState::Error);
         impl->notify_state();
       }

--- a/unilink/transport/uds/uds_server.hpp
+++ b/unilink/transport/uds/uds_server.hpp
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "unilink/base/visibility.hpp"
 #include "unilink/config/uds_config.hpp"
+#include "unilink/diagnostics/error_types.hpp"
 #include "unilink/interface/channel.hpp"
 
 namespace boost {
@@ -76,6 +78,7 @@ class UNILINK_API UdsServer : public interface::Channel, public std::enable_shar
   void on_backpressure(OnBackpressure cb) override;
   wrapper::RuntimeStats stats() const override;
   void reset_stats() override;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Multi-client support
   bool broadcast(std::string_view message);

--- a/unilink/wrapper/error_context_builder.hpp
+++ b/unilink/wrapper/error_context_builder.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "unilink/diagnostics/error_mapping.hpp"
+#include "unilink/interface/channel.hpp"
+#include "unilink/wrapper/context.hpp"
+
+// Shared replacement for the per-wrapper dynamic_pointer_cast<TcpClient>/
+// <UdsClient> special-casing (previously the only two transports whose
+// wrapper could report a detailed ErrorContext) and every other wrapper's
+// independent hardcoded generic-string fallback (jwsung91/unilink#445).
+// Works uniformly now that interface::Channel::last_error_info() is
+// virtual - no cast to a concrete transport type needed.
+namespace unilink {
+namespace wrapper {
+namespace detail {
+
+inline ErrorContext build_error_context(const interface::Channel& channel, std::string_view fallback_message,
+                                        std::optional<ClientId> client_id = std::nullopt) {
+  if (auto info = channel.last_error_info()) {
+    return diagnostics::to_error_context(*info, client_id);
+  }
+  return ErrorContext(ErrorCode::IoError, fallback_message, client_id);
+}
+
+}  // namespace detail
+}  // namespace wrapper
+}  // namespace unilink

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -33,6 +33,7 @@
 #include "unilink/base/constants.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/serial/serial.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -446,7 +447,8 @@ struct Serial::Impl {
             disconnect_handler_snapshot(ConnectionContext(0));
           }
           if (error_handler_snapshot) {
-            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+            error_handler_snapshot(channel ? detail::build_error_context(*channel, "Connection error")
+                                           : ErrorContext(ErrorCode::IoError, "Connection error"));
           }
           break;
         }

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -33,6 +33,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_client/tcp_client.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -439,16 +440,8 @@ struct TcpClient::Impl {
         if (state == base::LinkState::Closed && disconnect_handler) {
           disconnect_handler(ConnectionContext(0));
         } else if (state == base::LinkState::Error && error_handler) {
-          bool handled = false;
-          if (auto transport = std::dynamic_pointer_cast<transport::TcpClient>(channel_snapshot)) {
-            if (auto info = transport->last_error_info()) {
-              error_handler(diagnostics::to_error_context(*info));
-              handled = true;
-            }
-          }
-          if (!handled) {
-            error_handler(ErrorContext(ErrorCode::IoError, "Connection error"));
-          }
+          error_handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                         : ErrorContext(ErrorCode::IoError, "Connection error"));
         }
       }
     });

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/config/tcp_server_config.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_server/tcp_server.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -469,7 +470,8 @@ struct TcpServer::Impl {
           }
         }
         if (handler) {
-          handler(ErrorContext(ErrorCode::IoError, "Server error"));
+          handler(channel_ ? detail::build_error_context(*channel_, "Server error")
+                           : ErrorContext(ErrorCode::IoError, "Server error"));
         }
       }
     });

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -36,6 +36,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -432,7 +433,7 @@ struct UdpClient::Impl {
             disconnect_handler_snapshot(ConnectionContext(0));
           }
           if (error_handler_snapshot) {
-            error_handler_snapshot(ErrorContext(ErrorCode::IoError, "Connection error"));
+            error_handler_snapshot(detail::build_error_context(*channel, "Connection error"));
           }
           break;
         }

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -353,7 +354,8 @@ struct UdpServer::Impl {
       }
 
       if (error_handler_copy) {
-        error_handler_copy(ErrorContext(ErrorCode::IoError, "Server error"));
+        error_handler_copy(channel ? detail::build_error_context(*channel, "Server error")
+                                   : ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
   }

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -34,6 +34,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -386,16 +387,8 @@ struct UdsClient::Impl {
           channel_snapshot = channel_;
         }
         if (handler) {
-          bool handled = false;
-          if (auto transport = std::dynamic_pointer_cast<transport::UdsClient>(channel_snapshot)) {
-            if (auto info = transport->last_error_info()) {
-              handler(diagnostics::to_error_context(*info));
-              handled = true;
-            }
-          }
-          if (!handled) {
-            handler(ErrorContext(ErrorCode::IoError, "Connection error"));
-          }
+          handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                   : ErrorContext(ErrorCode::IoError, "Connection error"));
         }
       } else if (state == base::LinkState::Closed || state == base::LinkState::Idle) {
         ConnectionHandler handler;

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -13,6 +13,7 @@
 #include "unilink/framer/line_framer.hpp"
 #include "unilink/framer/packet_framer.hpp"
 #include "unilink/transport/uds/uds_server.hpp"
+#include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
 namespace wrapper {
@@ -369,7 +370,8 @@ struct UdsServer::Impl {
           }
         }
         if (handler) {
-          handler(ErrorContext(ErrorCode::IoError, "Server error"));
+          handler(server_ ? detail::build_error_context(*server_, "Server error")
+                          : ErrorContext(ErrorCode::IoError, "Server error"));
         }
       }
     });


### PR DESCRIPTION
## Summary
Part of #445 (step 7 of 7, final step, stacked on #473 → #472 → #471 → #470 → #469). Closes the two remaining consistency gaps the design plan called out:

1. **`UdpClientBuilder::remote_endpoint()`** now validates the address format immediately (throwing `diagnostics::BuilderException`), instead of silently accepting any string and only discovering the problem later when `build()` constructs the underlying `UdpChannel` (which throws a plain `std::runtime_error` from `Impl`'s constructor, transitively during `build()`). This matches every other builder's pattern of validating pure-input errors — detectable synchronously, no I/O, always the caller's fault — as soon as the value is provided rather than deferring to construction time. The transport-level check in `UdpChannel::Impl::set_remote_from_config()` is left as-is for defense in depth against direct (non-builder) `UdpChannel::create()` callers.

2. **`TcpServer::Impl`**'s two acceptor-creation failure sites now throw `diagnostics::BuilderException` instead of plain `std::runtime_error`, matching every other transport's construction-time exception type (both are still `std::runtime_error` subclasses, so this is behavior-preserving for any caller only catching `std::runtime_error`; tightened the existing `InjectedNullAcceptorThrows` test to assert the specific type).

## Test plan
- [x] `./scripts/verify.sh` passes (684 tests, +1 new)
- [x] New test (`UdpBuilderOptionsTest.InvalidRemoteAddressThrowsImmediately`) proves the address format check now fires at `remote_endpoint()` call time, not `build()` time

This completes all 7 steps of #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)