### PR TITLE
fix: revert invalid workflows permission, use PAT for auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,7 +5,6 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   dependabot:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,6 +5,7 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   dependabot:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,7 +24,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for Dependabot PRs
+        # GITHUB_TOKEN can never merge a PR that touches .github/workflows/*
+        # (GitHub blocks it to prevent workflow privilege escalation), so
+        # PRs bumping action versions need a PAT with the `workflow` scope.
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_PAT }}


### PR DESCRIPTION
## Summary
PR #520's auto-merge attempt failed because `GITHUB_TOKEN` can never merge a PR that touches `.github/workflows/*` files -- GitHub blocks this unconditionally (anti privilege-escalation). My first fix (merged in #522) added `workflows: write` to the job's `permissions:` key, but that is **not a valid GITHUB_TOKEN scope** -- it made `dependabot-auto-merge.yml` fail to parse entirely (0 jobs scheduled), so `main` currently has a broken workflow.

This PR:
1. Reverts the invalid `workflows: write` permission.
2. Points the "Enable auto-merge" step at a `DEPENDABOT_PAT` secret instead of `GITHUB_TOKEN` -- a personal access token with the `workflow` scope is the only kind of credential GitHub allows to perform this merge.

## Required manual step
Add a `DEPENDABOT_PAT` repository secret before this takes effect:
1. Create a fine-grained (or classic) PAT with `Contents: write` + `Workflows: write` (classic: `repo` + `workflow` scopes).
2. Settings -> Secrets and variables -> Actions -> New repository secret -> name it `DEPENDABOT_PAT`.

## Test plan
- [ ] Merge this PR to restore a valid `dependabot-auto-merge.yml` on `main`
- [ ] Add the `DEPENDABOT_PAT` secret
- [ ] Re-run auto-merge on an open workflow-bumping Dependabot PR (e.g. #520) to confirm it now succeeds