### PR TITLE
version: bump to v0.8.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.4
+  VERSION 0.8.5
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Summary
Covers the merged Phase 3 work since v0.8.4: #444-remainder (`TcpServer` `stop()` hygiene, uniform `on_backpressure` nulling, restart contract docs), #432 (config validation consolidated onto `base/constants.hpp`, fixed a live setter-bypass bug), #441 (narrowed receive-hot-path lock scope to a `shared_lock` snapshot, matching `try_send`), and #443 (each channel now owns its own memory pool instead of a contended global singleton, plus a bonus fix wiring up UDS's previously-dead pooling path).

All additions are backward-compatible (internal locking/allocation changes, new opt-in config checks), no breaking API changes.

## Test plan
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)