### PR TITLE
fix: default TCP/UDS server connection limit, close over-limit connections promptly

### DIFF
--- a/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
@@ -248,6 +248,49 @@ TEST_F(TcpServerWrapperLifecycleTest, MaxClientsWhileStoppedAppliesOnNextStart) 
   client2->stop();
 }
 
+// #437: an over-limit connection used to pause the accept loop entirely
+// (paused_accept_), leaving any client whose TCP handshake completed while
+// paused connected but silent until a slot freed up. Now the server accepts
+// and immediately closes over-limit connections, and keeps accepting
+// afterward instead of pausing.
+TEST_F(TcpServerWrapperLifecycleTest, OverLimitConnectionIsClosedPromptlyAndAcceptLoopKeepsRunning) {
+  server_ = unilink::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  server_->max_clients(1);
+  ASSERT_TRUE(server_->start().get());
+
+  auto client1 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client1->start().get());
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 5000));
+
+  // Second client is over the limit - must be closed promptly (not left
+  // connected-but-silent). Its own on_disconnect doesn't reliably fire here
+  // (an unlimited-retry client transitions Connected->Connecting again
+  // without a distinct Closed notification), so observe promptness via
+  // repeated connect attempts instead: the server accepting-then-closing
+  // each attempt drives the client's retry loop, which wouldn't advance at
+  // all if the connection were instead left open and silent.
+  auto client2 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  std::atomic<int> client2_connects{0};
+  client2->on_connect([&](const wrapper::ConnectionContext&) { client2_connects++; });
+  client2->start();
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return client2_connects.load() >= 3; }, 3000))
+      << "Over-limit client's retry loop did not advance - connection may have been left open and silent";
+  EXPECT_EQ(server_->client_count(), 1u);
+
+  // The accept loop must not have paused: after client1 disconnects and
+  // frees the only slot, a new client must still be able to connect without
+  // needing anything to explicitly "resume" accepting.
+  client1->stop();
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() == 0; }, 5000));
+
+  auto client3 = unilink::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client3->start().get());
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 5000));
+
+  client2->stop();
+  client3->stop();
+}
+
 TEST_F(TcpServerWrapperLifecycleTest, SendAndCountReflectLiveClientsAndReturnStatus) {
   std::vector<size_t> ids;
   std::mutex ids_mutex;

--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -274,6 +274,23 @@ TEST_F(ConfigTest, TcpClientConfigDirectValidation) {
 // ever checked, for both TcpClientConfig and UdsClientConfig - a
 // connection_timeout(0) reached connect_timer_ unclamped and caused an
 // instant-timeout reconnect loop (the reported failure scenario).
+// #437: max_connections used to default to 0 (unlimited), risking unbounded
+// memory growth from a large number of slow/malicious clients with no
+// built-in ceiling. Both server configs must now default to a finite limit.
+TEST_F(ConfigTest, ServerConfigsDefaultToAFiniteConnectionLimit) {
+  TcpServerConfig tcp_server;
+  EXPECT_EQ(tcp_server.max_connections, static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS));
+  EXPECT_GT(tcp_server.max_connections, 0);
+
+  UdsServerConfig uds_server;
+  EXPECT_EQ(uds_server.max_connections, static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS));
+  EXPECT_GT(uds_server.max_connections, 0);
+
+  // 0 must still mean "unlimited" for callers who explicitly opt into it.
+  tcp_server.max_connections = 0;
+  EXPECT_TRUE(tcp_server.is_valid());
+}
+
 TEST_F(ConfigTest, TcpClientAndUdsClientConfigTimeoutFieldsAreValidatedAndClamped) {
   TcpClientConfig tcp;
   EXPECT_TRUE(tcp.is_valid());

--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -86,7 +86,11 @@ constexpr unsigned MAX_CLEANUP_INTERVAL_MS = 1000;           // 1s maximum clean
 constexpr unsigned DEFAULT_HEALTH_CHECK_INTERVAL_MS = 1000;  // 1s health check interval
 
 // Connection and session constants
-constexpr size_t MAX_MAX_CONNECTIONS = 10000;   // Maximum allowed connections
+constexpr size_t MAX_MAX_CONNECTIONS = 10000;  // Maximum allowed connections
+// #437: a server started with defaults must have some ceiling on total
+// memory a large number of slow/malicious clients can consume - 0 (the old
+// default) meant unlimited.
+constexpr size_t DEFAULT_MAX_CONNECTIONS = 1024;
 constexpr size_t DEFAULT_IDLE_TIMEOUT_MS = 0;   // Idle timeout disabled by default
 constexpr size_t MIN_IDLE_TIMEOUT_MS = 1;       // 1ms minimum idle timeout when enabled
 constexpr size_t MAX_IDLE_TIMEOUT_MS = 300000;  // 5m maximum idle timeout

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -31,7 +31,10 @@ struct TcpServerConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  int max_connections = 0;  // Maximum concurrent connections (0 = unlimited)
+  // #437: 0 (unlimited) used to be the default, risking unbounded memory
+  // growth from a large number of slow/malicious clients. 0 still means
+  // unlimited for callers who explicitly opt into it.
+  int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
 
   // Port binding retry configuration
   bool enable_port_retry = false;     // Enable port binding retry

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -83,7 +83,10 @@ struct UdsServerConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  int max_connections = 0;  // Maximum concurrent connections (0 = unlimited)
+  // #437: 0 (unlimited) used to be the default, risking unbounded memory
+  // growth from a large number of slow/malicious clients. 0 still means
+  // unlimited for callers who explicitly opt into it.
+  int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
   int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
 
   bool is_valid() const {

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -72,7 +72,6 @@ struct TcpServer::Impl {
 
   size_t max_clients_;
   bool client_limit_enabled_;
-  bool paused_accept_ = false;
 
   std::shared_ptr<TcpServerSession> current_session_;
 
@@ -287,11 +286,19 @@ struct TcpServer::Impl {
       }
 
       if (accept_impl->client_limit_enabled_) {
-        std::lock_guard<std::mutex> lock(accept_impl->sessions_mutex_);
-        if (accept_impl->sessions_.size() >= accept_impl->max_clients_) {
+        bool over_limit;
+        {
+          std::lock_guard<std::mutex> lock(accept_impl->sessions_mutex_);
+          over_limit = accept_impl->sessions_.size() >= accept_impl->max_clients_;
+        }
+        if (over_limit) {
+          // #437: accept and immediately close over-limit connections
+          // instead of pausing the accept loop entirely - a client whose
+          // TCP handshake already completed while paused would otherwise
+          // sit connected but silent until a slot frees up.
           boost::system::error_code close_ec;
           sock.close(close_ec);
-          accept_impl->paused_accept_ = true;
+          accept_impl->do_accept(self);
           return;
         }
       }
@@ -349,11 +356,6 @@ struct TcpServer::Impl {
         {
           std::lock_guard<std::mutex> lock(close_impl->sessions_mutex_);
           close_impl->sessions_.erase(client_id);
-          if (close_impl->paused_accept_ &&
-              (!close_impl->client_limit_enabled_ || close_impl->sessions_.size() < close_impl->max_clients_)) {
-            close_impl->paused_accept_ = false;
-            net::post(close_impl->ioc_, [shared_self] { shared_self->get_impl()->do_accept(shared_self); });
-          }
           was_current = (close_impl->current_session_ == new_session);
           if (was_current) {
             if (!close_impl->sessions_.empty())
@@ -871,10 +873,6 @@ void TcpServer::set_client_limit(size_t max) {
     impl->client_limit_enabled_ = false;
   } else {
     impl->client_limit_enabled_ = true;
-  }
-  if (impl->paused_accept_ && (!impl->client_limit_enabled_ || impl->sessions_.size() < impl->max_clients_)) {
-    impl->paused_accept_ = false;
-    net::post(impl->ioc_, [self = shared_from_this()] { self->get_impl()->do_accept(self); });
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #437. `TcpServerConfig`/`UdsServerConfig::max_connections` defaulted to `0` (unlimited) - a server started with defaults had no built-in ceiling on total memory a large number of slow/malicious clients could consume. Added `DEFAULT_MAX_CONNECTIONS` (1024) to `base/constants.hpp` and changed both configs' default to it; `0` still means unlimited for callers who explicitly opt into it.

Checked `UdsServer`'s equivalent accept-limit logic for comparison before implementing: it already accepts and immediately closes over-limit connections, then keeps accepting right away. `TcpServer::do_accept()` instead set a `paused_accept_` flag and stopped the accept loop entirely once the limit was hit, leaving any client whose TCP handshake completed while paused sitting connected but silent until a slot freed up. Changed `TcpServer` to match `UdsServer`'s already-correct pattern. Removed the now-dead `paused_accept_` member and its other call sites since nothing sets it anymore.

## Test plan
- [x] `./scripts/verify.sh` passes (710 tests, +2 new)
- [x] `ServerConfigsDefaultToAFiniteConnectionLimit`: both server configs default to a finite limit, `0` remains valid as an explicit opt-in
- [x] `OverLimitConnectionIsClosedPromptlyAndAcceptLoopKeepsRunning`: a real `TcpServer` at the limit closes the (N+1)th connection promptly and keeps accepting afterward - a third client can still connect once the first disconnects. Verified this test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)