### PR TITLE
fix: cap macOS build parallelism in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,8 +182,12 @@ jobs:
         run: |
           BUILD_ARGS="--config Release --verbose"
           if [ "${{ runner.os }}" = "macOS" ]; then
-            CORES=$(sysctl -n hw.ncpu)
-            BUILD_ARGS="$BUILD_ARGS --parallel $CORES"
+            # Capped (not sysctl -n hw.ncpu) to match ci.yml's macOS Unit Tests
+            # job: full parallelism let ninja's gtest_discover_tests POST_BUILD
+            # step race other link/discovery jobs for CPU time, intermittently
+            # failing to produce its test-list JSON on a different test binary
+            # each run (observed across 3 consecutive release.yml runs for v0.8.9).
+            BUILD_ARGS="$BUILD_ARGS --parallel 4"
           else
             BUILD_ARGS="$BUILD_ARGS --parallel"
           fi


### PR DESCRIPTION
## Summary
`release.yml`'s macOS `Build` step used `--parallel $(sysctl -n hw.ncpu)` (full core count), unlike `ci.yml`'s macOS Unit Tests job which caps at `-j 4`. Under full parallelism, ninja's `gtest_discover_tests` POST_BUILD step (which runs each test binary with `--gtest_list_tests` to enumerate CTest tests) intermittently failed to produce its test-list JSON.

## Evidence
Three consecutive `release.yml` runs for the v0.8.9 tag (run [29579300040](https://github.com/jwsung91/unilink/actions/runs/29579300040)) failed on macOS, each time on a **different** test binary:
1. `run_integration_test_tcp_server_wrapper_lifecycle` — malformed/empty JSON
2. `run_integration_test_integration` — JSON file never created
3. `run_integration_transport_udp` — malformed/empty JSON

The same v0.8.9 commit (`8b0e4a12b`) built and ran its full test suite cleanly under `ci.yml`'s macOS Unit Tests job (`-j 4`), confirming this is a release-pipeline-specific resource-contention flake, not a code regression.

## Changes
- `.github/workflows/release.yml`: macOS build step now uses `--parallel 4` instead of `--parallel $(sysctl -n hw.ncpu)`, matching `ci.yml`'s existing cap.

## Validation
- [ ] Re-run the v0.8.9 release.yml macOS job with this fix to confirm it resolves the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)