### PR TITLE
fix: guard TcpClient/UdsClient destructors against a null (moved-from) impl_

### DIFF
--- a/test/unit/transport/transport_tcp_client_reconnect_test.cc
+++ b/test/unit/transport/transport_tcp_client_reconnect_test.cc
@@ -138,3 +138,21 @@ TEST_F(TcpClientReconnectTest, LiveSetRetryIntervalIsClampedNotUnbounded) {
 
   client->stop();
 }
+
+// #446: TcpClient's move ctor/assignment are defaulted (and public, unlike
+// its private regular constructors), so a moved-from instance has a null
+// impl_. Destroying it must not dereference that null pointer (matches
+// TcpServer/Serial/UdpChannel/UdsServer, whose destructors already
+// null-guard). Reachable via the public API by move-constructing from a
+// dereferenced create()'d shared_ptr, which leaves the original
+// (still-shared_ptr-owned) object moved-from; its destructor runs whenever
+// the shared_ptr's refcount reaches zero.
+TEST_F(TcpClientReconnectTest, DestroyingAMovedFromInstanceDoesNotCrash) {
+  config::TcpClientConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = port_;  // nothing needs to be listening for this test
+
+  auto client_ptr = TcpClient::create(cfg);
+  TcpClient moved_to(std::move(*client_ptr));
+  client_ptr.reset();  // destroys the now moved-from original - the assertion
+}

--- a/test/unit/transport/transport_uds_client.cc
+++ b/test/unit/transport/transport_uds_client.cc
@@ -441,3 +441,23 @@ TEST_F(TransportUdsClientTest, BackpressureCallbackExceptionsAreSwallowed) {
 
   local_client->stop();
 }
+
+// #446: UdsClient's move ctor/assignment are defaulted (and public, unlike
+// its private regular constructors), so a moved-from instance has a null
+// impl_. Destroying it must not dereference that null pointer (matches
+// TcpServer/Serial/UdpChannel/UdsServer, whose destructors already
+// null-guard). Reachable via the public API by move-constructing from a
+// dereferenced create()'d shared_ptr, which leaves the original
+// (still-shared_ptr-owned) object moved-from; its destructor runs whenever
+// the shared_ptr's refcount reaches zero.
+TEST(TransportUdsClientMoveTest, DestroyingAMovedFromInstanceDoesNotCrash) {
+  config::UdsClientConfig cfg;
+  cfg.socket_path = TestUtils::makeUniqueUdsSocketPath("ulc_move").string();
+  TestUtils::removeFileIfExists(cfg.socket_path);
+
+  auto client_ptr = UdsClient::create(cfg);
+  UdsClient moved_to(std::move(*client_ptr));
+  client_ptr.reset();  // destroys the now moved-from original - the assertion
+
+  TestUtils::removeFileIfExists(cfg.socket_path);
+}

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -198,6 +198,11 @@ TcpClient::TcpClient(const TcpClientConfig& cfg, boost::asio::io_context& ioc)
     : impl_(std::make_unique<Impl>(cfg, &ioc)) {}
 
 TcpClient::~TcpClient() {
+  // #446: null after being moved-from - the move ctor/assignment are
+  // defaulted, and destroying a moved-from instance must not dereference
+  // a null impl_ (matches TcpServer/Serial/UdpChannel/UdsServer's
+  // destructors, which already guard this way).
+  if (!impl_) return;
   stop();
   impl_->join_ioc_thread(true);
 

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -198,6 +198,11 @@ UdsClient::UdsClient(const UdsClientConfig& cfg, std::unique_ptr<interface::UdsS
     : impl_(std::make_unique<Impl>(cfg, &ioc, std::move(socket))) {}
 
 UdsClient::~UdsClient() {
+  // #446: null after being moved-from - the move ctor/assignment are
+  // defaulted, and destroying a moved-from instance must not dereference
+  // a null impl_ (matches TcpServer/Serial/UdpChannel/UdsServer's
+  // destructors, which already guard this way).
+  if (!impl_) return;
   stop();
 
   if (impl_->owns_ioc_ && impl_->ioc_thread_.joinable()) {


### PR DESCRIPTION
## Summary
Closes #446. `TcpClient` and `UdsClient`'s move constructor/assignment are defaulted and public (unlike their private, factory-only regular constructors), but their destructors dereferenced `impl_` unconditionally - destroying a moved-from instance was undefined behavior.

`TcpServer`, `Serial`, `UdpChannel`, and `UdsServer`'s destructors already null-guard `impl_` before touching it; only `TcpClient` and `UdsClient` were missing it. Added the same `if (!impl_) return;` guard to both, matching the established pattern rather than deleting move support (which would trade one 2-of-6 inconsistency for another).

This is reachable through the public API, not just theoretical: since `create()` is the only way to construct one (returning `shared_ptr<T>`) but the move ctor is public, `T moved_to(std::move(*ptr))` followed by `ptr`'s refcount reaching zero destroys the moved-from original.

## Test plan
- [x] Added `DestroyingAMovedFromInstanceDoesNotCrash` tests for both `TcpClient` and `UdsClient` exercising exactly this scenario
- [x] Verified both tests SEGFAULT without the guard (temporary revert-and-rerun) and pass cleanly with it
- [x] `./scripts/verify.sh` passes (only the documented pre-existing `TcpServerWrapperLifecycleTest.ConcurrentStartStop` flake, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)