### PR TITLE
version: bump to v0.8.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.6
+  VERSION 0.8.7
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Summary
Bumps `CMakeLists.txt`'s VERSION 0.8.6 → 0.8.7.

Since v0.8.6:
- #509: blocking Reliable sends (all 7 wrappers) now retry after a transient write rejection instead of giving up after one attempt (PR #510)
- #506: `TcpServer::Impl::start()`/`stop()` now copies the `channel_` shared_ptr under lock before unlocking, fixing the TSAN-confirmed data race that was the root cause of the `ConcurrentStartStop` SEGFAULT flake (PR #512)
- #511 investigated and closed as a known TSAN + Boost.Asio limitation, not a unilink bug

Verified clean via a manually-triggered TSAN workflow run before this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)