### PR TITLE
docs: fix quickstart's TCP client example hanging forever

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,12 +25,23 @@ This client expects a TCP server to be listening on `127.0.0.1:8080`.
 For a runnable client/server pair, see the full tutorials in
 `unilink-docs`.
 
+`max_retries` defaults to unlimited, so `start_sync()` blocks until a
+connection actually succeeds or fails outright - it never returns `false`
+on its own while the client keeps retrying an unreachable server. Set an
+explicit `max_retries`/`connection_timeout` (as below) if you want
+`start_sync()` to give up and return `false` after a bounded number of
+attempts, which is almost always what you want for a first run or a
+one-shot script.
+
 ```cpp
+#include <chrono>
 #include <iostream>
 #include <unilink/unilink.hpp>
 
 int main() {
     auto client = unilink::tcp_client("127.0.0.1", 8080)
+        .max_retries(3)
+        .connection_timeout(std::chrono::seconds(2))
         .on_data([](const unilink::MessageContext& ctx) {
             std::cout << "received " << ctx.data().size() << " bytes\n";
         })
@@ -40,6 +51,7 @@ int main() {
         .build();
 
     if (!client->start_sync()) {
+        std::cerr << "failed to connect - is a server listening on 127.0.0.1:8080?\n";
         return 1;
     }
 
@@ -56,6 +68,8 @@ int main() {
 - `ctx.data()` is a callback-scoped view. Copy data if it must outlive the callback.
 - Use `try_send(...)` for non-blocking producer loops.
 - Use `RuntimeStats` for diagnostics and queue/drop visibility.
+- `max_retries` defaults to unlimited (`-1`) - set it explicitly if you need
+  `start()`/`start_sync()` to eventually give up rather than retry forever.
 
 Related docs:
 


### PR DESCRIPTION
## Summary
Closes #447. Traced the root cause precisely: with the default `max_retries = -1`, a failed connection attempt transitions `Connecting -> Closed/Error -> Connecting` (retry) rather than reaching a terminal state - and the wrapper's promise-fulfillment only fires on `Connected` or a terminal `Closed`/`Error`, never on a transient retry-triggered `Connecting`. So `start()`'s future genuinely never resolves as long as retries continue, by design.

Went with fixing the example (rather than changing `start_sync()`'s resolution semantics) since that's a larger, cross-cutting change to promise-fulfillment semantics shared by every wrapper's reconnect logic - deserves its own dedicated design pass, not bundled here. Full reasoning posted on the issue.

Set an explicit `max_retries(3)` and `connection_timeout(2s)` in the example so `start_sync()` actually returns `false` within a bounded time when no server is listening, matching what the example's own `if (!client->start_sync()) return 1;` line already implies should happen.

## Test plan
- [x] `./scripts/verify.sh` passes (docs-only change)
- [x] Manually compiled and ran the updated example against no listening server: returns in ~2.1s with exit code 1 (previously hung forever)

🤖 Generated with [Claude Code](https://claude.com/claude-code)