### PR TITLE
fix: UdsServerWrapperLifecycleTest.LineSendingVariantsReachConnectedClients race

### DIFF
--- a/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
@@ -420,7 +420,19 @@ TEST(UdsServerWrapperLifecycleTest, LineSendingVariantsReachConnectedClients) {
   EXPECT_TRUE(server->send_to_line(client_id, "send-to"));
   EXPECT_TRUE(server->try_send_to_line(client_id, "try-send-to"));
 
-  ASSERT_TRUE(test::TestUtils::waitForCondition([&]() { return received.load() >= 1; }, 5000));
+  // Wait for all 4 lines to arrive, not just the first - each send/broadcast
+  // call can complete as a separate on_data invocation, so checking after
+  // only one has arrived is a race (matches the already-correct wait
+  // condition in TcpServerWrapperLifecycleTest's identically-named test).
+  ASSERT_TRUE(test::TestUtils::waitForCondition(
+      [&]() {
+        std::lock_guard<std::mutex> lock(received_mutex);
+        return received_data.find("broadcast\n") != std::string::npos &&
+               received_data.find("try-broadcast\n") != std::string::npos &&
+               received_data.find("send-to\n") != std::string::npos &&
+               received_data.find("try-send-to\n") != std::string::npos;
+      },
+      5000));
   std::lock_guard<std::mutex> lock(received_mutex);
   EXPECT_NE(received_data.find("broadcast\n"), std::string::npos);
   EXPECT_NE(received_data.find("try-broadcast\n"), std::string::npos);


### PR DESCRIPTION
## Summary
The v0.8.6 release workflow's macOS job hit an intermittent failure on this test (not reproducible locally - 10/10 clean on Linux). Root cause: the test sends 4 separate lines (`broadcast`/`try-broadcast`/`send-to`/`try-send-to`) but only waited for `received.load() >= 1` (the first message to arrive) before asserting all 4 strings are present in the accumulated `received_data` - a race whenever the 4 sends don't all complete before the first `on_data` callback fires and the wait condition is checked.

The identically-named `TcpServerWrapperLifecycleTest` test already waits correctly (checking for all 4 substrings, not just count >= 1) - fixed the UDS version to match that pattern.

## Test plan
- [x] 5/5 clean runs after the fix (previously intermittently failed on CI)
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)