### PR TITLE
docs: document the plaintext-only transport and intended trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Simple async C++ communication library for Serial, TCP, UDP, and Unix Domain Soc
 
 The project prioritizes **API clarity, predictable runtime behavior, and stability** over rapid feature expansion.
 
+> **Security note**: all transports send data in plaintext - there is no built-in TLS/DTLS support. See [Security and Threat Model](https://github.com/jwsung91/unilink/blob/main/docs/security.md) before using `unilink` over an untrusted network.
+
 ## Feature Highlights
 
 * **Unified transport surface**: Consistent builders and wrappers for TCP client/server, UDP, Serial, and UDS.
@@ -70,6 +72,7 @@ Core repository entrypoints:
 - [Installation](https://github.com/jwsung91/unilink/blob/main/docs/installation.md)
 - [API Stability Summary](https://github.com/jwsung91/unilink/blob/main/docs/api_stability.md)
 - [Error Model](https://github.com/jwsung91/unilink/blob/main/docs/error_model.md)
+- [Security and Threat Model](https://github.com/jwsung91/unilink/blob/main/docs/security.md)
 - [Callback Data Lifetime](https://github.com/jwsung91/unilink/blob/main/docs/callbacks.md)
 - [Performance Validation](https://github.com/jwsung91/unilink/blob/main/docs/performance_validation.md)
 - [Release Checklist](https://github.com/jwsung91/unilink/blob/main/docs/release_checklist.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,37 @@
+# Security and Threat Model
+
+## No transport encryption
+
+`unilink` does not implement TLS, DTLS, or any other transport-level
+encryption. Every transport (TCP, UDP, Serial, UDS) sends and receives data
+in plaintext. There is currently no pluggable hook (e.g. an
+`ssl::stream<tcp::socket>`-compatible interface) for adding encryption
+without patching the library.
+
+## Intended trust model
+
+`unilink` is designed for use over networks and channels you already trust:
+a local machine, a private LAN, a point-to-point serial/UDS link, or inside
+a network perimeter secured by other means (VPN, SSH tunnel, physical
+access control). It is **not** designed to be used directly over the public
+internet or any other untrusted network, since:
+
+- Data (including any application-level credentials or secrets your
+  protocol carries) is visible to anyone who can observe the traffic.
+- Data can be modified in transit without detection - there is no message
+  authentication.
+- `transport::TcpClient`/`transport::TcpServer` and `transport::UdsServer`
+  do not authenticate peers beyond what the transport itself provides (a
+  TCP handshake, or standard UDS file permissions - `UdsServer` supports
+  restricting the socket file's local permissions via
+  `UdsServer::socket_permissions(mode)`).
+
+If you need confidentiality, integrity, or peer authentication over an
+untrusted network, terminate TLS (or an equivalent) outside `unilink` -
+for example, a reverse proxy/stunnel in front of a TCP server, or an SSH/VPN
+tunnel wrapping the connection - and point `unilink` at the resulting local,
+trusted endpoint.
+
+## Reporting a vulnerability
+
+Open an issue on this repository.


### PR DESCRIPTION
## Summary
Closes #439. There is no TLS/DTLS support anywhere in the codebase and nothing in the public docs said so - consumers reasonably familiar with Boost.Asio might expect `ssl::stream` support to be available or pluggable.

Added `docs/security.md` describing the lack of transport encryption, the intended trust model (trusted network/local machine only, not the public internet), and the recommended mitigation (terminate TLS outside `unilink` and point it at the resulting local endpoint). Linked from README.md's documentation list, plus a one-line security note near the top of the README.

Did not attempt the issue's "medium term" suggestion (restructuring `transport::TcpClient` behind an interface for future `ssl::stream` support) - framed as a "consider whether" in the issue, and a much larger architectural question than this documentation gap.

## Test plan
- [x] Docs-only change; reviewed rendering manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)