### PR TITLE
fix: give each channel its own memory pool instead of the global singleton

### DIFF
--- a/test/unit/memory/test_pool_limits.cc
+++ b/test/unit/memory/test_pool_limits.cc
@@ -114,4 +114,31 @@ TEST_F(MemoryPoolLimitsTest, LargeAllocation) {
   pool_->release(std::move(buf), large_size);
 }
 
+// #443: PooledBuffer(size, pool) must draw from and release back to the
+// specific pool instance passed in, not GlobalMemoryPool::instance() -
+// this is what makes per-channel pools (one MemoryPool member per
+// transport instance) actually isolated from each other.
+TEST(PooledBufferPerPoolTest, DrawsFromAndReleasesToTheGivenPoolNotGlobal) {
+  MemoryPool pool_a(4, 16);
+  MemoryPool pool_b(4, 16);
+
+  {
+    PooledBuffer buf(MemoryPool::BufferSize::SMALL, pool_a);
+    EXPECT_TRUE(buf.valid());
+  }
+  // The buffer was acquired from and released back to pool_a - pool_a should
+  // show a recorded allocation, pool_b must remain completely untouched.
+  EXPECT_EQ(pool_a.stats().total_allocations, 1U);
+  EXPECT_EQ(pool_b.stats().total_allocations, 0U);
+
+  {
+    PooledBuffer buf(MemoryPool::BufferSize::SMALL, pool_a);
+    EXPECT_TRUE(buf.valid());
+  }
+  // Second acquire should hit the bucket populated by the first release.
+  EXPECT_EQ(pool_a.stats().pool_hits, 1U);
+  EXPECT_EQ(pool_b.stats().total_allocations, 0U);
+  EXPECT_EQ(pool_b.stats().pool_hits, 0U);
+}
+
 }  // namespace

--- a/unilink/memory/memory_pool.cc
+++ b/unilink/memory/memory_pool.cc
@@ -239,6 +239,15 @@ PooledBuffer::PooledBuffer(MemoryPool::BufferSize buffer_size)
   buffer_ = pool_->acquire(size_);
 }
 
+PooledBuffer::PooledBuffer(size_t size, MemoryPool& pool) : size_(size), pool_(&pool) {
+  buffer_ = pool_->acquire(size);
+}
+
+PooledBuffer::PooledBuffer(MemoryPool::BufferSize buffer_size, MemoryPool& pool)
+    : size_(static_cast<size_t>(buffer_size)), pool_(&pool) {
+  buffer_ = pool_->acquire(size_);
+}
+
 PooledBuffer::~PooledBuffer() {
   if (buffer_ && pool_) {
     pool_->release(std::move(buffer_), size_);

--- a/unilink/memory/memory_pool.hpp
+++ b/unilink/memory/memory_pool.hpp
@@ -147,6 +147,11 @@ class UNILINK_API PooledBuffer {
  public:
   explicit PooledBuffer(size_t size);
   explicit PooledBuffer(MemoryPool::BufferSize buffer_size);
+  // #443: draw from a specific pool (e.g. a per-channel instance) instead of
+  // the process-wide GlobalMemoryPool singleton, to avoid cross-channel
+  // contention on the singleton's bucket mutexes.
+  PooledBuffer(size_t size, MemoryPool& pool);
+  PooledBuffer(MemoryPool::BufferSize buffer_size, MemoryPool& pool);
   ~PooledBuffer();
 
   // Non-copyable, movable

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -67,6 +67,11 @@ struct Serial::Impl {
 
   std::unique_ptr<interface::SerialPortInterface> port_;
   config::SerialConfig cfg_;
+  // #443: per-channel pool instead of the process-wide GlobalMemoryPool
+  // singleton - avoids cross-channel contention on the singleton's bucket
+  // mutexes. Capacity is much smaller than the old shared default since
+  // it's no longer amortized across every channel in the process.
+  memory::MemoryPool pool_{50, 200};
   net::steady_timer retry_timer_;
 
   std::vector<uint8_t> rx_;
@@ -648,8 +653,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     return false;
   }
 
-  if (n <= 65536) {
-    memory::PooledBuffer pooled(n);
+  if (n <= 65536 && impl->cfg_.enable_memory_pool) {
+    memory::PooledBuffer pooled(n, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
       if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) {

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -90,6 +90,11 @@ struct TcpClient::Impl {
   // don't need this lock (#436).
   mutable std::mutex cfg_mtx_;
   TcpClientConfig cfg_;
+  // #443: per-channel pool instead of the process-wide GlobalMemoryPool
+  // singleton - avoids cross-channel contention on the singleton's bucket
+  // mutexes. Capacity is much smaller than the old shared default (400/2000)
+  // since it's no longer amortized across every channel in the process.
+  memory::MemoryPool pool_{50, 200};
   net::steady_timer retry_timer_;
   net::steady_timer connect_timer_;
   net::steady_timer idle_timer_;
@@ -321,9 +326,9 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
     return false;
   }
 
-  if (size <= 65536) {
+  if (size <= 65536 && impl_->cfg_.enable_memory_pool) {
     try {
-      memory::PooledBuffer pooled_buffer(size);
+      memory::PooledBuffer pooled_buffer(size, impl_->pool_);
       if (pooled_buffer.valid()) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -300,7 +300,8 @@ struct TcpServer::Impl {
 
       auto new_session = std::make_shared<TcpServerSession>(
           accept_impl->ioc_, std::move(sock), accept_impl->cfg_.backpressure_threshold,
-          accept_impl->cfg_.idle_timeout_ms, accept_impl->cfg_.backpressure_strategy);
+          accept_impl->cfg_.idle_timeout_ms, accept_impl->cfg_.backpressure_strategy,
+          accept_impl->cfg_.enable_memory_pool);
 
       ClientId client_id = accept_impl->next_client_id_.fetch_add(1);
 

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -27,11 +27,13 @@ namespace unilink {
 namespace transport {
 
 TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_t backpressure_threshold,
-                                   int idle_timeout_ms, base::constants::BackpressureStrategy strategy)
+                                   int idle_timeout_ms, base::constants::BackpressureStrategy strategy,
+                                   bool enable_memory_pool)
     : ioc_(ioc),
       strand_(ioc.get_executor()),
       idle_timer_(ioc),
       socket_(std::make_unique<BoostTcpSocket>(std::move(sock))),
+      enable_memory_pool_(enable_memory_pool),
       writing_(false),
       queue_bytes_(0),
       bp_strategy_(strategy),
@@ -47,11 +49,12 @@ TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_
 
 TcpServerSession::TcpServerSession(net::io_context& ioc, std::unique_ptr<interface::TcpSocketInterface> socket,
                                    size_t backpressure_threshold, int idle_timeout_ms,
-                                   base::constants::BackpressureStrategy strategy)
+                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool)
     : ioc_(ioc),
       strand_(ioc.get_executor()),
       idle_timer_(ioc),
       socket_(std::move(socket)),
+      enable_memory_pool_(enable_memory_pool),
       writing_(false),
       queue_bytes_(0),
       bp_strategy_(strategy),
@@ -92,8 +95,8 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Use memory pool for better performance (only for reasonable sizes)
-  if (size <= base::constants::LARGE_BUFFER_THRESHOLD) {  // Only use pool for buffers <= 64KB
-    memory::PooledBuffer pooled_buffer(size);
+  if (size <= base::constants::LARGE_BUFFER_THRESHOLD && enable_memory_pool_) {  // Only use pool for buffers <= 64KB
+    memory::PooledBuffer pooled_buffer(size, pool_);
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -59,12 +59,14 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   TcpServerSession(net::io_context& ioc, tcp::socket sock,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
-                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable);
+                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
+                   bool enable_memory_pool = true);
   // Constructor for testing with dependency injection
   TcpServerSession(net::io_context& ioc, std::unique_ptr<interface::TcpSocketInterface> socket,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
-                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable);
+                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
+                   bool enable_memory_pool = true);
 
   void start();
   bool async_write_copy(memory::ConstByteSpan data);
@@ -99,6 +101,12 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   net::strand<net::io_context::executor_type> strand_;
   net::steady_timer idle_timer_;
   std::unique_ptr<interface::TcpSocketInterface> socket_;
+  // #443: per-session pool instead of the process-wide GlobalMemoryPool
+  // singleton - avoids cross-channel contention on the singleton's bucket
+  // mutexes. Capacity is much smaller than the old shared default since
+  // it's no longer amortized across every connected client in the process.
+  memory::MemoryPool pool_{50, 200};
+  bool enable_memory_pool_ = true;
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -78,6 +78,11 @@ struct UdpChannel::Impl {
   bool writing_{false};
   std::atomic<size_t> queue_bytes_{0};
   config::UdpConfig cfg_;
+  // #443: per-channel pool instead of the process-wide GlobalMemoryPool
+  // singleton - avoids cross-channel contention on the singleton's bucket
+  // mutexes. Capacity is much smaller than the old shared default since
+  // it's no longer amortized across every channel in the process.
+  memory::MemoryPool pool_{50, 200};
   // Atomic rather than mutex-guarded: read both from the strand (report_backpressure,
   // do_write) and from arbitrary caller threads (the async_try_write_* fast-fail
   // prechecks) - a strand-post here would only protect the former, not the latter (#436).
@@ -796,7 +801,7 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
   }
 
   if (impl->cfg_.enable_memory_pool && size <= 65536) {
-    memory::PooledBuffer pooled(size);
+    memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
       if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
@@ -1047,7 +1052,7 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     return false;
   }
   if (impl->cfg_.enable_memory_pool && size <= 65536) {
-    memory::PooledBuffer pooled(size);
+    memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
       if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -69,6 +69,11 @@ struct UdsClient::Impl {
   // transport/tcp_client/tcp_client.cc (#436).
   mutable std::mutex cfg_mtx_;
   UdsClientConfig cfg_;
+  // #443: UDS never actually pooled - async_write_copy always heap-allocated
+  // a fresh std::vector, despite a dead PooledBuffer std::visit branch
+  // suggesting otherwise. Give it a real per-channel pool like every other
+  // transport, instead of the process-wide GlobalMemoryPool singleton.
+  memory::MemoryPool pool_{50, 200};
   net::steady_timer retry_timer_;
   net::steady_timer connect_timer_;
   bool owns_ioc_ = true;
@@ -286,6 +291,28 @@ void UdsClient::reset_stats() {
 boost::asio::any_io_executor UdsClient::get_executor() { return impl_->strand_; }
 
 bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
+  size_t size = data.size();
+  if (impl_->cfg_.enable_memory_pool && size > 0 && size <= 65536) {
+    if (!impl_->connected_.load() || impl_->stop_requested_.load()) {
+      impl_->stats_.record_failed_send();
+      return false;
+    }
+    memory::PooledBuffer pooled(size, impl_->pool_);
+    if (pooled.valid()) {
+      base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
+      if (impl_->queue_bytes_ + impl_->pending_bytes_ + size > impl_->bp_limit_) {
+        impl_->stats_.record_failed_send();
+        return false;
+      }
+      impl_->stats_.record_accepted(size);
+      net::post(impl_->strand_, [this, self = shared_from_this(), buf = std::move(pooled)]() mutable {
+        size_t added = buf.size();
+        impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added);
+      });
+      return true;
+    }
+  }
+
   std::vector<uint8_t> vec(data.begin(), data.end());
   return async_write_move(std::move(vec));
 }

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -536,7 +536,8 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
 
       auto session = std::make_shared<UdsServerSession>(
           *self->impl_->ioc_, std::move(socket), self->impl_->cfg_.backpressure_threshold,
-          self->impl_->cfg_.idle_timeout_ms, self->impl_->cfg_.backpressure_strategy);
+          self->impl_->cfg_.idle_timeout_ms, self->impl_->cfg_.backpressure_strategy,
+          self->impl_->cfg_.enable_memory_pool);
 
       std::weak_ptr<UdsServer> weak_self = self;
       session->on_bytes([weak_self, client_id](memory::ConstByteSpan data) {

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -23,11 +23,13 @@ namespace unilink {
 namespace transport {
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_t backpressure_threshold,
-                                   int idle_timeout_ms, base::constants::BackpressureStrategy strategy)
+                                   int idle_timeout_ms, base::constants::BackpressureStrategy strategy,
+                                   bool enable_memory_pool)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
       idle_timer_(ioc),
       socket_(std::make_unique<BoostUdsSocket>(std::move(sock))),
+      enable_memory_pool_(enable_memory_pool),
       bp_strategy_(strategy),
       bp_high_(backpressure_threshold),
       bp_low_(backpressure_threshold > 1 ? backpressure_threshold / 2 : backpressure_threshold),
@@ -37,11 +39,12 @@ UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
                                    size_t backpressure_threshold, int idle_timeout_ms,
-                                   base::constants::BackpressureStrategy strategy)
+                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
       idle_timer_(ioc),
       socket_(std::move(socket)),
+      enable_memory_pool_(enable_memory_pool),
       bp_strategy_(strategy),
       bp_high_(backpressure_threshold),
       bp_low_(backpressure_threshold > 1 ? backpressure_threshold / 2 : backpressure_threshold),
@@ -78,6 +81,29 @@ void UdsServerSession::reset_stats() {
 }
 
 bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
+  size_t size = data.size();
+  if (enable_memory_pool_ && size > 0 && size <= 65536) {
+    if (!alive_ || closing_) {
+      stats_.record_failed_send();
+      return false;
+    }
+    memory::PooledBuffer pooled(size, pool_);
+    if (pooled.valid()) {
+      base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
+      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+        stats_.record_failed_send();
+        return false;
+      }
+      stats_.record_accepted(size);
+      net::post(strand_, [this, self = shared_from_this(), buf = std::move(pooled)]() mutable {
+        if (!alive_) return;
+        size_t added = buf.size();
+        route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
+      });
+      return true;
+    }
+  }
+
   std::vector<uint8_t> vec(data.begin(), data.end());
   return async_write_move(std::move(vec));
 }

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -59,12 +59,14 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   UdsServerSession(net::io_context& ioc, uds::socket sock,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
-                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable);
+                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
+                   bool enable_memory_pool = true);
 
   UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
-                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable);
+                   base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
+                   bool enable_memory_pool = true);
 
   void start();
   bool async_write_copy(memory::ConstByteSpan data);
@@ -98,6 +100,12 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   net::strand<net::io_context::executor_type> strand_;
   net::steady_timer idle_timer_;
   std::unique_ptr<interface::UdsSocketInterface> socket_;
+  // #443: per-session pool instead of the process-wide GlobalMemoryPool
+  // singleton - avoids cross-channel contention on the singleton's bucket
+  // mutexes. Also fixes UDS never actually pooling at all (async_write_copy
+  // used to always heap-allocate a fresh std::vector).
+  memory::MemoryPool pool_{50, 200};
+  bool enable_memory_pool_ = true;
   std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;


### PR DESCRIPTION
## Summary
Addresses steps 1-2 of #443's design plan (step 3 - fixing UDS's dead pool path - done as a bonus below; step 4, routing "try" writes through the pool, is deferred as a separate follow-up given the larger restructuring it needs on the try-write call path, which has a different, vector-only public signature).

Every transport (`TcpClient`, `TcpServerSession`, `Serial`, `UdpChannel`, `UdsClient`, `UdsServerSession`) now owns its own `MemoryPool` member (capacity 50/200 per bucket - modest since it's no longer amortized across every channel in the process) instead of reaching for `GlobalMemoryPool::instance()`, eliminating cross-channel contention on the singleton's shared bucket mutexes. Added new `PooledBuffer(size, pool)`/`PooledBuffer(BufferSize, pool)` constructors that draw from (and release back to) a specific `MemoryPool` instance, alongside the existing constructors that still default to `GlobalMemoryPool` (kept as a public, general-purpose utility, not removed - other tests and potential consumers already use it directly).

**Also fixed**: `enable_memory_pool` was a no-op in 4 of 6 transports (`TcpClient`, `TcpServerSession`, `Serial`, and both UDS transports never checked it at all - only `UdpChannel` did). Now consistently gates pool usage everywhere.

**Bonus fix** while wiring in per-channel pools: both UDS transports (`UdsClient`, `UdsServerSession`) never actually pooled at all - `async_write_copy` always heap-allocated a fresh `std::vector` despite a dead `PooledBuffer` `std::visit` branch suggesting otherwise. Wired in real pooling for both, matching the other 4 transports' pattern.

## Test plan
- [x] `./scripts/verify.sh` passes (708 tests, +1 new)
- [x] New `PooledBufferPerPoolTest.DrawsFromAndReleasesToTheGivenPoolNotGlobal`: two separate `MemoryPool` instances, confirms a `PooledBuffer` constructed against one never touches the other's stats, proving per-channel pools are actually isolated from each other
- Note: `UdsServerWrapperLifecycleTest.LineSendingVariantsReachConnectedClients` failed once during a full `verify.sh` run but did not reproduce over 8 subsequent isolated/full-file runs or a second full `verify.sh` pass - consistent with a pre-existing, resource-contention-sensitive flake unrelated to this change (it doesn't touch write ordering or byte content, only where the copy's backing buffer comes from)

🤖 Generated with [Claude Code](https://claude.com/claude-code)