### PR TITLE
refactor: unify wrapper external-context thread type to jthread (#440/#454 step 6/8)

### DIFF
--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -47,7 +48,7 @@ struct TcpServer::Impl {
   std::shared_ptr<boost::asio::io_context> external_ioc_;
   std::atomic<bool> use_external_context_{false};
   std::atomic<bool> manage_external_context_{false};
-  std::thread external_thread_;
+  std::jthread external_thread_;
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
   std::vector<std::promise<bool>> pending_promises_;
@@ -243,8 +244,9 @@ struct TcpServer::Impl {
       }
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc_));
-      external_thread_ = std::thread([ioc = external_ioc_]() {
+      external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
         try {
+          std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();
         } catch (...) {
         }
@@ -287,6 +289,7 @@ struct TcpServer::Impl {
     if (should_join && external_thread_.joinable()) {
       try {
         if (std::this_thread::get_id() != external_thread_.get_id()) {
+          external_thread_.request_stop();
           external_thread_.join();
         } else {
           external_thread_.detach();

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -25,6 +25,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <vector>
 
@@ -48,7 +49,7 @@ struct UdsClient::Impl {
   std::shared_ptr<boost::asio::io_context> external_ioc_;
   std::atomic<bool> use_external_context_{false};
   std::atomic<bool> manage_external_context_{false};
-  std::thread external_thread_;
+  std::jthread external_thread_;
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
   std::vector<std::promise<bool>> pending_promises_;
@@ -188,9 +189,10 @@ struct UdsClient::Impl {
           }
           work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
               boost::asio::make_work_guard(*external_ioc_));
-          external_thread_ = std::thread([this]() {
+          external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
             try {
-              external_ioc_->run();
+              std::stop_callback cb(st, [ioc] { ioc->stop(); });
+              ioc->run();
             } catch (...) {
             }
           });
@@ -244,6 +246,7 @@ struct UdsClient::Impl {
     if (external_thread_.joinable()) {
       if (std::this_thread::get_id() != external_thread_.get_id()) {
         lock.unlock();  // RELEASE LOCK BEFORE JOINING
+        external_thread_.request_stop();
         external_thread_.join();
         lock.lock();  // RE-ACQUIRE
       } else {

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -6,6 +6,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <shared_mutex>
+#include <stop_token>
 #include <thread>
 
 #include "unilink/diagnostics/error_mapping.hpp"
@@ -29,7 +30,7 @@ struct UdsServer::Impl {
   std::condition_variable bp_cv_;
   std::shared_ptr<interface::Channel> server_;
   std::vector<std::promise<bool>> pending_promises_;
-  std::thread external_thread_;
+  std::jthread external_thread_;
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard_;
 
   std::atomic<bool> started_{false};
@@ -205,8 +206,9 @@ struct UdsServer::Impl {
       }
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc_));
-      external_thread_ = std::thread([ioc = external_ioc_]() {
+      external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
         try {
+          std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();
         } catch (...) {
         }
@@ -255,6 +257,7 @@ struct UdsServer::Impl {
     if (should_join && external_thread_.joinable()) {
       try {
         if (std::this_thread::get_id() != external_thread_.get_id()) {
+          external_thread_.request_stop();
           external_thread_.join();
         } else {
           external_thread_.detach();


### PR DESCRIPTION
## Summary
Part of #440/#454 (step 6 of 8, independent of steps 1-5 - different files, targets `main` directly). `TcpServer`/`UdsClient`/`UdsServer` wrappers used plain `std::thread` with manual `join()`/`detach()` for their externally-managed `io_context` run loop, while `TcpClient`/`Serial`/`UdpChannel`/`UdpServer` wrappers already used `std::jthread` + `stop_token` (also matching every transport's own owned-`io_context` jthread pattern, see #440 steps 1-2 and #454 step 5). Standardizes all three onto the same pattern: the run-loop lambda takes a `stop_token` and registers a `std::stop_callback` that calls `ioc->stop()` (mirroring every other jthread in the codebase), and `stop()` calls `request_stop()` before `join()` for symmetry with the cooperative-cancellation model (the actual unblock signal for `run()` still comes from the pre-existing direct `external_ioc_->stop()` call under the lock, same as before — calling `io_context::stop()` twice is idempotent).

**Incidental fix in `UdsClient`'s wrapper**: its run-loop lambda used to capture `this` and access `external_ioc_` through it, unlike every other wrapper's `[ioc = external_ioc_]` capture-by-value — switched to the safer by-value capture to match, removing a (currently benign, since the thread is always joined/detached before `Impl` would be destroyed, but needlessly fragile) implicit lifetime dependency on the `Impl` outliving the thread.

No behavior change in the responsiveness sense (unlike step 5's TCP client fix) — these three wrappers already blocked on `run()` rather than polling, so existing tests exercising `manage_external_context(true)` for each (`test_tcp_server_wrapper_lifecycle.cc`, `test_uds_wrapper_lifecycle.cc`) already provide regression coverage and continue to pass unchanged.

## Test plan
- [x] `./scripts/verify.sh` passes (696 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)