### PR TITLE
fix: filter UdpChannel::on_bytes to the established remote peer only

### DIFF
--- a/test/integration/transport/transport_udp.cc
+++ b/test/integration/transport/transport_udp.cc
@@ -259,6 +259,76 @@ TEST_F(TransportUdpTest, RemoteStaysFirstPeer) {
   channel->stop();
 }
 
+// #435: RemoteStaysFirstPeer above only checks that the channel keeps
+// *sending* to the first peer - it doesn't check whether a later, different
+// sender's data still gets *delivered* through on_bytes(). Confirms it
+// doesn't: once locked to peer1, peer2's datagrams are silently discarded
+// rather than treated as legitimate data (the actual spoofing/hijack risk).
+TEST_F(TransportUdpTest, DatagramsFromNonRemotePeerAreDiscardedNotDelivered) {
+  uint16_t port = TestUtils::getAvailableTestPort();
+  config::UdpConfig cfg;
+  cfg.local_port = port;
+
+  auto channel = UdpChannel::create(cfg);
+
+  std::vector<std::string> received;
+  std::mutex received_mutex;
+  channel->on_bytes([&](memory::ConstByteSpan data) {
+    std::lock_guard<std::mutex> lock(received_mutex);
+    received.emplace_back(reinterpret_cast<const char*>(data.data()), data.size());
+  });
+
+  std::atomic<bool> ready{false};
+  channel->on_state([&](base::LinkState s) {
+    if (s == base::LinkState::Listening) ready = true;
+  });
+
+  channel->start();
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return ready.load(); }, 1000));
+
+  net::io_context ioc;
+  udp::socket peer1(ioc, udp::endpoint(udp::v4(), 0));
+  udp::socket peer2(ioc, udp::endpoint(udp::v4(), 0));
+
+  const std::string legit1 = "legit-1";
+  const std::string spoofed = "spoofed";
+  const std::string legit2 = "legit-2";
+
+  peer1.send_to(net::buffer(legit1), udp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  EXPECT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        return !received.empty();
+      },
+      2000));
+
+  // peer2 (not the locked-in remote) tries to inject data - must not appear
+  // in on_bytes deliveries.
+  peer2.send_to(net::buffer(spoofed), udp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  TestUtils::waitFor(200);
+
+  // A second legitimate datagram from peer1 must still be delivered
+  // normally, proving the filter isn't overly broad.
+  peer1.send_to(net::buffer(legit2), udp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  EXPECT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        return received.size() >= 2;
+      },
+      2000));
+
+  {
+    std::lock_guard<std::mutex> lock(received_mutex);
+    for (const auto& msg : received) {
+      EXPECT_NE(msg, spoofed) << "Datagram from a non-remote sender was delivered to on_bytes";
+    }
+    EXPECT_EQ(received[0], legit1);
+    EXPECT_EQ(received.back(), legit2);
+  }
+
+  channel->stop();
+}
+
 TEST_F(TransportUdpTest, QueueLimitMovesToError) {
   net::io_context ioc;  // Use external IO context to control execution
   config::UdpConfig cfg;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -288,6 +288,15 @@ struct UdpChannel::Impl {
       transition_to(LinkState::Connected);
     }
 
+    // #435: once a remote peer is configured or locked in (above), only
+    // deliver data from that exact sender through on_bytes() - the
+    // point-to-point API. Without this, any other host could send spoofed
+    // datagrams after the fact and have them treated as legitimate data.
+    // on_bytes_from() is intentionally NOT filtered here: it's the
+    // multi-sender API (used by the UdpServer wrapper), which tracks and
+    // trusts each sender as its own session by design.
+    const bool from_established_remote = remote_endpoint_ && recv_endpoint_ == *remote_endpoint_;
+
     if (bytes > 0) {
       stats_.record_received(bytes);
       OnBytes on_bytes;
@@ -297,7 +306,7 @@ struct UdpChannel::Impl {
         on_bytes = on_bytes_;
         on_bytes_from = on_bytes_from_;
       }
-      if (on_bytes) {
+      if (on_bytes && from_established_remote) {
         try {
           on_bytes(memory::ConstByteSpan(rx_.data(), bytes));
         } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
Closes #435. Once a remote peer is configured (`cfg_.remote_address`) or locked in (the first datagram received when no remote is configured), `on_bytes()` now only fires for datagrams whose sender matches that remote endpoint exactly. Previously, any host could inject data at any time after the fact and have it delivered as if legitimate - "no per-datagram sender filtering once locked in", the more severe half of the reported spoofing/hijack risk.

`on_bytes_from()` is deliberately **not** filtered - it's the multi-sender API used internally by the `UdpServer` wrapper, which tracks and trusts each sender as its own session by design; filtering it here would break `UdpServer`'s actual multi-client functionality.

**Scoped out of this fix** (see issue comment for reasoning): making "first-sender lock-in" an explicit opt-in mode rather than the implicit default - a narrower, connection-setup-time race versus the ongoing-spoofing-after-lock-in hole fixed here.

## Test plan
- [x] `./scripts/verify.sh` passes (711 tests, +1 new)
- [x] `DatagramsFromNonRemotePeerAreDiscardedNotDelivered`: a second peer's datagram sent after the remote is locked in never appears in `on_bytes` deliveries, while the legitimate peer's data continues to be delivered normally before and after. Verified this test fails without the fix.
- Note: one unrelated, pre-existing flake observed during a full `verify.sh` run - `TcpServerWrapperLifecycleTest.ConcurrentStartStop` SEGFAULT - did not reproduce over 5 isolated runs or a second full `verify.sh` pass; this test doesn't touch UDP and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)