### PR TITLE
test: fix test_architecture.cc's stale IoContextManager assumptions (#440 step 7/8)

### DIFF
--- a/test/e2e/scenarios/test_architecture.cc
+++ b/test/e2e/scenarios/test_architecture.cc
@@ -121,6 +121,16 @@ TEST_F(ImprovedArchitectureTest, ProposedIndependentResourceManagement) {
 
 /**
  * @brief Upper API Auto-initialization Test
+ *
+ * Every builder constructor (TcpServerBuilder, TcpClientBuilder, etc.) calls
+ * AutoInitializer::ensure_io_context_running() unconditionally, so the global
+ * IoContextManager singleton comes up as a side effect of constructing *any*
+ * builder - this has nothing to do with whether the resulting transport
+ * actually uses that shared context. Since #440, TcpServer/Serial default to
+ * a dedicated io_context + thread and never touch the singleton at all; see
+ * TcpServerIndependentOfIoContextManager below for the assertion that
+ * actually matters post-#440 (the server keeps working even if the
+ * singleton is stopped).
  */
 TEST_F(ImprovedArchitectureTest, UpperAPIAutoInitialization) {
   std::cout << "Testing upper API auto-initialization..." << std::endl;
@@ -133,7 +143,8 @@ TEST_F(ImprovedArchitectureTest, UpperAPIAutoInitialization) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 
-  // IoContextManager starts automatically when using builder
+  // The *builder constructor* starts IoContextManager (AutoInitializer),
+  // regardless of whether build()'s resulting server ends up using it.
   server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
 
   ASSERT_NE(server_, nullptr);
@@ -142,6 +153,35 @@ TEST_F(ImprovedArchitectureTest, UpperAPIAutoInitialization) {
   EXPECT_TRUE(unilink::concurrency::IoContextManager::instance().is_running());
 
   std::cout << "Upper API auto-initialization test completed" << std::endl;
+}
+
+/**
+ * @brief #440: TcpServer defaults to a dedicated io_context + thread and
+ * must keep running normally even if the (now-unrelated) global
+ * IoContextManager singleton is stopped.
+ */
+TEST_F(ImprovedArchitectureTest, TcpServerIndependentOfIoContextManager) {
+  uint16_t test_port = TestUtils::getAvailableTestPort();
+
+  server_ = unilink::tcp_server(test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_NE(server_, nullptr);
+
+  auto f = server_->start();
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return server_->listening(); }, 1000));
+
+  // Stopping the global singleton (started as an AutoInitializer side effect
+  // of building the *builder*, not because this server needs it) must not
+  // affect this server's own dedicated io_context/thread at all.
+  if (unilink::concurrency::IoContextManager::instance().is_running()) {
+    unilink::concurrency::IoContextManager::instance().stop();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  EXPECT_TRUE(server_->listening());
+
+  client_ = unilink::tcp_client("127.0.0.1", test_port).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  client_->start();
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return client_->connected(); }, 2000));
 }
 
 /**


### PR DESCRIPTION
## Summary
Part of #440 (step 7 of 8, stacked on #478 → #477 → #476 since this test's assertions require steps 1-3's behavior to be meaningful). `UpperAPIAutoInitialization`'s comment implied that `TcpServer` needed the global `IoContextManager` singleton to function — misleading after steps 1-3, where `TcpServer` defaults to a dedicated `io_context` + thread and the singleton only starts as an unconditional side effect of `AutoInitializer::ensure_io_context_running()` (called by every builder constructor, regardless of the resulting transport's context ownership model). Clarified the comment to describe what's actually being asserted.

Added `TcpServerIndependentOfIoContextManager`: builds and starts a default `TcpServer`, stops the global `IoContextManager` singleton, and asserts the server keeps listening and can still accept a real client connection — the actual assertion that matters post-#440, and one that would fail against the pre-#440 shared-singleton default (stopping the manager would have stopped the server's own `io_context` along with it).

## Test plan
- [x] `./scripts/verify.sh` passes (699 tests, +1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)