### PR TITLE
docs: update repository branding to Wirestead

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -119,7 +119,7 @@ jobs:
 
           # Generate HTML report
           genhtml coverage_filtered.info --output-directory coverage_html \
-            --title "unilink Coverage Report" \
+            --title "Wirestead Coverage Report" \
             --legend --show-details \
             --branch-coverage \
             --rc lcov_branch_coverage=1
@@ -285,7 +285,7 @@ jobs:
           <html>
           <head>
             <meta charset="UTF-8">
-            <title>unilink Coverage Report</title>
+            <title>Wirestead Coverage Report</title>
             <style>
               body {
                 font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
@@ -321,16 +321,16 @@ jobs:
           </head>
           <body>
             <div class="container">
-              <h1>🎯 unilink Code Coverage</h1>
+              <h1>🎯 Wirestead Code Coverage</h1>
               <p class="timestamp">Generated: $(date '+%Y-%m-%d %H:%M:%S UTC')</p>
               <div class="coverage">Coverage: ${COVERAGE}</div>
               <div class="grade">Grade: ${GRADE}</div>
               <div class="badge">
-                <img src="https://img.shields.io/endpoint?url=https://jwsung91.github.io/unilink/coverage/badges/coverage.json" alt="Coverage Badge">
+                <img src="https://img.shields.io/endpoint?url=https://wirestead.github.io/wirestead/coverage/badges/coverage.json" alt="Coverage Badge">
               </div>
               <div class="links">
                 <a href="index-original.html" class="link">📊 Detailed Report</a>
-                <a href="https://github.com/jwsung91/unilink" class="link">📦 Repository</a>
+                <a href="https://github.com/wirestead/wirestead" class="link">📦 Repository</a>
               </div>
             </div>
           </body>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
   VERSION 0.8.9
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
-  HOMEPAGE_URL "https://github.com/jwsung91/unilink"
+  HOMEPAGE_URL "https://github.com/wirestead/wirestead"
   LANGUAGES CXX
 )
 

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ unilink: A cross-platform C++ communication library
 Copyright 2025 Jinwoo Sung
 
 This product includes software developed by Jinwoo Sung
-(https://github.com/jwsung91/unilink).
+(https://github.com/wirestead/wirestead).
 
 This project was developed independently and is not affiliated with
 any current or past employer. Commercial or internal usage is permitted

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 ![unilink](assets/logo/unilink-logo-light.png#gh-light-mode-only)
 ![unilink](assets/logo/unilink-logo-dark.png#gh-dark-mode-only)
 
-# unilink
+# Wirestead™
 
-**Unified async communication for modern C++20.**
+_Wirestead is the successor to UniLink._
+
+**Robust, simple async communication for modern C++20.**
 
 Serial · TCP · UDP · UDS
 
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20macOS-informational)
 ![vcpkg](https://img.shields.io/badge/vcpkg-jwsung91--unilink-0078D6)
-[![Coverage](https://img.shields.io/endpoint?url=https://jwsung91.github.io/unilink/coverage/badges/coverage.json)](https://jwsung91.github.io/unilink/coverage/)
+[![Coverage](https://img.shields.io/endpoint?url=https://wirestead.github.io/wirestead/coverage/badges/coverage.json)](https://wirestead.github.io/wirestead/coverage/)
 
 ## Description
 
@@ -19,7 +21,7 @@ Simple async C++ communication library for Serial, TCP, UDP, and Unix Domain Soc
 
 The project prioritizes **API clarity, predictable runtime behavior, and stability** over rapid feature expansion.
 
-> **Security note**: all transports send data in plaintext - there is no built-in TLS/DTLS support. See [Security and Threat Model](https://github.com/jwsung91/unilink/blob/main/docs/security.md) before using `unilink` over an untrusted network.
+> **Security note**: all transports send data in plaintext - there is no built-in TLS/DTLS support. See [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md) before using `unilink` over an untrusted network.
 
 ## Feature Highlights
 
@@ -70,14 +72,14 @@ https://github.com/unilink-lab/unilink-docs
 
 Core repository entrypoints:
 
-- [Quick Start](https://github.com/jwsung91/unilink/blob/main/docs/quickstart.md)
-- [Installation](https://github.com/jwsung91/unilink/blob/main/docs/installation.md)
-- [API Stability Summary](https://github.com/jwsung91/unilink/blob/main/docs/api_stability.md)
-- [Error Model](https://github.com/jwsung91/unilink/blob/main/docs/error_model.md)
-- [Security and Threat Model](https://github.com/jwsung91/unilink/blob/main/docs/security.md)
-- [Callback Data Lifetime](https://github.com/jwsung91/unilink/blob/main/docs/callbacks.md)
-- [Performance Validation](https://github.com/jwsung91/unilink/blob/main/docs/performance_validation.md)
-- [Release Checklist](https://github.com/jwsung91/unilink/blob/main/docs/release_checklist.md)
+- [Quick Start](https://github.com/wirestead/wirestead/blob/main/docs/quickstart.md)
+- [Installation](https://github.com/wirestead/wirestead/blob/main/docs/installation.md)
+- [API Stability Summary](https://github.com/wirestead/wirestead/blob/main/docs/api_stability.md)
+- [Error Model](https://github.com/wirestead/wirestead/blob/main/docs/error_model.md)
+- [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md)
+- [Callback Data Lifetime](https://github.com/wirestead/wirestead/blob/main/docs/callbacks.md)
+- [Performance Validation](https://github.com/wirestead/wirestead/blob/main/docs/performance_validation.md)
+- [Release Checklist](https://github.com/wirestead/wirestead/blob/main/docs/release_checklist.md)
 
 Useful external repositories:
 
@@ -88,7 +90,7 @@ Useful external repositories:
 
 ## 📄 License
 
-**unilink** is released under the Apache License, Version 2.0.
+**Wirestead** is released under the Apache License, Version 2.0.
 
 Commercial use, modification, and redistribution are permitted.
 For details, see the [LICENSE](./LICENSE) and [NOTICE](./NOTICE) files.

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -12,7 +12,7 @@ set(CPACK_PACKAGE_DESCRIPTION
 )
 set(CPACK_PACKAGE_VENDOR "Jinwoo Sung")
 set(CPACK_PACKAGE_CONTACT "jwsung91@gmail.com")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/jwsung91/unilink")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/wirestead/wirestead")
 
 # License and documentation
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")

--- a/cmake/unilink.pc.in
+++ b/cmake/unilink.pc.in
@@ -5,7 +5,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: unilink
 Description: A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, UDP, and UDS transports
-URL: https://github.com/jwsung91/unilink
+URL: https://github.com/wirestead/wirestead
 Version: @PROJECT_VERSION@
 Requires: @PKGCONFIG_REQUIRES@
 Requires.private: @PKGCONFIG_REQUIRES_PRIVATE@

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,8 +57,8 @@ cmake --build --preset dev-linux-x64 --parallel 1
 For a plain source install with an existing dependency setup:
 
 ```bash
-git clone https://github.com/jwsung91/unilink.git
-cd unilink
+git clone https://github.com/wirestead/wirestead.git
+cd wirestead
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel 1
 sudo cmake --install build


### PR DESCRIPTION
## Summary
Stage 1 of the UniLink → Wirestead migration: repository moved to wirestead/wirestead, so this brings externally-visible branding, links, and metadata in line with the new name and location. Documentation/metadata only — no public API, CMake compatibility surface, or vcpkg identifiers touched.

## Changes
- `README.md`: title → `Wirestead™`, added "Wirestead is the successor to UniLink." transition line, intro tagline reworded, coverage badge/link → `wirestead.github.io/wirestead`, security-doc link and all "Core repository entrypoints" links → `github.com/wirestead/wirestead`, license line → "**Wirestead** is released under...". Logo images and `unilink-lab/*` external-repo links (docs/containers/python/examples) intentionally left untouched — not part of the confirmed rename.
- `NOTICE`: repository URL only.
- `CMakeLists.txt`: `HOMEPAGE_URL` only; project name/description untouched.
- `cmake/UnilinkPackaging.cmake`: `CPACK_PACKAGE_HOMEPAGE_URL` only; contact email left as-is.
- `cmake/unilink.pc.in`: `URL:` field only; `Name:`, `Libs: -lunilink` untouched.
- `docs/installation.md`: source-build `git clone`/`cd` target only.
- `.github/workflows/coverage.yml`: badge endpoint, repo link, page `<title>`/`<h1>` text.

## Compatibility
No change to `find_package(unilink)`, `unilink::unilink`, `<unilink/...>` headers, `namespace unilink`, `UNILINK_*`, `libunilink`, or the vcpkg `unilink`/`jwsung91-unilink` identifiers — verified in the diff.

## Validation
- Ran: `git diff --check` (clean)
- Ran: manual review of every changed file to confirm no compatibility-surface strings were touched
- Not run: `cmake --build build -j2` — no code paths changed, not expected to be affected
- Tests: not added — text/metadata-only change
- Documentation: this PR is the documentation change

## Not Included
- **Logo replacement**: no approved Wirestead logo asset exists in the repo yet — README still references the old `unilink-logo-*.png` files.
- **GitHub About** (description, homepage, topics): live repo-settings change, left for a maintainer to apply with the desired copy.

## Risks / Follow-up
- Local clones still using the old `jwsung91/unilink` remote URL work via GitHub's redirect (confirmed when pushing this branch).
- Docs in `unilink-lab/unilink-docs`, `unilink-python`, `unilink-containers`, `unilink-examples` are out of scope here since only the main repo's move is confirmed.