### PR TITLE
perf: switch transport link-state tracking to lock-free AtomicLinkState

### DIFF
--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -49,7 +49,7 @@ namespace transport {
 
 namespace net = boost::asio;
 using base::LinkState;
-using concurrency::ThreadSafeLinkState;
+using concurrency::AtomicLinkState;
 
 using BufferVariant =
     std::variant<memory::PooledBuffer, std::vector<uint8_t>, std::shared_ptr<const std::vector<uint8_t>>>;
@@ -105,7 +105,7 @@ struct Serial::Impl {
   OnBackpressure on_bp_;
 
   std::atomic<bool> opened_{false};
-  ThreadSafeLinkState state_{LinkState::Idle};
+  AtomicLinkState state_{LinkState::Idle};
 
   ErrorInfoHolder error_info_holder_{"serial"};
 
@@ -164,7 +164,7 @@ struct Serial::Impl {
       tx_.clear();
       queued_bytes_ = 0;
       writing_ = false;
-      state_.set_state(LinkState::Error);
+      state_.set(LinkState::Error);
       notify_state();
       handle_error(self, "write_queue_overflow", make_error_code(boost::system::errc::no_buffer_space));
       return;
@@ -297,7 +297,7 @@ struct Serial::Impl {
     start_read(self);
 
     opened_.store(true);
-    state_.set_state(LinkState::Connected);
+    state_.set(LinkState::Connected);
     notify_state();
     do_write(self);
   }
@@ -328,7 +328,7 @@ struct Serial::Impl {
                                                       false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
-                impl->state_.set_state(LinkState::Error);
+                impl->state_.set(LinkState::Error);
                 impl->notify_state();
                 return;
               }
@@ -341,7 +341,7 @@ struct Serial::Impl {
                                                       "Unknown exception in callback", false, 0);
                 impl->opened_.store(false);
                 impl->close_port();
-                impl->state_.set_state(LinkState::Error);
+                impl->state_.set(LinkState::Error);
                 impl->notify_state();
                 return;
               }
@@ -420,7 +420,7 @@ struct Serial::Impl {
       writing_ = false;
       report_backpressure(queued_bytes_);
       opened_.store(false);
-      state_.set_state(LinkState::Closed);
+      state_.set(LinkState::Closed);
       notify_state();
     } catch (...) {
     }
@@ -453,13 +453,13 @@ struct Serial::Impl {
     if (cfg_.reopen_on_error) {
       opened_.store(false);
       close_port();
-      state_.set_state(LinkState::Connecting);
+      state_.set(LinkState::Connecting);
       notify_state();
       if (self) schedule_retry(self, where, ec);
     } else {
       opened_.store(false);
       close_port();
-      state_.set_state(LinkState::Error);
+      state_.set(LinkState::Error);
       notify_state();
     }
   }
@@ -490,7 +490,7 @@ struct Serial::Impl {
     }
     if (!on_state) return;
     try {
-      on_state(state_.state());
+      on_state(state_.get());
     } catch (...) {
     }
   }
@@ -587,7 +587,7 @@ void Serial::start() {
   net::post(impl->strand_, [self] {
     auto impl = self->get_impl();
     if (!impl->stopping_.load()) {
-      impl->state_.set_state(LinkState::Connecting);
+      impl->state_.set(LinkState::Connecting);
       impl->notify_state();
       impl->open_and_configure(self);
     }
@@ -598,7 +598,7 @@ void Serial::start() {
 void Serial::stop() {
   auto impl = get_impl();
   if (!impl->started_) {
-    impl->state_.set_state(LinkState::Closed);
+    impl->state_.set(LinkState::Closed);
     return;
   }
 

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -64,7 +64,7 @@ namespace net = boost::asio;
 using tcp = net::ip::tcp;
 
 using base::LinkState;
-using concurrency::ThreadSafeLinkState;
+using concurrency::AtomicLinkState;
 using config::TcpClientConfig;
 using interface::Channel;
 
@@ -126,7 +126,7 @@ struct TcpClient::Impl {
   OnBackpressure on_bp_;
   mutable std::mutex callback_mtx_;
   std::atomic<bool> connected_{false};
-  ThreadSafeLinkState state_{LinkState::Idle};
+  AtomicLinkState state_{LinkState::Idle};
   int retry_attempts_ = 0;
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
@@ -214,7 +214,7 @@ std::optional<diagnostics::ErrorInfo> TcpClient::last_error_info() const {
 }
 
 void TcpClient::start() {
-  auto current_state = impl_->state_.state();
+  auto current_state = impl_->state_.get();
   if (current_state == LinkState::Connecting || current_state == LinkState::Connected) {
     UNILINK_LOG_DEBUG("tcp_client", "start", "Start called while already active, ignoring");
     return;
@@ -1106,7 +1106,7 @@ void TcpClient::Impl::transition_to(LinkState next, const boost::system::error_c
     return;
   }
 
-  const auto current = state_.state();
+  const auto current = state_.get();
   const bool retrying_same_state = (next == LinkState::Connecting && current == LinkState::Connecting);
   if ((current == LinkState::Closed || current == LinkState::Error) &&
       (next == LinkState::Closed || next == LinkState::Error)) {
@@ -1121,7 +1121,7 @@ void TcpClient::Impl::transition_to(LinkState next, const boost::system::error_c
     return;
   }
 
-  state_.set_state(next);
+  state_.set(next);
   notify_state();
 }
 
@@ -1178,7 +1178,7 @@ void TcpClient::Impl::reset_start_state() {
   pending_.clear();
   pending_bytes_ = 0;
   backpressure_active_ = false;
-  state_.set_state(LinkState::Idle);
+  state_.set(LinkState::Idle);
 }
 
 void TcpClient::Impl::join_ioc_thread(bool allow_detach) {
@@ -1213,7 +1213,7 @@ void TcpClient::Impl::notify_state() {
   if (!on_state) return;
 
   try {
-    on_state(state_.state());
+    on_state(state_.get());
   } catch (const std::exception& e) {
     UNILINK_LOG_ERROR("tcp_client", "on_state", "Exception in state callback: " + std::string(e.what()));
   } catch (...) {

--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -58,7 +58,7 @@ struct TcpServer::Impl {
   std::unique_ptr<interface::TcpAcceptorInterface> acceptor_;
   config::TcpServerConfig cfg_;
 
-  concurrency::ThreadSafeLinkState state_{base::LinkState::Idle};
+  concurrency::AtomicLinkState state_{base::LinkState::Idle};
   OnBytes on_bytes_;
   OnState on_state_;
   OnBackpressure on_bp_;
@@ -136,7 +136,7 @@ struct TcpServer::Impl {
         cb = on_state_;
       }
       if (cb) {
-        cb(state_.state());
+        cb(state_.get());
       }
     } catch (...) {
     }
@@ -190,7 +190,7 @@ struct TcpServer::Impl {
       UNILINK_LOG_ERROR("tcp_server", "bind", msg);
       error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION, "bind",
                                       ec, msg, false, static_cast<uint32_t>(retry_count));
-      state_.set_state(base::LinkState::Error);
+      state_.set(base::LinkState::Error);
       notify_state();
       return;
     }
@@ -202,7 +202,7 @@ struct TcpServer::Impl {
         UNILINK_LOG_ERROR("tcp_server", "open", msg);
         error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open", ec,
                                         msg, false, static_cast<uint32_t>(retry_count));
-        state_.set_state(base::LinkState::Error);
+        state_.set(base::LinkState::Error);
         notify_state();
         return;
       }
@@ -227,7 +227,7 @@ struct TcpServer::Impl {
         UNILINK_LOG_ERROR("tcp_server", "bind", msg);
         error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "bind",
                                         ec, msg, false, static_cast<uint32_t>(retry_count));
-        state_.set_state(base::LinkState::Error);
+        state_.set(base::LinkState::Error);
         notify_state();
         return;
       }
@@ -239,12 +239,12 @@ struct TcpServer::Impl {
       UNILINK_LOG_ERROR("tcp_server", "listen", msg);
       error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "listen",
                                       ec, msg, false, static_cast<uint32_t>(retry_count));
-      state_.set_state(base::LinkState::Error);
+      state_.set(base::LinkState::Error);
       notify_state();
       return;
     }
 
-    state_.set_state(base::LinkState::Listening);
+    state_.set(base::LinkState::Listening);
     notify_state();
     do_accept(self);
   }
@@ -262,7 +262,7 @@ struct TcpServer::Impl {
           accept_impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR,
                                                        diagnostics::ErrorCategory::CONNECTION, "accept", ec,
                                                        fmt::format("Accept failed: {}", ec.message()), true, 0);
-          accept_impl->state_.set_state(base::LinkState::Error);
+          accept_impl->state_.set(base::LinkState::Error);
           accept_impl->notify_state();
         }
         if (!accept_impl->state_.is_state(base::LinkState::Closed) && !accept_impl->stopping_.load()) {
@@ -365,7 +365,7 @@ struct TcpServer::Impl {
           }
         }
         if (was_current) {
-          close_impl->state_.set_state(base::LinkState::Listening);
+          close_impl->state_.set(base::LinkState::Listening);
           close_impl->notify_state();
         }
       });
@@ -388,7 +388,7 @@ struct TcpServer::Impl {
       }
       if (connect_cb) connect_cb(client_id, client_info);
 
-      accept_impl->state_.set_state(base::LinkState::Connected);
+      accept_impl->state_.set(base::LinkState::Connected);
       accept_impl->notify_state();
       accept_impl->do_accept(self);
     });
@@ -418,7 +418,7 @@ struct TcpServer::Impl {
         }
       }
 
-      state_.set_state(base::LinkState::Closed);
+      state_.set(base::LinkState::Closed);
       notify_state();
     } catch (...) {
     }
@@ -511,7 +511,7 @@ TcpServer& TcpServer::operator=(TcpServer&&) noexcept = default;
 
 void TcpServer::start() {
   auto impl = get_impl();
-  auto current = impl->state_.state();
+  auto current = impl->state_.get();
   if (current == base::LinkState::Listening || current == base::LinkState::Connected ||
       current == base::LinkState::Connecting) {
     return;
@@ -528,7 +528,7 @@ void TcpServer::start() {
   if (!impl->acceptor_) {
     impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "start",
                                           {}, "No acceptor available", false, 0);
-    impl->state_.set_state(base::LinkState::Error);
+    impl->state_.set(base::LinkState::Error);
     impl->notify_state();
     return;
   }
@@ -876,7 +876,7 @@ void TcpServer::set_client_limit(size_t max) {
   }
 }
 
-base::LinkState TcpServer::state() const { return get_impl()->state_.state(); }
+base::LinkState TcpServer::state() const { return get_impl()->state_.get(); }
 
 }  // namespace transport
 }  // namespace unilink

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -49,7 +49,7 @@ namespace transport {
 namespace net = boost::asio;
 using udp = net::ip::udp;
 using base::LinkState;
-using concurrency::ThreadSafeLinkState;
+using concurrency::AtomicLinkState;
 
 struct UdpChannel::Impl {
   std::unique_ptr<net::io_context> owned_ioc_;
@@ -98,7 +98,7 @@ struct UdpChannel::Impl {
   std::atomic<bool> opened_{false};
   std::atomic<bool> connected_{false};
   bool started_{false};
-  ThreadSafeLinkState state_{LinkState::Idle};
+  AtomicLinkState state_{LinkState::Idle};
   std::atomic<bool> terminal_state_notified_{false};
 
   // Guards on_bytes_/on_bytes_from_/on_state_/on_bp_. Setters (called from
@@ -488,7 +488,7 @@ struct UdpChannel::Impl {
     }
     if (!on_state) return;
     try {
-      on_state(state_.state());
+      on_state(state_.get());
     } catch (const std::exception& e) {
       UNILINK_LOG_ERROR("udp", "on_state", fmt::format("Exception in state callback: {}", e.what()));
     } catch (...) {
@@ -593,7 +593,7 @@ struct UdpChannel::Impl {
       return;
     }
 
-    const auto current = state_.state();
+    const auto current = state_.get();
     if ((current == LinkState::Closed || current == LinkState::Error) &&
         (target == LinkState::Closed || target == LinkState::Error)) {
       return;
@@ -612,7 +612,7 @@ struct UdpChannel::Impl {
       return;
     }
 
-    state_.set_state(target);
+    state_.set(target);
     notify_state();
   }
 
@@ -723,7 +723,7 @@ void UdpChannel::start() {
     impl->writing_ = false;
     impl->queue_bytes_ = 0;
     impl->backpressure_active_ = false;
-    impl->state_.set_state(LinkState::Idle);
+    impl->state_.set(LinkState::Idle);
 
     impl->transition_to(LinkState::Connecting);
     impl->open_socket(self);

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -52,7 +52,7 @@ namespace net = boost::asio;
 using uds = net::local::stream_protocol;
 
 using base::LinkState;
-using concurrency::ThreadSafeLinkState;
+using concurrency::AtomicLinkState;
 using config::UdsClientConfig;
 using interface::Channel;
 
@@ -101,7 +101,7 @@ struct UdsClient::Impl {
   OnBackpressure on_bp_;
   mutable std::mutex callback_mtx_;
   std::atomic<bool> connected_{false};
-  ThreadSafeLinkState state_{LinkState::Idle};
+  AtomicLinkState state_{LinkState::Idle};
   int retry_attempts_ = 0;
   uint32_t reconnect_attempt_count_{0};
   std::optional<ReconnectPolicy> reconnect_policy_;
@@ -213,7 +213,7 @@ UdsClient::UdsClient(UdsClient&&) noexcept = default;
 UdsClient& UdsClient::operator=(UdsClient&&) noexcept = default;
 
 void UdsClient::start() {
-  auto current_state = impl_->state_.state();
+  auto current_state = impl_->state_.get();
   if (current_state == LinkState::Connecting || current_state == LinkState::Connected) {
     return;
   }
@@ -273,7 +273,7 @@ void UdsClient::stop() {
   }
 
   // Transition to Idle state (lock-free or safe call)
-  impl_->state_.set_state(LinkState::Idle);
+  impl_->state_.set(LinkState::Idle);
 }
 
 bool UdsClient::is_connected() const { return impl_->connected_.load(); }
@@ -681,7 +681,7 @@ void UdsClient::Impl::handle_close(std::shared_ptr<UdsClient> self, uint64_t seq
 }
 
 void UdsClient::Impl::transition_to(LinkState next, const boost::system::error_code&) {
-  state_.set_state(next);
+  state_.set(next);
   OnState cb;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
@@ -711,7 +711,7 @@ void UdsClient::Impl::perform_stop_cleanup(uint64_t seq) {
     work_guard_.reset();
   }
 
-  state_.set_state(LinkState::Idle);
+  state_.set(LinkState::Idle);
 }
 
 void UdsClient::Impl::close_socket() {

--- a/unilink/transport/uds/uds_server.cc
+++ b/unilink/transport/uds/uds_server.cc
@@ -58,7 +58,7 @@ struct UdsServer::Impl {
   std::unique_ptr<interface::UdsAcceptorInterface> acceptor_;
   config::UdsServerConfig cfg_;
 
-  concurrency::ThreadSafeLinkState state_{base::LinkState::Idle};
+  concurrency::AtomicLinkState state_{base::LinkState::Idle};
   OnBytes on_bytes_;
   OnState on_state_;
   OnBackpressure on_bp_;
@@ -125,7 +125,7 @@ struct UdsServer::Impl {
 
       std::remove(cfg_.socket_path.c_str());
 
-      state_.set_state(base::LinkState::Idle);
+      state_.set(base::LinkState::Idle);
       notify_state();
     } catch (...) {
     }
@@ -211,7 +211,7 @@ UdsServer::UdsServer(const config::UdsServerConfig& cfg, std::unique_ptr<interfa
 }
 
 UdsServer::~UdsServer() {
-  if (impl_ && impl_->state_.state() != base::LinkState::Idle) {
+  if (impl_ && impl_->state_.get() != base::LinkState::Idle) {
     impl_->stop(nullptr);
   }
 }
@@ -220,7 +220,7 @@ UdsServer::UdsServer(UdsServer&&) noexcept = default;
 UdsServer& UdsServer::operator=(UdsServer&&) noexcept = default;
 
 void UdsServer::start() {
-  if (impl_->state_.state() == base::LinkState::Listening) return;
+  if (impl_->state_.get() == base::LinkState::Listening) return;
 
   impl_->stopping_ = false;
 
@@ -228,7 +228,7 @@ void UdsServer::start() {
     UNILINK_LOG_ERROR("uds_server", "start", "Invalid UDS server configuration or socket path");
     impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
                                            "start", {}, "Invalid UDS server configuration or socket path", false, 0);
-    impl_->state_.set_state(base::LinkState::Error);
+    impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
   }
@@ -243,7 +243,7 @@ void UdsServer::start() {
     UNILINK_LOG_ERROR("uds_server", "start", msg);
     impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::SYSTEM, "open",
                                            ec, msg, false, 0);
-    impl_->state_.set_state(base::LinkState::Error);
+    impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
   }
@@ -257,7 +257,7 @@ void UdsServer::start() {
     impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
                                            "start", make_error_code(boost::system::errc::filename_too_long), msg, false,
                                            0);
-    impl_->state_.set_state(base::LinkState::Error);
+    impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
   }
@@ -268,7 +268,7 @@ void UdsServer::start() {
     UNILINK_LOG_ERROR("uds_server", "start", msg);
     impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
                                            "bind", ec, msg, false, 0);
-    impl_->state_.set_state(base::LinkState::Error);
+    impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
   }
@@ -279,12 +279,12 @@ void UdsServer::start() {
     UNILINK_LOG_ERROR("uds_server", "start", msg);
     impl_->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
                                            "listen", ec, msg, false, 0);
-    impl_->state_.set_state(base::LinkState::Error);
+    impl_->state_.set(base::LinkState::Error);
     impl_->notify_state();
     return;
   }
 
-  impl_->state_.set_state(base::LinkState::Listening);
+  impl_->state_.set(base::LinkState::Listening);
   impl_->notify_state();
 
   if (impl_->owns_ioc_ && !impl_->ioc_thread_.joinable()) {
@@ -307,7 +307,7 @@ void UdsServer::start() {
 
 void UdsServer::stop() { impl_->stop(shared_from_this()); }
 
-bool UdsServer::is_connected() const { return impl_->state_.state() == base::LinkState::Listening; }
+bool UdsServer::is_connected() const { return impl_->state_.get() == base::LinkState::Listening; }
 bool UdsServer::is_backpressure_active() const { return false; }
 
 bool UdsServer::is_backpressure_active(ClientId client_id) const {
@@ -513,7 +513,7 @@ void UdsServer::on_multi_disconnect(MultiClientDisconnectHandler handler) {
   impl_->on_multi_disconnect_ = std::move(handler);
 }
 
-base::LinkState UdsServer::state() const { return impl_->state_.state(); }
+base::LinkState UdsServer::state() const { return impl_->state_.get(); }
 
 void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
   acceptor_->async_accept([self](const boost::system::error_code& ec, uds::socket socket) {
@@ -598,7 +598,7 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
         UNILINK_LOG_ERROR("uds_server", "accept", msg);
         impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
                                               "accept", ec, msg, true, 0);
-        impl->state_.set_state(base::LinkState::Error);
+        impl->state_.set(base::LinkState::Error);
         impl->notify_state();
       }
 
@@ -622,7 +622,7 @@ void UdsServer::Impl::notify_state() {
     std::lock_guard<std::mutex> lock(sessions_mutex_);
     cb = on_state_;
   }
-  if (cb) cb(state_.state());
+  if (cb) cb(state_.get());
 }
 
 }  // namespace transport


### PR DESCRIPTION
## Summary
Closes #442. All 6 transports read connection state through `ThreadSafeLinkState` (a `shared_mutex`-based `ThreadSafeState<LinkState>`) on every send, even though a lock-free `AtomicLinkState` already existed unused in the same header. Reading a single enum value took a `shared_mutex` lock on every send call across all transports, causing unnecessary cache-line contention under concurrent multi-producer sending.

Confirmed none of the 6 transports (`TcpClient`, `TcpServer`, `Serial`, `UdpChannel`, `UdsClient`, `UdsServer`) use `ThreadSafeState`'s heavier API - no `add_state_change_callback`, no `wait_for_state`/`wait_for_state_change`, no `state_cv_` usage anywhere in `unilink/transport/`. Every call site is `.state()` (read), `.set_state(...)` (write), or `.is_state(...)` (read), all already provided by `AtomicState<LinkState>`. State-change notification to registered user callbacks goes through each transport's own separate `notify_state()`/`on_state_` mechanism, not `ThreadSafeState`'s built-in callback registry.

Mechanical rename only: `ThreadSafeLinkState state_` → `AtomicLinkState state_`, `.state()` → `.get()`, `.set_state(` → `.set(`. `.is_state(...)` call sites unchanged (same method name on both types).

## Test plan
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)