### PR TITLE
fix: blocking send from within a data/message callback fails fast instead of deadlocking

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -27,3 +27,29 @@ client->on_data([](const unilink::MessageContext& ctx) {
 ```
 
 For binary payloads, use `data_as_vector()` before the callback returns.
+
+## Do not call a blocking send from within a callback
+
+`on_data`/`on_message` (and every other) callback runs on the channel's own
+io thread. `send()`/`send_blocking()`/`send_move()`/`send_shared()` in the
+default Reliable backpressure strategy block the calling thread until
+backpressure clears - but clearing backpressure requires that same io
+thread to keep making progress. Calling a blocking send from within a
+callback while backpressure is active would deadlock the entire channel,
+since the thread that would clear it is the one now waiting.
+
+To prevent this, a blocking send called from inside a callback while
+backpressure is active returns `false` immediately instead of blocking:
+
+```cpp
+client->on_data([&](const unilink::MessageContext& ctx) {
+    // If backpressure happens to be active when this fires, send() returns
+    // false right away rather than deadlocking - it does not block here.
+    client->send("reply");
+});
+```
+
+Always use the non-blocking `try_send()`/`try_send_move()`/`try_send_shared()`
+API from within a callback - check the return value and handle a `false`
+result (e.g. drop, retry later, or switch to `BackpressureStrategy::BestEffort`)
+rather than relying on a blocking send inside callback context.

--- a/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_client_wrapper_lifecycle.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -426,6 +427,34 @@ TEST(TcpClientWrapperContractTest, StopSuppressesLateCallbacks) {
   fake_channel->emit_state(base::LinkState::Closed);
 
   EXPECT_EQ(callbacks.load(), 0);
+}
+
+// #449: a blocking Reliable-mode send() called from inside an on_data
+// callback while backpressure is active must fail fast (return false)
+// instead of deadlocking - clearing backpressure requires progress on the
+// same io thread that a blocking wait would now be stuck on. FakeChannel
+// dispatches on_bytes synchronously on the calling (test) thread, exactly
+// matching how a real transport's io thread would invoke it.
+TEST(TcpClientWrapperContractTest, BlockingSendFromDataCallbackFailsFastInsteadOfDeadlocking) {
+  auto fake_channel = std::make_shared<wrapper_support::FakeChannel>();
+  wrapper::TcpClient client(fake_channel);
+  client.backpressure_strategy(base::constants::BackpressureStrategy::Reliable);
+
+  auto started = client.start();
+  fake_channel->emit_state(base::LinkState::Connected);
+  ASSERT_TRUE(started.get());
+  fake_channel->set_backpressure_active(true);
+
+  std::optional<bool> send_result_from_callback;
+  client.on_data([&](const wrapper::MessageContext&) { send_result_from_callback = client.send("reply"); });
+
+  auto start_time = std::chrono::steady_clock::now();
+  fake_channel->emit_bytes("payload");
+  auto elapsed = std::chrono::steady_clock::now() - start_time;
+
+  ASSERT_TRUE(send_result_from_callback.has_value()) << "on_data callback never ran";
+  EXPECT_FALSE(*send_result_from_callback) << "blocking send() from within a data callback must fail fast, not send";
+  EXPECT_LT(elapsed, std::chrono::seconds(1)) << "emit_bytes should return promptly, not block on backpressure";
 }
 
 TEST(TcpClientWrapperContractTest, BestEffortDisconnectedSendReturnsFalse) {

--- a/test/utils/wrapper_contract_test_utils.hpp
+++ b/test/utils/wrapper_contract_test_utils.hpp
@@ -59,7 +59,8 @@ class FakeChannel : public interface::Channel {
     return async_write_shared(std::move(data));
   }
 
-  bool is_backpressure_active() const override { return false; }
+  bool is_backpressure_active() const override { return backpressure_active_; }
+  void set_backpressure_active(bool active) { backpressure_active_ = active; }
 
   void on_bytes(OnBytes cb) override { on_bytes_ = std::move(cb); }
   void on_state(OnState cb) override { on_state_ = std::move(cb); }
@@ -86,6 +87,7 @@ class FakeChannel : public interface::Channel {
 
  private:
   bool connected_{false};
+  bool backpressure_active_{false};
   int write_count_{0};
   OnBytes on_bytes_;
   OnState on_state_;

--- a/unilink/wrapper/callback_guard.hpp
+++ b/unilink/wrapper/callback_guard.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// #449: a blocking send (Reliable-mode send()/send_blocking()/send_move()/
+// send_shared()) called from inside a data/message callback deadlocks -
+// clearing backpressure requires progress on the same io thread that a
+// blocking wait would now be stuck on. This thread_local flag, set for the
+// duration of any data/message callback dispatch, lets the blocking-send
+// path detect that scenario and fail fast (return false) instead of
+// blocking forever. It intentionally isn't scoped per-channel: if the
+// current thread is inside ANY callback dispatch, that thread can't make
+// progress on I/O regardless of which channel triggered the callback -
+// including a second channel sharing the same io_context/thread.
+namespace unilink {
+namespace wrapper {
+namespace detail {
+
+inline thread_local bool g_in_data_callback = false;
+
+class CallbackGuard {
+ public:
+  CallbackGuard() { g_in_data_callback = true; }
+  ~CallbackGuard() { g_in_data_callback = false; }
+  CallbackGuard(const CallbackGuard&) = delete;
+  CallbackGuard& operator=(const CallbackGuard&) = delete;
+};
+
+inline bool in_data_callback() { return g_in_data_callback; }
+
+}  // namespace detail
+}  // namespace wrapper
+}  // namespace unilink

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -33,6 +33,7 @@
 #include "unilink/base/constants.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/serial/serial.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -308,19 +309,27 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   // registering to wait when the notify fires - in the rare case that race is lost, an
   // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
   // notify only costs a short delay rather than a permanent hang (see #427, #431).
-  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+  // Returns false instead of waiting if called from the channel's own io
+  // thread while backpressure is active - e.g. a blocking send() called
+  // from inside an on_data/on_message callback. Clearing backpressure
+  // requires that same io thread to make progress, so blocking here would
+  // deadlock forever rather than eventually clear (#449).
+  bool wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
     auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
     };
+    if (predicate()) return true;
+    if (detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
     }
+    return true;
   }
 
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_move(std::move(data));
@@ -332,7 +341,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
     if (!data || data->empty()) return false;
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_shared(std::move(data));
@@ -349,7 +358,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    wait_for_backpressure_clear(bp_lock);
+    if (!wait_for_backpressure_clear(bp_lock)) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel || !channel->is_connected()) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
@@ -382,6 +391,11 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       if (!impl_keepalive) return;
       auto alive = weak_alive.lock();
       if (!alive) return;
+
+      // #449: everything below runs synchronously on this io thread - mark
+      // it so a blocking send() called from within one of these callbacks
+      // fails fast instead of deadlocking.
+      detail::CallbackGuard callback_guard;
 
       // #441: snapshot the handler/framer pointers under a shared_lock (not
       // unique_lock) - this is a pure read, matching try_send's locking

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -34,6 +34,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_client/tcp_client.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -313,19 +314,28 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   // registering to wait when the notify fires - in the rare case that race is lost, an
   // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
   // notify only costs a short delay rather than a permanent hang (see #427, #431).
-  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+  //
+  // Returns false instead of waiting if called from the channel's own io
+  // thread while backpressure is active - e.g. a blocking send() called
+  // from inside an on_data/on_message callback. Clearing backpressure
+  // requires that same io thread to make progress, so blocking here would
+  // deadlock forever rather than eventually clear (#449).
+  bool wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
     auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel_ || !channel_->is_backpressure_active();
     };
+    if (predicate()) return true;
+    if (detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
     }
+    return true;
   }
 
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_move(std::move(data));
@@ -337,7 +347,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_shared(std::move(data));
@@ -354,7 +364,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    wait_for_backpressure_clear(bp_lock);
+    if (!wait_for_backpressure_clear(bp_lock)) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel_) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
@@ -394,6 +404,14 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       if (!impl_keepalive) return;
       auto alive = weak_alive.lock();
       if (!alive) return;
+
+      // #449: everything below (data_handler_/data_batch_handler_, and
+      // transitively message_handler_/message_batch_handler_ via
+      // framer_to_push->push_bytes() below) runs synchronously on this io
+      // thread. Mark it so a blocking send() called from within one of
+      // these callbacks fails fast instead of deadlocking waiting for this
+      // same thread to clear backpressure.
+      detail::CallbackGuard callback_guard;
 
       // #441: snapshot the handler/framer pointers under a shared_lock (not
       // unique_lock) - this is a pure read, matching try_send's locking

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -33,6 +33,7 @@
 #include "unilink/config/tcp_server_config.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/tcp_server/tcp_server.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -349,6 +350,13 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
   // process of registering to wait when the notify fires. Poll with a bounded timeout instead
   // of an unbounded wait() so a missed notify only costs a short delay rather than a
   // permanent hang (see #427, #431).
+  //
+  // Returns false without sending instead of waiting if called from the
+  // channel's own io thread while backpressure is active for this client -
+  // e.g. a blocking send_to() called from inside an on_data/on_message
+  // callback. Clearing backpressure requires that same io thread to make
+  // progress, so blocking here would deadlock forever rather than
+  // eventually clear (#449).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> lock(bp_mutex_);
     auto predicate = [this, client_id]() {
@@ -356,6 +364,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       const auto& ts = transport_cache_;
       return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
     };
+    if (!predicate() && detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
     }
     std::shared_lock<std::shared_mutex> rlock(mutex_);
@@ -431,6 +440,11 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         if (!impl_keepalive) return;
         auto alive = weak_alive.lock();
         if (!alive) return;
+
+        // #449: everything below runs synchronously on this io thread -
+        // mark it so a blocking send_to()/broadcast() called from within
+        // one of these callbacks fails fast instead of deadlocking.
+        detail::CallbackGuard callback_guard;
 
         // #441: snapshot the handler/framer pointers under a shared_lock
         // (not unique_lock) - this is a pure read, matching try_send's

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -36,6 +36,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -262,7 +263,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool send_move(std::vector<uint8_t>&& data) {
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_move(std::move(data));
@@ -274,7 +275,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
     if (!data || data->empty()) return false;
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel || !channel->is_connected()) return false;
       return channel->async_write_shared(std::move(data));
@@ -291,7 +292,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    wait_for_backpressure_clear(bp_lock);
+    if (!wait_for_backpressure_clear(bp_lock)) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel || !channel->is_connected()) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
@@ -305,13 +306,22 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
   // registering to wait when the notify fires - in the rare case that race is lost, an
   // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
   // notify only costs a short delay rather than a permanent hang (see #427).
-  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+  //
+  // Returns false instead of waiting if called from the channel's own io
+  // thread while backpressure is active - e.g. a blocking send() called
+  // from inside an on_data/on_message callback. Clearing backpressure
+  // requires that same io thread to make progress, so blocking here would
+  // deadlock forever rather than eventually clear (#449).
+  bool wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
     auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel || !channel->is_connected() || !channel->is_backpressure_active();
     };
+    if (predicate()) return true;
+    if (detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
     }
+    return true;
   }
 
   bool try_send(std::string_view data) {
@@ -365,6 +375,11 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       if (!impl_keepalive) return;
       auto alive = weak_alive.lock();
       if (!alive) return;
+
+      // #449: everything below runs synchronously on this io thread - mark
+      // it so a blocking send() called from within one of these callbacks
+      // fails fast instead of deadlocking.
+      detail::CallbackGuard callback_guard;
 
       // #441: snapshot the handler/framer pointers under a shared_lock (not
       // unique_lock) - this is a pure read, matching try_send's locking

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -32,6 +32,7 @@
 #include "unilink/base/common.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/udp/udp.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -248,6 +249,12 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
       // handlers, so a bare `this` could otherwise dangle.
       auto impl_keepalive = weak_impl.lock();
       if (!impl_keepalive) return;
+
+      // #449: everything below runs synchronously on this io thread - mark
+      // it so a blocking send_to() called from within one of these
+      // callbacks fails fast instead of deadlocking.
+      detail::CallbackGuard callback_guard;
+
       ClientId client_id = 0;
       bool is_new = false;
       ConnectionHandler connect_handler_copy{nullptr};
@@ -542,12 +549,20 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
   // registering to wait when the notify fires - in the rare case that race is lost, an
   // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
   // notify only costs a short delay rather than a permanent hang (see #427, #431).
+  //
+  // Returns false without sending instead of waiting if called from the
+  // channel's own io thread while backpressure is active - e.g. a blocking
+  // send_to() called from inside an on_data/on_message callback. Clearing
+  // backpressure requires that same io thread to make progress, so
+  // blocking here would deadlock forever rather than eventually clear
+  // (#449).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
     auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex);
       return !started.load() || !channel || !channel->is_backpressure_active();
     };
+    if (!predicate() && detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
     }
     return try_send_to(client_id, data);

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -35,6 +35,7 @@
 #include "unilink/diagnostics/error_mapping.hpp"
 #include "unilink/factory/channel_factory.hpp"
 #include "unilink/transport/uds/uds_client.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -280,19 +281,27 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
   // registering to wait when the notify fires - in the rare case that race is lost, an
   // unbounded wait() would block forever. Poll with a bounded timeout instead so a missed
   // notify only costs a short delay rather than a permanent hang (see #427, #431).
-  void wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
+  // Returns false instead of waiting if called from the channel's own io
+  // thread while backpressure is active - e.g. a blocking send() called
+  // from inside an on_data/on_message callback. Clearing backpressure
+  // requires that same io thread to make progress, so blocking here would
+  // deadlock forever rather than eventually clear (#449).
+  bool wait_for_backpressure_clear(std::unique_lock<std::mutex>& bp_lock) {
     auto predicate = [this] {
       std::shared_lock<std::shared_mutex> lock(mutex_);
       return !started_.load() || !channel_ || !channel_->is_connected() || !channel_->is_backpressure_active();
     };
+    if (predicate()) return true;
+    if (detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
     }
+    return true;
   }
 
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_move(std::move(data));
@@ -304,7 +313,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
       std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      wait_for_backpressure_clear(bp_lock);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
       std::shared_lock<std::shared_mutex> lock(mutex_);
       if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
       return channel_->async_write_shared(std::move(data));
@@ -321,7 +330,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
 
   bool send_blocking(std::string_view data) {
     std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    wait_for_backpressure_clear(bp_lock);
+    if (!wait_for_backpressure_clear(bp_lock)) return false;
     std::shared_lock<std::shared_mutex> lock(mutex_);
     if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
     return channel_->async_write_copy(
@@ -421,6 +430,11 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       if (!impl_keepalive) return;
       auto alive = weak_alive.lock();
       if (!alive) return;
+
+      // #449: everything below runs synchronously on this io thread - mark
+      // it so a blocking send() called from within one of these callbacks
+      // fails fast instead of deadlocking.
+      detail::CallbackGuard callback_guard;
 
       // #441: snapshot the handler/framer pointers under a shared_lock (not
       // unique_lock) - this is a pure read, matching try_send's locking

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -14,6 +14,7 @@
 #include "unilink/framer/line_framer.hpp"
 #include "unilink/framer/packet_framer.hpp"
 #include "unilink/transport/uds/uds_server.hpp"
+#include "unilink/wrapper/callback_guard.hpp"
 #include "unilink/wrapper/error_context_builder.hpp"
 
 namespace unilink {
@@ -151,6 +152,13 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
   // process of registering to wait when the notify fires. Poll with a bounded timeout instead
   // of an unbounded wait() so a missed notify only costs a short delay rather than a
   // permanent hang (see #427, #431).
+  //
+  // Returns false without sending instead of waiting if called from the
+  // channel's own io thread while backpressure is active for this client -
+  // e.g. a blocking send_to() called from inside an on_data/on_message
+  // callback. Clearing backpressure requires that same io thread to make
+  // progress, so blocking here would deadlock forever rather than
+  // eventually clear (#449).
   bool send_to_blocking(ClientId client_id, std::string_view data) {
     std::unique_lock<std::mutex> lock(bp_mutex_);
     auto predicate = [this, client_id]() {
@@ -158,6 +166,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
       return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
     };
+    if (!predicate() && detail::in_data_callback()) return false;
     while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
     }
     std::shared_lock<std::shared_mutex> rlock(mutex_);
@@ -308,6 +317,11 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
         if (!impl_keepalive) return;
         auto alive = weak_alive.lock();
         if (!alive) return;
+
+        // #449: everything below runs synchronously on this io thread -
+        // mark it so a blocking send_to() called from within one of these
+        // callbacks fails fast instead of deadlocking.
+        detail::CallbackGuard callback_guard;
 
         // #441: snapshot the handler/framer pointers under a shared_lock
         // (not unique_lock) - this is a pure read, matching try_send's


### PR DESCRIPTION
## Summary
Closes #449. `on_data`/`on_message` callbacks execute on the channel's own io thread. The default Reliable-mode `send()` blocks via `send_blocking()`/`send_to_blocking()` waiting on `bp_cv_` - but clearing backpressure requires `report_backpressure()` to run on that same io thread. Calling a blocking send from inside a callback while backpressure is active deadlocked the entire channel - the common request/response or echo pattern (receive data in a callback, send a response from within it).

Fixed across all 7 wrappers with a blocking-send path (TcpClient, Serial, UdpClient, UdsClient, TcpServer, UdsServer, UdpServer). Added `unilink/wrapper/callback_guard.hpp`: a `thread_local` flag set for the duration of each data/message callback dispatch, checked at the top of each wrapper's blocking-send wait helper. If backpressure is active and the caller is inside that same thread's callback dispatch, the blocking send now returns `false` immediately instead of waiting.

`boost::asio::any_io_executor` (what `interface::Channel::get_executor()` returns) doesn't expose `running_in_this_thread()`, so used a `thread_local` flag instead of comparing executors directly. The flag isn't scoped per-channel: if the current thread is inside any callback dispatch, it can't make io progress regardless of which channel triggered the callback.

Documented this explicitly in `docs/callbacks.md`, recommending the non-blocking `try_send*` API from within callbacks.

## Test plan
- [x] Added `BlockingSendFromDataCallbackFailsFastInsteadOfDeadlocking` (TcpClient wrapper, using the existing `FakeChannel` test double which dispatches `on_bytes` synchronously on the calling thread)
- [x] Verified it hangs without the fix (temporary revert-and-rerun with an 8s timeout) and passes in under a millisecond with it
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)