### PR TITLE
fix: remove dead MemoryPool stubs, make memory_usage() reflect releases

### DIFF
--- a/test/e2e/stress/test_stress.cc
+++ b/test/e2e/stress/test_stress.cc
@@ -39,17 +39,9 @@ using namespace std::chrono_literals;
 
 class StressTest : public BaseTest {
  protected:
-  void SetUp() override {
-    BaseTest::SetUp();
-    auto& pool = memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-  }
+  void SetUp() override { BaseTest::SetUp(); }
 
-  void TearDown() override {
-    auto& pool = memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    BaseTest::TearDown();
-  }
+  void TearDown() override { BaseTest::TearDown(); }
 };
 
 TEST_F(StressTest, RealNetworkHighThroughput) {

--- a/test/unit/common/test_boundary.cc
+++ b/test/unit/common/test_boundary.cc
@@ -55,19 +55,9 @@ namespace test {
  */
 class BoundaryTest : public BaseTest {
  protected:
-  void SetUp() override {
-    BaseTest::SetUp();
-    // Reset memory pool for clean testing
-    auto& pool = memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-  }
+  void SetUp() override { BaseTest::SetUp(); }
 
-  void TearDown() override {
-    // Clean up memory pool
-    auto& pool = memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    BaseTest::TearDown();
-  }
+  void TearDown() override { BaseTest::TearDown(); }
 };
 
 // ============================================================================

--- a/test/unit/common/test_memory.cc
+++ b/test/unit/common/test_memory.cc
@@ -50,19 +50,11 @@ class MemoryIntegratedTest : public ::testing::Test {
     // Initialize test state
     test_port_ = TestUtils::getAvailableTestPort();
 
-    // Reset memory pool for clean testing
-    auto& pool = GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-
     // Initialize memory tracking
     initial_memory_usage_ = get_memory_usage();
   }
 
   void TearDown() override {
-    // Clean up memory pool
-    auto& pool = GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-
     // Clean up any test state
     TestUtils::waitFor(100);
 
@@ -243,15 +235,7 @@ TEST_F(MemoryIntegratedTest, BasicMemoryLeakDetection) {
     for (auto& buffer : buffers) {
       pool.release(std::move(buffer), buffer_size);
     }
-
-    // Periodic cleanup
-    if (cycle % 10 == 0) {
-      pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    }
   }
-
-  // Force cleanup
-  pool.cleanup_old_buffers(std::chrono::milliseconds(0));
 
   // Get final stats
   auto final_stats = pool.stats();
@@ -302,15 +286,7 @@ TEST_F(MemoryIntegratedTest, LargeAllocationMemoryLeakDetection) {
     for (auto& buffer : buffers) {
       pool.release(std::move(buffer), buffer_size);
     }
-
-    // Periodic cleanup
-    if (cycle % 5 == 0) {
-      pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    }
   }
-
-  // Force cleanup
-  pool.cleanup_old_buffers(std::chrono::milliseconds(0));
 
   // Get final stats
   auto final_stats = pool.stats();
@@ -365,9 +341,6 @@ TEST_F(MemoryIntegratedTest, ConcurrentMemoryLeakDetection) {
   for (auto& thread : threads) {
     thread.join();
   }
-
-  // Force cleanup
-  pool.cleanup_old_buffers(std::chrono::milliseconds(0));
 
   // Get final stats
   auto final_stats = pool.stats();
@@ -443,17 +416,9 @@ TEST_F(MemoryIntegratedTest, StressMemoryLeakDetection) {
       buffer_sizes.clear();
     }
 
-    // Periodic cleanup
-    if (cycle % 5 == 0) {
-      pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    }
-
     // Small delay to prevent overwhelming the system
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-
-  // Force cleanup
-  pool.cleanup_old_buffers(std::chrono::milliseconds(0));
 
   // Get final stats
   auto final_stats = pool.stats();
@@ -512,9 +477,6 @@ TEST_F(MemoryIntegratedTest, MemoryUsageMonitoring) {
       std::cout << "Cycle " << cycle << " memory usage: " << current_memory << " bytes" << std::endl;
     }
   }
-
-  // Force cleanup
-  pool.cleanup_old_buffers(std::chrono::milliseconds(0));
 
   // Get final memory usage
   size_t final_memory = get_memory_usage();

--- a/test/unit/common/test_memory_pool_edge_cases.cc
+++ b/test/unit/common/test_memory_pool_edge_cases.cc
@@ -89,19 +89,41 @@ TEST(MemoryPoolEdgeCaseTest, StatsAndMetrics) {
   EXPECT_EQ(health.hit_rate, 0.0);
 }
 
-TEST(MemoryPoolEdgeCaseTest, MaintenanceNoopsAndNullReleaseAreSafe) {
+TEST(MemoryPoolEdgeCaseTest, NullReleaseIsSafe) {
   MemoryPool pool;
 
   std::unique_ptr<uint8_t[]> empty;
   EXPECT_NO_THROW(pool.release(std::move(empty), static_cast<size_t>(MemoryPool::BufferSize::SMALL)));
-  EXPECT_NO_THROW(pool.cleanup_old_buffers(std::chrono::milliseconds(1)));
-  EXPECT_NO_THROW(pool.resize_pool(128));
-  EXPECT_NO_THROW(pool.auto_tune());
 
   auto before = pool.memory_usage();
   auto health = pool.health_metrics();
-  EXPECT_EQ(before.first, before.second);
+  EXPECT_EQ(before.first, before.second);  // nothing acquired yet - both 0
   EXPECT_EQ(health.hit_rate, pool.hit_rate());
+}
+
+// #451: memory_usage() must reflect actual current usage - going down when
+// buffers are released - not a monotonically-increasing allocation count.
+// The peak (second) value must stay at the high-water mark rather than
+// following the current value back down.
+TEST(MemoryPoolEdgeCaseTest, MemoryUsageReflectsReleases) {
+  MemoryPool pool;
+  constexpr size_t kSize = static_cast<size_t>(MemoryPool::BufferSize::SMALL);
+
+  auto buf1 = pool.acquire(kSize);
+  auto buf2 = pool.acquire(kSize);
+  auto usage_after_two = pool.memory_usage();
+  EXPECT_EQ(usage_after_two.first, 2 * kSize);
+  EXPECT_EQ(usage_after_two.second, 2 * kSize);
+
+  pool.release(std::move(buf1), kSize);
+  auto usage_after_release = pool.memory_usage();
+  EXPECT_EQ(usage_after_release.first, kSize) << "current usage must decrease after release()";
+  EXPECT_EQ(usage_after_release.second, 2 * kSize) << "peak must remain at the prior high-water mark";
+
+  pool.release(std::move(buf2), kSize);
+  auto usage_after_both_released = pool.memory_usage();
+  EXPECT_EQ(usage_after_both_released.first, 0u);
+  EXPECT_EQ(usage_after_both_released.second, 2 * kSize);
 }
 
 TEST(MemoryPoolEdgeCaseTest, StandardBucketsReuseAcrossSizes) {

--- a/test/unit/common/test_pooled_buffer.cc
+++ b/test/unit/common/test_pooled_buffer.cc
@@ -24,14 +24,7 @@
 
 using namespace unilink::memory;
 
-class PooledBufferTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    // Ensure clean state
-    auto& pool = GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-  }
-};
+class PooledBufferTest : public ::testing::Test {};
 
 TEST_F(PooledBufferTest, ConstructionAndValidity) {
   PooledBuffer buffer(1024);

--- a/test/utils/test_utils.hpp
+++ b/test/utils/test_utils.hpp
@@ -341,19 +341,9 @@ class PerformanceTest : public BaseTest {
  */
 class MemoryTest : public BaseTest {
  protected:
-  void SetUp() override {
-    BaseTest::SetUp();
-    // Reset memory pool for clean testing
-    auto& pool = unilink::memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-  }
+  void SetUp() override { BaseTest::SetUp(); }
 
-  void TearDown() override {
-    // Clean up memory pool
-    auto& pool = unilink::memory::GlobalMemoryPool::instance();
-    pool.cleanup_old_buffers(std::chrono::milliseconds(0));
-    BaseTest::TearDown();
-  }
+  void TearDown() override { BaseTest::TearDown(); }
 };
 
 /**

--- a/unilink/memory/memory_pool.cc
+++ b/unilink/memory/memory_pool.cc
@@ -63,11 +63,14 @@ std::unique_ptr<uint8_t[]> MemoryPool::acquire(size_t size) {
     auto buffer = create_buffer(size);
     // create_buffer throws on failure, so if we are here, we succeeded.
     total_allocations_.fetch_add(1, std::memory_order_relaxed);
+    track_acquire(size);
     return buffer;
   }
 
   auto& bkt = bucket(size);
-  return acquire_from_bucket(bkt);
+  auto buffer = acquire_from_bucket(bkt);
+  if (buffer) track_acquire(bkt.size_);
+  return buffer;
 }
 
 std::unique_ptr<uint8_t[]> MemoryPool::acquire(BufferSize buffer_size) {
@@ -81,10 +84,12 @@ void MemoryPool::release(std::unique_ptr<uint8_t[]> buffer, size_t size) {
 
   if (size > static_cast<size_t>(BufferSize::XLARGE)) {
     MEMORY_TRACK_DEALLOCATION(buffer.get());
+    track_release(size);
     return;  // unique_ptr destructor handles cleanup
   }
 
   auto& bkt = bucket(size);
+  track_release(bkt.size_);
   release_to_bucket(bkt, std::move(buffer));
 }
 
@@ -103,26 +108,20 @@ double MemoryPool::hit_rate() const {
   return static_cast<double>(hits) / static_cast<double>(total);
 }
 
-void MemoryPool::cleanup_old_buffers(std::chrono::milliseconds max_age) {
-  // Simplified: cleanup functionality disabled
-  (void)max_age;  // prevent unused parameter warning
-}
-
 std::pair<size_t, size_t> MemoryPool::memory_usage() const {
-  // Simplified: return basic memory usage
-  size_t total_allocs = total_allocations_.load(std::memory_order_relaxed);
-  size_t current_usage = total_allocs * 4096;  // estimate average buffer size
-  return std::make_pair(current_usage, current_usage);
+  return std::make_pair(outstanding_bytes_.load(std::memory_order_relaxed),
+                        peak_bytes_.load(std::memory_order_relaxed));
 }
 
-void MemoryPool::resize_pool(size_t new_size) {
-  // Simplified: resize functionality disabled
-  (void)new_size;  // prevent unused parameter warning
+void MemoryPool::track_acquire(size_t size) {
+  size_t new_outstanding = outstanding_bytes_.fetch_add(size, std::memory_order_relaxed) + size;
+  size_t prev_peak = peak_bytes_.load(std::memory_order_relaxed);
+  while (new_outstanding > prev_peak &&
+         !peak_bytes_.compare_exchange_weak(prev_peak, new_outstanding, std::memory_order_relaxed)) {
+  }
 }
 
-void MemoryPool::auto_tune() {
-  // Simplified: auto_tune functionality disabled
-}
+void MemoryPool::track_release(size_t size) { outstanding_bytes_.fetch_sub(size, std::memory_order_relaxed); }
 
 MemoryPool::HealthMetrics MemoryPool::health_metrics() const {
   HealthMetrics metrics;

--- a/unilink/memory/memory_pool.hpp
+++ b/unilink/memory/memory_pool.hpp
@@ -18,7 +18,6 @@
 
 #include <array>
 #include <atomic>
-#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -75,10 +74,11 @@ class UNILINK_API MemoryPool {
   void release(std::unique_ptr<uint8_t[]> buffer, size_t size);
   PoolStats stats() const;
   double hit_rate() const;
-  void cleanup_old_buffers(std::chrono::milliseconds max_age = std::chrono::minutes(5));
+  // Returns (bytes currently checked out, peak bytes ever checked out
+  // concurrently). Unlike a monotonically-increasing allocation counter,
+  // both reflect actual acquire()/release() traffic - the first value goes
+  // down as buffers are released (#451).
   std::pair<size_t, size_t> memory_usage() const;
-  void resize_pool(size_t new_size);
-  void auto_tune();
   HealthMetrics health_metrics() const;
 
  private:
@@ -101,10 +101,17 @@ class UNILINK_API MemoryPool {
   // Internal statistics (atomic for thread safety)
   std::atomic<size_t> total_allocations_{0};
   std::atomic<size_t> pool_hits_{0};
+  // #451: real, fluctuating usage tracking for memory_usage() - incremented
+  // in acquire(), decremented in release(), unlike total_allocations_ above
+  // which only ever grows.
+  std::atomic<size_t> outstanding_bytes_{0};
+  std::atomic<size_t> peak_bytes_{0};
 
   // Helper functions
   PoolBucket& bucket(size_t size);
   size_t bucket_index(size_t size) const;
+  void track_acquire(size_t size);
+  void track_release(size_t size);
 
   // Allocation functions
   std::unique_ptr<uint8_t[]> acquire_from_bucket(PoolBucket& bucket);


### PR DESCRIPTION
## Summary
Closes #451. `cleanup_old_buffers`/`resize_pool`/`auto_tune` were all "simplified: disabled" no-op stubs that appeared to succeed while doing nothing, and `memory_usage()` returned `total_allocations * 4096` - a monotonically-increasing estimate that never decreased even as buffers were released, making it look like a permanent leak regardless of actual behavior.

Removed the 3 dead stub methods rather than implementing them for real - none are called anywhere outside tests exercising the stubs themselves. `unilink/memory/*` is explicitly listed in `docs/api_stability.md` as an internal header not covered by the pre-1.0 compatibility guarantee, so this is low-risk. Implementing real logic wasn't justified by any demonstrated need.

Fixed `memory_usage()` to track real, fluctuating usage: added `outstanding_bytes_`/`peak_bytes_` atomics, incremented in `acquire()` and decremented in `release()`. Reinterpreted the returned `std::pair<size_t,size_t>` as `(current, peak)` - matching the existing `(peak_allocations, peak_bytes_allocated)` convention in `memory_tracker.hpp`.

## Test plan
- [x] Updated all 7 test files that referenced the removed methods
- [x] Added `MemoryUsageReflectsReleases` (acquires 2 buffers, releases them one at a time, asserts current usage decreases correctly while peak stays fixed)
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)