### PR TITLE
fix: retry blocking Reliable sends after a transient write rejection (#509)

### DIFF
--- a/test/integration/wrapper/test_send_contract.cc
+++ b/test/integration/wrapper/test_send_contract.cc
@@ -42,6 +42,11 @@ class ContractChannel : public unilink::interface::Channel {
   bool async_write_copy(unilink::memory::ConstByteSpan data) override {
     std::lock_guard<std::mutex> lock(mutex_);
     ++write_copy_count_;
+    if (fail_next_writes_ > 0) {
+      --fail_next_writes_;
+      stats_.failed_sends += 1;
+      return false;
+    }
     stats_.messages_accepted += 1;
     stats_.bytes_accepted += data.size();
     return true;
@@ -50,6 +55,11 @@ class ContractChannel : public unilink::interface::Channel {
   bool async_write_move(std::vector<uint8_t>&& data) override {
     std::lock_guard<std::mutex> lock(mutex_);
     ++write_move_count_;
+    if (fail_next_writes_ > 0) {
+      --fail_next_writes_;
+      stats_.failed_sends += 1;
+      return false;
+    }
     stats_.messages_accepted += 1;
     stats_.bytes_accepted += data.size();
     return true;
@@ -59,6 +69,11 @@ class ContractChannel : public unilink::interface::Channel {
     if (!data) return false;
     std::lock_guard<std::mutex> lock(mutex_);
     ++write_shared_count_;
+    if (fail_next_writes_ > 0) {
+      --fail_next_writes_;
+      stats_.failed_sends += 1;
+      return false;
+    }
     stats_.messages_accepted += 1;
     stats_.bytes_accepted += data->size();
     return true;
@@ -99,6 +114,14 @@ class ContractChannel : public unilink::interface::Channel {
 
   void set_try_accepts(bool accepts) { try_accepts_ = accepts; }
   void set_backpressure_active(bool active) { backpressure_active_.store(active); }
+
+  // #509: makes the next `n` async_write_* calls fail (as if rejected by a
+  // hard queue-byte cap) regardless of is_backpressure_active(), simulating
+  // a write attempt losing the race against wait_for_backpressure_clear().
+  void fail_next_writes(int n) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fail_next_writes_ = n;
+  }
 
   int write_copy_count() const {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -141,6 +164,7 @@ class ContractChannel : public unilink::interface::Channel {
   bool connected_{true};
   std::atomic<bool> backpressure_active_{false};
   bool try_accepts_{false};
+  int fail_next_writes_{0};
   int write_copy_count_{0};
   int write_move_count_{0};
   int write_shared_count_{0};
@@ -245,6 +269,29 @@ void verify_blocking_send_recovers_without_notify(std::string_view name) {
   EXPECT_TRUE(sent_future.get());
 }
 
+// Regression test for jwsung91/unilink#509: wait_for_backpressure_clear()'s
+// condition (is_backpressure_active(), tied to bp_high) and the transport's
+// own hard queue-byte cap (bp_limit) are different thresholds checked at
+// different times, so a write attempt can still be rejected immediately
+// after the wait exits - even though nothing about the channel/connection
+// state has actually changed to make the caller give up. Simulates that
+// narrow race directly: backpressure is never active (so the wait returns
+// immediately), but the first write attempt is made to fail anyway. A
+// correct fix retries rather than giving up after one failed attempt.
+template <typename Wrapper>
+void verify_blocking_send_retries_after_transient_write_rejection(std::string_view name) {
+  SCOPED_TRACE(std::string(name));
+  auto channel = std::make_shared<ContractChannel>();
+  channel->fail_next_writes(1);
+
+  Wrapper wrapper(channel);
+  ASSERT_TRUE(wrapper.start().get());
+
+  EXPECT_TRUE(wrapper.send("blocked"))
+      << "blocking send gave up after a single transient write rejection instead of retrying";
+  EXPECT_GE(channel->write_copy_count(), 2) << "expected at least one retry after the first write was rejected";
+}
+
 }  // namespace
 
 TEST(WrapperSendContractTest, BlockingSendRecoversWithoutBackpressureNotification) {
@@ -266,4 +313,11 @@ TEST(WrapperSendContractTest, ReliableSendVariantsDoNotUseTryWritePath) {
   verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::UdpClient>("UdpClient");
   verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::UdsClient>("UdsClient");
   verify_reliable_send_uses_strategy_aware_write<unilink::wrapper::Serial>("Serial");
+}
+
+TEST(WrapperSendContractTest, BlockingSendRetriesAfterTransientWriteRejection) {
+  verify_blocking_send_retries_after_transient_write_rejection<unilink::wrapper::TcpClient>("TcpClient");
+  verify_blocking_send_retries_after_transient_write_rejection<unilink::wrapper::UdpClient>("UdpClient");
+  verify_blocking_send_retries_after_transient_write_rejection<unilink::wrapper::UdsClient>("UdsClient");
+  verify_blocking_send_retries_after_transient_write_rejection<unilink::wrapper::Serial>("Serial");
 }

--- a/unilink/wrapper/serial/serial.cc
+++ b/unilink/wrapper/serial/serial.cc
@@ -326,13 +326,24 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
     return true;
   }
 
+  // #509: wait_for_backpressure_clear()'s condition and the transport's own
+  // hard queue-byte cap are different thresholds observed at different
+  // times, so a single write attempt can spuriously fail right after the
+  // wait exits. Bounded retry rather than unbounded, so a payload that can
+  // never fit still fails in bounded time.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel || !channel->is_connected()) return false;
-      return channel->async_write_move(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel || !channel->is_connected()) return false;
+        if (channel->async_write_move(std::move(data))) return true;
+      }
+      return false;
     }
     return try_send_move(std::move(data));
   }
@@ -340,11 +351,15 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
     if (!data || data->empty()) return false;
     if (backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel || !channel->is_connected()) return false;
-      return channel->async_write_shared(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel || !channel->is_connected()) return false;
+        if (channel->async_write_shared(data)) return true;
+      }
+      return false;
     }
     return try_send_shared(std::move(data));
   }
@@ -357,13 +372,21 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   bool try_send_line(std::string_view line) { return try_send(std::string(line) + "\n"); }
 
   bool send_blocking(std::string_view data) {
-    std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    if (!wait_for_backpressure_clear(bp_lock)) return false;
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    if (!started_.load() || !channel || !channel->is_connected()) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
-    channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
-    return true;
+    memory::ConstByteSpan span(binary_view.first, binary_view.second);
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
+      bp_lock.unlock();
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      // #509: previously discarded async_write_copy()'s result and always
+      // returned true here, silently reporting success even when the write
+      // was actually rejected - now correctly forwards/retries like the
+      // other transports.
+      if (channel->async_write_copy(span)) return true;
+    }
+    return false;
   }
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }

--- a/unilink/wrapper/tcp_client/tcp_client.cc
+++ b/unilink/wrapper/tcp_client/tcp_client.cc
@@ -332,13 +332,33 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
     return true;
   }
 
+  // #509: wait_for_backpressure_clear()'s condition (is_backpressure_active(),
+  // tied to bp_high) and the transport's own hard queue-byte cap
+  // (bp_limit = bp_high * 4, rechecked inside each async_write_*) are
+  // different thresholds observed at different times - something else can
+  // refill the queue in the narrow window between the wait exiting and this
+  // write's own cap check, rejecting a write on an otherwise perfectly
+  // healthy channel. Retry a bounded number of times rather than giving up
+  // after one attempt, since the failure is almost always transient, not
+  // permanent. Bounded (rather than unbounded like the wait loop itself) so
+  // a payload that can never fit under a very small configured
+  // backpressure_threshold still fails in bounded time instead of hanging.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
-      return channel_->async_write_move(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+        // async_write_move only actually moves from `data` on success (see
+        // TcpClient::async_write_move), so retrying with the same `data`
+        // after a `false` return is safe.
+        if (channel_->async_write_move(std::move(data))) return true;
+      }
+      return false;
     }
     return try_send_move(std::move(data));
   }
@@ -346,11 +366,15 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
-      return channel_->async_write_shared(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+        if (channel_->async_write_shared(data)) return true;
+      }
+      return false;
     }
     return try_send_shared(std::move(data));
   }
@@ -363,12 +387,17 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool try_send_line(std::string_view line) { return try_send(std::string(line) + "\n"); }
 
   bool send_blocking(std::string_view data) {
-    std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    if (!wait_for_backpressure_clear(bp_lock)) return false;
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    if (!started_.load() || !channel_) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
-    return channel_->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+    memory::ConstByteSpan span(binary_view.first, binary_view.second);
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
+      bp_lock.unlock();
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_) return false;
+      if (channel_->async_write_copy(span)) return true;
+    }
+    return false;
   }
 
   bool send_line_blocking(std::string_view line) { return send_blocking(std::string(line) + "\n"); }

--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -357,19 +357,32 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
   // callback. Clearing backpressure requires that same io thread to make
   // progress, so blocking here would deadlock forever rather than
   // eventually clear (#449).
+  // #509: the wait predicate (is_backpressure_active(client_id), tied to
+  // bp_high) and the transport's own hard queue-byte cap for that session
+  // (bp_limit) are different thresholds observed at different times, so a
+  // single write attempt can spuriously fail right after the wait exits.
+  // Bounded retry rather than unbounded, so a payload that can never fit
+  // still fails in bounded time.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_to_blocking(ClientId client_id, std::string_view data) {
-    std::unique_lock<std::mutex> lock(bp_mutex_);
-    auto predicate = [this, client_id]() {
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> lock(bp_mutex_);
+      auto predicate = [this, client_id]() {
+        std::shared_lock<std::shared_mutex> rlock(mutex_);
+        const auto& ts = transport_cache_;
+        return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
+      };
+      if (!predicate() && detail::in_data_callback()) return false;
+      while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+      }
+      lock.unlock();
       std::shared_lock<std::shared_mutex> rlock(mutex_);
       const auto& ts = transport_cache_;
-      return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
-    };
-    if (!predicate() && detail::in_data_callback()) return false;
-    while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+      if (!ts) return false;
+      if (ts->send_to_client(client_id, data)) return true;
     }
-    std::shared_lock<std::shared_mutex> rlock(mutex_);
-    const auto& ts = transport_cache_;
-    return ts ? ts->send_to_client(client_id, data) : false;
+    return false;
   }
 
   void setup_internal_handlers() {

--- a/unilink/wrapper/udp/udp.cc
+++ b/unilink/wrapper/udp/udp.cc
@@ -260,13 +260,28 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
     return try_send(data);
   }
 
+  // #509: wait_for_backpressure_clear()'s condition and the transport's own
+  // hard queue-byte cap are different thresholds observed at different
+  // times, so a single write attempt can spuriously fail right after the
+  // wait exits. Bounded retry rather than unbounded, so a payload that can
+  // never fit still fails in bounded time. If a single write is rejected
+  // because the payload alone exceeds the transport's cap, UdpChannel also
+  // transitions to LinkState::Error (unlike TCP/UDS) - wait_for_backpressure_
+  // clear()'s own is_connected() check catches that and ends the retry loop
+  // after one real attempt, so this doesn't retry into a broken channel.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel || !channel->is_connected()) return false;
-      return channel->async_write_move(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel || !channel->is_connected()) return false;
+        if (channel->async_write_move(std::move(data))) return true;
+      }
+      return false;
     }
     return try_send_move(std::move(data));
   }
@@ -274,11 +289,15 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
     if (!data || data->empty()) return false;
     if (cfg.backpressure_strategy == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel || !channel->is_connected()) return false;
-      return channel->async_write_shared(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel || !channel->is_connected()) return false;
+        if (channel->async_write_shared(data)) return true;
+      }
+      return false;
     }
     return try_send_shared(std::move(data));
   }
@@ -291,12 +310,17 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool try_send_line(std::string_view line) { return try_send(std::string(line) + "\n"); }
 
   bool send_blocking(std::string_view data) {
-    std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    if (!wait_for_backpressure_clear(bp_lock)) return false;
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    if (!started_.load() || !channel || !channel->is_connected()) return false;
     auto binary_view = base::safe_convert::string_to_bytes(data);
-    return channel->async_write_copy(memory::ConstByteSpan(binary_view.first, binary_view.second));
+    memory::ConstByteSpan span(binary_view.first, binary_view.second);
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
+      bp_lock.unlock();
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel || !channel->is_connected()) return false;
+      if (channel->async_write_copy(span)) return true;
+    }
+    return false;
   }
 
   // channel->on_backpressure() calls bp_cv_.notify_all() from the transport's io_context

--- a/unilink/wrapper/udp/udp_server.cc
+++ b/unilink/wrapper/udp/udp_server.cc
@@ -556,16 +556,24 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
   // backpressure requires that same io thread to make progress, so
   // blocking here would deadlock forever rather than eventually clear
   // (#449).
+  // #509: see identical rationale in wrapper/tcp_server/tcp_server.cc -
+  // bounded retry rather than a single attempt after the wait exits.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_to_blocking(ClientId client_id, std::string_view data) {
-    std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    auto predicate = [this] {
-      std::shared_lock<std::shared_mutex> lock(mutex);
-      return !started.load() || !channel || !channel->is_backpressure_active();
-    };
-    if (!predicate() && detail::in_data_callback()) return false;
-    while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      auto predicate = [this] {
+        std::shared_lock<std::shared_mutex> lock(mutex);
+        return !started.load() || !channel || !channel->is_backpressure_active();
+      };
+      if (!predicate() && detail::in_data_callback()) return false;
+      while (!bp_cv_.wait_for(bp_lock, std::chrono::milliseconds(50), predicate)) {
+      }
+      bp_lock.unlock();
+      if (try_send_to(client_id, data)) return true;
     }
-    return try_send_to(client_id, data);
+    return false;
   }
 
   bool try_send_to(ClientId client_id, std::string_view data) {

--- a/unilink/wrapper/uds_client/uds_client.cc
+++ b/unilink/wrapper/uds_client/uds_client.cc
@@ -298,13 +298,25 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
     return true;
   }
 
+  // #509: see identical rationale in wrapper/tcp_client/tcp_client.cc -
+  // wait_for_backpressure_clear()'s condition and the transport's own hard
+  // queue-byte cap are different thresholds observed at different times, so
+  // a single write attempt can spuriously fail right after the wait exits.
+  // Bounded retry rather than unbounded, so a payload that can never fit
+  // still fails in bounded time.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_move(std::vector<uint8_t>&& data) {
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
-      return channel_->async_write_move(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+        if (channel_->async_write_move(std::move(data))) return true;
+      }
+      return false;
     }
     return try_send_move(std::move(data));
   }
@@ -312,11 +324,15 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
   bool send_shared(std::shared_ptr<const std::vector<uint8_t>> data) {
     if (!data || data->empty()) return false;
     if (backpressure_strategy_ == base::constants::BackpressureStrategy::Reliable) {
-      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-      if (!wait_for_backpressure_clear(bp_lock)) return false;
-      std::shared_lock<std::shared_mutex> lock(mutex_);
-      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
-      return channel_->async_write_shared(std::move(data));
+      for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+        std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+        if (!wait_for_backpressure_clear(bp_lock)) return false;
+        bp_lock.unlock();
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+        if (channel_->async_write_shared(data)) return true;
+      }
+      return false;
     }
     return try_send_shared(std::move(data));
   }
@@ -329,12 +345,16 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
   bool try_send_line(std::string_view line) { return try_send(std::string(line) + "\n"); }
 
   bool send_blocking(std::string_view data) {
-    std::unique_lock<std::mutex> bp_lock(bp_mutex_);
-    if (!wait_for_backpressure_clear(bp_lock)) return false;
-    std::shared_lock<std::shared_mutex> lock(mutex_);
-    if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
-    return channel_->async_write_copy(
-        memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+    memory::ConstByteSpan span(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> bp_lock(bp_mutex_);
+      if (!wait_for_backpressure_clear(bp_lock)) return false;
+      bp_lock.unlock();
+      std::shared_lock<std::shared_mutex> lock(mutex_);
+      if (!started_.load() || !channel_ || !channel_->is_connected()) return false;
+      if (channel_->async_write_copy(span)) return true;
+    }
+    return false;
   }
 
   bool try_send(std::string_view data) {

--- a/unilink/wrapper/uds_server/uds_server.cc
+++ b/unilink/wrapper/uds_server/uds_server.cc
@@ -160,19 +160,28 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
   // callback. Clearing backpressure requires that same io thread to make
   // progress, so blocking here would deadlock forever rather than
   // eventually clear (#449).
+  // #509: see identical rationale in wrapper/tcp_server/tcp_server.cc -
+  // bounded retry rather than a single attempt after the wait exits.
+  static constexpr int kMaxBlockingSendAttempts = 5;
+
   bool send_to_blocking(ClientId client_id, std::string_view data) {
-    std::unique_lock<std::mutex> lock(bp_mutex_);
-    auto predicate = [this, client_id]() {
+    for (int attempt = 0; attempt < kMaxBlockingSendAttempts; ++attempt) {
+      std::unique_lock<std::mutex> lock(bp_mutex_);
+      auto predicate = [this, client_id]() {
+        std::shared_lock<std::shared_mutex> rlock(mutex_);
+        auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
+        return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
+      };
+      if (!predicate() && detail::in_data_callback()) return false;
+      while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+      }
+      lock.unlock();
       std::shared_lock<std::shared_mutex> rlock(mutex_);
       auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
-      return !started_.load() || !ts || !ts->is_backpressure_active(client_id);
-    };
-    if (!predicate() && detail::in_data_callback()) return false;
-    while (!bp_cv_.wait_for(lock, std::chrono::milliseconds(50), predicate)) {
+      if (!ts) return false;
+      if (ts->send_to_client(client_id, data)) return true;
     }
-    std::shared_lock<std::shared_mutex> rlock(mutex_);
-    auto ts = std::dynamic_pointer_cast<transport::UdsServer>(server_);
-    return ts ? ts->send_to_client(client_id, data) : false;
+    return false;
   }
 
   void schedule_batch_timer() {


### PR DESCRIPTION
## Summary
Closes #509.

`wait_for_backpressure_clear()`'s condition (`is_backpressure_active()`, tied to `bp_high`) and the transport's own hard queue-byte cap (`bp_limit = bp_high * 4`, rechecked inside each `async_write_*`) are different thresholds observed at different times. Something else can refill the queue in the narrow window between the wait exiting and the write's own cap check, rejecting a write attempt on an otherwise perfectly healthy channel. `send_blocking()`/`send_move()`/`send_shared()` (and `send_to_blocking()` on the server side) made exactly one write attempt after waiting and gave up permanently on that single failure.

Found while investigating a v0.8.6 benchmark result where `UdsClient` Reliable-strategy sends failed with `max_queued_bytes` sitting at exactly `bp_limit` (4 MiB with defaults) despite a single-threaded sender - confirmed the same wait-then-single-attempt shape in all 4 client wrappers (TcpClient, UdpClient, UdsClient, Serial) and the `send_to_blocking()` path of all 3 server wrappers (TcpServer, UdsServer, UdpServer).

## Fix
Wrap the wait-then-attempt sequence in a bounded retry loop (`kMaxBlockingSendAttempts = 5`) - if a write attempt fails, loop back to waiting for backpressure to clear rather than giving up. Bounded (not unbounded like the wait itself) so a payload that can never fit under a very small configured `backpressure_threshold` still fails in bounded time rather than hanging. Retrying with the same buffer is safe: `async_write_move`/`async_write_shared` only actually consume their argument on the success path in every transport, never on a `false` return - verified by reading each transport's implementation.

Also fixed a separate bug found in the same function while there: Serial's `send_blocking()` discarded `async_write_copy()`'s result and unconditionally returned `true`, silently reporting success even when the underlying write had actually been rejected.

## Test plan
- [x] Added `WrapperSendContractTest.BlockingSendRetriesAfterTransientWriteRejection`, which makes a `ContractChannel` test double fail exactly one write attempt while backpressure is never active (so the wait returns immediately) - confirmed this fails without the fix (single attempt, `false` return) and passes with it (retries, succeeds) across all 4 client wrappers
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)