### PR TITLE
version: bump to v0.8.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.5
+  VERSION 0.8.6
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Summary
Covers the merged Medium/Low severity Fable-audit work since v0.8.5: #433 (wrapper-layer default literals consolidated onto named `base::constants::DEFAULT_*` constants), #438 (UDS server no longer silently deletes/hijacks a live listener's socket path; added `socket_permissions` config), #439 (documented the plaintext-only transport and trust model), #442 (transport link-state tracking switched to lock-free `AtomicLinkState`), #446 (TcpClient/UdsClient destructors now guard against a null `impl_` after being moved-from), #449 (a blocking send from inside a data/message callback now fails fast instead of deadlocking), and #451 (removed MemoryPool's dead stub methods; `memory_usage()` now reflects real current/peak usage).

This completes the entire original Fable broad-audit backlog (#431-451). All additions are backward-compatible, no breaking API changes.

## Test plan
- [x] `./scripts/verify.sh` passes on `main` (verified throughout this batch's individual PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)