### PR TITLE
refactor: migrate TcpClient/UdsClient onto the shared ErrorInfoHolder (#445 step 4/7)

### DIFF
--- a/test/unit/transport/transport_uds_client.cc
+++ b/test/unit/transport/transport_uds_client.cc
@@ -145,6 +145,30 @@ TEST_F(TransportUdsClientTest, ConnectionFailure) {
   EXPECT_TRUE(has_error);
 }
 
+// Regression test for jwsung91/unilink#445: record_error()'s retry_count
+// parameter used to be silently discarded here (an unnamed uint32_t
+// parameter in the pre-ErrorInfoHolder implementation), so
+// last_error_info()->retry_count always reported 0 regardless of how many
+// reconnect attempts had actually happened - unlike TcpClient's equivalent,
+// which always set it correctly. Asserts it's now propagated end-to-end
+// through the shared ErrorInfoHolder.
+TEST_F(TransportUdsClientTest, RepeatedConnectionFailuresRecordIncreasingRetryCount) {
+  cfg.retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+  cfg.max_retries = -1;
+  EXPECT_CALL(*mock_socket, async_connect(_, _))
+      .WillRepeatedly(Invoke([this](const net::local::stream_protocol::endpoint&,
+                                    std::function<void(const boost::system::error_code&)> handler) {
+        net::post(ioc, [handler]() { handler(make_error_code(boost::asio::error::connection_refused)); });
+      }));
+
+  client->start();
+  ioc.restart();
+  ioc.run_for(std::chrono::milliseconds(1500));
+
+  ASSERT_TRUE(client->last_error_info().has_value());
+  EXPECT_GT(client->last_error_info()->retry_count, 0u);
+}
+
 TEST_F(TransportUdsClientTest, WriteData) {
   // Setup successful connection first
   std::cout << "WriteData: setting up async_connect mock" << std::endl;

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -54,6 +54,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/tcp_client/detail/reconnect_decider.hpp"
 
 namespace unilink {
@@ -125,8 +126,7 @@ struct TcpClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"tcp_client"};
 
   Impl(const TcpClientConfig& cfg, net::io_context* ioc_ptr)
       : owned_ioc_(ioc_ptr ? nullptr : std::make_shared<net::io_context>()),
@@ -205,8 +205,7 @@ TcpClient::TcpClient(TcpClient&&) noexcept = default;
 TcpClient& TcpClient::operator=(TcpClient&&) noexcept = default;
 
 std::optional<diagnostics::ErrorInfo> TcpClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void TcpClient::start() {
@@ -730,11 +729,7 @@ void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t s
     return;
   }
 
-  std::optional<diagnostics::ErrorInfo> last_err;
-  {
-    std::lock_guard<std::mutex> lock(last_err_mtx_);
-    last_err = last_error_info_;
-  }
+  std::optional<diagnostics::ErrorInfo> last_err = error_info_holder_.last_error_info();
 
   if (!last_err) {
     last_err = diagnostics::ErrorInfo(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
@@ -1215,10 +1210,7 @@ void TcpClient::Impl::notify_state() {
 void TcpClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
                                    std::string_view msg, bool retryable, uint32_t retry_count) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  diagnostics::ErrorInfo info(lvl, cat, "tcp_client", operation, msg, ec, retryable);
-  info.retry_count = retry_count;
-  last_error_info_ = info;
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 void TcpClient::Impl::reset_io_objects() {

--- a/unilink/transport/tcp_client/tcp_client.hpp
+++ b/unilink/transport/tcp_client/tcp_client.hpp
@@ -85,7 +85,7 @@ class UNILINK_API TcpClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   // Dynamic configuration methods. Thread-safe; take effect for the next
   // reconnect/idle-timeout decision, not retroactively for one already in

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -41,6 +41,7 @@
 #include "unilink/memory/memory_pool.hpp"
 #include "unilink/transport/base/bp_state_machine.hpp"
 #include "unilink/transport/base/bp_utils.hpp"
+#include "unilink/transport/base/error_info_holder.hpp"
 #include "unilink/transport/uds/boost_uds_socket.hpp"
 #include "unilink/transport/uds/detail/reconnect_decider.hpp"
 
@@ -100,8 +101,7 @@ struct UdsClient::Impl {
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
 
-  mutable std::mutex last_err_mtx_;
-  std::optional<diagnostics::ErrorInfo> last_error_info_;
+  ErrorInfoHolder error_info_holder_{"uds_client"};
 
   Impl(const UdsClientConfig& cfg, net::io_context* ioc_ptr,
        std::unique_ptr<interface::UdsSocketInterface> socket = nullptr)
@@ -458,8 +458,7 @@ void UdsClient::set_reconnect_policy(ReconnectPolicy policy) {
 }
 
 std::optional<diagnostics::ErrorInfo> UdsClient::last_error_info() const {
-  std::lock_guard<std::mutex> lock(impl_->last_err_mtx_);
-  return impl_->last_error_info_;
+  return impl_->error_info_holder_.last_error_info();
 }
 
 void UdsClient::Impl::do_connect(std::shared_ptr<UdsClient> self, uint64_t seq) {
@@ -769,9 +768,8 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
 
 void UdsClient::Impl::record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat,
                                    std::string_view operation, const boost::system::error_code& ec,
-                                   std::string_view msg, bool retryable, uint32_t) {
-  std::lock_guard<std::mutex> lock(last_err_mtx_);
-  last_error_info_ = diagnostics::ErrorInfo(lvl, cat, "uds_client", operation, msg, ec, retryable);
+                                   std::string_view msg, bool retryable, uint32_t retry_count) {
+  error_info_holder_.record_error(lvl, cat, operation, ec, msg, retryable, retry_count);
 }
 
 }  // namespace transport

--- a/unilink/transport/uds/uds_client.hpp
+++ b/unilink/transport/uds/uds_client.hpp
@@ -88,7 +88,7 @@ class UNILINK_API UdsClient : public Channel, public std::enable_shared_from_thi
   void on_state(OnState cb) override;
   void on_backpressure(OnBackpressure cb) override;
 
-  std::optional<diagnostics::ErrorInfo> last_error_info() const;
+  std::optional<diagnostics::ErrorInfo> last_error_info() const override;
 
   void set_backpressure_strategy(base::constants::BackpressureStrategy strategy);
   void set_retry_interval(unsigned interval_ms);


### PR DESCRIPTION
## Summary
Part of #445 (step 4 of 7). Both transports' `record_error()`/`last_error_info()` now delegate to the `ErrorInfoHolder` extracted in #469, instead of each independently holding its own mutex + `std::optional<ErrorInfo>`. Behavior-neutral for `TcpClient` — same locking, same fields set.

`UdsClient` gets an actual behavior fix in the process: its `record_error()` took a `retry_count` parameter but the name was omitted (`uint32_t` with no identifier), so it was silently discarded and `last_error_info()->retry_count` always reported 0 regardless of how many reconnect attempts had actually happened — unlike `TcpClient`'s version, which always set it correctly. Routing both through the same `ErrorInfoHolder::record_error()` makes this class of independent drift structurally impossible going forward.

Both `last_error_info()` overrides are now marked `override` against `interface::Channel`'s virtual.

(Replaces #471, which GitHub auto-closed when its stacked base branch `feat/error-context-builder` was deleted after #470 merged — same content, now targeting `main` directly.)

## Test plan
- [x] `./scripts/verify.sh` passes
- [x] New regression test (`RepeatedConnectionFailuresRecordIncreasingRetryCount`) drives several real reconnect cycles against a mocked socket and asserts `retry_count` ends up > 0 — fails against the pre-fix implementation and passes now, proving the fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)