### PR TITLE
build: introduce Wirestead package names with UniLink compatibility

### DIFF
--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -190,6 +190,20 @@ if(UNILINK_ENABLE_INSTALL)
     COMPATIBILITY SameMajorVersion
   )
 
+  # find_package(wirestead) - see cmake/WiresteadConfig.cmake.in for how this
+  # reuses unilink's own config instead of duplicating dependency resolution.
+  configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/WiresteadConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/wiresteadConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wirestead
+  )
+
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/wiresteadConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+  )
+
   if(UNILINK_ENABLE_PKGCONFIG)
     set(PKGCONFIG_REQUIRES "")
     # Derived from
@@ -205,6 +219,11 @@ if(UNILINK_ENABLE_INSTALL)
     configure_file(
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/unilink.pc.in
       ${CMAKE_CURRENT_BINARY_DIR}/unilink.pc @ONLY
+    )
+
+    configure_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/wirestead.pc.in
+      ${CMAKE_CURRENT_BINARY_DIR}/wirestead.pc @ONLY
     )
   endif()
 endif()
@@ -279,9 +298,24 @@ if(UNILINK_ENABLE_INSTALL)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/unilink
   )
 
+  # find_package(wirestead) config - installed alongside, not instead of, the
+  # unilink one above. See cmake/WiresteadConfig.cmake.in.
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/wiresteadConfig.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/wiresteadConfigVersion.cmake
+    COMPONENT cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wirestead
+  )
+
   if(UNILINK_ENABLE_PKGCONFIG)
     install(
       FILES ${CMAKE_CURRENT_BINARY_DIR}/unilink.pc
+      COMPONENT pkgconfig
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+
+    install(
+      FILES ${CMAKE_CURRENT_BINARY_DIR}/wirestead.pc
       COMPONENT pkgconfig
       DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     )

--- a/cmake/WiresteadConfig.cmake.in
+++ b/cmake/WiresteadConfig.cmake.in
@@ -1,0 +1,21 @@
+@PACKAGE_INIT@
+
+# find_package(wirestead) support. Wirestead does not maintain a separate build
+# of the library - it reuses the unilink package's own config (which owns the
+# real Boost/spdlog/Threads dependency resolution and the actual
+# unilink::unilink_shared / unilink::unilink_static imported targets) and only
+# adds a wirestead::wirestead alias on top. See docs/migration-from-unilink.md
+# for why the underlying library, headers, and binary name stay unilink-named
+# for now.
+
+include(CMakeFindDependencyMacro)
+find_dependency(
+  unilink CONFIG REQUIRED HINTS "${CMAKE_CURRENT_LIST_DIR}/../unilink"
+)
+
+if(NOT TARGET wirestead::wirestead)
+  add_library(wirestead::wirestead INTERFACE IMPORTED)
+  target_link_libraries(wirestead::wirestead INTERFACE unilink::unilink)
+endif()
+
+check_required_components(wirestead)

--- a/cmake/wirestead.pc.in
+++ b/cmake/wirestead.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: wirestead
+Description: A cross-platform asynchronous C++ communication library providing a unified API for Serial, TCP, UDP, and UDS transports (formerly unilink)
+URL: https://github.com/wirestead/wirestead
+Version: @PROJECT_VERSION@
+Requires: @PKGCONFIG_REQUIRES@
+Requires.private: @PKGCONFIG_REQUIRES_PRIVATE@
+Libs: -L${libdir} -lunilink
+Libs.private: @PKGCONFIG_LIBS_PRIVATE@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@

--- a/scripts/verify_installed_consumer.sh
+++ b/scripts/verify_installed_consumer.sh
@@ -386,7 +386,9 @@ cat > "$wirestead_consumer_dir/main.cpp" <<'EOF'
 #include <unilink/unilink.hpp>
 
 int main() {
-    auto tcp_server = unilink::tcp_server(0).auto_start(false).build();
+    // Port is never bound (auto_start(false), never start_sync()'d) - any
+    // valid port number satisfies this build()-only smoke check.
+    auto tcp_server = unilink::tcp_server(45678).auto_start(false).build();
     return tcp_server ? 0 : 1;
 }
 EOF

--- a/scripts/verify_installed_consumer.sh
+++ b/scripts/verify_installed_consumer.sh
@@ -362,3 +362,61 @@ fi
 
 echo
 echo "Installed consumer smoke passed for library mode: $LIBRARY_MODE"
+
+wirestead_consumer_dir="${CONSUMER_DIR}-wirestead"
+rm -rf "$wirestead_consumer_dir"
+mkdir -p "$wirestead_consumer_dir"
+
+log_step "Generating find_package(wirestead) consumer project"
+cat > "$wirestead_consumer_dir/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.12)
+project(wirestead_consumer_smoke LANGUAGES CXX)
+
+find_package(wirestead CONFIG REQUIRED)
+
+add_executable(wirestead_consumer_smoke main.cpp)
+target_link_libraries(wirestead_consumer_smoke PRIVATE wirestead::wirestead)
+target_compile_features(wirestead_consumer_smoke PRIVATE cxx_std_20)
+EOF
+
+# Headers still live under <unilink/...> at this stage of the migration (see
+# docs/migration-from-unilink.md) - this only proves the wirestead::wirestead
+# target resolves to the real library and links, not the header story.
+cat > "$wirestead_consumer_dir/main.cpp" <<'EOF'
+#include <unilink/unilink.hpp>
+
+int main() {
+    auto tcp_server = unilink::tcp_server(0).auto_start(false).build();
+    return tcp_server ? 0 : 1;
+}
+EOF
+
+wirestead_consumer_build_dir="$wirestead_consumer_dir/build"
+
+wirestead_consumer_args=(
+  -S "$wirestead_consumer_dir"
+  -B "$wirestead_consumer_build_dir"
+  -G "$CMAKE_GENERATOR"
+  -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"
+  -DCMAKE_PREFIX_PATH="$INSTALL_PREFIX"
+)
+
+if [[ -n "${CMAKE_TOOLCHAIN_FILE:-}" ]]; then
+  wirestead_consumer_args+=("-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+fi
+
+if [[ -n "${VCPKG_TARGET_TRIPLET:-}" ]]; then
+  wirestead_consumer_args+=("-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
+fi
+
+log_step "Configuring find_package(wirestead) consumer"
+cmake "${wirestead_consumer_args[@]}"
+
+log_step "Building find_package(wirestead) consumer"
+cmake --build "$wirestead_consumer_build_dir" --parallel
+
+log_step "Running find_package(wirestead) consumer runtime smoke"
+"$wirestead_consumer_build_dir/wirestead_consumer_smoke"
+
+echo
+echo "Installed find_package(wirestead) consumer smoke passed for library mode: $LIBRARY_MODE"


### PR DESCRIPTION
## Summary
Stage 4 (first half) of the UniLink → Wirestead migration plan, per the compatibility table in #531 (`docs/migration-from-unilink.md`): adds `find_package(wirestead)` and the `wirestead::wirestead` CMake target, and a `wirestead.pc` pkg-config file, alongside — not instead of — the existing `unilink` ones.

## Changes
- `cmake/WiresteadConfig.cmake.in` (new): does **not** duplicate `unilink`'s Boost/spdlog/Threads dependency resolution. It calls `find_dependency(unilink CONFIG REQUIRED HINTS ...)` against the sibling install directory and only adds `wirestead::wirestead` as an `INTERFACE IMPORTED` alias of `unilink::unilink`. One place resolves real dependencies; this just aliases on top.
- `cmake/wirestead.pc.in` (new): same real Boost/spdlog linkage as `unilink.pc` — only `Name`/`Description`/`URL` differ. `Libs:` still points at `-lunilink`, matching the compatibility policy that the binary name doesn't change before v1.0.0 (see #531).
- `cmake/UnilinkPackaging.cmake`: generates and installs the two new files above, alongside the existing `unilinkConfig.cmake`/`unilink.pc` generation — purely additive, no existing install rule changed.
- `scripts/verify_installed_consumer.sh`: after the existing `find_package(unilink)` smoke test, also generates, builds, and runs a minimal `find_package(wirestead)` consumer against the same installed prefix, so this is actually exercised in CI (`Consumer Smoke` workflow already watches `cmake/**`), not just added and hoped to work.

## Compatibility
`find_package(unilink)`, `unilink::unilink`, and `unilink.pc` are untouched — same generation, same install destination, same content. No public API, namespace, header, or binary-name change (see #531 for why those are explicitly *not* part of this PR).

## Validation
- Ran: `git diff --check` (clean)
- Ran: `bash -n scripts/verify_installed_consumer.sh` (syntax check)
- Not run locally: an actual `cmake --install` + consume cycle — no vcpkg checkout available in this environment to resolve Boost/spdlog. The `Consumer Smoke` workflow (`installed-consumer` job, ubuntu-24.04 shared+static) is what actually exercises this end-to-end; watch that on this PR before merging.
- Tests: added (see `scripts/verify_installed_consumer.sh` change above)

## Not Included
- `<wirestead/...>` headers, `WIRESTEAD_*` CMake options, `WIRESTEAD_LOG_LEVEL`, `WIRESTEAD_API` — that's the second half of Stage 4 (`refactor: add Wirestead headers, options and public API aliases`), coming as a separate PR per the plan's recommended split.
- vcpkg port changes — Stage 6, blocked on a v0.9.0 release existing first.

## Risks / Follow-up
- The `find_dependency(... HINTS "${CMAKE_CURRENT_LIST_DIR}/../unilink")` relative-path assumption only holds when both configs are installed from the same prefix in the same build (always true for this project's own install/package/vcpkg flow, but would break if someone tried to install a standalone `wirestead` config pointing at a differently-located `unilink` install — not a supported scenario here).
- Watch the `Consumer Smoke` CI job on this PR specifically, since it's the only thing that actually proves the new config resolves correctly.