### PR TITLE
ci: fix formatting and switch to DISCOVERY_MODE PRE_TEST (fixes main after #530)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,8 +109,8 @@ if(REMAINING_TESTS)
                                      GTest::gmock
     )
     gtest_discover_tests(
-      run_architecture_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS
-                                                             "legacy_e2e"
+      run_architecture_tests DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
+      PROPERTIES LABELS "legacy_e2e"
     )
     unilink_copy_runtime_dependency(run_architecture_tests)
   endif()
@@ -123,7 +123,8 @@ if(REMAINING_TESTS)
                                 GTest::gmock
     )
     gtest_discover_tests(
-      run_builder_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS "legacy_unit"
+      run_builder_tests DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
+      PROPERTIES LABELS "legacy_unit"
     )
     unilink_copy_runtime_dependency(run_builder_tests)
   endif()
@@ -136,7 +137,8 @@ if(REMAINING_TESTS)
                                GTest::gmock
     )
     gtest_discover_tests(
-      run_common_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS "legacy_unit"
+      run_common_tests DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
+      PROPERTIES LABELS "legacy_unit"
     )
     unilink_copy_runtime_dependency(run_common_tests)
   endif()
@@ -149,7 +151,7 @@ if(REMAINING_TESTS)
                                       GTest::gmock
     )
     gtest_discover_tests(
-      run_communication_tests DISCOVERY_TIMEOUT 60
+      run_communication_tests DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
       PROPERTIES LABELS "legacy_integration"
     )
     unilink_copy_runtime_dependency(run_communication_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,7 +110,7 @@ if(REMAINING_TESTS)
     )
     gtest_discover_tests(
       run_architecture_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS
-      "legacy_e2e"
+                                                             "legacy_e2e"
     )
     unilink_copy_runtime_dependency(run_architecture_tests)
   endif()
@@ -149,8 +149,8 @@ if(REMAINING_TESTS)
                                       GTest::gmock
     )
     gtest_discover_tests(
-      run_communication_tests DISCOVERY_TIMEOUT 60 PROPERTIES LABELS
-      "legacy_integration"
+      run_communication_tests DISCOVERY_TIMEOUT 60
+      PROPERTIES LABELS "legacy_integration"
     )
     unilink_copy_runtime_dependency(run_communication_tests)
   endif()

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(test_file test_architecture.cc test_error_recovery.cc)
                                  ${CMAKE_SOURCE_DIR}/test/fixtures
   )
   gtest_discover_tests(
-    run_e2e_${test_name} DISCOVERY_TIMEOUT 60
+    run_e2e_${test_name} DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
     PROPERTIES LABELS "e2e_scenario_slow"
     TIMEOUT 90 RESOURCE_LOCK "tcp_port_allocation"
   )
@@ -48,7 +48,7 @@ target_include_directories(
                               ${CMAKE_SOURCE_DIR}/test/fixtures
 )
 gtest_discover_tests(
-  run_e2e_test_stress DISCOVERY_TIMEOUT 60
+  run_e2e_test_stress DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
   PROPERTIES LABELS "e2e_stress_slow"
   TIMEOUT 120 RESOURCE_LOCK "tcp_port_allocation"
 )

--- a/test/e2e/CMakeLists.txt
+++ b/test/e2e/CMakeLists.txt
@@ -30,8 +30,7 @@ foreach(test_file test_architecture.cc test_error_recovery.cc)
                                  ${CMAKE_SOURCE_DIR}/test/fixtures
   )
   gtest_discover_tests(
-    run_e2e_${test_name}
-    DISCOVERY_TIMEOUT 60
+    run_e2e_${test_name} DISCOVERY_TIMEOUT 60
     PROPERTIES LABELS "e2e_scenario_slow"
     TIMEOUT 90 RESOURCE_LOCK "tcp_port_allocation"
   )
@@ -49,8 +48,7 @@ target_include_directories(
                               ${CMAKE_SOURCE_DIR}/test/fixtures
 )
 gtest_discover_tests(
-  run_e2e_test_stress
-  DISCOVERY_TIMEOUT 60
+  run_e2e_test_stress DISCOVERY_TIMEOUT 60
   PROPERTIES LABELS "e2e_stress_slow"
   TIMEOUT 120 RESOURCE_LOCK "tcp_port_allocation"
 )

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -37,7 +37,8 @@ function(unilink_add_integration_gtest target source_path labels timeout)
   endif()
 
   gtest_discover_tests(
-    ${target} DISCOVERY_TIMEOUT 60 PROPERTIES ${_test_properties}
+    ${target} DISCOVERY_TIMEOUT 60 DISCOVERY_MODE PRE_TEST
+    PROPERTIES ${_test_properties}
   )
 endfunction()
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,8 +22,12 @@ find_package(
   REQUIRED
 )
 
-# Default: discover after build so test executables exist
-set(_UNILINK_GTEST_DISCOVERY_MODE POST_BUILD)
+# PRE_TEST (not the default POST_BUILD): running --gtest_list_tests for many
+# targets concurrently as part of the parallel build intermittently crashed
+# discovery on macOS CI, non-deterministically hitting a different target each
+# run and independent of DISCOVERY_TIMEOUT. PRE_TEST defers discovery to
+# ctest-time, after the build has finished.
+set(_UNILINK_GTEST_DISCOVERY_MODE PRE_TEST)
 
 set(_unilink_unit_test_targets)
 
@@ -45,7 +49,8 @@ function(unilink_add_unit_gtest target source_path labels timeout)
   endif()
 
   gtest_discover_tests(
-    ${target} DISCOVERY_TIMEOUT 60 PROPERTIES ${_test_properties}
+    ${target} DISCOVERY_TIMEOUT 60 DISCOVERY_MODE
+    ${_UNILINK_GTEST_DISCOVERY_MODE} PROPERTIES ${_test_properties}
   )
 
   list(APPEND _unilink_unit_test_targets ${target})


### PR DESCRIPTION
## Summary
#530 merged with a stale head ref — it landed only the first `DISCOVERY_TIMEOUT 60` commit, not the two follow-up commits that were pushed to that branch afterward and verified green in CI before the merge. `main` is currently red because of this: **Code Formatting** fails (the cmake-format fix never merged), and **CMake** fails on the same macOS `gtest_discover_tests` JSON-parse race #530 claimed to fix — because `DISCOVERY_TIMEOUT` alone was already proven insufficient (PR #530's own CI hit the identical error on a different target with the timeout in place, before this correction was pushed).

This PR is exactly the two commits that didn't make it into #530's merge, cherry-picked onto current `main`. No new content beyond what was already reviewed there.

## Changes
- `style: apply cmake-format to gtest_discover_tests DISCOVERY_TIMEOUT edits` — reformats `test/CMakeLists.txt` and `test/e2e/CMakeLists.txt` to match what CI's `cmake-format -i` produces (this is what was failing **Code Formatting**).
- `ci: switch gtest discovery to PRE_TEST, DISCOVERY_TIMEOUT wasn't the cause` — adds `DISCOVERY_MODE PRE_TEST` to all 8 `gtest_discover_tests()` call sites, deferring test discovery from build-time (competing with every other parallel build job) to ctest-time. Also wires up `test/unit/CMakeLists.txt`'s previously-unused `_UNILINK_GTEST_DISCOVERY_MODE` variable to actually do this instead of sitting dead.

## Compatibility
No public API, CMake/vcpkg surface, or test behavior changed — only when/how CMake enumerates tests.

## Validation
- Ran: `git diff main --check` (clean)
- These exact two commits were already pushed to #530's branch and their CI checks (Code Formatting, macOS Unit Tests) passed before the merge happened on stale content — see that PR's commit history for the individual run results.
- Not yet re-verified on *this* branch specifically — this PR's own CI is the check to watch before merging.

## Not Included
- The Trivy Security Scan failure currently on `main` is unrelated (a `Resource not accessible by integration` permissions error uploading SARIF, likely needing an Actions/security-scanning permissions fix on the `wirestead` org side) and out of scope for this PR.
- The intermittent `C++ (Windows, MSVC)` failure seen on both #529 and `main` looks like a pre-existing flaky test (`UdpClientWrapperLifecycleTest.RestartAfterStopResolvesFutureAndReinstallsHandlers`), also unrelated and out of scope here.

## Risks / Follow-up
- Please verify this PR's head SHA matches what actually gets tested before merging — the whole reason this PR exists is that ref sync didn't behave as expected last time.