### PR TITLE
docs: update IoContextManager's stale doc comment (#440 step 4/8)

### DIFF
--- a/unilink/concurrency/io_context_manager.hpp
+++ b/unilink/concurrency/io_context_manager.hpp
@@ -26,8 +26,14 @@ namespace unilink {
 namespace concurrency {
 
 /**
- * Global io_context manager
- * All Transports share one io_context for improved memory efficiency
+ * Global io_context manager.
+ *
+ * Every transport (TcpClient/TcpServer/UdsClient/UdsServer/UdpChannel/Serial)
+ * owns a dedicated io_context + thread by default (#440). This singleton
+ * backs the opt-in shared_context() builder/wrapper setter on TcpServer and
+ * Serial only, for callers who deliberately want many instances in one
+ * process to share a single thread (trading per-instance parallelism for
+ * reduced thread/memory overhead) instead of each running independently.
  */
 class UNILINK_API IoContextManager {
  public:


### PR DESCRIPTION
## Summary
Part of #440 (step 4 of 8, stacked on #478 → #477 → #476). The class doc comment said "All Transports share one io_context for improved memory efficiency" — no longer true after steps 1-3 flipped TcpServer/Serial to per-instance dedicated ownership by default and reintroduced the shared singleton as an explicit opt-in (`shared_context()`) rather than the default for any transport.

## Test plan
- [x] Doc-only change; build + a quick unit sanity pass confirm nothing broke

🤖 Generated with [Claude Code](https://claude.com/claude-code)