### PR TITLE
version: bump to v0.8.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.3
+  VERSION 0.8.4
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Summary
Covers the merged Phase 2 work since v0.8.3: #436 (sync-policy unification), #434 (shared backpressure/enqueue state machine), #445 (error propagation unification across all 7 transports/wrappers), and #440/#454 (io_context threading model — `TcpServer`/`Serial` now default to a dedicated context+thread like every other transport, with an explicit `shared_context()` opt-in for the old singleton behavior; wrapper run-loop/thread-type consistency).

All additions are backward-compatible (new opt-in methods/config fields), no breaking API changes.

## Test plan
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)