### PR TITLE
ci: raise gtest_discover_tests timeout to stop macOS discovery races

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,10 @@ if(REMAINING_TESTS)
       run_architecture_tests PRIVATE ${_unilink_test_lib} GTest::gtest_main
                                      GTest::gmock
     )
-    gtest_discover_tests(run_architecture_tests PROPERTIES LABELS "legacy_e2e")
+    gtest_discover_tests(
+      run_architecture_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS
+      "legacy_e2e"
+    )
     unilink_copy_runtime_dependency(run_architecture_tests)
   endif()
 
@@ -119,7 +122,9 @@ if(REMAINING_TESTS)
       run_builder_tests PRIVATE ${_unilink_test_lib} GTest::gtest_main
                                 GTest::gmock
     )
-    gtest_discover_tests(run_builder_tests PROPERTIES LABELS "legacy_unit")
+    gtest_discover_tests(
+      run_builder_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS "legacy_unit"
+    )
     unilink_copy_runtime_dependency(run_builder_tests)
   endif()
 
@@ -130,7 +135,9 @@ if(REMAINING_TESTS)
       run_common_tests PRIVATE ${_unilink_test_lib} GTest::gtest_main
                                GTest::gmock
     )
-    gtest_discover_tests(run_common_tests PROPERTIES LABELS "legacy_unit")
+    gtest_discover_tests(
+      run_common_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS "legacy_unit"
+    )
     unilink_copy_runtime_dependency(run_common_tests)
   endif()
 
@@ -142,7 +149,8 @@ if(REMAINING_TESTS)
                                       GTest::gmock
     )
     gtest_discover_tests(
-      run_communication_tests PROPERTIES LABELS "legacy_integration"
+      run_communication_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS
+      "legacy_integration"
     )
     unilink_copy_runtime_dependency(run_communication_tests)
   endif()

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(test_file test_architecture.cc test_error_recovery.cc)
   )
   gtest_discover_tests(
     run_e2e_${test_name}
+    DISCOVERY_TIMEOUT 60
     PROPERTIES LABELS "e2e_scenario_slow"
     TIMEOUT 90 RESOURCE_LOCK "tcp_port_allocation"
   )
@@ -49,6 +50,7 @@ target_include_directories(
 )
 gtest_discover_tests(
   run_e2e_test_stress
+  DISCOVERY_TIMEOUT 60
   PROPERTIES LABELS "e2e_stress_slow"
   TIMEOUT 120 RESOURCE_LOCK "tcp_port_allocation"
 )

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -36,7 +36,9 @@ function(unilink_add_integration_gtest target source_path labels timeout)
     list(APPEND _test_properties RESOURCE_LOCK "${ARGV4}")
   endif()
 
-  gtest_discover_tests(${target} PROPERTIES ${_test_properties})
+  gtest_discover_tests(
+    ${target} DISCOVERY_TIMEOUT 60 PROPERTIES ${_test_properties}
+  )
 endfunction()
 
 foreach(

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -44,7 +44,9 @@ function(unilink_add_unit_gtest target source_path labels timeout)
     list(APPEND _test_properties RESOURCE_LOCK "${ARGV4}")
   endif()
 
-  gtest_discover_tests(${target} PROPERTIES ${_test_properties})
+  gtest_discover_tests(
+    ${target} DISCOVERY_TIMEOUT 60 PROPERTIES ${_test_properties}
+  )
 
   list(APPEND _unilink_unit_test_targets ${target})
   set(_unilink_unit_test_targets


### PR DESCRIPTION
## Summary
release.yml's macOS Build job still failed after #528 capped build parallelism to 4: run [29622855042](https://github.com/wirestead/wirestead/actions/runs/29622855042) hit the same `gtest_discover_tests` JSON-parse error on `run_unit_test_input_validator_edge`'s POST_BUILD discovery step. This raises the discovery timeout to give test-binary enumeration enough headroom under CI load.

## Changes
Added `DISCOVERY_TIMEOUT 60` to all `gtest_discover_tests()` call sites (default is 5s):
- `test/unit/CMakeLists.txt` (`unilink_add_unit_gtest`)
- `test/integration/CMakeLists.txt` (`unilink_add_integration_gtest`)
- `test/e2e/CMakeLists.txt` (scenario tests + stress test)
- `test/CMakeLists.txt` (4 legacy test targets)

## Root cause
The job log shows:
```
CMake Error at .../GoogleTest/ParseTestList.cmake:96 (string):
  string sub-command JSON failed parsing json string:
  * Line 1, Column 1
    Syntax error: value, object or array expected.
```
Each target's discovery/tests filenames are already unique (named by target, not solely by the args hash) — this rules out the output-file-collision theory. Instead: several linked test binaries (each pulling in Boost/spdlog/fmt/gtest static init) run their POST_BUILD `--gtest_list_tests` enumeration back-to-back on the macos-15 runner; under CI load one can miss the default 5s `DISCOVERY_TIMEOUT`, leaving CMake to parse an empty/truncated JSON file.

## Compatibility
No public API, CMake/vcpkg surface, or test behavior changed — only how long CMake waits for test enumeration at build time.

## Validation
- Ran: `git diff --check` (clean)
- Ran: manual review of `gtest_discover_tests()` call syntax against CMake's `GoogleTest` module signature (`DISCOVERY_TIMEOUT` is a valid top-level keyword, placed before `PROPERTIES`)
- Ran: `gh api` job-log inspection of the failed macOS release run to confirm root cause
- Not run locally: no vcpkg checkout present locally, so a full configure/build wasn't attempted; relying on this PR's own CI as validation
- Tests: not added — this is CI/build infra, not test logic

## Not Included
- Haven't yet confirmed 3 consecutive green macOS CI runs (per the migration plan's Stage 2 completion criteria) — that's what this PR's CI checks (and any manual re-runs) should establish.
- If this timeout bump doesn't fully eliminate the race, `DISCOVERY_MODE PRE_TEST` (moves enumeration from build-time to ctest-time) is the next lever, deliberately not reached for yet since it's a bigger behavioral change.

## Risks / Follow-up
- Watch this PR's CI (and ideally re-run it a couple more times) before merging, to build confidence the race is actually gone rather than just less likely.
- Once macOS is green, still need: Linux/Windows regression check, a Release workflow re-run, and macOS artifacts backfilled for v0.8.9 (or folded into the next release).