### PR TITLE
test: add Serial thread-per-instance regression tests for #440 (final step)

### DIFF
--- a/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
+++ b/test/unit/wrapper/test_serial_wrapper_lifecycle.cc
@@ -216,6 +216,54 @@ TEST_F(SerialWrapperLifecycleTest, AutoManageStartsAndStopsChannel) {
   EXPECT_TRUE(disconnected.load() || !serial->connected());
 }
 
+// #440: Serial now defaults to a dedicated io_context + thread instead of
+// the shared IoContextManager singleton. Two default-built instances must
+// run their callbacks on distinct threads. Uses device_ (/dev/null or NUL),
+// which opens successfully but fails baud-rate configuration since it isn't
+// a real TTY - that failure fires on_error on the transport's own thread,
+// giving a portable way to observe thread identity without a real device.
+TEST_F(SerialWrapperLifecycleTest, DefaultUsesDistinctThreadsPerInstance) {
+  std::atomic<std::thread::id> thread1{};
+  std::atomic<std::thread::id> thread2{};
+
+  auto serial1 = unilink::serial(device_, 9600).reopen_on_error(false).build();
+  auto serial2 = unilink::serial(device_, 9600).reopen_on_error(false).build();
+  serial1->on_error([&](const wrapper::ErrorContext&) { thread1 = std::this_thread::get_id(); });
+  serial2->on_error([&](const wrapper::ErrorContext&) { thread2 = std::this_thread::get_id(); });
+
+  serial1->start();
+  serial2->start();
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] { return thread1.load() != std::thread::id{} && thread2.load() != std::thread::id{}; }, 2000));
+  EXPECT_NE(thread1.load(), thread2.load());
+
+  serial1->stop();
+  serial2->stop();
+}
+
+// #440: .shared_context(true) opts back into the shared IoContextManager
+// singleton - two such instances should end up driven by the same thread.
+TEST_F(SerialWrapperLifecycleTest, SharedContextOptInUsesOneThread) {
+  std::atomic<std::thread::id> thread1{};
+  std::atomic<std::thread::id> thread2{};
+
+  auto serial1 = unilink::serial(device_, 9600).shared_context(true).reopen_on_error(false).build();
+  auto serial2 = unilink::serial(device_, 9600).shared_context(true).reopen_on_error(false).build();
+  serial1->on_error([&](const wrapper::ErrorContext&) { thread1 = std::this_thread::get_id(); });
+  serial2->on_error([&](const wrapper::ErrorContext&) { thread2 = std::this_thread::get_id(); });
+
+  serial1->start();
+  serial2->start();
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] { return thread1.load() != std::thread::id{} && thread2.load() != std::thread::id{}; }, 2000));
+  EXPECT_EQ(thread1.load(), thread2.load());
+
+  serial1->stop();
+  serial2->stop();
+}
+
 TEST_F(SerialWrapperLifecycleTest, ConfigurationSetters) {
   auto serial = std::make_shared<wrapper::Serial>(device_, 9600);
 


### PR DESCRIPTION
## Summary
Part of #440/#454 (final step, stacked on #478 → #477 → #476 since it needs `Serial`'s `shared_context()` API). Adds the `Serial`-side equivalent of the `TcpServer` tests already added in #478: `DefaultUsesDistinctThreadsPerInstance` (two default-built `Serial` instances observe distinct thread IDs) and `SharedContextOptInUsesOneThread` (two `.shared_context(true)` instances observe the same thread ID). Closes the last item from #440's design plan's "New tests" list that wasn't already covered incrementally by earlier steps in this series (thread-per-instance and backward-compat opt-in were done for `TcpServer` in #478; wrapper responsiveness was done for `TcpClient` in #480).

Uses `device_` (`/dev/null` or `NUL`, already the fixture's existing device for other tests in this file) with `reopen_on_error(false)`: opening `/dev/null` as a serial port succeeds, but configuring it (baud rate/etc.) fails since it isn't a real TTY — with `reopen_on_error(false)` that failure transitions straight to a terminal Error state and fires `on_error` on the transport's own thread, giving a portable way to observe thread identity without needing real hardware or CI-specific pty/socat setup.

**Intentionally not adding** the design plan's suggested "concurrent throughput test" (N servers under busy echo load showing near-linear scaling vs today's ~Nx degradation) — throughput/scaling assertions are inherently environment-dependent and prone to flaking in CI (shared runners, variable core counts), and the thread-identity tests above already directly verify the actual mechanism (distinct threads per instance) that the scaling behavior would depend on.

## Test plan
- [x] `./scripts/verify.sh` passes (700 tests, +2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)