### PR TITLE
fix: narrow receive-hot-path lock scope in all 7 wrappers

### DIFF
--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <boost/asio.hpp>
 #include <chrono>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -470,6 +471,59 @@ TEST(TcpClientWrapperContractTest, InjectedChannelBatchesRawDataAndFramedMessage
   ASSERT_EQ(framed_payloads.size(), 2U);
   EXPECT_EQ(framed_payloads[0], "msg1");
   EXPECT_EQ(framed_payloads[1], "msg2");
+
+  client.stop();
+}
+
+// #441: on_bytes only ever needs a shared_lock to snapshot the handler
+// pointer (try_send takes the same shared_lock on the same mutex) - the
+// user callback itself already runs outside any lock. Proves a slow/blocked
+// on_data callback does not stall a concurrent try_send call.
+TEST(TcpClientWrapperContractTest, TrySendDoesNotBlockOnConcurrentSlowDataCallback) {
+  auto channel = std::make_shared<ControlledChannel>();
+  wrapper::TcpClient client(std::static_pointer_cast<interface::Channel>(channel));
+
+  std::mutex cb_mutex;
+  std::condition_variable cb_started_cv;
+  std::condition_variable cb_release_cv;
+  bool cb_started = false;
+  bool release_cb = false;
+
+  client.on_data([&](const wrapper::MessageContext&) {
+    {
+      std::lock_guard<std::mutex> lock(cb_mutex);
+      cb_started = true;
+    }
+    cb_started_cv.notify_all();
+    std::unique_lock<std::mutex> lock(cb_mutex);
+    cb_release_cv.wait(lock, [&] { return release_cb; });
+  });
+
+  auto started = client.start();
+  channel->emit_state(base::LinkState::Connected);
+  ASSERT_TRUE(started.get());
+
+  std::thread receiver([&] { channel->emit_bytes("payload"); });
+
+  {
+    std::unique_lock<std::mutex> lock(cb_mutex);
+    ASSERT_TRUE(cb_started_cv.wait_for(lock, 2s, [&] { return cb_started; }));
+  }
+
+  // The on_data callback above is still blocked. try_send must still
+  // complete promptly - it only needs a shared_lock snapshot of the
+  // channel pointer, which on_bytes no longer holds exclusively.
+  auto begin = std::chrono::steady_clock::now();
+  EXPECT_TRUE(client.try_send("concurrent"));
+  auto elapsed = std::chrono::steady_clock::now() - begin;
+  EXPECT_LT(elapsed, 200ms) << "try_send blocked on a concurrent, still-running on_data callback";
+
+  {
+    std::lock_guard<std::mutex> lock(cb_mutex);
+    release_cb = true;
+  }
+  cb_release_cv.notify_all();
+  receiver.join();
 
   client.stop();
 }

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -373,33 +373,42 @@ struct Serial::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      // #441: snapshot the handler/framer pointers under a shared_lock (not
+      // unique_lock) - this is a pure read, matching try_send's locking
+      // level so it no longer blocks concurrent sends even briefly.
+      bool batch_mode;
+      MessageHandler handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (data_batch_handler_) {
-        data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
-        if (data_batch_queue_.size() >= max_batch_size_) {
-          auto handler = data_batch_handler_;
-          auto batch = std::move(data_batch_queue_);
-          data_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-          lock.lock();
-        } else if (data_batch_queue_.size() == 1) {
-          schedule_batch_timer();
-        }
-      } else {
-        MessageHandler handler = data_handler;
-        if (handler) {
-          lock.unlock();
-          handler(MessageContext(0, memory::SafeDataBuffer(data)));
-          lock.lock();
-        }
-      }
-
-      if (framer) {
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(data_batch_handler_);
+        handler = data_handler;
         framer_to_push = framer;
       }
-      lock.unlock();
+
+      if (batch_mode) {
+        // #441: build the copy before taking the exclusive lock, so the
+        // lock is only held for the queue mutation itself, not the
+        // allocation.
+        MessageContext ctx(0, memory::SafeDataBuffer(data));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          data_batch_queue_.emplace_back(std::move(ctx));
+          if (data_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = data_batch_handler_;
+            batch = std::move(data_batch_queue_);
+            data_batch_queue_.clear();
+          } else if (data_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
+        }
+        if (flush_handler) flush_handler(batch);
+      } else if (handler) {
+        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+      }
+
       if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
@@ -462,24 +471,36 @@ struct Serial::Impl {
   void attach_framer_callback() {
     if (!framer) return;
     framer->on_message([this](memory::ConstByteSpan msg) {
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (message_batch_handler_) {
-        message_batch_queue_.emplace_back(0, memory::SafeDataBuffer(msg));
-        if (message_batch_queue_.size() >= max_batch_size_) {
-          auto handler = message_batch_handler_;
-          auto batch = std::move(message_batch_queue_);
-          message_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-        } else if (message_batch_queue_.size() == 1) {
-          schedule_batch_timer();
+      // #441: snapshot under a shared_lock (pure read), build the copy
+      // before taking the exclusive lock for queue mutation.
+      bool batch_mode;
+      MessageHandler handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(message_batch_handler_);
+        handler = message_handler;
+      }
+
+      if (batch_mode) {
+        MessageContext ctx(0, memory::SafeDataBuffer(msg));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          message_batch_queue_.emplace_back(std::move(ctx));
+          if (message_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = message_batch_handler_;
+            batch = std::move(message_batch_queue_);
+            message_batch_queue_.clear();
+          } else if (message_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
         }
+        if (flush_handler) flush_handler(batch);
         return;
       }
 
-      MessageHandler handler = message_handler;
       if (handler) {
-        lock.unlock();
         handler(MessageContext(0, memory::SafeDataBuffer(msg)));
       }
     });

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -380,33 +380,42 @@ struct TcpClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      // #441: snapshot the handler/framer pointers under a shared_lock (not
+      // unique_lock) - this is a pure read, matching try_send's locking
+      // level so it no longer blocks concurrent sends even briefly.
+      bool batch_mode;
+      MessageHandler handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (data_batch_handler_) {
-        data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
-        if (data_batch_queue_.size() >= max_batch_size_) {
-          auto handler = data_batch_handler_;
-          auto batch = std::move(data_batch_queue_);
-          data_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-          lock.lock();
-        } else if (data_batch_queue_.size() == 1) {
-          schedule_batch_timer();
-        }
-      } else {
-        MessageHandler handler = data_handler_;
-        if (handler) {
-          lock.unlock();
-          handler(MessageContext(0, memory::SafeDataBuffer(data)));
-          lock.lock();
-        }
-      }
-
-      if (framer_) {
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(data_batch_handler_);
+        handler = data_handler_;
         framer_to_push = framer_;
       }
-      lock.unlock();
+
+      if (batch_mode) {
+        // #441: build the copy before taking the exclusive lock, so the
+        // lock is only held for the queue mutation itself, not the
+        // allocation.
+        MessageContext ctx(0, memory::SafeDataBuffer(data));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          data_batch_queue_.emplace_back(std::move(ctx));
+          if (data_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = data_batch_handler_;
+            batch = std::move(data_batch_queue_);
+            data_batch_queue_.clear();
+          } else if (data_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
+        }
+        if (flush_handler) flush_handler(batch);
+      } else if (handler) {
+        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+      }
+
       if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
@@ -461,24 +470,36 @@ struct TcpClient::Impl {
   void attach_framer_callback() {
     if (!framer_) return;
     framer_->on_message([this](memory::ConstByteSpan msg) {
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (message_batch_handler_) {
-        message_batch_queue_.emplace_back(0, memory::SafeDataBuffer(msg));
-        if (message_batch_queue_.size() >= max_batch_size_) {
-          auto handler = message_batch_handler_;
-          auto batch = std::move(message_batch_queue_);
-          message_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-        } else if (message_batch_queue_.size() == 1) {
-          schedule_batch_timer();
+      // #441: snapshot under a shared_lock (pure read), build the copy
+      // before taking the exclusive lock for queue mutation.
+      bool batch_mode;
+      MessageHandler handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(message_batch_handler_);
+        handler = message_handler_;
+      }
+
+      if (batch_mode) {
+        MessageContext ctx(0, memory::SafeDataBuffer(msg));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          message_batch_queue_.emplace_back(std::move(ctx));
+          if (message_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = message_batch_handler_;
+            batch = std::move(message_batch_queue_);
+            message_batch_queue_.clear();
+          } else if (message_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
         }
+        if (flush_handler) flush_handler(batch);
         return;
       }
 
-      MessageHandler handler = message_handler_;
       if (handler) {
-        lock.unlock();
         handler(MessageContext(0, memory::SafeDataBuffer(msg)));
       }
     });

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -377,24 +377,36 @@ struct TcpServer::Impl {
             if (framer) {
               auto shared_framer = std::shared_ptr<framer::IFramer>(std::move(framer));
               shared_framer->on_message([this, id](memory::ConstByteSpan msg) {
-                std::unique_lock<std::shared_mutex> lock(mutex_);
-                if (message_batch_handler_) {
-                  message_batch_queue_.emplace_back(id, memory::SafeDataBuffer(msg));
-                  if (message_batch_queue_.size() >= max_batch_size_) {
-                    auto handler = message_batch_handler_;
-                    auto batch = std::move(message_batch_queue_);
-                    message_batch_queue_.clear();
-                    lock.unlock();
-                    handler(batch);
-                  } else if (message_batch_queue_.size() == 1) {
-                    schedule_batch_timer();
+                // #441: snapshot under a shared_lock (pure read), build the
+                // copy before taking the exclusive lock for queue mutation.
+                bool batch_mode;
+                MessageHandler on_message_handler;
+                {
+                  std::shared_lock<std::shared_mutex> lock(mutex_);
+                  batch_mode = static_cast<bool>(message_batch_handler_);
+                  on_message_handler = on_message_;
+                }
+
+                if (batch_mode) {
+                  MessageContext ctx(id, memory::SafeDataBuffer(msg));
+                  BatchMessageHandler flush_handler;
+                  std::vector<MessageContext> batch;
+                  {
+                    std::unique_lock<std::shared_mutex> lock(mutex_);
+                    message_batch_queue_.emplace_back(std::move(ctx));
+                    if (message_batch_queue_.size() >= max_batch_size_) {
+                      flush_handler = message_batch_handler_;
+                      batch = std::move(message_batch_queue_);
+                      message_batch_queue_.clear();
+                    } else if (message_batch_queue_.size() == 1) {
+                      schedule_batch_timer();
+                    }
                   }
+                  if (flush_handler) flush_handler(batch);
                   return;
                 }
 
-                MessageHandler on_message_handler = on_message_;
                 if (on_message_handler) {
-                  lock.unlock();
                   on_message_handler(MessageContext(id, memory::SafeDataBuffer(msg)));
                 }
               });
@@ -409,34 +421,46 @@ struct TcpServer::Impl {
         auto alive = weak_alive.lock();
         if (!alive) return;
 
+        // #441: snapshot the handler/framer pointers under a shared_lock
+        // (not unique_lock) - this is a pure read, matching try_send's
+        // locking level so it no longer blocks concurrent sends even
+        // briefly.
+        bool batch_mode;
+        MessageHandler handler;
         std::shared_ptr<framer::IFramer> framer;
-        std::unique_lock<std::shared_mutex> lock(mutex_);
-        if (data_batch_handler_) {
-          data_batch_queue_.emplace_back(id, memory::SafeDataBuffer(data_span));
-          if (data_batch_queue_.size() >= max_batch_size_) {
-            auto handler = data_batch_handler_;
-            auto batch = std::move(data_batch_queue_);
-            data_batch_queue_.clear();
-            lock.unlock();
-            handler(batch);
-            lock.lock();
-          } else if (data_batch_queue_.size() == 1) {
-            schedule_batch_timer();
-          }
-        } else {
-          MessageHandler handler = on_data_;
-          if (handler) {
-            lock.unlock();
-            handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
-            lock.lock();
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          batch_mode = static_cast<bool>(data_batch_handler_);
+          handler = on_data_;
+          auto it = framers_.find(id);
+          if (it != framers_.end()) {
+            framer = it->second;
           }
         }
 
-        auto it = framers_.find(id);
-        if (it != framers_.end()) {
-          framer = it->second;
+        if (batch_mode) {
+          // #441: build the copy before taking the exclusive lock, so the
+          // lock is only held for the queue mutation itself, not the
+          // allocation.
+          MessageContext ctx(id, memory::SafeDataBuffer(data_span));
+          BatchMessageHandler flush_handler;
+          std::vector<MessageContext> batch;
+          {
+            std::unique_lock<std::shared_mutex> lock(mutex_);
+            data_batch_queue_.emplace_back(std::move(ctx));
+            if (data_batch_queue_.size() >= max_batch_size_) {
+              flush_handler = data_batch_handler_;
+              batch = std::move(data_batch_queue_);
+              data_batch_queue_.clear();
+            } else if (data_batch_queue_.size() == 1) {
+              schedule_batch_timer();
+            }
+          }
+          if (flush_handler) flush_handler(batch);
+        } else if (handler) {
+          handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
         }
-        lock.unlock();
+
         if (framer) framer->push_bytes(data_span);
       });
       transport_server->on_multi_disconnect([this, weak_alive](ClientId id) {

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -357,33 +357,42 @@ struct UdpClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      // #441: snapshot the handler/framer pointers under a shared_lock (not
+      // unique_lock) - this is a pure read, matching try_send's locking
+      // level so it no longer blocks concurrent sends even briefly.
+      bool batch_mode;
+      MessageHandler handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (data_batch_handler_) {
-        data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
-        if (data_batch_queue_.size() >= max_batch_size_) {
-          auto handler = data_batch_handler_;
-          auto batch = std::move(data_batch_queue_);
-          data_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-          lock.lock();
-        } else if (data_batch_queue_.size() == 1) {
-          schedule_batch_timer();
-        }
-      } else {
-        MessageHandler handler = data_handler;
-        if (handler) {
-          lock.unlock();
-          handler(MessageContext(0, memory::SafeDataBuffer(data)));
-          lock.lock();
-        }
-      }
-
-      if (framer) {
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(data_batch_handler_);
+        handler = data_handler;
         framer_to_push = framer;
       }
-      lock.unlock();
+
+      if (batch_mode) {
+        // #441: build the copy before taking the exclusive lock, so the
+        // lock is only held for the queue mutation itself, not the
+        // allocation.
+        MessageContext ctx(0, memory::SafeDataBuffer(data));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          data_batch_queue_.emplace_back(std::move(ctx));
+          if (data_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = data_batch_handler_;
+            batch = std::move(data_batch_queue_);
+            data_batch_queue_.clear();
+          } else if (data_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
+        }
+        if (flush_handler) flush_handler(batch);
+      } else if (handler) {
+        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+      }
+
       if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
@@ -446,24 +455,36 @@ struct UdpClient::Impl {
   void attach_framer_callback() {
     if (!framer) return;
     framer->on_message([this](memory::ConstByteSpan msg) {
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (message_batch_handler_) {
-        message_batch_queue_.emplace_back(0, memory::SafeDataBuffer(msg));
-        if (message_batch_queue_.size() >= max_batch_size_) {
-          auto handler = message_batch_handler_;
-          auto batch = std::move(message_batch_queue_);
-          message_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-        } else if (message_batch_queue_.size() == 1) {
-          schedule_batch_timer();
+      // #441: snapshot under a shared_lock (pure read), build the copy
+      // before taking the exclusive lock for queue mutation.
+      bool batch_mode;
+      MessageHandler handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(message_batch_handler_);
+        handler = message_handler;
+      }
+
+      if (batch_mode) {
+        MessageContext ctx(0, memory::SafeDataBuffer(msg));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          message_batch_queue_.emplace_back(std::move(ctx));
+          if (message_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = message_batch_handler_;
+            batch = std::move(message_batch_queue_);
+            message_batch_queue_.clear();
+          } else if (message_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
         }
+        if (flush_handler) flush_handler(batch);
         return;
       }
 
-      MessageHandler handler = message_handler;
       if (handler) {
-        lock.unlock();
         handler(MessageContext(0, memory::SafeDataBuffer(msg)));
       }
     });

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -254,24 +254,36 @@ struct UdpServer::Impl {
             auto framer = framer_factory();
             if (framer) {
               framer->on_message([this, client_id](memory::ConstByteSpan msg) {
-                std::unique_lock<std::shared_mutex> lock(mutex);
-                if (on_message_batch_) {
-                  message_batch_queue_.emplace_back(client_id, memory::SafeDataBuffer(msg));
-                  if (message_batch_queue_.size() >= max_batch_size_) {
-                    auto handler = on_message_batch_;
-                    auto batch = std::move(message_batch_queue_);
-                    message_batch_queue_.clear();
-                    lock.unlock();
-                    handler(batch);
-                  } else if (message_batch_queue_.size() == 1) {
-                    schedule_batch_timer();
+                // #441: snapshot under a shared_lock (pure read), build the
+                // copy before taking the exclusive lock for queue mutation.
+                bool batch_mode;
+                MessageHandler on_message_handler;
+                {
+                  std::shared_lock<std::shared_mutex> lock(mutex);
+                  batch_mode = static_cast<bool>(on_message_batch_);
+                  on_message_handler = on_message;
+                }
+
+                if (batch_mode) {
+                  MessageContext ctx(client_id, memory::SafeDataBuffer(msg));
+                  BatchMessageHandler flush_handler;
+                  std::vector<MessageContext> batch;
+                  {
+                    std::unique_lock<std::shared_mutex> lock(mutex);
+                    message_batch_queue_.emplace_back(std::move(ctx));
+                    if (message_batch_queue_.size() >= max_batch_size_) {
+                      flush_handler = on_message_batch_;
+                      batch = std::move(message_batch_queue_);
+                      message_batch_queue_.clear();
+                    } else if (message_batch_queue_.size() == 1) {
+                      schedule_batch_timer();
+                    }
                   }
+                  if (flush_handler) flush_handler(batch);
                   return;
                 }
 
-                MessageHandler on_message_handler = on_message;
                 if (on_message_handler) {
-                  lock.unlock();
                   on_message_handler(MessageContext(client_id, memory::SafeDataBuffer(msg)));
                 }
               });
@@ -291,25 +303,38 @@ struct UdpServer::Impl {
       }
 
       {
-        std::unique_lock<std::shared_mutex> lock(mutex);
-        if (on_data_batch_) {
-          data_batch_queue_.emplace_back(client_id, memory::SafeDataBuffer(data));
-          if (data_batch_queue_.size() >= max_batch_size_) {
-            auto handler = on_data_batch_;
-            auto batch = std::move(data_batch_queue_);
-            data_batch_queue_.clear();
-            lock.unlock();
-            handler(batch);
-          } else if (data_batch_queue_.size() == 1) {
-            schedule_batch_timer();
+        // #441: snapshot the handler under a shared_lock (not unique_lock) -
+        // this is a pure read, matching try_send's locking level so it no
+        // longer blocks concurrent sends even briefly.
+        bool batch_mode;
+        MessageHandler data_handler_copy;
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex);
+          batch_mode = static_cast<bool>(on_data_batch_);
+          data_handler_copy = on_data;
+        }
+
+        if (batch_mode) {
+          // #441: build the copy before taking the exclusive lock, so the
+          // lock is only held for the queue mutation itself, not the
+          // allocation.
+          MessageContext ctx(client_id, memory::SafeDataBuffer(data));
+          BatchMessageHandler flush_handler;
+          std::vector<MessageContext> batch;
+          {
+            std::unique_lock<std::shared_mutex> lock(mutex);
+            data_batch_queue_.emplace_back(std::move(ctx));
+            if (data_batch_queue_.size() >= max_batch_size_) {
+              flush_handler = on_data_batch_;
+              batch = std::move(data_batch_queue_);
+              data_batch_queue_.clear();
+            } else if (data_batch_queue_.size() == 1) {
+              schedule_batch_timer();
+            }
           }
-        } else {
-          MessageHandler data_handler_copy = on_data;
-          if (data_handler_copy) {
-            lock.unlock();
-            data_handler_copy(MessageContext(client_id, memory::SafeDataBuffer(data)));
-            lock.lock();
-          }
+          if (flush_handler) flush_handler(batch);
+        } else if (data_handler_copy) {
+          data_handler_copy(MessageContext(client_id, memory::SafeDataBuffer(data)));
         }
       }
 

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -411,33 +411,42 @@ struct UdsClient::Impl {
       auto alive = weak_alive.lock();
       if (!alive) return;
 
+      // #441: snapshot the handler/framer pointers under a shared_lock (not
+      // unique_lock) - this is a pure read, matching try_send's locking
+      // level so it no longer blocks concurrent sends even briefly.
+      bool batch_mode;
+      MessageHandler handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (data_batch_handler_) {
-        data_batch_queue_.emplace_back(0, memory::SafeDataBuffer(data));
-        if (data_batch_queue_.size() >= max_batch_size_) {
-          auto handler = data_batch_handler_;
-          auto batch = std::move(data_batch_queue_);
-          data_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-          lock.lock();
-        } else if (data_batch_queue_.size() == 1) {
-          schedule_batch_timer();
-        }
-      } else {
-        MessageHandler handler = data_handler_;
-        if (handler) {
-          lock.unlock();
-          handler(MessageContext(0, memory::SafeDataBuffer(data)));
-          lock.lock();
-        }
-      }
-
-      if (framer_) {
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(data_batch_handler_);
+        handler = data_handler_;
         framer_to_push = framer_;
       }
-      lock.unlock();
+
+      if (batch_mode) {
+        // #441: build the copy before taking the exclusive lock, so the
+        // lock is only held for the queue mutation itself, not the
+        // allocation.
+        MessageContext ctx(0, memory::SafeDataBuffer(data));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          data_batch_queue_.emplace_back(std::move(ctx));
+          if (data_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = data_batch_handler_;
+            batch = std::move(data_batch_queue_);
+            data_batch_queue_.clear();
+          } else if (data_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
+        }
+        if (flush_handler) flush_handler(batch);
+      } else if (handler) {
+        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+      }
+
       if (framer_to_push) framer_to_push->push_bytes(data);
     });
 
@@ -459,24 +468,36 @@ struct UdsClient::Impl {
   void attach_framer_callback() {
     if (!framer_) return;
     framer_->on_message([this](memory::ConstByteSpan msg) {
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (message_batch_handler_) {
-        message_batch_queue_.emplace_back(0, memory::SafeDataBuffer(msg));
-        if (message_batch_queue_.size() >= max_batch_size_) {
-          auto handler = message_batch_handler_;
-          auto batch = std::move(message_batch_queue_);
-          message_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-        } else if (message_batch_queue_.size() == 1) {
-          schedule_batch_timer();
+      // #441: snapshot under a shared_lock (pure read), build the copy
+      // before taking the exclusive lock for queue mutation.
+      bool batch_mode;
+      MessageHandler handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(message_batch_handler_);
+        handler = message_handler_;
+      }
+
+      if (batch_mode) {
+        MessageContext ctx(0, memory::SafeDataBuffer(msg));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          message_batch_queue_.emplace_back(std::move(ctx));
+          if (message_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = message_batch_handler_;
+            batch = std::move(message_batch_queue_);
+            message_batch_queue_.clear();
+          } else if (message_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
         }
+        if (flush_handler) flush_handler(batch);
         return;
       }
 
-      MessageHandler handler = message_handler_;
       if (handler) {
-        lock.unlock();
         handler(MessageContext(0, memory::SafeDataBuffer(msg)));
       }
     });

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -298,34 +298,46 @@ struct UdsServer::Impl {
         auto alive = weak_alive.lock();
         if (!alive) return;
 
+        // #441: snapshot the handler/framer pointers under a shared_lock
+        // (not unique_lock) - this is a pure read, matching try_send's
+        // locking level so it no longer blocks concurrent sends even
+        // briefly.
+        bool batch_mode;
+        MessageHandler handler;
         std::shared_ptr<framer::IFramer> framer_to_push;
-        std::unique_lock<std::shared_mutex> lock(mutex_);
-        if (data_batch_handler_) {
-          data_batch_queue_.emplace_back(id, memory::SafeDataBuffer(data_span));
-          if (data_batch_queue_.size() >= max_batch_size_) {
-            auto handler = data_batch_handler_;
-            auto batch = std::move(data_batch_queue_);
-            data_batch_queue_.clear();
-            lock.unlock();
-            handler(batch);
-            lock.lock();
-          } else if (data_batch_queue_.size() == 1) {
-            schedule_batch_timer();
-          }
-        } else {
-          MessageHandler handler = data_handler_;
-          if (handler) {
-            lock.unlock();
-            handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
-            lock.lock();
+        {
+          std::shared_lock<std::shared_mutex> lock(mutex_);
+          batch_mode = static_cast<bool>(data_batch_handler_);
+          handler = data_handler_;
+          auto it = framers_.find(id);
+          if (it != framers_.end()) {
+            framer_to_push = it->second;
           }
         }
 
-        auto it = framers_.find(id);
-        if (it != framers_.end()) {
-          framer_to_push = it->second;
+        if (batch_mode) {
+          // #441: build the copy before taking the exclusive lock, so the
+          // lock is only held for the queue mutation itself, not the
+          // allocation.
+          MessageContext ctx(id, memory::SafeDataBuffer(data_span));
+          BatchMessageHandler flush_handler;
+          std::vector<MessageContext> batch;
+          {
+            std::unique_lock<std::shared_mutex> lock(mutex_);
+            data_batch_queue_.emplace_back(std::move(ctx));
+            if (data_batch_queue_.size() >= max_batch_size_) {
+              flush_handler = data_batch_handler_;
+              batch = std::move(data_batch_queue_);
+              data_batch_queue_.clear();
+            } else if (data_batch_queue_.size() == 1) {
+              schedule_batch_timer();
+            }
+          }
+          if (flush_handler) flush_handler(batch);
+        } else if (handler) {
+          handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
         }
-        lock.unlock();
+
         if (framer_to_push) framer_to_push->push_bytes(data_span);
       });
       transport_server->on_multi_disconnect([this, weak_alive](ClientId id) {
@@ -396,24 +408,36 @@ struct UdsServer::Impl {
     if (it == framers_.end()) return;
 
     it->second->on_message([this, id](memory::ConstByteSpan msg) {
-      std::unique_lock<std::shared_mutex> lock(mutex_);
-      if (on_message_batch_) {
-        message_batch_queue_.emplace_back(id, memory::SafeDataBuffer(msg));
-        if (message_batch_queue_.size() >= max_batch_size_) {
-          auto handler = on_message_batch_;
-          auto batch = std::move(message_batch_queue_);
-          message_batch_queue_.clear();
-          lock.unlock();
-          handler(batch);
-        } else if (message_batch_queue_.size() == 1) {
-          schedule_batch_timer();
+      // #441: snapshot under a shared_lock (pure read), build the copy
+      // before taking the exclusive lock for queue mutation.
+      bool batch_mode;
+      MessageHandler handler;
+      {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        batch_mode = static_cast<bool>(on_message_batch_);
+        handler = on_message_;
+      }
+
+      if (batch_mode) {
+        MessageContext ctx(id, memory::SafeDataBuffer(msg));
+        BatchMessageHandler flush_handler;
+        std::vector<MessageContext> batch;
+        {
+          std::unique_lock<std::shared_mutex> lock(mutex_);
+          message_batch_queue_.emplace_back(std::move(ctx));
+          if (message_batch_queue_.size() >= max_batch_size_) {
+            flush_handler = on_message_batch_;
+            batch = std::move(message_batch_queue_);
+            message_batch_queue_.clear();
+          } else if (message_batch_queue_.size() == 1) {
+            schedule_batch_timer();
+          }
         }
+        if (flush_handler) flush_handler(batch);
         return;
       }
 
-      MessageHandler handler = on_message_;
       if (handler) {
-        lock.unlock();
         handler(MessageContext(id, memory::SafeDataBuffer(msg)));
       }
     });


### PR DESCRIPTION
## Summary
Addresses steps 1-2 of #441's design plan (step 3, a non-owning-view `MessageContext`, is a larger follow-up).

Traced the actual locking behavior before implementing: the exclusive lock is **not** held for the user callback's duration today - that was already fixed by PR #370, before this issue was filed. The callback runs after `lock.unlock()` in the common single-handler case. What actually remained:

1. The brief "snapshot handler/framer pointers" step used `unique_lock` for a pure read, when `try_send` (which reads only the channel pointer under the same mutex) already uses `shared_lock`. Switched the snapshot to `shared_lock` in all 7 wrappers' `on_bytes`/`on_multi_data` dispatch, plus their `attach_framer_callback`'s framed-message dispatch.
2. The batch-handler path constructed the `SafeDataBuffer` copy *while* holding the exclusive lock needed for `data_batch_queue_.emplace_back()`. Restructured so the copy happens first (no lock needed), and the exclusive lock is only taken for the actual queue push/flush decision.

`UdpServer::on_bytes_from` has extra session/framer-creation logic for new clients that genuinely needs exclusivity (mutating `sessions_`/`endpoint_to_id`) - only the data-dispatch portion of that handler was restructured.

## Test plan
- [x] `./scripts/verify.sh` passes (707 tests, +1 new)
- [x] New `TrySendDoesNotBlockOnConcurrentSlowDataCallback` test: registers an `on_data` handler that blocks until released, triggers it on a background thread, and asserts a concurrent `try_send()` from the main thread still completes promptly rather than waiting for the still-running callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)