### PR TITLE
fix: TcpServer::stop() always dispatches cleanup onto ioc_ for a managed external context

### DIFF
--- a/unilink/transport/tcp_server/tcp_server.cc
+++ b/unilink/transport/tcp_server/tcp_server.cc
@@ -46,6 +46,16 @@ using tcp = net::ip::tcp;
 
 struct TcpServer::Impl {
   std::atomic<bool> stopping_{false};
+  // #503: stop() can call perform_cleanup() from two different paths - the
+  // dispatched-onto-the-io_context call, and (if that doesn't complete
+  // within the timeout below) a direct fallback call on the stopping
+  // thread. Under slow/instrumented builds (TSAN) the dispatched call can
+  // still be mid-flight when the timeout fires, so both could run
+  // perform_cleanup()'s body concurrently - including acceptor_->close(),
+  // racing with the io_context thread's own concurrent async_accept.
+  // Guards perform_cleanup() to run its body at most once per stop cycle,
+  // reset back to false in start() alongside stopping_.
+  std::atomic<bool> cleanup_started_{false};
   std::atomic<ClientId> next_client_id_{0};
 
   std::unique_ptr<net::io_context> owned_ioc_;
@@ -395,6 +405,7 @@ struct TcpServer::Impl {
   }
 
   void perform_cleanup() {
+    if (cleanup_started_.exchange(true)) return;
     try {
       boost::system::error_code ec;
       if (acceptor_ && acceptor_->is_open()) {
@@ -445,9 +456,22 @@ struct TcpServer::Impl {
       return;
     }
 
-    bool has_active_ioc = owns_ioc_ || (uses_shared_context_ && concurrency::IoContextManager::instance().is_running());
-
-    if (has_active_ioc && self) {
+    // #503: previously gated on has_active_ioc (owns_ioc_ || a running
+    // shared IoContextManager) before deciding to dispatch perform_cleanup()
+    // onto ioc_ vs. calling it directly - but a "managed external context"
+    // (owns_ioc_ == false, since some other owner constructed the
+    // io_context, yet that owner's own thread may still be actively
+    // running it, e.g. the wrapper layer's own io_context+thread) fell
+    // through to the direct-call branch, racing acceptor_->close() against
+    // that thread's concurrent async_accept(). Whenever we have a valid
+    // self to dispatch through, always prefer dispatching onto ioc_ (with
+    // the same timeout-based direct-call fallback for the case where
+    // nothing is actually pumping it) - a stale, unserviced io_context only
+    // costs one extra harmless wait before falling back to the exact same
+    // direct call as before; self is only null when called from the
+    // destructor, where shared_from_this() isn't available and a direct
+    // call is the only option.
+    if (self) {
       auto cleanup_promise = std::make_shared<std::promise<void>>();
       auto cleanup_future = cleanup_promise->get_future();
 
@@ -517,6 +541,7 @@ void TcpServer::start() {
     return;
   }
   impl->stopping_.store(false);
+  impl->cleanup_started_.store(false);
 
   if (impl->uses_shared_context_) {
     auto& manager = concurrency::IoContextManager::instance();


### PR DESCRIPTION
## Summary
Closes #503. The nightly ThreadSanitizer workflow caught a real data race: `TcpServer::Impl::stop()` decided whether to dispatch `perform_cleanup()` onto `ioc_` or call it directly, gated on `owns_ioc_ || (uses_shared_context_ && IoContextManager is running)`.

For a **managed external context** (the wrapper layer constructs its own io_context and thread, then hands it down to the transport as "external"), `owns_ioc_` is false and `uses_shared_context_` is also false - so `stop()` fell through to calling `perform_cleanup()` (including `acceptor_->close()`) directly on the calling thread, while the wrapper's own background thread could still be mid-flight inside `async_accept`. That's the exact race TSAN caught.

Removed the `has_active_ioc` gate: whenever there's a valid `self` to dispatch through, always prefer `net::dispatch`-onto-`ioc_` (with the existing 2-second timeout-based direct-call fallback unchanged) rather than deciding based on ownership.

Also added a `cleanup_started_` atomic exchange-guard around `perform_cleanup()`'s body as defense-in-depth (verified this alone did NOT clear the race - the `has_active_ioc` removal was the actual fix).

**Separate finding filed as #506** (not fixed here, to avoid scope creep): the full test suite under TSAN also flagged `TcpServerWrapperLifecycleTest.ConcurrentStartStop` with 4 warnings in the wrapper layer's own `channel_` shared_ptr handling - very likely the root cause of the already-documented Windows CI SEGFAULT flake for that test.

## Test plan
- [x] Built a local TSAN-instrumented configuration and ran the previously-failing test 10 times - clean every time
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)