### PR TITLE
fix: refuse to bind/hijack an existing UDS socket path, add permission control

### DIFF
--- a/test/integration/transport/transport_uds_server_security_test.cc
+++ b/test/integration/transport/transport_uds_server_security_test.cc
@@ -18,8 +18,11 @@
 
 #ifndef _WIN32
 
+#include <sys/stat.h>
+
 #include <boost/asio.hpp>
 #include <chrono>
+#include <fstream>
 #include <memory>
 #include <thread>
 
@@ -150,6 +153,117 @@ TEST_F(TransportUdsServerSecurityTest, IdleTimeoutResetOnMessage) {
     net::write(client, net::buffer("keepalive"), ec);
     ASSERT_FALSE(ec) << "Write " << i << " failed — client was disconnected prematurely";
   }
+}
+
+// #438: a regular file at the configured socket path must never be silently
+// deleted and bound over - that would destroy whatever the file was for
+// with no warning, on nothing more than a path collision.
+TEST_F(TransportUdsServerSecurityTest, RegularFileAtSocketPathBlocksBind) {
+  {
+    std::ofstream f(socket_path_);
+    f << "not a socket";
+  }
+  ASSERT_TRUE(std::filesystem::exists(socket_path_));
+
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  server_ = UdsServer::create(cfg);
+  server_->start();
+
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Error; }, 5000))
+      << "Server should have entered Error state instead of deleting the regular file";
+  EXPECT_TRUE(std::filesystem::exists(socket_path_)) << "The pre-existing regular file must not have been deleted";
+}
+
+// #438: if another process is already listening on the configured path, a
+// second server must fail to start rather than silently deleting the first
+// server's socket file and taking over the address (hijack).
+TEST_F(TransportUdsServerSecurityTest, LiveListenerAtSocketPathBlocksSecondBind) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  server_ = UdsServer::create(cfg);
+  server_->start();
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000));
+
+  auto second_server = UdsServer::create(cfg);
+  second_server->start();
+  EXPECT_TRUE(test::TestUtils::waitForCondition(
+      [&] { return second_server->state() == unilink::base::LinkState::Error; }, 5000))
+      << "Second server should fail to bind instead of hijacking the live listener's socket";
+  second_server->stop();
+
+  // The first server must still be reachable - proving its socket survived.
+  net::io_context client_ioc;
+  uds_socket client(client_ioc);
+  boost::system::error_code ec;
+  for (int i = 0; i < 50; ++i) {
+    client = uds_socket(client_ioc);
+    client.connect(uds_endpoint(socket_path_.string()), ec);
+    if (!ec) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_FALSE(ec) << "First server's socket should still be live and connectable";
+}
+
+// #438: a leftover socket file from a process that's no longer running
+// (nothing accepts a probe connect) must still be removable so the server
+// can bind normally - the fix must not regress the ordinary restart case.
+TEST_F(TransportUdsServerSecurityTest, StaleSocketFileDoesNotBlockBind) {
+  {
+    net::io_context probe_ioc;
+    uds_socket probe(probe_ioc);
+    boost::system::error_code ec;
+    probe.open(net::local::stream_protocol(), ec);
+    ASSERT_FALSE(ec);
+    probe.bind(uds_endpoint(socket_path_.string()), ec);
+    ASSERT_FALSE(ec);
+    // Deliberately never call listen()/close the fd cleanly via destructor
+    // going out of scope - leaves a bound-but-abandoned socket file behind,
+    // matching a process that crashed without cleanup.
+  }
+  ASSERT_TRUE(std::filesystem::exists(socket_path_));
+
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  server_ = UdsServer::create(cfg);
+  server_->start();
+
+  EXPECT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000))
+      << "A stale (unlistened) socket file must not block a fresh bind";
+}
+
+TEST_F(TransportUdsServerSecurityTest, SocketPermissionsAreAppliedAfterBind) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  cfg.socket_permissions = 0600;
+
+  server_ = UdsServer::create(cfg);
+  server_->start();
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000));
+
+  struct stat st {};
+  ASSERT_EQ(::stat(socket_path_.string().c_str(), &st), 0);
+  EXPECT_EQ(st.st_mode & 0777, 0600u) << "Socket file permissions should match the configured mode";
+}
+
+TEST_F(TransportUdsServerSecurityTest, NoSocketPermissionsChangeByDefault) {
+  config::UdsServerConfig cfg;
+  cfg.socket_path = socket_path_.string();
+  // socket_permissions left at its default (-1) - no chmod should occur.
+
+  server_ = UdsServer::create(cfg);
+  server_->start();
+  ASSERT_TRUE(
+      test::TestUtils::waitForCondition([&] { return server_->state() == unilink::base::LinkState::Listening; }, 5000));
+
+  struct stat st {};
+  ASSERT_EQ(::stat(socket_path_.string().c_str(), &st), 0);
+  // Not asserting an exact mode here (depends on umask) - just that start()
+  // didn't crash/error when socket_permissions is left unset.
 }
 
 #endif  // _WIN32

--- a/unilink/config/uds_config.hpp
+++ b/unilink/config/uds_config.hpp
@@ -88,13 +88,19 @@ struct UdsServerConfig {
   // unlimited for callers who explicitly opt into it.
   int max_connections = static_cast<int>(base::constants::DEFAULT_MAX_CONNECTIONS);
   int idle_timeout_ms = static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS);  // 0 = disabled
+  // #438: POSIX file permission bits (e.g. 0660) applied to the socket file
+  // after bind, restricting which local users/groups can connect. -1 (the
+  // default) leaves the socket at whatever the process umask produces,
+  // matching prior behavior. Ignored on Windows.
+  int socket_permissions = -1;
 
   bool is_valid() const {
     return util::InputValidator::is_valid_uds_path(socket_path) &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections >= 0 &&
            (idle_timeout_ms == 0 || (idle_timeout_ms >= static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS) &&
-                                     idle_timeout_ms <= static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS)));
+                                     idle_timeout_ms <= static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS))) &&
+           (socket_permissions == -1 || (socket_permissions >= 0 && socket_permissions <= 0777));
   }
 
   void validate_and_clamp() {
@@ -118,6 +124,10 @@ struct UdsServerConfig {
       } else if (idle_timeout_ms > static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS)) {
         idle_timeout_ms = static_cast<int>(base::constants::MAX_IDLE_TIMEOUT_MS);
       }
+    }
+
+    if (socket_permissions != -1 && (socket_permissions < 0 || socket_permissions > 0777)) {
+      socket_permissions = -1;
     }
   }
 };

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -21,7 +21,9 @@
 #include <algorithm>
 #include <atomic>
 #include <boost/asio.hpp>
+#include <cerrno>
 #include <cstdio>
+#include <cstring>
 #include <future>
 #include <mutex>
 #include <stop_token>
@@ -29,6 +31,7 @@
 #include <thread>
 #include <unordered_map>
 
+#include "unilink/base/platform.hpp"
 #include "unilink/builder/auto_initializer.hpp"
 #include "unilink/concurrency/io_context_manager.hpp"
 #include "unilink/concurrency/thread_safe_state.hpp"
@@ -39,11 +42,58 @@
 #include "unilink/transport/uds/boost_uds_acceptor.hpp"
 #include "unilink/transport/uds/uds_server_session.hpp"
 
+#if !defined(UNILINK_PLATFORM_WINDOWS)
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#endif
+
 namespace unilink {
 namespace transport {
 
 namespace net = boost::asio;
 using uds = net::local::stream_protocol;
+
+namespace {
+
+// #438: an existing path at the configured socket location should only ever
+// be silently removed if it's a genuinely stale (no longer listened-on)
+// socket file - not a regular file/directory (misconfiguration) and not a
+// socket another live process is still listening on (which would otherwise
+// be silently hijacked instead of failing with a clear error). Returns a
+// non-empty reason string if bind should be refused; empty if it's safe to
+// remove the path (or there's nothing there) and proceed.
+std::string existing_uds_path_blocks_bind(const std::string& path) {
+#if defined(UNILINK_PLATFORM_WINDOWS)
+  (void)path;
+  return {};
+#else
+  struct stat st {};
+  if (::stat(path.c_str(), &st) != 0) {
+    return {};  // nothing exists at this path - nothing to check
+  }
+  if (!S_ISSOCK(st.st_mode)) {
+    return "existing path is not a socket file";
+  }
+
+  int probe_fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (probe_fd < 0) {
+    return {};  // can't probe - fall back to prior (remove-and-proceed) behavior
+  }
+  struct sockaddr_un addr {};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+  int rc = ::connect(probe_fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
+  ::close(probe_fd);
+  if (rc == 0) {
+    return "another process is already listening on this socket path";
+  }
+  return {};  // stale socket (nothing accepted the probe connect) - safe to remove
+#endif
+}
+
+}  // namespace
 
 struct UdsServer::Impl {
   std::unique_ptr<net::io_context> owned_ioc_;
@@ -54,6 +104,13 @@ struct UdsServer::Impl {
 
   std::atomic<bool> stopping_{false};
   std::atomic<ClientId> next_client_id_{0};
+  // #438: only this instance's own successful bind() may remove the socket
+  // file on cleanup. Without this, a second UdsServer pointed at the same
+  // path whose start() failed before ever binding (e.g. because a live
+  // listener already owns that path) would still delete the first server's
+  // socket file the moment stop()/the destructor ran - the exact hijack
+  // #438 is about, just reached via stop() instead of start().
+  std::atomic<bool> bound_{false};
 
   std::unique_ptr<interface::UdsAcceptorInterface> acceptor_;
   config::UdsServerConfig cfg_;
@@ -95,8 +152,11 @@ struct UdsServer::Impl {
         }
       }
     }
-    // UDS Cleanup: socket file should be removed.
-    std::remove(cfg_.socket_path.c_str());
+    // UDS Cleanup: socket file should be removed, but only if this instance
+    // actually bound it (#438).
+    if (bound_.load()) {
+      std::remove(cfg_.socket_path.c_str());
+    }
   }
   void do_accept(std::shared_ptr<UdsServer> self);
   void notify_state();
@@ -123,7 +183,9 @@ struct UdsServer::Impl {
         }
       }
 
-      std::remove(cfg_.socket_path.c_str());
+      if (bound_.exchange(false)) {
+        std::remove(cfg_.socket_path.c_str());
+      }
 
       state_.set(base::LinkState::Idle);
       notify_state();
@@ -233,7 +295,21 @@ void UdsServer::start() {
     return;
   }
 
-  // Cleanup old socket file if exists
+  // #438: only remove an existing path at this location if it's actually a
+  // stale socket - never a regular file/directory (misconfiguration), and
+  // never a socket another live process is still listening on (that would
+  // otherwise be silently hijacked instead of failing loudly).
+  std::string block_reason = existing_uds_path_blocks_bind(impl_->cfg_.socket_path);
+  if (!block_reason.empty()) {
+    std::string msg = fmt::format("Refusing to bind {}: {}", impl_->cfg_.socket_path, block_reason);
+    UNILINK_LOG_ERROR("uds_server", "start", msg);
+    impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "start", make_error_code(boost::system::errc::address_in_use), msg, false,
+                                           0);
+    impl_->state_.set(base::LinkState::Error);
+    impl_->notify_state();
+    return;
+  }
   std::remove(impl_->cfg_.socket_path.c_str());
 
   boost::system::error_code ec;
@@ -272,6 +348,7 @@ void UdsServer::start() {
     impl_->notify_state();
     return;
   }
+  impl_->bound_.store(true);
 
   impl_->acceptor_->listen(net::socket_base::max_listen_connections, ec);
   if (ec) {
@@ -282,6 +359,20 @@ void UdsServer::start() {
     impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
+  }
+
+  // #438: restrict local access to the socket file if requested. Best-effort
+  // - a chmod failure is logged but does not fail startup, since the socket
+  // is already bound and listening at this point.
+  if (impl_->cfg_.socket_permissions != -1) {
+#if !defined(UNILINK_PLATFORM_WINDOWS)
+    if (::chmod(impl_->cfg_.socket_path.c_str(), static_cast<mode_t>(impl_->cfg_.socket_permissions)) != 0) {
+      UNILINK_LOG_WARNING("uds_server", "start",
+                          fmt::format("Failed to chmod socket {}: {}", impl_->cfg_.socket_path, strerror(errno)));
+    }
+#else
+    UNILINK_LOG_WARNING("uds_server", "start", "socket_permissions is ignored on Windows");
+#endif
   }
 
   impl_->state_.set(base::LinkState::Listening);

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -42,6 +42,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<int> idle_timeout_ms_{static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS)};
   std::atomic<size_t> max_clients_{0};
   std::atomic<bool> client_limit_enabled_{false};
+  std::atomic<int> socket_permissions_{-1};
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
@@ -199,6 +200,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           static_cast<int>(std::min(max_clients_.load(), static_cast<size_t>(base::constants::MAX_MAX_CONNECTIONS)));
       config.backpressure_threshold = backpressure_threshold_.load();
       config.backpressure_strategy = backpressure_strategy_.load();
+      config.socket_permissions = socket_permissions_.load();
       server_ = factory::ChannelFactory::create(config, external_ioc_);
       setup_internal_handlers();
     }
@@ -590,6 +592,11 @@ UdsServer& UdsServer::max_clients(size_t max) {
   }
   auto ts = std::dynamic_pointer_cast<transport::UdsServer>(impl_->server_);
   if (ts) ts->set_client_limit(max);
+  return *this;
+}
+
+UdsServer& UdsServer::socket_permissions(int mode) {
+  impl_->socket_permissions_.store(mode);
   return *this;
 }
 

--- a/unilink/wrapper/uds_server/uds_server.hpp
+++ b/unilink/wrapper/uds_server/uds_server.hpp
@@ -98,6 +98,13 @@ class UNILINK_API UdsServer : public ServerInterface {
   UdsServer& auto_start(bool manage = true) override;
   UdsServer& idle_timeout(std::chrono::milliseconds timeout);
   UdsServer& max_clients(size_t max);
+  /**
+   * @brief Restrict local access to the socket file after bind.
+   *
+   * @param mode POSIX permission bits (e.g. 0660). Ignored on Windows.
+   *   Must be set before start() to take effect.
+   */
+  UdsServer& socket_permissions(int mode);
   UdsServer& backpressure_threshold(size_t threshold);
   UdsServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdsServer& manage_external_context(bool manage);


### PR DESCRIPTION
## Summary
Closes #438. `UdsServer::start()` called `std::remove()` on the configured socket path unconditionally before bind, with no check for whether the existing file was actually a stale socket - a misconfigured path pointing at a regular file got silently deleted, and a live listener already on that path got silently hijacked instead of failing with a clear error.

- Added `existing_uds_path_blocks_bind()`: `stat()`s the path first - a non-socket file now fails `start()` loudly (`Error` state) instead of being deleted. If it is a socket, probes it with a real `connect()` - if something answers, another process is still listening and bind is refused. Only a genuinely stale/abandoned socket file falls through to the existing remove-then-bind path, preserving the ordinary restart-after-crash case. POSIX-only (guarded behind `!UNILINK_PLATFORM_WINDOWS`); a no-op on Windows.
- Added `config::UdsServerConfig::socket_permissions` (default `-1` = unchanged) and a `UdsServer::socket_permissions(int mode)` fluent setter. `chmod()`'d after a successful `listen()`; a chmod failure is logged as a warning rather than failing startup since the socket is already live by that point.

**Related bug found while testing the hijack-refusal scenario**: starting a live listener, then starting a second server at the same path (now correctly refused), then calling `stop()` on the second one, made the *first* server's socket unreachable. Root cause: `perform_cleanup()`/`~Impl()` both called `std::remove()` on the configured path unconditionally on stop/destruction, regardless of whether *this* instance ever actually bound it. A server whose `start()` failed before `bind()` (including via this very fix) would still delete another server's live socket file the moment `stop()` ran - the same hijack, reached through the stop path instead of start. Added a `bound_` flag set only after a successful `bind()`, guarding both cleanup sites on it.

## Test plan
- [x] New `test/integration/transport/transport_uds_server_security_test.cc` coverage: `RegularFileAtSocketPathBlocksBind`, `LiveListenerAtSocketPathBlocksSecondBind` (caught the `bound_` bug above), `StaleSocketFileDoesNotBlockBind` (regression guard for the ordinary case), `SocketPermissionsAreAppliedAfterBind`, `NoSocketPermissionsChangeByDefault`
- [x] `./scripts/verify.sh` passes (only failure is the documented pre-existing `TcpServerWrapperLifecycleTest.ConcurrentStartStop` SEGFAULT flake, unrelated to this change and confirmed non-reproducing in 3 isolated reruns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)