### PR TITLE
chore: ignore local agent entrypoint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ env.bak/
 venv.bak/
 
 .codex
+
+# agent-rules (local only)
+AGENTS.md
+CLAUDE.md
+GEMINI.md


### PR DESCRIPTION
## Summary
- Adds AGENTS.md/CLAUDE.md/GEMINI.md to .gitignore, generated by agent-rules' scripts/adopt.py. These agent instruction entrypoint files are local-only and intentionally not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)