### PR TITLE
Fix accept-then-drop race in Reliable-strategy blocking writes

### DIFF
--- a/test/integration/transport/test_backpressure_strategy.cc
+++ b/test/integration/transport/test_backpressure_strategy.cc
@@ -610,9 +610,8 @@ TEST(BackpressureStrategyTest, Reliable_ConcurrentPlainWritesNeverDropAcceptedMe
 
   auto stats = session->stats();
   EXPECT_EQ(stats.messages_accepted, static_cast<uint64_t>(accepted_count.load()));
-  EXPECT_EQ(stats.dropped_messages, 0u)
-      << stats.dropped_messages << " of " << accepted_count.load()
-      << " accepted messages were dropped after routing (jwsung91/unilink#517)";
+  EXPECT_EQ(stats.dropped_messages, 0u) << stats.dropped_messages << " of " << accepted_count.load()
+                                        << " accepted messages were dropped after routing (jwsung91/unilink#517)";
 
   work.reset();
   drain_and_stop(sock, session, ioc);

--- a/test/integration/transport/test_backpressure_strategy.cc
+++ b/test/integration/transport/test_backpressure_strategy.cc
@@ -546,6 +546,80 @@ TEST(BackpressureStrategyTest, Reliable_CombinedLimit_LargeWriteRejected) {
   drain_and_stop(sock, session, ioc);
 }
 
+// Reproduces jwsung91/unilink#517: the plain (blocking-capable) async_write_*
+// path used to precheck queue_bytes_+pending_bytes_+added>bp_limit_ on the
+// caller's own thread without reserving the bytes, then re-decide on the
+// strand once the write was actually routed. Concurrent callers could all
+// pass the precheck, and once routed the real combined total exceeded
+// bp_limit_, so some already-`accepted` messages got silently reclassified
+// as `dropped` - a real-world 0.05%-0.7% loss confirmed on Jetson benchmark
+// data for Reliable strategy, which must never drop. try_reserve_limit_bytes()
+// closes this by reserving atomically at accept time; this test drives many
+// concurrent writers through a real io_context/strand (not manual ioc.poll()
+// stepping) so the accept-time precheck and the strand's routing genuinely
+// overlap across threads, and asserts every message the precheck accepted
+// survives routing.
+TEST(BackpressureStrategyTest, Reliable_ConcurrentPlainWritesNeverDropAcceptedMessages) {
+  constexpr size_t kBpHigh = 1024;
+  constexpr int kThreadCount = 8;
+  constexpr int kMessagesPerThread = 3000;
+  constexpr size_t kPayload = 100;  // 8*3000*100 = 2.4 MB requested, ~2.4x bp_limit_ (1 MiB)
+
+  net::io_context ioc;
+  auto work = net::make_work_guard(ioc);
+  std::thread io_thread([&] { ioc.run(); });
+
+  auto socket = std::make_unique<StallingTcpSocket>(ioc);
+  auto* sock = socket.get();
+  auto session =
+      std::make_shared<transport::TcpServerSession>(ioc, std::move(socket), kBpHigh, 0, BackpressureStrategy::Reliable);
+  session->on_backpressure([](size_t) {});
+  session->start();
+
+  std::atomic<int> accepted_count{0};
+  std::vector<std::thread> writers;
+  writers.reserve(kThreadCount);
+  for (int t = 0; t < kThreadCount; ++t) {
+    writers.emplace_back([&] {
+      for (int i = 0; i < kMessagesPerThread; ++i) {
+        if (session->async_write_move(std::vector<uint8_t>(kPayload, 0xAB))) {
+          accepted_count.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+  for (auto& th : writers) th.join();
+
+  // route_enqueued_buffer() runs on the session's strand inside io_thread;
+  // wait for the posted-write backlog to fully drain (queued_bytes_ +
+  // pending_bytes_ + dropped_bytes stops changing) before reading final
+  // stats, rather than a single fixed sleep.
+  size_t stable_bytes = 0;
+  int stable_iterations = 0;
+  for (int i = 0; i < 500 && stable_iterations < 5; ++i) {
+    std::this_thread::sleep_for(2ms);
+    auto s = session->stats();
+    const size_t current = s.queued_bytes + s.pending_bytes + s.dropped_bytes;
+    if (current == stable_bytes) {
+      ++stable_iterations;
+    } else {
+      stable_bytes = current;
+      stable_iterations = 0;
+    }
+  }
+
+  auto stats = session->stats();
+  EXPECT_EQ(stats.messages_accepted, static_cast<uint64_t>(accepted_count.load()));
+  EXPECT_EQ(stats.dropped_messages, 0u)
+      << stats.dropped_messages << " of " << accepted_count.load()
+      << " accepted messages were dropped after routing (jwsung91/unilink#517)";
+
+  work.reset();
+  drain_and_stop(sock, session, ioc);
+  ioc.stop();
+  io_thread.join();
+}
+
 // When OFF fires and the flushed pending_ bytes push queue above bp_high_,
 // the ON callback is re-fired immediately in the same report_backpressure call.
 TEST(BackpressureStrategyTest, Reliable_BurstOnOFF_ImmediateOnReactivation) {

--- a/test/integration/transport/transport_tcp_client.cc
+++ b/test/integration/transport/transport_tcp_client.cc
@@ -197,20 +197,22 @@ TEST_F(TransportTcpClientTest, QueueLimitDropsMessage) {
 
   // bp_limit_ = max(backpressure_threshold * 4, DEFAULT_BACKPRESSURE_THRESHOLD) = 1MB here
   // (backpressure_threshold=1024 * 4 = 4KB is below the 1MB default floor).
-  // A 2MB write exceeds it outright: message dropped, backpressure fires,
-  // connection stays alive.
+  // A 2MB write exceeds it outright and is now rejected synchronously via
+  // try_reserve_limit_bytes() (jwsung91/unilink#517) instead of being
+  // accepted and only discovered too-large once routed onto the strand -
+  // matching every other transport's existing fallback-path precheck (see
+  // e.g. TransportTcpServerSessionTest.QueueLimitDropsMessage). Backpressure
+  // does not fire since the write is never queued.
   std::vector<uint8_t> huge(2 * 1024 * 1024, 0xEF);
-  client_->async_write_copy(memory::ConstByteSpan(huge.data(), huge.size()));
+  EXPECT_FALSE(client_->async_write_copy(memory::ConstByteSpan(huge.data(), huge.size())));
 
   ioc.run_for(std::chrono::milliseconds(50));
 
-  EXPECT_TRUE(backpressure_seen.load());
-  // #448: this rejection path used to leave RuntimeStats showing the
-  // message as accepted with no corresponding dropped/sent/queued
-  // accounting - confirm it now shows up as a recorded drop.
+  EXPECT_FALSE(backpressure_seen.load());
   auto stats = client_->stats();
-  EXPECT_GE(stats.dropped_messages, 1u);
-  EXPECT_GE(stats.dropped_bytes, huge.size());
+  EXPECT_GE(stats.failed_sends, 1u);
+  EXPECT_EQ(stats.dropped_messages, 0u);
+  EXPECT_EQ(stats.dropped_bytes, 0u);
 
   client_->stop();
   client_.reset();

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -62,6 +62,52 @@ inline void release_reserved_write_bytes(std::atomic<size_t>& queue_bytes, size_
   }
 }
 
+// Atomically reserves `added` bytes against bp_limit for the plain
+// (blocking-capable) async_write_* entry points, accounting for bytes
+// already reserved-but-not-yet-routed via `inflight_bytes` in addition to
+// `queue_bytes`/`pending_bytes`. Closes an accept-then-drop race where the
+// caller-thread precheck used to only read queue_bytes+pending_bytes
+// non-atomically without reserving space: concurrent callers could all pass
+// the check, then get rejected once actually routed onto the strand, where
+// the real combined total exceeded bp_limit (jwsung91/unilink#517).
+// Deliberately omits the bp_high/backpressure_active gate that
+// try_reserve_write_bytes() applies above - a plain write is allowed to land
+// in pending_ while backpressure is active, unlike the non-blocking
+// try_write path.
+inline bool try_reserve_limit_bytes(const std::atomic<size_t>& queue_bytes, const std::atomic<size_t>& pending_bytes,
+                                    std::atomic<size_t>& inflight_bytes, size_t added, size_t bp_limit) {
+  if (added == 0 || added > bp_limit) return false;
+
+  size_t current_inflight = inflight_bytes.load(std::memory_order_relaxed);
+  for (;;) {
+    const size_t queue = queue_bytes.load(std::memory_order_relaxed);
+    const size_t pending = pending_bytes.load(std::memory_order_relaxed);
+    if (queue > bp_limit || pending > bp_limit - queue || current_inflight > bp_limit - queue - pending ||
+        added > bp_limit - queue - pending - current_inflight) {
+      return false;
+    }
+
+    if (inflight_bytes.compare_exchange_weak(current_inflight, current_inflight + added, std::memory_order_acq_rel,
+                                             std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+}
+
+// Releases a reservation made by try_reserve_limit_bytes(). Callers that
+// route the message into queue_bytes_/pending_bytes_ must increment that
+// counter *before* calling this, so a concurrent try_reserve_limit_bytes()
+// on another thread never observes a transient total lower than what's
+// truly reserved (which would let it over-admit past bp_limit).
+inline void release_reserved_limit_bytes(std::atomic<size_t>& inflight_bytes, size_t bytes) {
+  size_t current = inflight_bytes.load(std::memory_order_relaxed);
+  for (;;) {
+    const size_t next = current > bytes ? current - bytes : 0;
+    if (inflight_bytes.compare_exchange_weak(current, next, std::memory_order_acq_rel, std::memory_order_relaxed))
+      return;
+  }
+}
+
 // Returns the byte size of a buffer held in a transport BufferVariant alternative.
 // shared_ptr<const vector<uint8_t>> goes through ->size(); everything else via .size().
 template <typename T>

--- a/unilink/transport/base/bp_utils.hpp
+++ b/unilink/transport/base/bp_utils.hpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -62,50 +63,82 @@ inline void release_reserved_write_bytes(std::atomic<size_t>& queue_bytes, size_
   }
 }
 
-// Atomically reserves `added` bytes against bp_limit for the plain
-// (blocking-capable) async_write_* entry points, accounting for bytes
-// already reserved-but-not-yet-routed via `inflight_bytes` in addition to
+// Reserves `added` bytes against bp_limit for the plain (blocking-capable)
+// async_write_* entry points, accounting for bytes already
+// reserved-but-not-yet-routed via `inflight_bytes` in addition to
 // `queue_bytes`/`pending_bytes`. Closes an accept-then-drop race where the
 // caller-thread precheck used to only read queue_bytes+pending_bytes
 // non-atomically without reserving space: concurrent callers could all pass
 // the check, then get rejected once actually routed onto the strand, where
 // the real combined total exceeded bp_limit (jwsung91/unilink#517).
-// Deliberately omits the bp_high/backpressure_active gate that
-// try_reserve_write_bytes() applies above - a plain write is allowed to land
-// in pending_ while backpressure is active, unlike the non-blocking
-// try_write path.
-inline bool try_reserve_limit_bytes(const std::atomic<size_t>& queue_bytes, const std::atomic<size_t>& pending_bytes,
-                                    std::atomic<size_t>& inflight_bytes, size_t added, size_t bp_limit) {
+//
+// Guarded by `mtx` rather than a lock-free CAS on `inflight_bytes` alone:
+// queue_bytes/pending_bytes/inflight_bytes are three independently-atomic
+// counters, so no CAS retry loop touching only one of them can make a
+// check spanning all three race-free - the strand's commit_reserved_limit_bytes()
+// promoting inflight_bytes into queue_bytes/pending_bytes is itself two
+// separate atomic ops, and a concurrent reservation's queue_bytes/pending_bytes
+// reads can land in the gap between them while its CAS against a stale
+// inflight_bytes snapshot still spuriously succeeds. This was caught by a
+// CI run reproducing a 1-in-~10000 dropped message under this exact
+// window. `mtx` must be the same mutex passed to commit_reserved_limit_bytes()
+// for a given transport instance. Deliberately omits the
+// bp_high/backpressure_active gate that try_reserve_write_bytes() applies
+// above - a plain write is allowed to land in pending_ while backpressure
+// is active, unlike the non-blocking try_write path.
+inline bool try_reserve_limit_bytes(std::mutex& mtx, const std::atomic<size_t>& queue_bytes,
+                                    const std::atomic<size_t>& pending_bytes, std::atomic<size_t>& inflight_bytes,
+                                    size_t added, size_t bp_limit) {
   if (added == 0 || added > bp_limit) return false;
 
-  size_t current_inflight = inflight_bytes.load(std::memory_order_relaxed);
-  for (;;) {
-    const size_t queue = queue_bytes.load(std::memory_order_relaxed);
-    const size_t pending = pending_bytes.load(std::memory_order_relaxed);
-    if (queue > bp_limit || pending > bp_limit - queue || current_inflight > bp_limit - queue - pending ||
-        added > bp_limit - queue - pending - current_inflight) {
-      return false;
-    }
-
-    if (inflight_bytes.compare_exchange_weak(current_inflight, current_inflight + added, std::memory_order_acq_rel,
-                                             std::memory_order_relaxed)) {
-      return true;
-    }
+  std::lock_guard<std::mutex> lock(mtx);
+  const size_t queue = queue_bytes.load(std::memory_order_relaxed);
+  const size_t pending = pending_bytes.load(std::memory_order_relaxed);
+  const size_t inflight = inflight_bytes.load(std::memory_order_relaxed);
+  if (queue > bp_limit || pending > bp_limit - queue || inflight > bp_limit - queue - pending ||
+      added > bp_limit - queue - pending - inflight) {
+    return false;
   }
+  inflight_bytes.fetch_add(added, std::memory_order_relaxed);
+  return true;
 }
 
-// Releases a reservation made by try_reserve_limit_bytes(). Callers that
-// route the message into queue_bytes_/pending_bytes_ must increment that
-// counter *before* calling this, so a concurrent try_reserve_limit_bytes()
-// on another thread never observes a transient total lower than what's
-// truly reserved (which would let it over-admit past bp_limit).
-inline void release_reserved_limit_bytes(std::atomic<size_t>& inflight_bytes, size_t bytes) {
-  size_t current = inflight_bytes.load(std::memory_order_relaxed);
-  for (;;) {
-    const size_t next = current > bytes ? current - bytes : 0;
-    if (inflight_bytes.compare_exchange_weak(current, next, std::memory_order_acq_rel, std::memory_order_relaxed))
-      return;
-  }
+// Releases a reservation made by try_reserve_limit_bytes(), for the case
+// where the message never gets promoted into queue_bytes_/pending_bytes_
+// (route_enqueued_buffer's Rejected branch - expected to be effectively
+// unreachable given the reservation above, but kept as a safety net).
+inline void release_reserved_limit_bytes(std::mutex& mtx, std::atomic<size_t>& inflight_bytes, size_t bytes) {
+  std::lock_guard<std::mutex> lock(mtx);
+  const size_t current = inflight_bytes.load(std::memory_order_relaxed);
+  inflight_bytes.store(current > bytes ? current - bytes : 0, std::memory_order_relaxed);
+}
+
+// Promotes a reservation made by try_reserve_limit_bytes() into `counter`
+// (queue_bytes_ or pending_bytes_) once route_enqueued_buffer() has decided
+// where the message lands. Must run under the same `mtx` as
+// try_reserve_limit_bytes() and perform both the increment and the
+// inflight_bytes release as one critical section - doing them as two
+// separately-locked steps would reopen the exact gap described above.
+inline void commit_reserved_limit_bytes(std::mutex& mtx, std::atomic<size_t>& counter,
+                                        std::atomic<size_t>& inflight_bytes, size_t bytes) {
+  std::lock_guard<std::mutex> lock(mtx);
+  counter.fetch_add(bytes, std::memory_order_relaxed);
+  const size_t current = inflight_bytes.load(std::memory_order_relaxed);
+  inflight_bytes.store(current > bytes ? current - bytes : 0, std::memory_order_relaxed);
+}
+
+// Locked increment for the rare plain-write path that skips
+// try_reserve_limit_bytes() entirely (tcp_client's BestEffort fallback,
+// which - unlike every other transport's plain path - has no precheck at
+// all, matching its pre-existing behavior). Still must go through the same
+// `mtx` as try_reserve_limit_bytes()/commit_reserved_limit_bytes() for this
+// transport instance: an increment landing outside the lock could let a
+// concurrent Reliable reservation's already-approved check get silently
+// invalidated by bytes it never accounted for, reopening the same race for
+// Reliable messages that this whole reservation scheme exists to close.
+inline void commit_unreserved_limit_bytes(std::mutex& mtx, std::atomic<size_t>& counter, size_t bytes) {
+  std::lock_guard<std::mutex> lock(mtx);
+  counter.fetch_add(bytes, std::memory_order_relaxed);
 }
 
 // Returns the byte size of a buffer held in a transport BufferVariant alternative.

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -669,8 +669,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(n, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
-      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
-                                               impl->bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_,
+                                               impl->inflight_bytes_, n, impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -684,8 +684,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, n, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -710,8 +710,8 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, added, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -734,8 +734,8 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, added, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stop_token>
 #include <string>
@@ -83,8 +84,11 @@ struct Serial::Impl {
   std::atomic<size_t> queued_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queued_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) - a
   // strand-post/dispatch here would only protect the former (#436).
@@ -161,7 +165,7 @@ struct Serial::Impl {
       // #448: record as dropped so it's reflected in RuntimeStats instead of
       // silently vanishing after being counted as accepted.
       stats_.record_dropped(1, added);
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
       if (reliable_pending_active) {
         return;
       }
@@ -175,14 +179,12 @@ struct Serial::Impl {
       return;
     }
     if (decision == queue_util::EnqueueDecision::Pending) {
-      pending_bytes_ += added;
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, added);
       pending_.emplace_back(std::move(buf));
       observe_queue();
       return;
     }
-    queued_bytes_ += added;
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queued_bytes_, inflight_bytes_, added);
     tx_.emplace_back(std::move(buf));
     observe_queue();
     report_backpressure(queued_bytes_);
@@ -667,7 +669,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(n, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
-      if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
                                                impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
@@ -682,7 +684,7 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
@@ -708,7 +710,7 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
@@ -732,7 +734,7 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;

--- a/unilink/transport/serial/serial.cc
+++ b/unilink/transport/serial/serial.cc
@@ -81,6 +81,10 @@ struct Serial::Impl {
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queued_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) - a
   // strand-post/dispatch here would only protect the former (#436).
@@ -157,6 +161,7 @@ struct Serial::Impl {
       // #448: record as dropped so it's reflected in RuntimeStats instead of
       // silently vanishing after being counted as accepted.
       stats_.record_dropped(1, added);
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
       if (reliable_pending_active) {
         return;
       }
@@ -171,11 +176,13 @@ struct Serial::Impl {
     }
     if (decision == queue_util::EnqueueDecision::Pending) {
       pending_bytes_ += added;
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
       pending_.emplace_back(std::move(buf));
       observe_queue();
       return;
     }
     queued_bytes_ += added;
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     tx_.emplace_back(std::move(buf));
     observe_queue();
     report_backpressure(queued_bytes_);
@@ -660,7 +667,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(n, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), n);
-      if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
+                                               impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -674,7 +682,8 @@ bool Serial::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (impl->queued_bytes_ + impl->pending_bytes_ + n > impl->bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, n,
+                                           impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -699,7 +708,8 @@ bool Serial::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
+                                           impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -722,7 +732,8 @@ bool Serial::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> data
     return false;
   }
   const auto added = data->size();
-  if (impl->queued_bytes_ + impl->pending_bytes_ + added > impl->bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(impl->queued_bytes_, impl->pending_bytes_, impl->inflight_bytes_, added,
+                                           impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -111,6 +111,10 @@ struct TcpClient::Impl {
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) (#436).
   std::atomic<base::constants::BackpressureStrategy> bp_strategy_{base::constants::BackpressureStrategy::Reliable};
@@ -174,7 +178,11 @@ struct TcpClient::Impl {
   void report_backpressure(std::shared_ptr<TcpClient> self, size_t queued_bytes);
   void observe_queue();
   // Shared decide_enqueue()/route dispatch used by all 3 async_write_* variants (#434).
-  void route_enqueued_buffer(std::shared_ptr<TcpClient> self, BufferVariant&& buf, size_t added);
+  // `reserved` tells this whether the caller reserved `added` bytes into
+  // inflight_bytes_ via try_reserve_limit_bytes() - only Reliable-strategy
+  // sends do (jwsung91/unilink#517); BestEffort's plain path has no
+  // precheck and relies entirely on decide_enqueue()'s own keep-latest trim.
+  void route_enqueued_buffer(std::shared_ptr<TcpClient> self, BufferVariant&& buf, size_t added, bool reserved);
   queue_util::BackpressureFields bp_fields();
   void notify_state();
   void reset_io_objects();
@@ -337,15 +345,17 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
       if (pooled_buffer.valid()) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
-        if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-            impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+        const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
+        if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+                                                              impl_->inflight_bytes_, added, impl_->bp_limit_)) {
           impl_->stats_.record_failed_send();
           return false;
         }
         impl_->stats_.record_accepted(added);
-        net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(pooled_buffer), added]() mutable {
-          self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added);
-        });
+        net::dispatch(impl_->strand_,
+                      [self = shared_from_this(), buf = std::move(pooled_buffer), added, reliable]() mutable {
+                        self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added, reliable);
+                      });
         return true;
       }
     } catch (const std::exception& e) {
@@ -355,10 +365,16 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
 
   std::vector<uint8_t> fallback(data.begin(), data.end());
   const auto added = fallback.size();
+  const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
+    impl_->stats_.record_failed_send();
+    return false;
+  }
   impl_->stats_.record_accepted(added);
 
-  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(fallback), added]() mutable {
-    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added);
+  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(fallback), added, reliable]() mutable {
+    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added, reliable);
   });
   return true;
 }
@@ -383,14 +399,15 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
   }
 
   const auto added = size;
-  if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+  const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
   impl_->stats_.record_accepted(added);
-  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
-    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added);
+  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added, reliable]() mutable {
+    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added, reliable);
   });
   return true;
 }
@@ -415,14 +432,15 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
   }
 
   const auto added = size;
-  if (impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable &&
-      impl_->queue_bytes_ + impl_->pending_bytes_ + added > impl_->bp_limit_) {
+  const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
   impl_->stats_.record_accepted(added);
-  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
-    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added);
+  net::dispatch(impl_->strand_, [self = shared_from_this(), buf = std::move(data), added, reliable]() mutable {
+    self->impl_->route_enqueued_buffer(self, BufferVariant{std::move(buf)}, added, reliable);
   });
   return true;
 }
@@ -1040,8 +1058,11 @@ queue_util::BackpressureFields TcpClient::Impl::bp_fields() {
                                         bp_strategy_.load(std::memory_order_relaxed)};
 }
 
-void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, BufferVariant&& buf, size_t added) {
+void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, BufferVariant&& buf, size_t added,
+                                            bool reserved) {
   if (stop_requested_.load() || state_.is_state(LinkState::Closed) || state_.is_state(LinkState::Error)) {
+    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    stats_.record_failed_send();
     return;
   }
 
@@ -1059,16 +1080,19 @@ void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, Buf
     // sent/dropped/queued accounting - record it as dropped so it's at
     // least observable.
     stats_.record_dropped(1, added);
+    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
     pending_bytes_ += added;
+    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
   queue_bytes_ += added;
+  if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(self, queue_bytes_);

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -350,8 +350,9 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
         const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-        if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
-                                                              impl_->inflight_bytes_, added, impl_->bp_limit_)) {
+        if (reliable &&
+            !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                                 impl_->inflight_bytes_, added, impl_->bp_limit_)) {
           impl_->stats_.record_failed_send();
           return false;
         }
@@ -370,8 +371,9 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> fallback(data.begin(), data.end());
   const auto added = fallback.size();
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
-                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
+  if (reliable &&
+      !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                           impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
@@ -404,8 +406,9 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
 
   const auto added = size;
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
-                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
+  if (reliable &&
+      !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                           impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
@@ -437,8 +440,9 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
 
   const auto added = size;
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
-                                                        impl_->inflight_bytes_, added, impl_->bp_limit_)) {
+  if (reliable &&
+      !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                           impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/tcp_client/tcp_client.cc
+++ b/unilink/transport/tcp_client/tcp_client.cc
@@ -31,6 +31,7 @@
 #include <deque>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stop_token>
 #include <string>
@@ -113,8 +114,11 @@ struct TcpClient::Impl {
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queue_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) (#436).
   std::atomic<base::constants::BackpressureStrategy> bp_strategy_{base::constants::BackpressureStrategy::Reliable};
@@ -346,7 +350,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
         base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
         const auto added = pooled_buffer.size();
         const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-        if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+        if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
                                                               impl_->inflight_bytes_, added, impl_->bp_limit_)) {
           impl_->stats_.record_failed_send();
           return false;
@@ -366,7 +370,7 @@ bool TcpClient::async_write_copy(memory::ConstByteSpan data) {
   std::vector<uint8_t> fallback(data.begin(), data.end());
   const auto added = fallback.size();
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
                                                         impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
@@ -400,7 +404,7 @@ bool TcpClient::async_write_move(std::vector<uint8_t>&& data) {
 
   const auto added = size;
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
                                                         impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
@@ -433,7 +437,7 @@ bool TcpClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
 
   const auto added = size;
   const bool reliable = impl_->bp_strategy_ == base::constants::BackpressureStrategy::Reliable;
-  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_,
+  if (reliable && !queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
                                                         impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
@@ -1061,7 +1065,7 @@ queue_util::BackpressureFields TcpClient::Impl::bp_fields() {
 void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, BufferVariant&& buf, size_t added,
                                             bool reserved) {
   if (stop_requested_.load() || state_.is_state(LinkState::Closed) || state_.is_state(LinkState::Error)) {
-    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    if (reserved) queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
     stats_.record_failed_send();
     return;
   }
@@ -1080,19 +1084,25 @@ void TcpClient::Impl::route_enqueued_buffer(std::shared_ptr<TcpClient> self, Buf
     // sent/dropped/queued accounting - record it as dropped so it's at
     // least observable.
     stats_.record_dropped(1, added);
-    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    if (reserved) queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
-    pending_bytes_ += added;
-    if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    if (reserved) {
+      queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, added);
+    } else {
+      queue_util::commit_unreserved_limit_bytes(write_reserve_mtx_, pending_bytes_, added);
+    }
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
-  queue_bytes_ += added;
-  if (reserved) queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+  if (reserved) {
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queue_bytes_, inflight_bytes_, added);
+  } else {
+    queue_util::commit_unreserved_limit_bytes(write_reserve_mtx_, queue_bytes_, added);
+  }
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(self, queue_bytes_);

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -100,14 +100,18 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
-      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
       stats_.record_accepted(size);
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
-        if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
         const auto added = buf.size();
+        if (!self->alive_ || self->closing_) {  // Double-check in case session was closed
+          queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+          self->stats_.record_failed_send();
+          return;
+        }
         self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
       });
       return true;
@@ -115,17 +119,20 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Fallback to regular allocation for large buffers or pool exhaustion
-  if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   std::vector<uint8_t> fallback(data.begin(), data.end());
   stats_.record_accepted(size);
 
-  net::post(strand_, [self = shared_from_this(), buf = std::move(fallback)]() mutable {
-    if (!self->alive_ || self->closing_) return;  // Double-check in case session was closed
-    const auto added = buf.size();
-    self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
+  net::post(strand_, [self = shared_from_this(), buf = std::move(fallback), size]() mutable {
+    if (!self->alive_ || self->closing_) {  // Double-check in case session was closed
+      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, size);
+      self->stats_.record_failed_send();
+      return;
+    }
+    self->route_enqueued_buffer(BufferVariant{std::move(buf)}, size);
   });
   return true;
 }
@@ -145,13 +152,17 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
-    if (!self->alive_ || self->closing_) return;
+    if (!self->alive_ || self->closing_) {
+      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+      self->stats_.record_failed_send();
+      return;
+    }
     self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
   });
   return true;
@@ -168,13 +179,17 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + added > bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
-    if (!self->alive_ || self->closing_) return;
+    if (!self->alive_ || self->closing_) {
+      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+      self->stats_.record_failed_send();
+      return;
+    }
     self->route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
   });
   return true;
@@ -477,16 +492,19 @@ void TcpServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
     pending_bytes_ += added;
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
   queue_bytes_ += added;
+  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(queue_bytes_);

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -100,7 +100,8 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size,
+                                               bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
@@ -119,7 +120,8 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Fallback to regular allocation for large buffers or pool exhaustion
-  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size,
+                                           bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
@@ -152,7 +154,8 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added,
+                                           bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
@@ -179,7 +182,8 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added,
+                                           bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/tcp_server/tcp_server_session.cc
+++ b/unilink/transport/tcp_server/tcp_server_session.cc
@@ -100,7 +100,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
     if (pooled_buffer.valid()) {
       // Copy data to pooled buffer safely
       base::safe_memory::safe_memcpy(pooled_buffer.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
@@ -108,7 +108,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
       net::post(strand_, [self = shared_from_this(), buf = std::move(pooled_buffer)]() mutable {
         const auto added = buf.size();
         if (!self->alive_ || self->closing_) {  // Double-check in case session was closed
-          queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+          queue_util::release_reserved_limit_bytes(self->write_reserve_mtx_, self->inflight_bytes_, added);
           self->stats_.record_failed_send();
           return;
         }
@@ -119,7 +119,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
   }
 
   // Fallback to regular allocation for large buffers or pool exhaustion
-  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
@@ -128,7 +128,7 @@ bool TcpServerSession::async_write_copy(memory::ConstByteSpan data) {
 
   net::post(strand_, [self = shared_from_this(), buf = std::move(fallback), size]() mutable {
     if (!self->alive_ || self->closing_) {  // Double-check in case session was closed
-      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, size);
+      queue_util::release_reserved_limit_bytes(self->write_reserve_mtx_, self->inflight_bytes_, size);
       self->stats_.record_failed_send();
       return;
     }
@@ -152,14 +152,14 @@ bool TcpServerSession::async_write_move(std::vector<uint8_t>&& data) {
     stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) {
-      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+      queue_util::release_reserved_limit_bytes(self->write_reserve_mtx_, self->inflight_bytes_, added);
       self->stats_.record_failed_send();
       return;
     }
@@ -179,14 +179,14 @@ bool TcpServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [self = shared_from_this(), buf = std::move(data), added]() mutable {
     if (!self->alive_ || self->closing_) {
-      queue_util::release_reserved_limit_bytes(self->inflight_bytes_, added);
+      queue_util::release_reserved_limit_bytes(self->write_reserve_mtx_, self->inflight_bytes_, added);
       self->stats_.record_failed_send();
       return;
     }
@@ -492,19 +492,17 @@ void TcpServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
-    pending_bytes_ += added;
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
-  queue_bytes_ += added;
-  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+  queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queue_bytes_, inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(queue_bytes_);

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -114,6 +114,10 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   base::constants::BackpressureStrategy bp_strategy_{base::constants::BackpressureStrategy::Reliable};
   size_t bp_high_;   // Configurable backpressure threshold
   size_t bp_limit_;  // Hard cap for queued bytes

--- a/unilink/transport/tcp_server/tcp_server_session.hpp
+++ b/unilink/transport/tcp_server/tcp_server_session.hpp
@@ -23,6 +23,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -116,8 +117,11 @@ class UNILINK_API TcpServerSession : public std::enable_shared_from_this<TcpServ
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queue_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   base::constants::BackpressureStrategy bp_strategy_{base::constants::BackpressureStrategy::Reliable};
   size_t bp_high_;   // Configurable backpressure threshold
   size_t bp_limit_;  // Hard cap for queued bytes

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -827,8 +827,8 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                               impl->bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                               impl->inflight_bytes_, size, impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -842,8 +842,8 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, size, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -883,8 +883,8 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, size, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -924,8 +924,8 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, size, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -1086,8 +1086,8 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                               impl->bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                               impl->inflight_bytes_, size, impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -1101,8 +1101,8 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
-                                           impl->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_,
+                                           impl->inflight_bytes_, size, impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <deque>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <stop_token>
@@ -79,8 +80,11 @@ struct UdpChannel::Impl {
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queue_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   config::UdpConfig cfg_;
   // #443: per-channel pool instead of the process-wide GlobalMemoryPool
   // singleton - avoids cross-channel contention on the singleton's bucket
@@ -538,7 +542,7 @@ struct UdpChannel::Impl {
                       std::optional<udp::endpoint> dest = std::nullopt) {
     if (stopping_.load() || stop_requested_.load() || state_.is_state(LinkState::Closed) ||
         state_.is_state(LinkState::Error)) {
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
+      queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, size);
       stats_.record_failed_send();
       return false;
     }
@@ -565,21 +569,19 @@ struct UdpChannel::Impl {
       // #448: record as dropped so it's reflected in RuntimeStats instead of
       // silently vanishing after being counted as accepted.
       stats_.record_dropped(1, size);
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
+      queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, size);
       report_backpressure(self, queue_bytes_ + size);
       return false;
     }
 
     if (decision == queue_util::EnqueueDecision::Pending) {
-      pending_bytes_ += size;
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
+      queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, size);
       pending_.push_back({std::move(buffer), dest});
       observe_queue();
       return true;
     }
 
-    queue_bytes_ += size;
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queue_bytes_, inflight_bytes_, size);
     tx_.push_back({std::move(buffer), dest});
     observe_queue();
     report_backpressure(self, queue_bytes_);
@@ -825,7 +827,7 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                                impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
@@ -840,7 +842,7 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
@@ -881,7 +883,7 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
@@ -922,7 +924,7 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
     impl->stats_.record_failed_send();
     return false;
   }
-  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
@@ -1084,7 +1086,7 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+      if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                                impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
@@ -1099,7 +1101,7 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     }
   }
 
-  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+  if (!queue_util::try_reserve_limit_bytes(impl->write_reserve_mtx_, impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
                                            impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;

--- a/unilink/transport/udp/udp.cc
+++ b/unilink/transport/udp/udp.cc
@@ -77,6 +77,10 @@ struct UdpChannel::Impl {
   std::atomic<size_t> pending_bytes_{0};
   bool writing_{false};
   std::atomic<size_t> queue_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   config::UdpConfig cfg_;
   // #443: per-channel pool instead of the process-wide GlobalMemoryPool
   // singleton - avoids cross-channel contention on the singleton's bucket
@@ -534,6 +538,8 @@ struct UdpChannel::Impl {
                       std::optional<udp::endpoint> dest = std::nullopt) {
     if (stopping_.load() || stop_requested_.load() || state_.is_state(LinkState::Closed) ||
         state_.is_state(LinkState::Error)) {
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
+      stats_.record_failed_send();
       return false;
     }
 
@@ -559,18 +565,21 @@ struct UdpChannel::Impl {
       // #448: record as dropped so it's reflected in RuntimeStats instead of
       // silently vanishing after being counted as accepted.
       stats_.record_dropped(1, size);
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
       report_backpressure(self, queue_bytes_ + size);
       return false;
     }
 
     if (decision == queue_util::EnqueueDecision::Pending) {
       pending_bytes_ += size;
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
       pending_.push_back({std::move(buffer), dest});
       observe_queue();
       return true;
     }
 
     queue_bytes_ += size;
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, size);
     tx_.push_back({std::move(buffer), dest});
     observe_queue();
     report_backpressure(self, queue_bytes_);
@@ -816,7 +825,8 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                               impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -830,6 +840,11 @@ bool UdpChannel::async_write_copy(memory::ConstByteSpan data) {
     }
   }
 
+  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                           impl->bp_limit_)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::vector<uint8_t> copy(data.begin(), data.end());
   impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size]() mutable {
@@ -866,7 +881,8 @@ bool UdpChannel::async_write_move(std::vector<uint8_t>&& data) {
     impl->stats_.record_failed_send();
     return false;
   }
-  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                           impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -906,7 +922,8 @@ bool UdpChannel::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
     impl->stats_.record_failed_send();
     return false;
   }
-  if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                           impl->bp_limit_)) {
     impl->stats_.record_failed_send();
     return false;
   }
@@ -1067,7 +1084,8 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     memory::PooledBuffer pooled(size, impl->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl->queue_bytes_ + impl->pending_bytes_ + size > impl->bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                               impl->bp_limit_)) {
         impl->stats_.record_failed_send();
         return false;
       }
@@ -1081,6 +1099,11 @@ bool UdpChannel::async_write_to(memory::ConstByteSpan data, const boost::asio::i
     }
   }
 
+  if (!queue_util::try_reserve_limit_bytes(impl->queue_bytes_, impl->pending_bytes_, impl->inflight_bytes_, size,
+                                           impl->bp_limit_)) {
+    impl->stats_.record_failed_send();
+    return false;
+  }
   std::vector<uint8_t> copy(data.begin(), data.end());
   impl->stats_.record_accepted(size);
   net::post(impl->strand_, [self = shared_from_this(), buf = std::move(copy), size, destination]() mutable {

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -312,8 +312,8 @@ bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl_->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_,
-                                               size, impl_->bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                               impl_->inflight_bytes_, size, impl_->bp_limit_)) {
         impl_->stats_.record_failed_send();
         return false;
       }
@@ -340,8 +340,8 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     return false;
   }
   const auto added = data.size();
-  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
-                                           impl_->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                           impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
@@ -358,8 +358,8 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
-                                           impl_->bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_,
+                                           impl_->inflight_bytes_, added, impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -89,8 +89,11 @@ struct UdsClient::Impl {
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queue_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) (#436).
   std::atomic<base::constants::BackpressureStrategy> bp_strategy_{base::constants::BackpressureStrategy::Reliable};
@@ -309,7 +312,7 @@ bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl_->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_,
+      if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_,
                                                size, impl_->bp_limit_)) {
         impl_->stats_.record_failed_send();
         return false;
@@ -337,7 +340,7 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     return false;
   }
   const auto added = data.size();
-  if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
+  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
                                            impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
@@ -355,7 +358,7 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
+  if (!queue_util::try_reserve_limit_bytes(impl_->write_reserve_mtx_, impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
                                            impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
@@ -762,19 +765,17 @@ void UdsClient::Impl::route_enqueued_buffer(std::shared_ptr<UdsClient> self, Buf
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
-    pending_bytes_ += added;
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
-  queue_bytes_ += added;
-  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+  queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queue_bytes_, inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(self, queue_bytes_);

--- a/unilink/transport/uds/uds_client.cc
+++ b/unilink/transport/uds/uds_client.cc
@@ -87,6 +87,10 @@ struct UdsClient::Impl {
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   // Atomic rather than mutex-guarded: read both from the strand and from
   // arbitrary caller threads (async_try_write_* fast-fail prechecks) (#436).
   std::atomic<base::constants::BackpressureStrategy> bp_strategy_{base::constants::BackpressureStrategy::Reliable};
@@ -305,7 +309,8 @@ bool UdsClient::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, impl_->pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (impl_->queue_bytes_ + impl_->pending_bytes_ + size > impl_->bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_,
+                                               size, impl_->bp_limit_)) {
         impl_->stats_.record_failed_send();
         return false;
       }
@@ -331,13 +336,14 @@ bool UdsClient::async_write_move(std::vector<uint8_t>&& data) {
     impl_->stats_.record_failed_send();
     return false;
   }
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data.size() > impl_->bp_limit_) {
+  const auto added = data.size();
+  if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
+                                           impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
-  impl_->stats_.record_accepted(data.size());
-  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
-    size_t added = data.size();
+  impl_->stats_.record_accepted(added);
+  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     impl_->route_enqueued_buffer(self, BufferVariant{std::move(data)}, added);
   });
   return true;
@@ -348,13 +354,14 @@ bool UdsClient::async_write_shared(std::shared_ptr<const std::vector<uint8_t>> d
     impl_->stats_.record_failed_send();
     return false;
   }
-  if (impl_->queue_bytes_ + impl_->pending_bytes_ + data->size() > impl_->bp_limit_) {
+  const auto added = data->size();
+  if (!queue_util::try_reserve_limit_bytes(impl_->queue_bytes_, impl_->pending_bytes_, impl_->inflight_bytes_, added,
+                                           impl_->bp_limit_)) {
     impl_->stats_.record_failed_send();
     return false;
   }
-  impl_->stats_.record_accepted(data->size());
-  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
-    size_t added = data->size();
+  impl_->stats_.record_accepted(added);
+  net::post(impl_->strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     impl_->route_enqueued_buffer(self, BufferVariant{std::move(data)}, added);
   });
   return true;
@@ -755,16 +762,19 @@ void UdsClient::Impl::route_enqueued_buffer(std::shared_ptr<UdsClient> self, Buf
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     report_backpressure(self, queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
     pending_bytes_ += added;
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
   queue_bytes_ += added;
+  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(self, queue_bytes_);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -90,7 +90,7 @@ bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
@@ -98,7 +98,7 @@ bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
       net::post(strand_, [this, self = shared_from_this(), buf = std::move(pooled)]() mutable {
         size_t added = buf.size();
         if (!alive_) {
-          queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+          queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
           stats_.record_failed_send();
           return;
         }
@@ -122,14 +122,14 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
     return false;
   }
   const auto added = data.size();
-  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!alive_) {
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
       stats_.record_failed_send();
       return;
     }
@@ -144,14 +144,14 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
   stats_.record_accepted(added);
   net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
     if (!alive_) {
-      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
       stats_.record_failed_send();
       return;
     }
@@ -389,19 +389,17 @@ void UdsServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::release_reserved_limit_bytes(write_reserve_mtx_, inflight_bytes_, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
-    pending_bytes_ += added;
-    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+    queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, pending_bytes_, inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
-  queue_bytes_ += added;
-  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+  queue_util::commit_reserved_limit_bytes(write_reserve_mtx_, queue_bytes_, inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(queue_bytes_);

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -90,7 +90,8 @@ bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
+      if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, size,
+                                               bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
@@ -122,7 +123,8 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
     return false;
   }
   const auto added = data.size();
-  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added,
+                                           bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
@@ -144,7 +146,8 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     return false;
   }
   const auto added = data->size();
-  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
+  if (!queue_util::try_reserve_limit_bytes(write_reserve_mtx_, queue_bytes_, pending_bytes_, inflight_bytes_, added,
+                                           bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }

--- a/unilink/transport/uds/uds_server_session.cc
+++ b/unilink/transport/uds/uds_server_session.cc
@@ -90,14 +90,18 @@ bool UdsServerSession::async_write_copy(memory::ConstByteSpan data) {
     memory::PooledBuffer pooled(size, pool_);
     if (pooled.valid()) {
       base::safe_memory::safe_memcpy(pooled.data(), data.data(), size);
-      if (queue_bytes_ + pending_bytes_ + size > bp_limit_) {
+      if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, size, bp_limit_)) {
         stats_.record_failed_send();
         return false;
       }
       stats_.record_accepted(size);
       net::post(strand_, [this, self = shared_from_this(), buf = std::move(pooled)]() mutable {
-        if (!alive_) return;
         size_t added = buf.size();
+        if (!alive_) {
+          queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+          stats_.record_failed_send();
+          return;
+        }
         route_enqueued_buffer(BufferVariant{std::move(buf)}, added);
       });
       return true;
@@ -117,14 +121,18 @@ bool UdsServerSession::async_write_move(std::vector<uint8_t>&& data) {
     stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + data.size() > bp_limit_) {
+  const auto added = data.size();
+  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
-  stats_.record_accepted(data.size());
-  net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
-    if (!alive_) return;
-    size_t added = data.size();
+  stats_.record_accepted(added);
+  net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!alive_) {
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      stats_.record_failed_send();
+      return;
+    }
     route_enqueued_buffer(BufferVariant{std::move(data)}, added);
   });
   return true;
@@ -135,14 +143,18 @@ bool UdsServerSession::async_write_shared(std::shared_ptr<const std::vector<uint
     stats_.record_failed_send();
     return false;
   }
-  if (queue_bytes_ + pending_bytes_ + data->size() > bp_limit_) {
+  const auto added = data->size();
+  if (!queue_util::try_reserve_limit_bytes(queue_bytes_, pending_bytes_, inflight_bytes_, added, bp_limit_)) {
     stats_.record_failed_send();
     return false;
   }
-  stats_.record_accepted(data->size());
-  net::post(strand_, [this, self = shared_from_this(), data = std::move(data)]() mutable {
-    if (!alive_) return;
-    size_t added = data->size();
+  stats_.record_accepted(added);
+  net::post(strand_, [this, self = shared_from_this(), data = std::move(data), added]() mutable {
+    if (!alive_) {
+      queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
+      stats_.record_failed_send();
+      return;
+    }
     route_enqueued_buffer(BufferVariant{std::move(data)}, added);
   });
   return true;
@@ -377,16 +389,19 @@ void UdsServerSession::route_enqueued_buffer(BufferVariant&& buf, size_t added) 
     // #448: record as dropped so it's reflected in RuntimeStats instead of
     // silently vanishing after being counted as accepted.
     stats_.record_dropped(1, added);
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     report_backpressure(queue_bytes_ + added);
     return;
   }
   if (decision == queue_util::EnqueueDecision::Pending) {
     pending_bytes_ += added;
+    queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
     pending_.emplace_back(std::move(buf));
     observe_queue();
     return;
   }
   queue_bytes_ += added;
+  queue_util::release_reserved_limit_bytes(inflight_bytes_, added);
   tx_.emplace_back(std::move(buf));
   observe_queue();
   report_backpressure(queue_bytes_);

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -113,6 +113,10 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   std::optional<BufferVariant> current_write_buffer_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
+  // Bytes accepted by a plain async_write_* call but not yet routed onto the
+  // strand - reserved via try_reserve_limit_bytes() to close the
+  // accept-then-drop race (jwsung91/unilink#517).
+  std::atomic<size_t> inflight_bytes_{0};
   base::constants::BackpressureStrategy bp_strategy_{base::constants::BackpressureStrategy::Reliable};
   size_t bp_high_;
   size_t bp_low_;

--- a/unilink/transport/uds/uds_server_session.hpp
+++ b/unilink/transport/uds/uds_server_session.hpp
@@ -23,6 +23,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -115,8 +116,11 @@ class UNILINK_API UdsServerSession : public std::enable_shared_from_this<UdsServ
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
   // strand - reserved via try_reserve_limit_bytes() to close the
-  // accept-then-drop race (jwsung91/unilink#517).
+  // accept-then-drop race (jwsung91/unilink#517). inflight_bytes_ mutations
+  // and the queue_bytes_/pending_bytes_ increments that promote a
+  // reservation both go through write_reserve_mtx_ - see bp_utils.hpp.
   std::atomic<size_t> inflight_bytes_{0};
+  std::mutex write_reserve_mtx_;
   base::constants::BackpressureStrategy bp_strategy_{base::constants::BackpressureStrategy::Reliable};
   size_t bp_high_;
   size_t bp_low_;


### PR DESCRIPTION
## Summary

- Fixes #517: the plain (blocking-capable) `async_write_copy/_move/_shared` path in all 6 transports (tcp_client, tcp_server_session, uds_client, uds_server_session, serial, udp) prechecked `queue_bytes_+pending_bytes_+added > bp_limit_` non-atomically on the caller's thread without reserving the bytes, then re-decided on the strand once the write was actually routed. Concurrent callers could all pass the precheck, then get rejected once the real combined total (across all their in-flight writes) exceeded `bp_limit_` - silently dropping messages that Reliable strategy promises never to drop.
- Found by comparing the v0.8.7/v0.8.8 Jetson benchmark releases (`unilink-benchmarks`), which showed 0.05%-0.7% message loss for Reliable strategy at saturation with large payloads - something the benchmark report itself flags as abnormal.
- Adds `try_reserve_limit_bytes()` / `release_reserved_limit_bytes()` to `bp_utils.hpp`: a CAS-reserved `inflight_bytes_` counter per transport (accepted-but-not-yet-routed bytes), closing the race the same way `try_reserve_write_bytes()` already does for the non-blocking `async_try_write_*` path.
- Also fixes a handful of early-return paths across the transports where an already-`record_accepted()`-ed message vanished with no corresponding stats update at all (now releases the reservation + `record_failed_send()`, matching the non-blocking path's sibling code).
- `tcp_client`'s fallback (non-pooled, >64KB) write path previously had **no** precheck at all for BestEffort and only a Reliable-only precheck for large payloads - unified it with the other 5 transports' existing unconditional precheck. Updated `TransportTcpClientTest.QueueLimitDropsMessage` accordingly: an oversized single write is now rejected synchronously via `failed_sends` instead of being accepted and only discovered too-large once routed onto the strand (matching the already-correct `TransportTcpServerSessionTest.QueueLimitDropsMessage`).

## Test plan

- [x] Added `BackpressureStrategyTest.Reliable_ConcurrentPlainWritesNeverDropAcceptedMessages`, a multi-threaded stress test driving concurrent Reliable blocking writes through a real io_context/strand near `bp_limit_`.
- [x] Confirmed it reliably reproduces ~17-22% message loss on pre-fix code (verified by temporarily reverting the transport changes) and passes cleanly (5/5 runs) with the fix.
- [x] `scripts/verify.sh --tests-only` green (full build + test suite, 727 tests).
- [ ] Re-run the Jetson benchmark release workflow against this branch (no release publish) to confirm 0 dropped messages across all Reliable rows in the strategy sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)