### PR TITLE
fix: record dropped messages when the shared enqueue decision rejects a write

### DIFF
--- a/test/integration/transport/transport_tcp_client.cc
+++ b/test/integration/transport/transport_tcp_client.cc
@@ -195,13 +195,22 @@ TEST_F(TransportTcpClientTest, QueueLimitDropsMessage) {
   std::atomic<bool> backpressure_seen{false};
   client_->on_backpressure([&](size_t) { backpressure_seen = true; });
 
-  // 1MB exceeds bp_limit (512KB): message dropped, backpressure fires, connection stays alive
-  std::vector<uint8_t> huge(1024 * 1024, 0xEF);
+  // bp_limit_ = max(backpressure_threshold * 4, DEFAULT_BACKPRESSURE_THRESHOLD) = 1MB here
+  // (backpressure_threshold=1024 * 4 = 4KB is below the 1MB default floor).
+  // A 2MB write exceeds it outright: message dropped, backpressure fires,
+  // connection stays alive.
+  std::vector<uint8_t> huge(2 * 1024 * 1024, 0xEF);
   client_->async_write_copy(memory::ConstByteSpan(huge.data(), huge.size()));
 
   ioc.run_for(std::chrono::milliseconds(50));
 
   EXPECT_TRUE(backpressure_seen.load());
+  // #448: this rejection path used to leave RuntimeStats showing the
+  // message as accepted with no corresponding dropped/sent/queued
+  // accounting - confirm it now shows up as a recorded drop.
+  auto stats = client_->stats();
+  EXPECT_GE(stats.dropped_messages, 1u);
+  EXPECT_GE(stats.dropped_bytes, huge.size());
 
   client_->stop();
   client_.reset();

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -154,6 +154,9 @@ struct Serial::Impl {
 
     if (decision == queue_util::EnqueueDecision::Rejected) {
       UNILINK_LOG_ERROR("serial", "write", "Queue limit exceeded, dropping message");
+      // #448: record as dropped so it's reflected in RuntimeStats instead of
+      // silently vanishing after being counted as accepted.
+      stats_.record_dropped(1, added);
       if (reliable_pending_active) {
         return;
       }

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -1049,6 +1049,11 @@ void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, Buf
     UNILINK_LOG_ERROR("tcp_client", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + added));
     record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write",
                  boost::asio::error::no_buffer_space, "Queue limit exceeded", false, 0);
+    // #448: this path used to leave RuntimeStats showing the message as
+    // accepted (from the caller-thread pre-check) with no corresponding
+    // sent/dropped/queued accounting - record it as dropped so it's at
+    // least observable.
+    stats_.record_dropped(1, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -474,6 +474,9 @@ void TcpServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
 
   if (decision == queue_util::EnqueueDecision::Rejected) {
     UNILINK_LOG_ERROR("tcp_server_session", "write", "Queue limit exceeded, dropping message");
+    // #448: record as dropped so it's reflected in RuntimeStats instead of
+    // silently vanishing after being counted as accepted.
+    stats_.record_dropped(1, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -547,6 +547,9 @@ struct UdpChannel::Impl {
       // the Reliable+pending case: queued_bytes is already >= bp_high_ or
       // this rejection couldn't have happened, so report_backpressure()'s
       // OFF-transition check (<= bp_low_) can't fire here either way.
+      // #448: record as dropped so it's reflected in RuntimeStats instead of
+      // silently vanishing after being counted as accepted.
+      stats_.record_dropped(1, size);
       report_backpressure(self, queue_bytes_ + size);
       return false;
     }

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -747,6 +747,9 @@ void UdsClient::Impl::route_enqueued_buffer(std::shared_ptr<UdsClient> self, Buf
 
   if (decision == queue_util::EnqueueDecision::Rejected) {
     UNILINK_LOG_ERROR("uds_client", "write", fmt::format("Queue limit exceeded ({} bytes)", queue_bytes_ + added));
+    // #448: record as dropped so it's reflected in RuntimeStats instead of
+    // silently vanishing after being counted as accepted.
+    stats_.record_dropped(1, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -374,6 +374,9 @@ void UdsServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
 
   if (decision == queue_util::EnqueueDecision::Rejected) {
     UNILINK_LOG_ERROR("uds_server_session", "write", "Queue limit exceeded, dropping message");
+    // #448: record as dropped so it's reflected in RuntimeStats instead of
+    // silently vanishing after being counted as accepted.
+    stats_.record_dropped(1, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }


### PR DESCRIPTION
## Summary
Closes #448 (the "not reflected in stats" half). Confirmed the gap is systemic, not specific to `tcp_client.cc` as the issue's evidence suggested: all 6 transports share the same `decide_enqueue()` `Rejected` branch (unified under #434), and none of the 6 called `record_dropped()` on it - only logging and reporting backpressure. A message silently dropped due to a full queue used to leave `RuntimeStats` showing it as accepted with no corresponding sent/dropped/queued accounting anywhere. Fixed all 6.

**Scoped out of this fix** (full reasoning on the issue): making the caller-thread capacity pre-check and the strand-side reservation atomic via `try_reserve_write_bytes`. That needs `decide_enqueue()` - shared by all 6 transports - to know a reservation already happened on the caller thread and skip its own independent accounting, a real design change to shared logic that deserves its own pass. The actual data-loss behavior under concurrent racing sends is unchanged, but it's no longer silent.

## Test plan
- [x] `./scripts/verify.sh` passes (711 tests, 1 extended)
- [x] Extended `TransportTcpClientTest.QueueLimitDropsMessage` to also assert `RuntimeStats` reflects the drop. Corrected a stale comment in the process (the test's actual `bp_limit_` is 1MB, not 512KB as previously claimed) and bumped the test payload to 2MB to reliably trigger rejection past that boundary. Verified the new assertions fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)