### PR TITLE
version: bump to v0.8.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.8
+  VERSION 0.8.9
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/jwsung91/unilink"


### PR DESCRIPTION
## Summary
Bumps `CMakeLists.txt`'s VERSION 0.8.8 → 0.8.9.

Since v0.8.8:
- #517: accept-then-drop race in Reliable-strategy blocking writes across all 6 transports (tcp_client, tcp_server_session, uds_client, uds_server_session, serial, udp) could silently drop messages under concurrent load, violating the Reliable strategy's no-drop guarantee. Reproduced 17-22% message loss pre-fix in a dedicated stress test; also explains the 0.05%-0.7% loss seen in v0.8.7/v0.8.8 Jetson benchmark comparisons (PR #518).
- #526: contributor guide (`CONTRIBUTING.md`), a "choosing a send method" comparison table in `docs/error_model.md`, `on_backpressure()` now logs a warning instead of silently discarding the handler when unsupported, and macOS/Windows CTest presets added to `CMakePresets.json`. Docs/DX only, no public API or behavior change for existing transports.

## Known gap before tagging
PR #518's own test plan left one item unchecked: re-running the Jetson benchmark workflow against the fix to confirm 0 dropped messages across the Reliable strategy sweep. That hasn't been done yet. Recommend doing that (or explicitly noting its absence in the release notes) before pushing the `v0.8.9` tag, since this release's main purpose is shipping that fix.

## Test plan
- [x] CI green on `main` at the base commit (`ba12f395b`, includes #526)
- [ ] Jetson benchmark re-validation for #518 - not yet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)