### PR TITLE
fix: replace duplicated wrapper-layer default literals with named constants

### DIFF
--- a/unilink/base/constants.hpp
+++ b/unilink/base/constants.hpp
@@ -66,6 +66,10 @@ constexpr unsigned MAX_CONNECTION_TIMEOUT_MS = 300000;    // 5 minutes maximum
 constexpr int DEFAULT_MAX_RETRIES = -1;  // Unlimited retries
 constexpr int MAX_RETRIES_LIMIT = 1000;  // Maximum retry limit
 
+// Socket option constants
+constexpr bool DEFAULT_TCP_NO_DELAY = true;  // Disable Nagle's algorithm by default (#429)
+constexpr bool DEFAULT_KEEP_ALIVE = false;   // TCP keep-alive off by default
+
 // Memory pool constants
 constexpr size_t DEFAULT_MEMORY_POOL_SIZE = 100;  // Number of pre-allocated buffers
 constexpr size_t MIN_MEMORY_POOL_SIZE = 10;       // Minimum pool size

--- a/unilink/config/tcp_client_config.hpp
+++ b/unilink/config/tcp_client_config.hpp
@@ -30,14 +30,14 @@ struct TcpClientConfig {
   uint16_t port = 9000;
   unsigned retry_interval_ms = base::constants::DEFAULT_RETRY_INTERVAL_MS;
   unsigned connection_timeout_ms = base::constants::DEFAULT_CONNECTION_TIMEOUT_MS;
-  unsigned idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
+  unsigned idle_timeout_ms = base::constants::DEFAULT_IDLE_TIMEOUT_MS;  // 0 = disabled
   IdleTimeoutAction idle_timeout_action = IdleTimeoutAction::Reconnect;
   int max_retries = base::constants::DEFAULT_MAX_RETRIES;
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
-  bool tcp_no_delay = true;
-  bool keep_alive = false;
+  bool tcp_no_delay = base::constants::DEFAULT_TCP_NO_DELAY;
+  bool keep_alive = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;
 

--- a/unilink/config/tcp_server_config.hpp
+++ b/unilink/config/tcp_server_config.hpp
@@ -41,9 +41,9 @@ struct TcpServerConfig {
   int max_port_retries = 3;           // Maximum number of retry attempts
   int port_retry_interval_ms = 1000;  // Retry interval in milliseconds
 
-  int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
-  bool tcp_no_delay = true;
-  bool keep_alive = false;
+  int idle_timeout_ms = static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS);  // 0 = disabled
+  bool tcp_no_delay = base::constants::DEFAULT_TCP_NO_DELAY;
+  bool keep_alive = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;
 

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -87,7 +87,7 @@ struct UdsServerConfig {
   // growth from a large number of slow/malicious clients. 0 still means
   // unlimited for callers who explicitly opt into it.
   int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
-  int idle_timeout_ms = 0;  // Idle connection timeout in milliseconds (0 = disabled)
+  int idle_timeout_ms = static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS);  // 0 = disabled
 
   bool is_valid() const {
     return util::InputValidator::is_valid_uds_path(socket_path) &&

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -76,9 +76,9 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
 
   std::atomic<bool> auto_start_ = false;
   std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
-  int max_retries_ = -1;
-  std::chrono::milliseconds connection_timeout_{5000};
-  std::chrono::milliseconds idle_timeout_{0};
+  int max_retries_ = base::constants::DEFAULT_MAX_RETRIES;
+  std::chrono::milliseconds connection_timeout_{base::constants::DEFAULT_CONNECTION_TIMEOUT_MS};
+  std::chrono::milliseconds idle_timeout_{base::constants::DEFAULT_IDLE_TIMEOUT_MS};
   IdleTimeoutAction idle_timeout_action_{IdleTimeoutAction::Reconnect};
   size_t backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   // Atomic rather than mutex-guarded: read from the send()/send_line() fast
@@ -86,8 +86,8 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   // concurrently from any other thread (#436).
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
-  bool tcp_no_delay_ = true;
-  bool keep_alive_ = false;
+  bool tcp_no_delay_ = base::constants::DEFAULT_TCP_NO_DELAY;
+  bool keep_alive_ = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size_ = 0;
   size_t receive_buffer_size_ = 0;
 

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -62,14 +62,14 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<bool> port_retry_enabled_{false};
   std::atomic<int> max_port_retries_{3};
   std::atomic<int> port_retry_interval_ms_{1000};
-  std::atomic<int> idle_timeout_ms_{0};
+  std::atomic<int> idle_timeout_ms_{static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)};
   std::atomic<bool> client_limit_enabled_{false};
   std::atomic<size_t> max_clients_{0};
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
-  std::atomic<bool> tcp_no_delay_{true};
-  std::atomic<bool> keep_alive_{false};
+  std::atomic<bool> tcp_no_delay_{base::constants::DEFAULT_TCP_NO_DELAY};
+  std::atomic<bool> keep_alive_{base::constants::DEFAULT_KEEP_ALIVE};
   std::atomic<size_t> send_buffer_size_{0};
   std::atomic<size_t> receive_buffer_size_{0};
 
@@ -102,7 +102,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
-        idle_timeout_ms_(0),
+        idle_timeout_ms_(static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)),
         client_limit_enabled_(false),
         max_clients_(0),
         backpressure_threshold_(base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
@@ -119,7 +119,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
-        idle_timeout_ms_(0),
+        idle_timeout_ms_(static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)),
         client_limit_enabled_(false),
         max_clients_(0),
         backpressure_threshold_(base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
@@ -134,7 +134,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         port_retry_enabled_(false),
         max_port_retries_(3),
         port_retry_interval_ms_(1000),
-        idle_timeout_ms_(0),
+        idle_timeout_ms_(static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)),
         client_limit_enabled_(false),
         max_clients_(0),
         backpressure_threshold_(base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -76,8 +76,8 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
 
   std::atomic<bool> auto_start_ = false;
   std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
-  int max_retries_ = -1;
-  std::chrono::milliseconds connection_timeout_{5000};
+  int max_retries_ = base::constants::DEFAULT_MAX_RETRIES;
+  std::chrono::milliseconds connection_timeout_{base::constants::DEFAULT_CONNECTION_TIMEOUT_MS};
   size_t backpressure_threshold_ = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   // Atomic rather than mutex-guarded: read from the send()/send_line() fast
   // path on arbitrary caller threads while the setter can be called

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -39,7 +39,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
 
   // Configuration
   std::atomic<bool> auto_start_{false};
-  std::atomic<int> idle_timeout_ms_{0};
+  std::atomic<int> idle_timeout_ms_{static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)};
   std::atomic<size_t> max_clients_{0};
   std::atomic<bool> client_limit_enabled_{false};
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};


### PR DESCRIPTION
## Summary
Closes #433. The wrapper `Impl` layer initialized several fields from independent hardcoded literals rather than the `base::constants::DEFAULT_*` constant already used elsewhere for the same value - the same "three copies of one default, only some got updated" class of bug fixed for `tcp_no_delay` in #426/#429.

- `tcp_client.cc`: `connection_timeout_`/`max_retries_`/`idle_timeout_` now reference `DEFAULT_CONNECTION_TIMEOUT_MS`/`DEFAULT_MAX_RETRIES`/`DEFAULT_IDLE_TIMEOUT_MS` instead of `5000`/`-1`/`0`.
- `tcp_server.cc`: same `tcp_no_delay_`/`keep_alive_` duplication, plus `idle_timeout_ms_{0}` was re-asserted as an explicit constructor-init-list override in all 3 constructors (fixed all 3).
- `uds_client.cc`: `max_retries_`/`connection_timeout_` - the exact pattern the issue's evidence cites, just in a different file.
- `uds_server.cc`: `idle_timeout_ms_`.

`tcp_no_delay`/`keep_alive` had no named constant at all - both `TcpClientConfig` and `TcpServerConfig` independently hardcoded `true`/`false`. Added `DEFAULT_TCP_NO_DELAY`/`DEFAULT_KEEP_ALIVE` and pointed both the config structs and the wrapper `Impl` structs at them.

Scoped out `serial.cc`'s `data_bits`/`stop_bits`/`parity`/`flow_control`/`reopen_on_error` and `tcp_server.cc`'s `max_port_retries_`/`port_retry_interval_ms_`: none have a pre-existing named `DEFAULT_*` constant, so introducing new ones would be scope creep beyond this issue's bug class - documented on the issue.

## Test plan
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)