### PR TITLE
fix: TcpServer stop() hygiene + document/complete the #444 restart contract

### DIFF
--- a/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
@@ -182,6 +182,72 @@ TEST_F(TcpServerWrapperLifecycleTest, ManagedExternalContextRestartsStoppedIoCon
   EXPECT_TRUE(ioc->stopped());
 }
 
+// #444-remainder: full end-to-end restart correctness - stop() then start()
+// again must behave like a clean, fresh server. No leaked client count or
+// session state from the stopped instance's transport_cache_/framers_
+// carries over into the second instance's client_count()/connected_clients().
+TEST_F(TcpServerWrapperLifecycleTest, StopClearsTransportCacheAndFramersBeforeRestart) {
+  server_ = unilink::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto f1 = server_->start();
+  ASSERT_TRUE(f1.get());
+
+  auto client1 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client1->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 5000));
+
+  client1->stop();
+  server_->stop();
+
+  // transport_cache_ must be reset by now - client_count() must not report
+  // stale state from the now-stopped transport.
+  EXPECT_EQ(server_->client_count(), 0u);
+  EXPECT_TRUE(server_->connected_clients().empty());
+
+  auto f2 = server_->start();
+  ASSERT_TRUE(f2.get());
+  EXPECT_TRUE(server_->listening());
+
+  auto client2 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client2->start().get());
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 5000));
+  // Exactly one live client after the restart - no leaked session/framer
+  // state from before the stop() carried over.
+  EXPECT_EQ(server_->client_count(), 1u);
+
+  client2->stop();
+}
+
+// #444-remainder: max_clients() reaches transport_cache_ directly
+// (`if (impl_->transport_cache_) impl_->transport_cache_->set_client_limit(max)`)
+// - calling it while stopped must not crash on a stale cached pointer, and
+// the new limit must still take effect via the wrapper's retained config on
+// the next start() regardless of whether transport_cache_ was live to
+// receive the call.
+TEST_F(TcpServerWrapperLifecycleTest, MaxClientsWhileStoppedAppliesOnNextStart) {
+  server_ = unilink::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(server_->start().get());
+  server_->stop();
+
+  // Must not crash even if transport_cache_ is stale/reset at this point.
+  server_->max_clients(1);
+
+  ASSERT_TRUE(server_->start().get());
+
+  auto client1 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto client2 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client1->start().get());
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 5000));
+
+  client2->start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  // The max_clients(1) set while stopped must be honored: the second
+  // connection is rejected, so client_count() stays at 1.
+  EXPECT_EQ(server_->client_count(), 1u);
+
+  client1->stop();
+  client2->stop();
+}
+
 TEST_F(TcpServerWrapperLifecycleTest, SendAndCountReflectLiveClientsAndReturnStatus) {
   std::vector<size_t> ids;
   std::mutex ids_mutex;

--- a/unilink/wrapper/ichannel.hpp
+++ b/unilink/wrapper/ichannel.hpp
@@ -51,7 +51,8 @@ class UNILINK_API ChannelInterface {
    * @return A future that resolves to true when the channel is connected/listening,
    *         or false if startup failed (e.g. connection refused, max retries exhausted).
    *         On false, the registered on_error() callback will have been invoked with
-   *         the specific failure reason.
+   *         the specific failure reason. This future always resolves - including on a
+   *         restart after stop() (#444) - never blocks indefinitely.
    */
   [[nodiscard]] virtual std::future<bool> start() = 0;
 
@@ -68,6 +69,16 @@ class UNILINK_API ChannelInterface {
    *
    * Safe to call from any thread. After stop() returns, no further callbacks will fire
    * and it is safe to destroy the object. Calling stop() more than once is a no-op.
+   *
+   * Restart contract (#444): stop() fully tears down the underlying transport
+   * (socket/serial port, queues, timers) rather than leaving it in a reusable
+   * half-alive state. Every on_*() callback and every config setter ever
+   * called on this wrapper remains in force across any number of stop()/
+   * start() cycles - a subsequent start() reconstructs the transport from
+   * this wrapper's retained configuration and re-registers all callbacks
+   * automatically, including config changes made while stopped. Session/
+   * client-id state and stats() reset on restart. Callers never need to
+   * re-register callbacks or reconfigure after a stop()/start() cycle.
    */
   virtual void stop() = 0;
   virtual bool connected() const = 0;

--- a/unilink/wrapper/iserver.hpp
+++ b/unilink/wrapper/iserver.hpp
@@ -44,6 +44,14 @@ class UNILINK_API ServerInterface {
   virtual ~ServerInterface() = default;
 
   // Lifecycle
+  /**
+   * @brief Start the server asynchronously.
+   *
+   * @return A future that resolves to true when listening, or false on failure
+   *         (e.g. bind failure, port already in use). This future always
+   *         resolves - including on a restart after stop() (#444) - never
+   *         blocks indefinitely.
+   */
   [[nodiscard]] virtual std::future<bool> start() = 0;
 
   /**
@@ -56,6 +64,16 @@ class UNILINK_API ServerInterface {
    *
    * Safe to call from any thread. After stop() returns, no further callbacks will fire
    * and it is safe to destroy the object. Calling stop() more than once is a no-op.
+   *
+   * Restart contract (#444): stop() fully tears down the underlying transport
+   * (acceptor, sessions, timers) rather than leaving it in a reusable
+   * half-alive state. Every on_*() callback and every config setter ever
+   * called on this wrapper remains in force across any number of stop()/
+   * start() cycles - a subsequent start() reconstructs the transport from
+   * this wrapper's retained configuration and re-registers all callbacks
+   * automatically, including config changes made while stopped. Connected-
+   * client state and stats() reset on restart. Callers never need to
+   * re-register callbacks or reconfigure after a stop()/start() cycle.
    */
   virtual void stop() = 0;
   virtual bool listening() const = 0;

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -240,6 +240,7 @@ struct TcpClient::Impl {
         if (channel_ == ch) {
           channel_->on_bytes(nullptr);
           channel_->on_state(nullptr);
+          channel_->on_backpressure(nullptr);
         }
       }
       if (use_external_context_.load() && manage_external_context_.load()) {

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -274,6 +274,7 @@ struct TcpServer::Impl {
       if (channel_) {
         channel_->on_bytes(nullptr);
         channel_->on_state(nullptr);
+        channel_->on_backpressure(nullptr);
         auto transport_server = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
         if (transport_server) transport_server->request_stop();
         lock.unlock();
@@ -285,6 +286,14 @@ struct TcpServer::Impl {
         if (external_ioc_) external_ioc_->stop();
         should_join = true;
       }
+      // #444: transport_cache_ is a separate cached shared_ptr to the same
+      // transport object channel_ points at - without this, send_to()/
+      // broadcast()/max_clients() could still reach the stopped transport
+      // via transport_cache_ even after channel_.reset() below. framers_
+      // must also be cleared so a restart doesn't resume per-client framing
+      // state from stale ClientIds (mirrors UdsServer's existing behavior).
+      transport_cache_.reset();
+      framers_.clear();
       fulfill_all_locked(false);
       is_listening_.store(false);
     }

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -230,6 +230,7 @@ struct UdsClient::Impl {
     if (channel_) {
       channel_->on_bytes(nullptr);
       channel_->on_state(nullptr);
+      channel_->on_backpressure(nullptr);
       lock.unlock();
       channel_->stop();
       lock.lock();

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -238,6 +238,7 @@ struct UdsServer::Impl {
       if (server_) {
         server_->on_bytes(nullptr);
         server_->on_state(nullptr);
+        server_->on_backpressure(nullptr);
         lock.unlock();
         server_->stop();
         lock.lock();


### PR DESCRIPTION
## Summary
Finishes the remaining steps of #444's design plan (steps 3, 4, and 6; steps 1-2, the Serial/UdpClient restart-hang fixes, already landed in Phase 0 via #457). #444 itself is already closed since the critical hang was fixed; this is cleanup work explicitly called out in that issue's design-plan comment but not yet implemented.

`TcpServer::Impl::stop()` now resets `transport_cache_` and clears `framers_`, matching `UdsServer`'s already-correct pattern. `transport_cache_` is a separate cached `shared_ptr` to the same transport `channel_` points at — without this, `max_clients()` (which reaches `transport_cache_` directly) could operate on a stale, stopped transport object between `stop()` and the next `start()`. `framers_` must also be cleared so a restart doesn't resume per-client framing state from stale `ClientId`s.

**Optional consistency pass** (design plan step 4): null `on_backpressure` alongside `on_bytes`/`on_state` in all four wrappers that were missing it (`TcpClient`, `TcpServer`, `UdsClient`, `UdsServer`) — `Serial`/`UdpClient`/`UdpServer` already did this as part of their Phase 0 fix.

**Documented the restart contract** (design plan step 6) in both `ChannelInterface` and `ServerInterface`'s `start()`/`stop()` doc comments: `stop()` fully tears down the transport; every `on_*()` callback and config setter remains in force across any number of `stop()`/`start()` cycles; config changes made while stopped take effect on the next `start()`; `start()`'s future always resolves, including on a restart, never blocks indefinitely.

## Test plan
- [x] `./scripts/verify.sh` passes (702 tests, +2 new)
- [x] New tests in `test_tcp_server_wrapper_lifecycle.cc`: `StopClearsTransportCacheAndFramersBeforeRestart` (full restart cycle with real client connections, asserting no leaked state) and `MaxClientsWhileStoppedAppliesOnNextStart` (calling `max_clients()` while stopped doesn't crash, and the new limit correctly applies on the next `start()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)