### PR TITLE
feat: add explicit shared_context() opt-in for TcpServer/Serial (#440 step 3/8)

### DIFF
--- a/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
@@ -64,6 +64,75 @@ TEST_F(TcpServerWrapperLifecycleTest, ServerStartStopMultipleTimes) {
   }
 }
 
+// #440: TcpServer now defaults to a dedicated io_context + thread instead of
+// the shared IoContextManager singleton. Two default-constructed servers
+// must run their callbacks on distinct threads.
+TEST_F(TcpServerWrapperLifecycleTest, DefaultUsesDistinctThreadsPerInstance) {
+  uint16_t port2 = TestUtils::getAvailableTestPort();
+
+  std::atomic<std::thread::id> thread1{};
+  std::atomic<std::thread::id> thread2{};
+  auto server1 = unilink::tcp_server(test_port_).on_error([](auto&&) {}).build();
+  auto server2 = unilink::tcp_server(port2).on_error([](auto&&) {}).build();
+
+  server1->on_connect([&](const wrapper::ConnectionContext&) { thread1 = std::this_thread::get_id(); });
+  server2->on_connect([&](const wrapper::ConnectionContext&) { thread2 = std::this_thread::get_id(); });
+
+  auto f1 = server1->start();
+  auto f2 = server2->start();
+  EXPECT_TRUE(f1.get());
+  EXPECT_TRUE(f2.get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server1->listening() && server2->listening(); }, 1000));
+
+  auto client1 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto client2 = unilink::tcp_client("127.0.0.1", port2).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  client1->start();
+  client2->start();
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] { return thread1.load() != std::thread::id{} && thread2.load() != std::thread::id{}; }, 2000));
+  EXPECT_NE(thread1.load(), thread2.load());
+
+  client1->stop();
+  client2->stop();
+  server1->stop();
+  server2->stop();
+}
+
+// #440: .shared_context(true) opts back into the shared IoContextManager
+// singleton - two such servers should end up driven by the same thread.
+TEST_F(TcpServerWrapperLifecycleTest, SharedContextOptInUsesOneThread) {
+  uint16_t port2 = TestUtils::getAvailableTestPort();
+
+  std::atomic<std::thread::id> thread1{};
+  std::atomic<std::thread::id> thread2{};
+  auto server1 = unilink::tcp_server(test_port_).shared_context(true).on_error([](auto&&) {}).build();
+  auto server2 = unilink::tcp_server(port2).shared_context(true).on_error([](auto&&) {}).build();
+
+  server1->on_connect([&](const wrapper::ConnectionContext&) { thread1 = std::this_thread::get_id(); });
+  server2->on_connect([&](const wrapper::ConnectionContext&) { thread2 = std::this_thread::get_id(); });
+
+  auto f1 = server1->start();
+  auto f2 = server2->start();
+  EXPECT_TRUE(f1.get());
+  EXPECT_TRUE(f2.get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server1->listening() && server2->listening(); }, 1000));
+
+  auto client1 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto client2 = unilink::tcp_client("127.0.0.1", port2).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  client1->start();
+  client2->start();
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] { return thread1.load() != std::thread::id{} && thread2.load() != std::thread::id{}; }, 2000));
+  EXPECT_EQ(thread1.load(), thread2.load());
+
+  client1->stop();
+  client2->stop();
+  server1->stop();
+  server2->stop();
+}
+
 TEST_F(TcpServerWrapperLifecycleTest, ExternalContextNotStoppedWhenNotManaged) {
   auto ioc = std::make_shared<boost::asio::io_context>();
   // Critical: Keep ioc running even when server stops

--- a/unilink/builder/serial_builder.cc
+++ b/unilink/builder/serial_builder.cc
@@ -33,6 +33,7 @@ SerialBuilder<State>::SerialBuilder(const std::string& device, uint32_t baud_rat
       baud_rate_(baud_rate),
       auto_start_(false),
       independent_context_(false),
+      shared_context_(false),
       retry_interval_ms_(base::constants::DEFAULT_RETRY_INTERVAL_MS),
       char_size_(8),
       stop_bits_(1),
@@ -54,6 +55,7 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   } else {
     serial = std::make_unique<wrapper::Serial>(device_, baud_rate_);
   }
+  if (shared_context_) serial->shared_context(true);
 
   if (this->on_data_) serial->on_data(this->on_data_);
   if (this->on_data_batch_) serial->on_data_batch(this->on_data_batch_);
@@ -192,6 +194,12 @@ SerialBuilder<State>& SerialBuilder<State>::retry_interval(std::chrono::millisec
 template <uint32_t State>
 SerialBuilder<State>& SerialBuilder<State>::independent_context(bool use_independent) {
   independent_context_ = use_independent;
+  return *this;
+}
+
+template <uint32_t State>
+SerialBuilder<State>& SerialBuilder<State>::shared_context(bool use_shared) {
+  shared_context_ = use_shared;
   return *this;
 }
 

--- a/unilink/builder/serial_builder.hpp
+++ b/unilink/builder/serial_builder.hpp
@@ -50,6 +50,7 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
         baud_rate_(other.baud_rate_),
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
+        shared_context_(other.shared_context_),
         retry_interval_ms_(other.retry_interval_ms_),
         retry_interval_set_(other.retry_interval_set_),
         char_size_(other.char_size_),
@@ -94,6 +95,11 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
   SerialBuilder<State>& reopen_on_error(bool enable = true);
   SerialBuilder<State>& retry_interval(std::chrono::milliseconds interval);
   SerialBuilder<State>& independent_context(bool use_independent = true);
+  // Opt into the shared IoContextManager singleton instead of the default
+  // dedicated io_context + thread (#440). Only meaningful for deliberately
+  // trading per-instance parallelism for reduced thread/memory overhead
+  // across many instances in one process; most callers should not need this.
+  SerialBuilder<State>& shared_context(bool use_shared = true);
 
  private:
   template <uint32_t S>
@@ -103,6 +109,7 @@ class UNILINK_API SerialBuilder : public BuilderInterface<wrapper::Serial, Seria
   uint32_t baud_rate_;
   bool auto_start_;
   bool independent_context_;
+  bool shared_context_{false};
 
   uint32_t retry_interval_ms_;
   bool retry_interval_set_{false};

--- a/unilink/builder/tcp_server_builder.cc
+++ b/unilink/builder/tcp_server_builder.cc
@@ -30,6 +30,7 @@ TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
       bind_address_("0.0.0.0"),
       auto_start_(false),
       independent_context_(false),
+      shared_context_(false),
       max_clients_(0),
       client_limit_enabled_(false),
       port_retry_enabled_(false),
@@ -56,6 +57,7 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
   } else {
     server = std::make_unique<wrapper::TcpServer>(port_);
   }
+  if (shared_context_) server->shared_context(true);
 
   if (this->on_data_) server->on_data(this->on_data_);
   if (this->on_data_batch_) server->on_data_batch(this->on_data_batch_);
@@ -115,6 +117,12 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::bind_address(const std::string
 template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::independent_context(bool use_independent) {
   independent_context_ = use_independent;
+  return *this;
+}
+
+template <uint32_t State>
+TcpServerBuilder<State>& TcpServerBuilder<State>::shared_context(bool use_shared) {
+  shared_context_ = use_shared;
   return *this;
 }
 

--- a/unilink/builder/tcp_server_builder.hpp
+++ b/unilink/builder/tcp_server_builder.hpp
@@ -52,6 +52,7 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
         bind_address_set_(other.bind_address_set_),
         auto_start_(other.auto_start_),
         independent_context_(other.independent_context_),
+        shared_context_(other.shared_context_),
         max_clients_(other.max_clients_),
         client_limit_enabled_(other.client_limit_enabled_),
         port_retry_enabled_(other.port_retry_enabled_),
@@ -94,6 +95,11 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
   TcpServerBuilder<State>& auto_start(bool auto_start = true) override;
   TcpServerBuilder<State>& bind_address(const std::string& address);
   TcpServerBuilder<State>& independent_context(bool use_independent = true);
+  // Opt into the shared IoContextManager singleton instead of the default
+  // dedicated io_context + thread (#440). Only meaningful for deliberately
+  // trading per-instance parallelism for reduced thread/memory overhead
+  // across many servers in one process; most callers should not need this.
+  TcpServerBuilder<State>& shared_context(bool use_shared = true);
   TcpServerBuilder<State>& max_clients(uint32_t max_clients);
   TcpServerBuilder<State>& enable_port_retry(bool enable = true);
   TcpServerBuilder<State>& max_port_retries(uint32_t max_retries);
@@ -126,6 +132,7 @@ class UNILINK_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer,
   bool bind_address_set_{false};
   bool auto_start_;
   bool independent_context_;
+  bool shared_context_{false};
 
   uint32_t max_clients_;
   bool client_limit_enabled_;

--- a/unilink/config/serial_config.hpp
+++ b/unilink/config/serial_config.hpp
@@ -46,6 +46,12 @@ struct SerialConfig {
   unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
   int max_retries = base::constants::DEFAULT_MAX_RETRIES;
 
+  // Opt into the shared IoContextManager singleton instead of a dedicated
+  // io_context + thread (the default since #440). Only meaningful for
+  // deliberately trading per-instance parallelism for reduced thread/memory
+  // overhead across many instances in one process.
+  bool use_shared_context = false;
+
   // Validation methods
   bool is_valid() const {
     return !device.empty() && baud_rate > 0 && char_size >= 5 && char_size <= 8 && (stop_bits == 1 || stop_bits == 2) &&

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -44,6 +44,12 @@ struct TcpServerConfig {
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;
 
+  // Opt into the shared IoContextManager singleton instead of a dedicated
+  // io_context + thread (the default since #440). Only meaningful for
+  // deliberately trading per-instance parallelism for reduced thread/memory
+  // overhead across many instances in one process.
+  bool use_shared_context = false;
+
   // Validation methods
   bool is_valid() const {
     return (util::InputValidator::is_valid_ipv4(bind_address) || util::InputValidator::is_valid_ipv6(bind_address)) &&

--- a/unilink/factory/channel_factory.cc
+++ b/unilink/factory/channel_factory.cc
@@ -61,7 +61,7 @@ std::shared_ptr<interface::Channel> ChannelFactory::create_tcp_server(
     auto acceptor = std::make_unique<transport::BoostTcpAcceptor>(*external_ioc);
     return transport::TcpServer::create(cfg, std::move(acceptor), *external_ioc);
   }
-  return transport::TcpServer::create(cfg);
+  return transport::TcpServer::create(cfg, cfg.use_shared_context);
 }
 
 std::shared_ptr<interface::Channel> ChannelFactory::create_tcp_client(
@@ -77,7 +77,7 @@ std::shared_ptr<interface::Channel> ChannelFactory::create_serial(
   if (external_ioc) {
     return transport::Serial::create(cfg, std::make_unique<transport::BoostSerialPort>(*external_ioc), *external_ioc);
   }
-  return transport::Serial::create(cfg);
+  return transport::Serial::create(cfg, cfg.use_shared_context);
 }
 
 std::shared_ptr<interface::Channel> ChannelFactory::create_udp(const config::UdpConfig& cfg,

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -32,6 +32,7 @@
 
 #include "unilink/base/common.hpp"
 #include "unilink/base/constants.hpp"
+#include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/error_handler.hpp"
 #include "unilink/diagnostics/logger.hpp"
@@ -59,6 +60,7 @@ struct Serial::Impl {
   std::unique_ptr<net::io_context> owned_ioc_;
   net::io_context& ioc_;
   bool owns_ioc_{false};
+  bool uses_shared_context_{false};
   net::strand<net::io_context::executor_type> strand_;
   std::unique_ptr<net::executor_work_guard<net::io_context::executor_type>> work_guard_;
   std::jthread ioc_thread_;
@@ -172,10 +174,11 @@ struct Serial::Impl {
     if (!writing_) do_write(self);
   }
 
-  explicit Impl(const config::SerialConfig& cfg)
-      : owned_ioc_(std::make_unique<net::io_context>()),
-        ioc_(*owned_ioc_),
-        owns_ioc_(true),
+  explicit Impl(const config::SerialConfig& cfg, bool use_shared_context)
+      : owned_ioc_(use_shared_context ? nullptr : std::make_unique<net::io_context>()),
+        ioc_(use_shared_context ? concurrency::IoContextManager::instance().get_context() : *owned_ioc_),
+        owns_ioc_(!use_shared_context),
+        uses_shared_context_(use_shared_context),
         strand_(ioc_.get_executor()),
         cfg_(cfg),
         retry_timer_(ioc_),
@@ -517,8 +520,8 @@ struct Serial::Impl {
   }
 };
 
-std::shared_ptr<Serial> Serial::create(const config::SerialConfig& cfg) {
-  return std::shared_ptr<Serial>(new Serial(cfg));
+std::shared_ptr<Serial> Serial::create(const config::SerialConfig& cfg, bool use_shared_context) {
+  return std::shared_ptr<Serial>(new Serial(cfg, use_shared_context));
 }
 
 std::shared_ptr<Serial> Serial::create(const config::SerialConfig& cfg, net::io_context& ioc) {
@@ -530,7 +533,8 @@ std::shared_ptr<Serial> Serial::create(const config::SerialConfig& cfg,
   return std::shared_ptr<Serial>(new Serial(cfg, std::move(port), ioc));
 }
 
-Serial::Serial(const config::SerialConfig& cfg) : impl_(std::make_unique<Impl>(cfg)) {}
+Serial::Serial(const config::SerialConfig& cfg, bool use_shared_context)
+    : impl_(std::make_unique<Impl>(cfg, use_shared_context)) {}
 
 Serial::Serial(const config::SerialConfig& cfg, std::unique_ptr<interface::SerialPortInterface> port,
                net::io_context& ioc)
@@ -555,6 +559,11 @@ void Serial::start() {
   if (impl->started_) return;
   impl->stopping_.store(false);
   UNILINK_LOG_INFO("serial", "start", fmt::format("Starting device: {}", impl->cfg_.device));
+  if (impl->uses_shared_context_) {
+    auto& manager = concurrency::IoContextManager::instance();
+    if (!manager.is_running()) manager.start();
+    if (impl->ioc_.stopped()) impl->ioc_.restart();
+  }
   impl->work_guard_ =
       std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(impl->ioc_.get_executor());
   if (impl->owns_ioc_) {

--- a/unilink/transport/serial/serial.hpp
+++ b/unilink/transport/serial/serial.hpp
@@ -45,7 +45,12 @@ namespace transport {
  */
 class UNILINK_API Serial : public interface::Channel, public std::enable_shared_from_this<Serial> {
  public:
-  static std::shared_ptr<Serial> create(const config::SerialConfig& cfg);
+  // use_shared_context: opt into the shared IoContextManager singleton
+  // instead of the default dedicated io_context + thread. Only meaningful
+  // for multi-instance-per-process deployments deliberately trading
+  // parallelism for reduced thread/memory overhead (#440); most callers
+  // should leave this false.
+  static std::shared_ptr<Serial> create(const config::SerialConfig& cfg, bool use_shared_context = false);
   static std::shared_ptr<Serial> create(const config::SerialConfig& cfg, boost::asio::io_context& ioc);
   static std::shared_ptr<Serial> create(const config::SerialConfig& cfg,
                                         std::unique_ptr<interface::SerialPortInterface> port,
@@ -85,7 +90,7 @@ class UNILINK_API Serial : public interface::Channel, public std::enable_shared_
   void set_retry_interval(unsigned interval_ms);
 
  private:
-  explicit Serial(const config::SerialConfig& cfg);
+  explicit Serial(const config::SerialConfig& cfg, bool use_shared_context);
   Serial(const config::SerialConfig& cfg, std::unique_ptr<interface::SerialPortInterface> port,
          boost::asio::io_context& ioc);
 

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -28,6 +28,7 @@
 #include <thread>
 #include <unordered_map>
 
+#include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
 #include "unilink/diagnostics/exceptions.hpp"
 #include "unilink/diagnostics/logger.hpp"
@@ -49,6 +50,7 @@ struct TcpServer::Impl {
 
   std::unique_ptr<net::io_context> owned_ioc_;
   bool owns_ioc_;
+  bool uses_shared_context_{false};
   net::io_context& ioc_;
   std::unique_ptr<net::executor_work_guard<net::io_context::executor_type>> work_guard_;
   std::jthread ioc_thread_;
@@ -76,10 +78,11 @@ struct TcpServer::Impl {
 
   ErrorInfoHolder error_info_holder_{"tcp_server"};
 
-  explicit Impl(const config::TcpServerConfig& cfg)
-      : owned_ioc_(std::make_unique<net::io_context>()),
-        owns_ioc_(true),
-        ioc_(*owned_ioc_),
+  explicit Impl(const config::TcpServerConfig& cfg, bool use_shared_context)
+      : owned_ioc_(use_shared_context ? nullptr : std::make_unique<net::io_context>()),
+        owns_ioc_(!use_shared_context),
+        uses_shared_context_(use_shared_context),
+        ioc_(use_shared_context ? concurrency::IoContextManager::instance().get_context() : *owned_ioc_),
         cfg_(cfg),
         max_clients_(cfg.max_connections > 0 ? static_cast<size_t>(cfg.max_connections) : 0),
         client_limit_enabled_(cfg.max_connections > 0) {
@@ -439,7 +442,7 @@ struct TcpServer::Impl {
       return;
     }
 
-    bool has_active_ioc = owns_ioc_;
+    bool has_active_ioc = owns_ioc_ || (uses_shared_context_ && concurrency::IoContextManager::instance().is_running());
 
     if (has_active_ioc && self) {
       auto cleanup_promise = std::make_shared<std::promise<void>>();
@@ -476,8 +479,8 @@ struct TcpServer::Impl {
   }
 };
 
-std::shared_ptr<TcpServer> TcpServer::create(const config::TcpServerConfig& cfg) {
-  return std::shared_ptr<TcpServer>(new TcpServer(cfg));
+std::shared_ptr<TcpServer> TcpServer::create(const config::TcpServerConfig& cfg, bool use_shared_context) {
+  return std::shared_ptr<TcpServer>(new TcpServer(cfg, use_shared_context));
 }
 
 std::shared_ptr<TcpServer> TcpServer::create(const config::TcpServerConfig& cfg,
@@ -486,7 +489,8 @@ std::shared_ptr<TcpServer> TcpServer::create(const config::TcpServerConfig& cfg,
   return std::shared_ptr<TcpServer>(new TcpServer(cfg, std::move(acceptor), ioc));
 }
 
-TcpServer::TcpServer(const config::TcpServerConfig& cfg) : impl_(std::make_unique<Impl>(cfg)) {}
+TcpServer::TcpServer(const config::TcpServerConfig& cfg, bool use_shared_context)
+    : impl_(std::make_unique<Impl>(cfg, use_shared_context)) {}
 
 TcpServer::TcpServer(const config::TcpServerConfig& cfg, std::unique_ptr<interface::TcpAcceptorInterface> acceptor,
                      net::io_context& ioc)
@@ -510,6 +514,13 @@ void TcpServer::start() {
     return;
   }
   impl->stopping_.store(false);
+
+  if (impl->uses_shared_context_) {
+    auto& manager = concurrency::IoContextManager::instance();
+    if (!manager.is_running()) {
+      manager.start();
+    }
+  }
 
   if (!impl->acceptor_) {
     impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "start",

--- a/unilink/transport/tcp_server/tcp_server.hpp
+++ b/unilink/transport/tcp_server/tcp_server.hpp
@@ -46,7 +46,12 @@ namespace transport {
  */
 class UNILINK_API TcpServer : public interface::Channel, public std::enable_shared_from_this<TcpServer> {
  public:
-  static std::shared_ptr<TcpServer> create(const config::TcpServerConfig& cfg);
+  // use_shared_context: opt into the shared IoContextManager singleton
+  // instead of the default dedicated io_context + thread. Only meaningful
+  // for multi-server-per-process deployments deliberately trading
+  // parallelism for reduced thread/memory overhead (#440); most callers
+  // should leave this false.
+  static std::shared_ptr<TcpServer> create(const config::TcpServerConfig& cfg, bool use_shared_context = false);
   static std::shared_ptr<TcpServer> create(const config::TcpServerConfig& cfg,
                                            std::unique_ptr<interface::TcpAcceptorInterface> acceptor,
                                            boost::asio::io_context& ioc);
@@ -105,7 +110,7 @@ class UNILINK_API TcpServer : public interface::Channel, public std::enable_shar
   base::LinkState state() const;
 
  private:
-  explicit TcpServer(const config::TcpServerConfig& cfg);
+  explicit TcpServer(const config::TcpServerConfig& cfg, bool use_shared_context);
   TcpServer(const config::TcpServerConfig& cfg, std::unique_ptr<interface::TcpAcceptorInterface> acceptor,
             boost::asio::io_context& ioc);
 

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -83,6 +83,7 @@ struct Serial::Impl {
 
   // Configuration
   std::atomic<bool> auto_start_ = false;
+  std::atomic<bool> shared_context_{false};
   int data_bits = 8;
   int stop_bits = 1;
   std::string parity = "none";
@@ -528,6 +529,7 @@ struct Serial::Impl {
     config.reopen_on_error = reopen_on_error;
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
+    config.use_shared_context = shared_context_.load();
     return config;
   }
 };
@@ -614,6 +616,11 @@ Serial& Serial::on_message_batch(BatchMessageHandler h) {
 Serial& Serial::auto_start(bool m) {
   impl_->auto_start_.store(m);
   if (impl_->auto_start_.load() && !impl_->started_.load()) start();
+  return *this;
+}
+
+Serial& Serial::shared_context(bool use_shared) {
+  impl_->shared_context_.store(use_shared);
   return *this;
 }
 

--- a/unilink/wrapper/serial/serial.hpp
+++ b/unilink/wrapper/serial/serial.hpp
@@ -93,6 +93,12 @@ class UNILINK_API Serial : public ChannelInterface {
   Serial& on_message_batch(BatchMessageHandler handler) override;
 
   Serial& auto_start(bool manage = true) override;
+  // Opt into the shared IoContextManager singleton instead of the default
+  // dedicated io_context + thread (#440). Must be set before the first
+  // start() call to take effect. Only meaningful for deliberately trading
+  // per-instance parallelism for reduced thread/memory overhead across many
+  // instances in one process; most callers should not need this.
+  Serial& shared_context(bool use_shared = true);
 
   // Serial-specific methods
   Serial& baud_rate(uint32_t baud_rate);

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -57,6 +57,7 @@ struct TcpServer::Impl {
 
   // Configuration
   std::atomic<bool> auto_start_{false};
+  std::atomic<bool> shared_context_{false};
   std::atomic<bool> port_retry_enabled_{false};
   std::atomic<int> max_port_retries_{3};
   std::atomic<int> port_retry_interval_ms_{1000};
@@ -223,6 +224,7 @@ struct TcpServer::Impl {
       config.keep_alive = keep_alive_.load();
       config.send_buffer_size = send_buffer_size_.load();
       config.receive_buffer_size = receive_buffer_size_.load();
+      config.use_shared_context = shared_context_.load();
 
       channel_ = factory::ChannelFactory::create(config, external_ioc_);
       transport_cache_ = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
@@ -592,6 +594,11 @@ TcpServer& TcpServer::auto_start(bool m) {
 TcpServer& TcpServer::bind_address(const std::string& address) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->bind_address_ = address;
+  return *this;
+}
+
+TcpServer& TcpServer::shared_context(bool use_shared) {
+  impl_->shared_context_.store(use_shared);
   return *this;
 }
 

--- a/unilink/wrapper/tcp_server/tcp_server.hpp
+++ b/unilink/wrapper/tcp_server/tcp_server.hpp
@@ -96,6 +96,12 @@ class UNILINK_API TcpServer : public ServerInterface {
   // Configuration (Fluent API)
   TcpServer& auto_start(bool manage = true) override;
   TcpServer& bind_address(const std::string& address);
+  // Opt into the shared IoContextManager singleton instead of the default
+  // dedicated io_context + thread (#440). Must be set before the first
+  // start() call to take effect. Only meaningful for deliberately trading
+  // per-instance parallelism for reduced thread/memory overhead across many
+  // servers in one process; most callers should not need this.
+  TcpServer& shared_context(bool use_shared = true);
   TcpServer& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
   /**
    * @brief Configure application-level idle timeout for accepted sessions.


### PR DESCRIPTION
## Summary
Part of #440 (step 3 of 8, stacked on #477 → #476 since this step needs both). Steps 1-2 (#476, #477) flipped `TcpServer`/`Serial`'s default from the shared `IoContextManager` singleton to a dedicated `io_context` + thread, removing the singleton dependency entirely. This restores that shared mode as an explicit, deliberate opt-in for the genuine multi-instance-per-process use case the design plan called out (trading per-instance parallelism for reduced thread/memory overhead), rather than silently dropping the capability.

Threaded a new `use_shared_context` bool through the full stack for both transports:
- `config::TcpServerConfig` / `config::SerialConfig`: new field, defaults to false (matching the new per-instance-ownership default).
- `transport::TcpServer::create()`/`Serial::create()`: new optional bool parameter (defaults to false, so existing call sites are unaffected); `Impl` gains a `uses_shared_context_` flag distinct from `owns_ioc_` (needed because both the shared-context path and the pre-existing external-`io_context` constructor path have `owns_ioc_ == false`, but only the former should manage the `IoContextManager` singleton's lifecycle in `start()`/`stop()`).
- `factory::ChannelFactory::create_tcp_server()`/`create_serial()`: forward `cfg.use_shared_context` when no external `io_context` was given.
- `wrapper::TcpServer::shared_context()`/`wrapper::Serial::shared_context()`: new fluent setter, must be called before the first `start()`.
- `builder::TcpServerBuilder::shared_context()`/`SerialBuilder::shared_context()`: new fluent builder method, wired into `build()`.

## Test plan
- [x] `./scripts/verify.sh` passes (698 tests, +2 new)
- [x] New tests (`TcpServerWrapperLifecycleTest`, wrapper-level since that's where the fluent API lives): `DefaultUsesDistinctThreadsPerInstance` (two default-built servers observe distinct thread IDs from real client connections — the actual regression the whole #440 issue is about) and `SharedContextOptInUsesOneThread` (two `.shared_context(true)` servers observe the *same* thread ID, proving the opt-in correctly restores the old consolidated-thread behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)