### PR TITLE
feat: TcpServer defaults to a dedicated io_context + thread (#440 step 1/8)

### DIFF
--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -28,7 +28,6 @@
 #include <thread>
 #include <unordered_map>
 
-#include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
 #include "unilink/diagnostics/logger.hpp"
@@ -50,8 +49,8 @@ struct TcpServer::Impl {
 
   std::unique_ptr<net::io_context> owned_ioc_;
   bool owns_ioc_;
-  bool uses_global_ioc_;
   net::io_context& ioc_;
+  std::unique_ptr<net::executor_work_guard<net::io_context::executor_type>> work_guard_;
   std::jthread ioc_thread_;
 
   std::unique_ptr<interface::TcpAcceptorInterface> acceptor_;
@@ -78,9 +77,9 @@ struct TcpServer::Impl {
   ErrorInfoHolder error_info_holder_{"tcp_server"};
 
   explicit Impl(const config::TcpServerConfig& cfg)
-      : owns_ioc_(false),
-        uses_global_ioc_(true),
-        ioc_(concurrency::IoContextManager::instance().get_context()),
+      : owned_ioc_(std::make_unique<net::io_context>()),
+        owns_ioc_(true),
+        ioc_(*owned_ioc_),
         cfg_(cfg),
         max_clients_(cfg.max_connections > 0 ? static_cast<size_t>(cfg.max_connections) : 0),
         client_limit_enabled_(cfg.max_connections > 0) {
@@ -97,7 +96,6 @@ struct TcpServer::Impl {
   Impl(const config::TcpServerConfig& cfg, std::unique_ptr<interface::TcpAcceptorInterface> acceptor,
        net::io_context& ioc)
       : owns_ioc_(false),
-        uses_global_ioc_(false),
         ioc_(ioc),
         acceptor_(std::move(acceptor)),
         cfg_(cfg),
@@ -441,7 +439,7 @@ struct TcpServer::Impl {
       return;
     }
 
-    bool has_active_ioc = owns_ioc_ || (uses_global_ioc_ && concurrency::IoContextManager::instance().is_running());
+    bool has_active_ioc = owns_ioc_;
 
     if (has_active_ioc && self) {
       auto cleanup_promise = std::make_shared<std::promise<void>>();
@@ -463,14 +461,17 @@ struct TcpServer::Impl {
       perform_cleanup();
     }
 
-    if (owns_ioc_ && ioc_thread_.joinable()) {
-      if (std::this_thread::get_id() == ioc_thread_.get_id()) {
-        ioc_thread_.detach();
-      } else {
-        ioc_thread_.request_stop();
-        ioc_thread_.join();
+    if (owns_ioc_) {
+      if (work_guard_) work_guard_->reset();
+      if (ioc_thread_.joinable()) {
+        if (std::this_thread::get_id() == ioc_thread_.get_id()) {
+          ioc_thread_.detach();
+        } else {
+          ioc_thread_.request_stop();
+          ioc_thread_.join();
+        }
+        ioc_.restart();
       }
-      ioc_.restart();
     }
   }
 };
@@ -510,13 +511,6 @@ void TcpServer::start() {
   }
   impl->stopping_.store(false);
 
-  if (impl->uses_global_ioc_) {
-    auto& manager = concurrency::IoContextManager::instance();
-    if (!manager.is_running()) {
-      manager.start();
-    }
-  }
-
   if (!impl->acceptor_) {
     impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "start",
                                           {}, "No acceptor available", false, 0);
@@ -525,7 +519,12 @@ void TcpServer::start() {
     return;
   }
 
-  if (impl->owns_ioc_) {
+  if (impl->owns_ioc_ && !impl->ioc_thread_.joinable()) {
+    if (impl->ioc_.stopped()) {
+      impl->ioc_.restart();
+    }
+    impl->work_guard_ =
+        std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(impl->ioc_.get_executor());
     impl->ioc_thread_ = std::jthread([impl](std::stop_token st) {
       try {
         std::stop_callback cb(st, [impl] { impl->ioc_.stop(); });


### PR DESCRIPTION
## Summary
Part of #440 (step 1 of 8). `TcpServer`'s default constructor (`TcpServer::create(cfg)`, used whenever a caller doesn't provide their own `io_context`) used to join the global `IoContextManager` singleton, unlike every other transport (`TcpClient`/`UdsClient`/`UdsServer`/`UdpChannel`), which all default to owning a dedicated `io_context` + `jthread`. This meant every `TcpServer` in a process — including all of its sessions' I/O and user callbacks — serialized onto one shared thread with no way to use multiple cores, with no opt-out short of manually supplying an external `io_context`.

Per the design plan on #440 (git-archaeology found this was accidental, introduced by a single commit that pulled `TcpClient` and `TcpServer` in opposite directions while fixing unrelated test deadlocks, not a deliberate resource-saving decision) and the recommendation to make per-instance ownership the default (a thread pool wouldn't even solve the real problem, since one server's sessions already share a single executor reference — pooling would only parallelize *across* server instances, and it would silently break the existing assumption that callbacks sharing the singleton never run concurrently).

`TcpServer::Impl`'s default constructor now owns its own `io_context` + `executor_work_guard` + `jthread`, exactly mirroring `TcpClient`'s pattern. The external-`io_context` constructor overload (`TcpServer::create(cfg, acceptor, ioc)`) is unaffected. Removed the now-dead `uses_global_ioc_` flag and the `IoContextManager` include/dependency from this file entirely — the explicit shared-mode opt-in this removes is being reintroduced properly at the builder layer in the next step (#440 step 3), not silently dropped.

**Found and fixed a real concurrency bug while testing this**: the first attempt added a stale-thread join directly inside `start()` (to support repeated start()/stop() cycles), but `TcpServerWrapperLifecycleTest.ConcurrentStartStop` (two threads calling start()/stop() concurrently on the same wrapper) hung — `std::jthread::join()` is only safe to call from one thread at a time, and a concurrent `stop()` could be joining the same jthread simultaneously. Fixed by only spawning a new thread when none is currently joinable, without ever joining from `start()` itself (`stop()` already fully joins before returning). Confirmed clean over 5 repeated runs of the previously-hanging test.

## Test plan
- [x] `./scripts/verify.sh` passes (684 tests)
- [x] `TcpServerWrapperLifecycleTest.ConcurrentStartStop` (pre-existing) hung before the concurrency fix, passes consistently after

🤖 Generated with [Claude Code](https://claude.com/claude-code)