### PR TITLE
fix: copy channel_ shared_ptr before unlocking in start()/stop() (#506)

### DIFF
--- a/unilink/wrapper/tcp_server/tcp_server.cc
+++ b/unilink/wrapper/tcp_server/tcp_server.cc
@@ -245,8 +245,15 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         }
       }
     }
+    // #506: take a local copy of the shared_ptr before unlocking. Calling
+    // through the raw channel_ member here would race a concurrent stop()'s
+    // channel_.reset() on the member itself (not just the pointee) - TSAN
+    // caught exactly this under TcpServerWrapperLifecycleTest.
+    // ConcurrentStartStop. A local copy holds its own reference, so it stays
+    // valid and race-free even if another thread resets the member.
+    auto channel_copy = channel_;
     lock.unlock();
-    channel_->start();
+    channel_copy->start();
     if (use_external_context_.load() && manage_external_context_.load() && !external_thread_.joinable()) {
       if (external_ioc_ && external_ioc_->stopped()) {
         external_ioc_->restart();
@@ -284,8 +291,11 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         channel_->on_backpressure(nullptr);
         auto transport_server = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
         if (transport_server) transport_server->request_stop();
+        // #506: same rationale as start() above - copy before unlocking so
+        // this call can't race a concurrent channel_.reset() on the member.
+        auto channel_copy = channel_;
         lock.unlock();
-        channel_->stop();
+        channel_copy->stop();
         lock.lock();
       }
       if (use_external_context_.load() && manage_external_context_.load()) {


### PR DESCRIPTION
## Summary
Closes #506.

`start()` and `stop()` both unlock `mutex_` before calling `channel_->start()`/`channel_->stop()` (to avoid holding the wrapper lock across a potentially-blocking transport-level call), but did so by reading the raw `channel_` member directly rather than a locally-held copy. That races a concurrent `stop()`'s later `channel_.reset()` on the member itself - not just the pointee - since a `std::shared_ptr`'s own storage isn't safe for a concurrent unguarded read to race a guarded write.

## Evidence
Confirmed via a local ThreadSanitizer build: running `TcpServerWrapperLifecycleTest.ConcurrentStartStop` reproduced the exact race TSAN originally reported in #506 (write of size 8 in `std::__shared_ptr::swap`/`reset()` at `tcp_server.cc:319`, racing an unguarded read elsewhere) with the fix reverted, and 10/10 clean runs with it applied - this is also the confirmed root cause of the previously-mysterious Windows CI SEGFAULT flake for the same test (documented in the `windows_ci_known_flakes` project notes).

## Fix
Take a local copy of the shared_ptr while still holding the lock, then unlock and call through the local copy instead of the member, in both `start()` and `stop()`. The local copy holds its own reference so it stays valid and race-free regardless of what another thread does to the member afterward.

## Test plan
- [x] `TcpServerWrapperLifecycleTest.ConcurrentStartStop` under a local TSAN build: 10/10 clean runs (was failing intermittently before)
- [x] Full `run_integration_test_tcp_server_wrapper_lifecycle` suite under TSAN: no data-race warnings (confirmed the exact same race reappears when the fix is reverted, ruling out a false negative)
- [x] `./scripts/verify.sh` passes

## Note
Also found but deliberately not fixed here (filed as #511 instead, to avoid scope creep): a separate TSAN "thread leak" warning in a different test (`MaxClientsWhileStoppedAppliesOnNextStart`), confirmed present independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)