### PR TITLE
fix: add Requires.private for external spdlog in unilink.pc

### DIFF
--- a/.github/workflows/ci-install-consume.yml
+++ b/.github/workflows/ci-install-consume.yml
@@ -99,7 +99,11 @@ jobs:
 
       - name: Test pkg-config
         run: |
-          export PKG_CONFIG_PATH="$RUNNER_TEMP/unilink-install/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          # unilink.pc's Requires.private now names spdlog's own .pc module
+          # (jwsung91/unilink#514) when spdlog is external, as vcpkg's spdlog
+          # port always is here - pkg-config needs that module's directory on
+          # the search path too, not just unilink's own install prefix.
+          export PKG_CONFIG_PATH="$RUNNER_TEMP/unilink-install/lib/pkgconfig:$VCPKG_ROOT/installed/$VCPKG_TARGET_TRIPLET/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           echo "Testing pkg-config integration..."
           pkg-config --cflags --libs unilink
           echo "pkg-config test completed successfully!"

--- a/cmake/UnilinkDependencies.cmake
+++ b/cmake/UnilinkDependencies.cmake
@@ -241,6 +241,9 @@ endif()
 # drift apart the way they previously did (the .pc file used to hardcode its own
 # separate, incomplete copy of this list — see UnilinkPackaging.cmake).
 set(UNILINK_PKGCONFIG_LIBS_PRIVATE "")
+# pkg-config modules (matched by .pc filename, not their internal Name: field) a
+# pkg-config consumer must also pull in via Requires.private.
+set(UNILINK_PKGCONFIG_REQUIRES_PRIVATE "")
 
 # Link common dependencies
 target_link_libraries(unilink_dependencies INTERFACE Threads::Threads)
@@ -257,6 +260,11 @@ if(_UNILINK_SPDLOG_BUILD_TARGET)
     # A FetchContent-built spdlog is always a real compiled static library (not
     # header-only), so static consumers need it explicitly.
     list(APPEND UNILINK_PKGCONFIG_LIBS_PRIVATE "-lspdlog")
+  else()
+    # An external (find_package) spdlog isn't linked directly here - point
+    # pkg-config consumers at its own .pc module instead, so its own flags (and
+    # transitive deps like fmt) come along too.
+    list(APPEND UNILINK_PKGCONFIG_REQUIRES_PRIVATE "spdlog")
   endif()
 endif()
 if(UNILINK_LINK_BOOST_SYSTEM)

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -192,13 +192,14 @@ if(UNILINK_ENABLE_INSTALL)
 
   if(UNILINK_ENABLE_PKGCONFIG)
     set(PKGCONFIG_REQUIRES "")
-    set(PKGCONFIG_REQUIRES_PRIVATE "")
-    # Derived from UNILINK_PKGCONFIG_LIBS_PRIVATE (built up in
-    # UnilinkDependencies.cmake alongside the real
+    # Derived from
+    # UNILINK_PKGCONFIG_LIBS_PRIVATE/UNILINK_PKGCONFIG_REQUIRES_PRIVATE (built
+    # up in UnilinkDependencies.cmake alongside the real
     # target_link_libraries(unilink_dependencies ...) calls) instead of a
     # separately hardcoded list, so this can no longer silently drift out of
     # sync with what unilink_static actually links against.
     list(JOIN UNILINK_PKGCONFIG_LIBS_PRIVATE " " PKGCONFIG_LIBS_PRIVATE)
+    list(JOIN UNILINK_PKGCONFIG_REQUIRES_PRIVATE " " PKGCONFIG_REQUIRES_PRIVATE)
     set(PKGCONFIG_CFLAGS "")
 
     configure_file(


### PR DESCRIPTION
## Summary
Closes #514.

PR #430 fixed `unilink.pc`'s `Libs.private` to include `-lspdlog` when spdlog is bundled via FetchContent, and the Windows socket libs (`ws2_32`/`mswsock`/`iphlpapi`). But when spdlog is *external* (found via `find_package(spdlog)` - always true for vcpkg builds, since vcpkg provides its own spdlog port), `unilink.pc` declared **neither** `-lspdlog` (correctly, since it's external) **nor** `Requires: spdlog` (incorrectly - the way a pkg-config consumer is supposed to be told about an external dependency's own flags, including its own transitive deps like fmt).

Found while updating the `jwsung91-unilink` vcpkg port to v0.8.7: building with a static-linkage triplet and inspecting the raw generated `.pc` file showed empty `Requires`/`Requires.private` despite spdlog being a real link-time dependency in that configuration.

## Fix
Append `spdlog` (the `.pc` filename vcpkg's spdlog port installs, not its internal `Name: libspdlog` field - pkg-config `Requires:` resolves by filename) to a new `UNILINK_PKGCONFIG_REQUIRES_PRIVATE` list when spdlog isn't bundled, mirroring the existing `UNILINK_PKGCONFIG_LIBS_PRIVATE` pattern, and wire it into `UnilinkPackaging.cmake`'s `PKGCONFIG_REQUIRES_PRIVATE` instead of the previously-hardcoded empty string.

## Test plan
- [x] Built unilink locally against vcpkg-provided spdlog and confirmed the installed `unilink.pc` now has `Requires.private: spdlog` (was empty before)
- [x] `./scripts/verify.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)