### PR TITLE
fix: consolidate config validation onto base/constants.hpp, fix setter-bypass gap

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -191,6 +191,16 @@ unilink_add_unit_gtest(
   "unit_transport_reconnect_stable" 30
 )
 
+# Real-socket TcpClient reconnect behavior (server restart, live retry_interval
+# clamping - #432). Uses real sockets/timing so it's not in the fast foreach
+# above; was previously written but never wired into the build (added #332,
+# orphaned since).
+unilink_add_unit_gtest(
+  run_unit_transport_tcp_client_reconnect_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/transport/transport_tcp_client_reconnect_test.cc
+  "unit_transport_reconnect_stable" 30
+)
+
 # Shared backpressure state machine (#434) - isolated, no sockets/io_context
 unilink_add_unit_gtest(
   run_unit_test_bp_state_machine

--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -269,6 +269,110 @@ TEST_F(ConfigTest, TcpClientConfigDirectValidation) {
   EXPECT_TRUE(config.is_valid());
 }
 
+// #432: connection_timeout_ms/idle_timeout_ms had constants in
+// base/constants.hpp that neither is_valid() nor validate_and_clamp()
+// ever checked, for both TcpClientConfig and UdsClientConfig - a
+// connection_timeout(0) reached connect_timer_ unclamped and caused an
+// instant-timeout reconnect loop (the reported failure scenario).
+TEST_F(ConfigTest, TcpClientAndUdsClientConfigTimeoutFieldsAreValidatedAndClamped) {
+  TcpClientConfig tcp;
+  EXPECT_TRUE(tcp.is_valid());
+
+  tcp.connection_timeout_ms = base::constants::MIN_CONNECTION_TIMEOUT_MS - 1;
+  EXPECT_FALSE(tcp.is_valid()) << "connection_timeout_ms below the minimum must be rejected";
+  tcp.validate_and_clamp();
+  EXPECT_EQ(tcp.connection_timeout_ms, base::constants::MIN_CONNECTION_TIMEOUT_MS);
+
+  tcp.connection_timeout_ms = base::constants::MAX_CONNECTION_TIMEOUT_MS + 1;
+  EXPECT_FALSE(tcp.is_valid());
+  tcp.validate_and_clamp();
+  EXPECT_EQ(tcp.connection_timeout_ms, base::constants::MAX_CONNECTION_TIMEOUT_MS);
+
+  tcp.idle_timeout_ms = base::constants::MAX_IDLE_TIMEOUT_MS + 1;
+  EXPECT_FALSE(tcp.is_valid());
+  tcp.validate_and_clamp();
+  EXPECT_EQ(tcp.idle_timeout_ms, base::constants::MAX_IDLE_TIMEOUT_MS);
+
+  // 0 means "disabled" and must not be clamped up to MIN_IDLE_TIMEOUT_MS.
+  tcp.idle_timeout_ms = 0;
+  EXPECT_TRUE(tcp.is_valid());
+  tcp.validate_and_clamp();
+  EXPECT_EQ(tcp.idle_timeout_ms, 0u);
+
+  UdsClientConfig uds;
+  EXPECT_TRUE(uds.is_valid());
+  uds.connection_timeout_ms = base::constants::MIN_CONNECTION_TIMEOUT_MS - 1;
+  EXPECT_FALSE(uds.is_valid());
+  uds.validate_and_clamp();
+  EXPECT_EQ(uds.connection_timeout_ms, base::constants::MIN_CONNECTION_TIMEOUT_MS);
+}
+
+// #432: TcpServerConfig/UdsServerConfig's idle_timeout_ms only had a
+// lower-bound clamp (< 0 -> 0); an over-large value was never rejected or
+// capped even though MAX_IDLE_TIMEOUT_MS exists.
+TEST_F(ConfigTest, ServerConfigIdleTimeoutUpperBoundIsEnforced) {
+  TcpServerConfig tcp_server;
+  tcp_server.idle_timeout_ms = static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS) + 1;
+  EXPECT_FALSE(tcp_server.is_valid());
+  tcp_server.validate_and_clamp();
+  EXPECT_EQ(tcp_server.idle_timeout_ms, static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS));
+
+  UdsServerConfig uds_server;
+  uds_server.idle_timeout_ms = static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS) + 1;
+  EXPECT_FALSE(uds_server.is_valid());
+  uds_server.validate_and_clamp();
+  EXPECT_EQ(uds_server.idle_timeout_ms, static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS));
+}
+
+// #432: SerialConfig::is_valid() never checked the device path format
+// (InputValidator::is_valid_device_path existed but was private/unwired)
+// nor baud_rate's upper bound.
+TEST_F(ConfigTest, SerialConfigDevicePathAndBaudRateAreValidated) {
+  SerialConfig cfg;
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.device = "not-a-real-device";
+  EXPECT_FALSE(cfg.is_valid()) << "device path must match /dev/... or COMn";
+#ifdef _WIN32
+  cfg.device = "COM7";
+#else
+  cfg.device = "/dev/ttyUSB1";
+#endif
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.baud_rate = base::constants::MAX_BAUD_RATE + 1;
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.validate_and_clamp();
+  EXPECT_EQ(cfg.baud_rate, base::constants::MAX_BAUD_RATE);
+
+  cfg.baud_rate = base::constants::MIN_BAUD_RATE - 1;
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.validate_and_clamp();
+  EXPECT_EQ(cfg.baud_rate, base::constants::MIN_BAUD_RATE);
+}
+
+// #432: UdpConfig never checked bind_address/remote_address format at all,
+// even though both are passed straight to boost::asio::ip::make_address()
+// (literal IPv4/IPv6 only, no hostname resolution).
+TEST_F(ConfigTest, UdpConfigAddressFormatIsValidated) {
+  UdpConfig cfg;
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.bind_address = "not-an-ip";
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.bind_address = "0.0.0.0";
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.remote_address = "not-an-ip";
+  cfg.remote_port = 9000;
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.remote_address = "127.0.0.1";
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.bind_address = "::1";
+  EXPECT_TRUE(cfg.is_valid()) << "IPv6 bind address should be valid";
+}
+
 TEST(SocketTuningConfigTest, SocketBufferConfigValidationAndClamping) {
   TcpClientConfig tcp_client;
   EXPECT_TRUE(tcp_client.tcp_no_delay);
@@ -322,7 +426,11 @@ TEST_F(ConfigTest, SerialConfigDirectValidationAndClamping) {
 
   config.device.clear();
   EXPECT_FALSE(config.is_valid());
-  config.device = "loopback";
+#ifdef _WIN32
+  config.device = "COM3";
+#else
+  config.device = "/dev/ttyFake";
+#endif
 
   config.baud_rate = 0;
   EXPECT_FALSE(config.is_valid());

--- a/test/unit/transport/transport_tcp_client_reconnect_test.cc
+++ b/test/unit/transport/transport_tcp_client_reconnect_test.cc
@@ -92,7 +92,7 @@ TEST_F(TcpClientReconnectTest, LiveSetRetryIntervalIsClampedNotUnbounded) {
   cfg.host = "127.0.0.1";
   cfg.port = port_;  // nothing listens here
   cfg.max_retries = -1;
-  cfg.retry_interval_ms = 500;  // deliberately not the eventual live value
+  cfg.retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
 
   auto client = TcpClient::create(cfg);
 
@@ -109,18 +109,28 @@ TEST_F(TcpClientReconnectTest, LiveSetRetryIntervalIsClampedNotUnbounded) {
   });
 
   client->start();
+
+  // Wait for the first connect attempt before flipping the live setter, so
+  // the 0-clamp is guaranteed to apply to every retry timer scheduled
+  // afterward rather than racing the client's own startup.
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    ASSERT_TRUE(cv.wait_for(lock, 5s, [&] { return !connecting_at.empty(); }))
+        << "Client never made its first connect attempt";
+  }
+
   client->set_retry_interval(0);  // the live setter-bypass scenario from #432
 
   std::unique_lock<std::mutex> lock(mtx);
-  ASSERT_TRUE(cv.wait_for(lock, 5s, [&] { return connecting_at.size() >= 4; }))
+  ASSERT_TRUE(cv.wait_for(lock, 10s, [&] { return connecting_at.size() >= 3; }))
       << "Client never retried enough times to measure spacing";
 
-  // Compare the last two gaps (earlier ones may still reflect the
-  // pre-live-set 500ms interval or in-flight timers).
+  // Use the last gap: guaranteed to be scheduled after set_retry_interval(0)
+  // took effect.
   auto it = connecting_at.end();
-  auto t3 = *(--it);
-  auto t2 = *(--it);
-  auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
+  auto t_last = *(--it);
+  auto t_prev = *(--it);
+  auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(t_last - t_prev).count();
   lock.unlock();
 
   EXPECT_GE(gap, static_cast<long>(base::constants::MIN_RETRY_INTERVAL_MS) - 20)

--- a/test/unit/transport/transport_tcp_client_reconnect_test.cc
+++ b/test/unit/transport/transport_tcp_client_reconnect_test.cc
@@ -4,9 +4,11 @@
 #include <boost/asio.hpp>
 #include <chrono>
 #include <condition_variable>
+#include <deque>
 #include <thread>
 
 #include "test_utils.hpp"
+#include "unilink/base/constants.hpp"
 #include "unilink/config/tcp_client_config.hpp"
 #include "unilink/transport/tcp_client/tcp_client.hpp"
 
@@ -33,9 +35,11 @@ TEST_F(TcpClientReconnectTest, ReconnectAfterServerStop) {
   std::condition_variable cv;
 
   auto client = TcpClient::create(cfg);
-  client->on_connect([&](const wrapper::ConnectionContext&) {
-    connect_count++;
-    cv.notify_all();
+  client->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) {
+      connect_count++;
+      cv.notify_all();
+    }
   });
 
   // 1. Start server and connect client
@@ -74,4 +78,53 @@ TEST_F(TcpClientReconnectTest, ReconnectAfterServerStop) {
   client->stop();
   server_ioc2->stop();
   if (server_thread2.joinable()) server_thread2.join();
+}
+
+// #432: TcpClient::set_retry_interval() wrote straight into cfg_.retry_interval_ms
+// with no re-validation, unlike the one-time validate_and_clamp() call at
+// construction. Calling it live with 0 used to produce an unbounded tight
+// reconnect loop (the same bug class reported for connection_timeout_ms).
+// Verifies retry_interval(0) on an already-running client is floored at
+// MIN_RETRY_INTERVAL_MS, by measuring spacing between repeated failed
+// connect attempts against a port nothing is listening on.
+TEST_F(TcpClientReconnectTest, LiveSetRetryIntervalIsClampedNotUnbounded) {
+  config::TcpClientConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = port_;  // nothing listens here
+  cfg.max_retries = -1;
+  cfg.retry_interval_ms = 500;  // deliberately not the eventual live value
+
+  auto client = TcpClient::create(cfg);
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  std::deque<std::chrono::steady_clock::time_point> connecting_at;
+
+  client->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connecting) {
+      std::lock_guard<std::mutex> lock(mtx);
+      connecting_at.push_back(std::chrono::steady_clock::now());
+      cv.notify_all();
+    }
+  });
+
+  client->start();
+  client->set_retry_interval(0);  // the live setter-bypass scenario from #432
+
+  std::unique_lock<std::mutex> lock(mtx);
+  ASSERT_TRUE(cv.wait_for(lock, 5s, [&] { return connecting_at.size() >= 4; }))
+      << "Client never retried enough times to measure spacing";
+
+  // Compare the last two gaps (earlier ones may still reflect the
+  // pre-live-set 500ms interval or in-flight timers).
+  auto it = connecting_at.end();
+  auto t3 = *(--it);
+  auto t2 = *(--it);
+  auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
+  lock.unlock();
+
+  EXPECT_GE(gap, static_cast<long>(base::constants::MIN_RETRY_INTERVAL_MS) - 20)
+      << "retry_interval(0) must be floored at MIN_RETRY_INTERVAL_MS, not left unbounded";
+
+  client->stop();
 }

--- a/test/unit/transport/transport_uds_client.cc
+++ b/test/unit/transport/transport_uds_client.cc
@@ -271,7 +271,10 @@ TEST_F(TransportUdsClientTest, InvalidConfigMovesToErrorAndRecordsLastError) {
 }
 
 TEST_F(TransportUdsClientTest, ConnectionTimeoutRecordsLastError) {
-  cfg.connection_timeout_ms = 20;
+  // #432: connection_timeout_ms is now clamped to MIN_CONNECTION_TIMEOUT_MS -
+  // use that value explicitly (rather than an arbitrarily smaller one that
+  // would silently get clamped up) and give run_for() enough margin past it.
+  cfg.connection_timeout_ms = base::constants::MIN_CONNECTION_TIMEOUT_MS;
   cfg.max_retries = 0;
 
   auto local_mock = new MockUdsSocket();
@@ -292,7 +295,7 @@ TEST_F(TransportUdsClientTest, ConnectionTimeoutRecordsLastError) {
 
   local_client->start();
   ioc.restart();
-  ioc.run_for(std::chrono::milliseconds(100));
+  ioc.run_for(std::chrono::milliseconds(base::constants::MIN_CONNECTION_TIMEOUT_MS) + std::chrono::milliseconds(200));
 
   EXPECT_TRUE(error_seen.load());
   ASSERT_TRUE(local_client->last_error_info().has_value());

--- a/unilink/config/serial_config.hpp
+++ b/unilink/config/serial_config.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "unilink/base/constants.hpp"
+#include "unilink/util/input_validator.hpp"
 
 namespace unilink {
 namespace config {
@@ -54,8 +55,9 @@ struct SerialConfig {
 
   // Validation methods
   bool is_valid() const {
-    return !device.empty() && baud_rate > 0 && char_size >= 5 && char_size <= 8 && (stop_bits == 1 || stop_bits == 2) &&
-           retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
+    return util::InputValidator::is_valid_device_path(device) && baud_rate >= base::constants::MIN_BAUD_RATE &&
+           baud_rate <= base::constants::MAX_BAUD_RATE && char_size >= 5 && char_size <= 8 &&
+           (stop_bits == 1 || stop_bits == 2) && retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
@@ -64,6 +66,12 @@ struct SerialConfig {
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
+    if (baud_rate < base::constants::MIN_BAUD_RATE) {
+      baud_rate = base::constants::MIN_BAUD_RATE;
+    } else if (baud_rate > base::constants::MAX_BAUD_RATE) {
+      baud_rate = base::constants::MAX_BAUD_RATE;
+    }
+
     if (char_size < 5)
       char_size = 5;
     else if (char_size > 8)

--- a/unilink/config/tcp_client_config.hpp
+++ b/unilink/config/tcp_client_config.hpp
@@ -52,6 +52,10 @@ struct TcpClientConfig {
     return util::InputValidator::is_valid_host(host) && port > 0 &&
            retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
+           connection_timeout_ms >= base::constants::MIN_CONNECTION_TIMEOUT_MS &&
+           connection_timeout_ms <= base::constants::MAX_CONNECTION_TIMEOUT_MS &&
+           (idle_timeout_ms == 0 || (idle_timeout_ms >= base::constants::MIN_IDLE_TIMEOUT_MS &&
+                                     idle_timeout_ms <= base::constants::MAX_IDLE_TIMEOUT_MS)) &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
            (send_buffer_size == 0 || (send_buffer_size >= base::constants::MIN_SOCKET_BUFFER_SIZE &&
@@ -67,6 +71,20 @@ struct TcpClientConfig {
       retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
     } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
       retry_interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
+    }
+
+    if (connection_timeout_ms < base::constants::MIN_CONNECTION_TIMEOUT_MS) {
+      connection_timeout_ms = base::constants::MIN_CONNECTION_TIMEOUT_MS;
+    } else if (connection_timeout_ms > base::constants::MAX_CONNECTION_TIMEOUT_MS) {
+      connection_timeout_ms = base::constants::MAX_CONNECTION_TIMEOUT_MS;
+    }
+
+    if (idle_timeout_ms != 0) {
+      if (idle_timeout_ms < base::constants::MIN_IDLE_TIMEOUT_MS) {
+        idle_timeout_ms = base::constants::MIN_IDLE_TIMEOUT_MS;
+      } else if (idle_timeout_ms > base::constants::MAX_IDLE_TIMEOUT_MS) {
+        idle_timeout_ms = base::constants::MAX_IDLE_TIMEOUT_MS;
+      }
     }
 
     if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -55,7 +55,8 @@ struct TcpServerConfig {
     return (util::InputValidator::is_valid_ipv4(bind_address) || util::InputValidator::is_valid_ipv6(bind_address)) &&
            port > 0 && backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections >= 0 &&
-           idle_timeout_ms >= 0 &&
+           (idle_timeout_ms == 0 || (idle_timeout_ms >= static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS) &&
+                                     idle_timeout_ms <= static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS))) &&
            (send_buffer_size == 0 || (send_buffer_size >= base::constants::MIN_SOCKET_BUFFER_SIZE &&
                                       send_buffer_size <= base::constants::MAX_SOCKET_BUFFER_SIZE)) &&
            (receive_buffer_size == 0 || (receive_buffer_size >= base::constants::MIN_SOCKET_BUFFER_SIZE &&
@@ -78,6 +79,12 @@ struct TcpServerConfig {
 
     if (idle_timeout_ms < 0) {
       idle_timeout_ms = 0;
+    } else if (idle_timeout_ms != 0) {
+      if (idle_timeout_ms < static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS)) {
+        idle_timeout_ms = static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS);
+      } else if (idle_timeout_ms > static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS)) {
+        idle_timeout_ms = static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS);
+      }
     }
 
     if (send_buffer_size != 0 && send_buffer_size < base::constants::MIN_SOCKET_BUFFER_SIZE) {

--- a/unilink/config/udp_config.hpp
+++ b/unilink/config/udp_config.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "unilink/base/constants.hpp"
+#include "unilink/util/input_validator.hpp"
 
 namespace unilink {
 namespace config {
@@ -40,11 +41,21 @@ struct UdpConfig {
   size_t receive_buffer_size = 0;
 
   bool is_valid() const {
+    // bind_address/remote_address are passed straight to
+    // boost::asio::ip::make_address() (unilink/transport/udp/udp.cc) -
+    // literal IPv4/IPv6 addresses only, no hostname resolution.
+    if (!util::InputValidator::is_valid_ipv4(bind_address) && !util::InputValidator::is_valid_ipv6(bind_address)) {
+      return false;
+    }
     if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD ||
         backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
       return false;
     }
     if (remote_address.has_value() != remote_port.has_value()) return false;
+    if (remote_address && !util::InputValidator::is_valid_ipv4(*remote_address) &&
+        !util::InputValidator::is_valid_ipv6(*remote_address)) {
+      return false;
+    }
     if (remote_port && *remote_port == 0) return false;
     if (send_buffer_size != 0 && (send_buffer_size < base::constants::MIN_SOCKET_BUFFER_SIZE ||
                                   send_buffer_size > base::constants::MAX_SOCKET_BUFFER_SIZE)) {

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -43,6 +43,8 @@ struct UdsClientConfig {
     return util::InputValidator::is_valid_uds_path(socket_path) &&
            retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
+           connection_timeout_ms >= base::constants::MIN_CONNECTION_TIMEOUT_MS &&
+           connection_timeout_ms <= base::constants::MAX_CONNECTION_TIMEOUT_MS &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
            (max_retries == -1 || (max_retries >= 0 && max_retries <= base::constants::MAX_RETRIES_LIMIT));
@@ -53,6 +55,12 @@ struct UdsClientConfig {
       retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
     } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
       retry_interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
+    }
+
+    if (connection_timeout_ms < base::constants::MIN_CONNECTION_TIMEOUT_MS) {
+      connection_timeout_ms = base::constants::MIN_CONNECTION_TIMEOUT_MS;
+    } else if (connection_timeout_ms > base::constants::MAX_CONNECTION_TIMEOUT_MS) {
+      connection_timeout_ms = base::constants::MAX_CONNECTION_TIMEOUT_MS;
     }
 
     if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
@@ -82,7 +90,8 @@ struct UdsServerConfig {
     return util::InputValidator::is_valid_uds_path(socket_path) &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections >= 0 &&
-           idle_timeout_ms >= 0;
+           (idle_timeout_ms == 0 || (idle_timeout_ms >= static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS) &&
+                                     idle_timeout_ms <= static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS)));
   }
 
   void validate_and_clamp() {
@@ -100,6 +109,12 @@ struct UdsServerConfig {
 
     if (idle_timeout_ms < 0) {
       idle_timeout_ms = 0;
+    } else if (idle_timeout_ms != 0) {
+      if (idle_timeout_ms < static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS)) {
+        idle_timeout_ms = static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS);
+      } else if (idle_timeout_ms > static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS)) {
+        idle_timeout_ms = static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS);
+      }
     }
   }
 };

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -845,6 +845,11 @@ void Serial::set_backpressure_strategy(base::constants::BackpressureStrategy str
 }
 
 void Serial::set_retry_interval(unsigned interval_ms) {
+  if (interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
+    interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
+  } else if (interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
+    interval_ms = base::constants::MAX_RETRY_INTERVAL_MS;
+  }
   get_impl()->retry_interval_ms_.store(interval_ms, std::memory_order_relaxed);
 }
 

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -546,18 +546,22 @@ void TcpClient::set_backpressure_strategy(base::constants::BackpressureStrategy 
 void TcpClient::set_retry_interval(unsigned interval_ms) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);
   impl_->cfg_.retry_interval_ms = interval_ms;
+  impl_->cfg_.validate_and_clamp();
 }
 void TcpClient::set_max_retries(int max_retries) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);
   impl_->cfg_.max_retries = max_retries;
+  impl_->cfg_.validate_and_clamp();
 }
 void TcpClient::set_connection_timeout(unsigned timeout_ms) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);
   impl_->cfg_.connection_timeout_ms = timeout_ms;
+  impl_->cfg_.validate_and_clamp();
 }
 void TcpClient::set_idle_timeout(unsigned timeout_ms) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);
   impl_->cfg_.idle_timeout_ms = timeout_ms;
+  impl_->cfg_.validate_and_clamp();
 }
 void TcpClient::set_idle_timeout_action(IdleTimeoutAction action) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -861,6 +861,9 @@ void TcpServer::on_multi_disconnect(MultiClientDisconnectHandler h) {
 
 void TcpServer::set_client_limit(size_t max) {
   auto impl = get_impl();
+  if (max > base::constants::MAX_MAX_CONNECTIONS) {
+    max = base::constants::MAX_MAX_CONNECTIONS;
+  }
   std::lock_guard<std::mutex> l(impl->sessions_mutex_);
   impl->max_clients_ = max;
   if (max == 0) {

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -446,6 +446,7 @@ void UdsClient::set_backpressure_strategy(base::constants::BackpressureStrategy 
 void UdsClient::set_retry_interval(unsigned interval_ms) {
   std::lock_guard<std::mutex> lock(impl_->cfg_mtx_);
   impl_->cfg_.retry_interval_ms = interval_ms;
+  impl_->cfg_.validate_and_clamp();
 }
 
 void UdsClient::set_reconnect_policy(ReconnectPolicy policy) {

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -77,6 +77,7 @@ struct UdsServer::Impl {
         ioc_(ioc_ptr ? ioc_ptr : owned_ioc_.get()),
         owns_ioc_(!ioc_ptr),
         cfg_(cfg) {
+    cfg_.validate_and_clamp();
     acceptor_ = std::make_unique<BoostUdsAcceptor>(*ioc_);
   }
   ~Impl() {

--- a/unilink/util/input_validator.hpp
+++ b/unilink/util/input_validator.hpp
@@ -77,11 +77,9 @@ class UNILINK_API InputValidator {
   static bool is_valid_ipv6(const std::string& address);
   static bool is_valid_hostname(std::string_view hostname);
   static bool is_valid_uds_path(const std::string& path);
-
- private:
-  // Helper methods
   static bool is_valid_device_path(const std::string& device);
 
+ private:
   // Constants for retry count
   static constexpr int FINITE_MIN_RETRY_COUNT = 0;
   static constexpr int FINITE_MAX_RETRY_COUNT = base::constants::MAX_RETRIES_LIMIT;


### PR DESCRIPTION
## Summary
Closes #432. Config validation was split across `is_valid()`/`validate_and_clamp()`/`InputValidator` with no agreement between them - several fields with defined ranges in `base/constants.hpp` were checked/clamped by none of the three. Worse, `is_valid()` itself was dead code in production for 3 of 6 config structs (only `validate_and_clamp()` is ever called, once, at transport construction), and `UdsServerConfig::validate_and_clamp()` was never called at all. Full investigation and design plan posted on the issue before implementing.

**Field-level fixes** (`is_valid()`/`validate_and_clamp()` now agree, both referencing `base::constants` directly):
- `TcpClientConfig`/`UdsClientConfig.connection_timeout_ms`: had no check or clamp anywhere - the reported bug. `connection_timeout(0ms)` reached `connect_timer_` unclamped, producing an instant-timeout reconnect loop.
- `TcpClientConfig.idle_timeout_ms`: same gap.
- `TcpServerConfig`/`UdsServerConfig.idle_timeout_ms`: only had a lower clamp, no upper bound despite `MAX_IDLE_TIMEOUT_MS` existing.
- `SerialConfig.device`: `InputValidator::is_valid_device_path` existed but was `private` and never wired in. Promoted it to the public "validation helpers" section and wired it in.
- `SerialConfig.baud_rate`: only had a lower bound, no upper clamp.
- `UdpConfig.bind_address`/`remote_address`: no format check at all, even though both are passed straight to `boost::asio::ip::make_address()` (literal IPv4/IPv6 only).
- `UdsServerConfig::validate_and_clamp()` wired into `UdsServer::Impl`'s constructor (previously dead).

**Setter-bypass gap**: builder/wrapper setters that mutate a validated config field after construction (`TcpClient::set_retry_interval`/`set_max_retries`/`set_connection_timeout`/`set_idle_timeout`, `UdsClient::set_retry_interval`, `Serial::set_retry_interval`, `TcpServer::set_client_limit`) wrote straight into the field with zero re-validation. This is the actual live path for the reported bug scenario. Each setter now re-clamps immediately after writing.

## Test plan
- [x] `./scripts/verify.sh` passes (706 tests, +6 new)
- [x] New config-level tests in `test_config.cc` covering every fixed field
- [x] New `LiveSetRetryIntervalIsClampedNotUnbounded` test reproduces the exact live setter-bypass scenario against a real socket, measuring actual retry spacing. Verified it fails without the fix (0ms gap) and passes with it (~100ms gap).
- [x] Found and fixed `transport_tcp_client_reconnect_test.cc` was never wired into `CMakeLists.txt` and didn't even compile (stale `on_connect`/`ConnectionContext` API from #332) - fixed and added to the build so its existing `ReconnectAfterServerStop` test actually runs in CI now too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)