### PR TITLE
refactor: add Wirestead headers, options and public API aliases

### DIFF
--- a/cmake/UnilinkOptions.cmake
+++ b/cmake/UnilinkOptions.cmake
@@ -1,6 +1,42 @@
 # Unilink build options This file centralizes all build options for better
 # maintainability
 
+# WIRESTEAD_<X> mirrors UNILINK_<X> for every build option below (see the
+# reconciliation loop after they're all declared). Capture which of each pair
+# the user explicitly set - via -D or an existing cache entry - *before* any
+# option() calls run, since DEFINED becomes true for every option() variable
+# afterward regardless of how it ended up with its value. See
+# docs/migration-from-unilink.md for the conflict-handling policy this
+# implements.
+set(_unilink_option_suffixes
+    BUILD_SHARED
+    BUILD_STATIC
+    BUILD_TESTS
+    BUILD_DOCS
+    ENABLE_CONFIG
+    ENABLE_MEMORY_TRACKING
+    ENABLE_SANITIZERS
+    ENABLE_INSTALL
+    ENABLE_PKGCONFIG
+    ENABLE_EXPORT_HEADER
+    ENABLE_WARNINGS
+    ENABLE_WERROR
+    ENABLE_COVERAGE
+    ENABLE_ASAN
+    ENABLE_UBSAN
+    ENABLE_TSAN
+    ENABLE_LTO
+    ENABLE_PCH
+)
+foreach(_suffix IN LISTS _unilink_option_suffixes)
+  if(DEFINED UNILINK_${_suffix})
+    set(_unilink_explicit_UNILINK_${_suffix} TRUE)
+  endif()
+  if(DEFINED WIRESTEAD_${_suffix})
+    set(_unilink_explicit_WIRESTEAD_${_suffix} TRUE)
+  endif()
+endforeach()
+
 # Build type options
 option(UNILINK_BUILD_SHARED "Build shared library" ON)
 option(UNILINK_BUILD_STATIC "Build static library" ON)
@@ -52,6 +88,44 @@ option(UNILINK_ENABLE_TSAN "Enable ThreadSanitizer" OFF)
 # Performance options
 option(UNILINK_ENABLE_LTO "Enable Link Time Optimization" OFF)
 option(UNILINK_ENABLE_PCH "Enable Precompiled Headers" OFF)
+
+# Wirestead option mirrors. For each UNILINK_<X> above, define WIRESTEAD_<X> as
+# a visible CACHE option defaulting to the same value, then reconcile: an
+# explicit conflict between the two is a hard error (build-time configuration
+# should never be silently ambiguous); otherwise whichever one was explicitly
+# set wins and is forwarded onto the other, so UNILINK_<X> - which the rest of
+# the build reads - is always the effective value either way.
+foreach(_suffix IN LISTS _unilink_option_suffixes)
+  set(_unilink_var "UNILINK_${_suffix}")
+  set(_wirestead_var "WIRESTEAD_${_suffix}")
+
+  option(${_wirestead_var} "Wirestead alias for ${_unilink_var}"
+         ${${_unilink_var}}
+  )
+
+  if(_unilink_explicit_UNILINK_${_suffix}
+     AND _unilink_explicit_WIRESTEAD_${_suffix}
+  )
+    if(NOT "${${_unilink_var}}" STREQUAL "${${_wirestead_var}}")
+      message(
+        FATAL_ERROR
+          "${_unilink_var}=${${_unilink_var}} conflicts with "
+          "${_wirestead_var}=${${_wirestead_var}}. Set only one of them, or "
+          "set both to the same value."
+      )
+    endif()
+  elseif(_unilink_explicit_WIRESTEAD_${_suffix})
+    set(${_unilink_var}
+        ${${_wirestead_var}}
+        CACHE BOOL "" FORCE
+    )
+  endif()
+  # else: UNILINK_<X> was explicit-only, or neither was explicit - UNILINK_<X>
+  # (read by the rest of the build) is already correct, and WIRESTEAD_<X>
+  # already defaulted to match it above.
+endforeach()
+
+unset(_unilink_option_suffixes)
 
 # Consolidate build outputs into predictable bin/lib directories so Docker and
 # tests can copy artifacts reliably without relying on generator defaults.

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -284,6 +284,15 @@ if(UNILINK_ENABLE_INSTALL)
     PATTERN "*.h"
   )
 
+  # <wirestead/unilink.hpp> forwarding header - see wirestead/unilink.hpp. Deep
+  # <unilink/...> includes have no wirestead equivalent; only the documented
+  # public entrypoint does (docs/api_stability.md).
+  install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/wirestead/unilink.hpp
+    COMPONENT headers
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wirestead
+  )
+
   install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/unilinkConfig.cmake
           ${CMAKE_CURRENT_BINARY_DIR}/unilinkConfigVersion.cmake

--- a/test/unit/common/test_logger_behaviors.cc
+++ b/test/unit/common/test_logger_behaviors.cc
@@ -64,6 +64,7 @@ class LoggerBehaviorTest : public ::testing::Test {
     Logger::instance().set_callback(nullptr);
     Logger::instance().set_format("{timestamp} [{level}] [{component}] [{operation}] {message}");
     clearLogLevelEnv();
+    clearWiresteadLogLevelEnv();
   }
 
   void setLogLevelEnv(const std::string& value) {
@@ -79,6 +80,22 @@ class LoggerBehaviorTest : public ::testing::Test {
     _putenv_s("UNILINK_LOG_LEVEL", "");
 #else
     unsetenv("UNILINK_LOG_LEVEL");
+#endif
+  }
+
+  void setWiresteadLogLevelEnv(const std::string& value) {
+#ifdef _WIN32
+    _putenv_s("WIRESTEAD_LOG_LEVEL", value.c_str());
+#else
+    setenv("WIRESTEAD_LOG_LEVEL", value.c_str(), 1);
+#endif
+  }
+
+  void clearWiresteadLogLevelEnv() {
+#ifdef _WIN32
+    _putenv_s("WIRESTEAD_LOG_LEVEL", "");
+#else
+    unsetenv("WIRESTEAD_LOG_LEVEL");
 #endif
   }
 
@@ -490,6 +507,38 @@ TEST_F(LoggerBehaviorTest, ReloadsLogLevelAliasesAndReportsInvalidEnvironment) {
   EXPECT_FALSE(Logger::instance().last_error().empty());
 
   clearLogLevelEnv();
+}
+
+TEST_F(LoggerBehaviorTest, WiresteadLogLevelTakesPrecedenceOverUnilinkLogLevel) {
+  // UNILINK_LOG_LEVEL alone still works (no regression).
+  Logger::instance().set_enabled(true);
+  setLogLevelEnv("ERROR");
+  Logger::instance().reload_from_environment();
+  EXPECT_TRUE(Logger::instance().enabled());
+  EXPECT_EQ(Logger::instance().level(), LogLevel::ERROR);
+  EXPECT_TRUE(Logger::instance().last_error().empty());
+  clearLogLevelEnv();
+
+  // WIRESTEAD_LOG_LEVEL alone works the same way as UNILINK_LOG_LEVEL.
+  Logger::instance().set_enabled(true);
+  setWiresteadLogLevelEnv("WARNING");
+  Logger::instance().reload_from_environment();
+  EXPECT_TRUE(Logger::instance().enabled());
+  EXPECT_EQ(Logger::instance().level(), LogLevel::WARNING);
+  EXPECT_TRUE(Logger::instance().last_error().empty());
+  clearWiresteadLogLevelEnv();
+
+  // When both are set to different values, WIRESTEAD_LOG_LEVEL wins.
+  Logger::instance().set_enabled(true);
+  setLogLevelEnv("ERROR");
+  setWiresteadLogLevelEnv("DEBUG");
+  Logger::instance().reload_from_environment();
+  EXPECT_TRUE(Logger::instance().enabled());
+  EXPECT_EQ(Logger::instance().level(), LogLevel::DEBUG);
+  EXPECT_TRUE(Logger::instance().last_error().empty());
+
+  clearLogLevelEnv();
+  clearWiresteadLogLevelEnv();
 }
 
 TEST_F(LoggerBehaviorTest, CallbackReenabledAfterOutputsDisabled) {

--- a/unilink/base/visibility.hpp
+++ b/unilink/base/visibility.hpp
@@ -55,3 +55,11 @@
 #ifndef UNILINK_NO_EXPORT
 #define UNILINK_NO_EXPORT UNILINK_LOCAL
 #endif
+
+// Wirestead alias: every symbol is annotated with UNILINK_API, not a
+// separately-tracked macro, so WIRESTEAD_API always mirrors whatever
+// UNILINK_API resolved to above rather than duplicating the dllexport/
+// dllimport/visibility logic. See docs/migration-from-unilink.md.
+#ifndef WIRESTEAD_API
+#define WIRESTEAD_API UNILINK_API
+#endif

--- a/unilink/diagnostics/logger.cc
+++ b/unilink/diagnostics/logger.cc
@@ -279,15 +279,28 @@ struct Logger::Impl {
   }
 
   void apply_environment_settings() {
-    const char* env_level = std::getenv("UNILINK_LOG_LEVEL");
+    // WIRESTEAD_LOG_LEVEL takes priority over UNILINK_LOG_LEVEL when both are
+    // set (docs/migration-from-unilink.md compatibility policy), with a
+    // startup log line so the choice is discoverable rather than silent.
+    const char* wirestead_env = std::getenv("WIRESTEAD_LOG_LEVEL");
+    const char* unilink_env = std::getenv("UNILINK_LOG_LEVEL");
+    const bool has_wirestead_env = wirestead_env && *wirestead_env != '\0';
+    const bool has_unilink_env = unilink_env && *unilink_env != '\0';
+
+    const char* env_level = has_wirestead_env ? wirestead_env : unilink_env;
+    const char* env_name = has_wirestead_env ? "WIRESTEAD_LOG_LEVEL" : "UNILINK_LOG_LEVEL";
     if (!env_level || *env_level == '\0') {
       return;
+    }
+
+    if (has_wirestead_env && has_unilink_env && spd_logger_) {
+      spd_logger_->info("WIRESTEAD_LOG_LEVEL is set alongside UNILINK_LOG_LEVEL; WIRESTEAD_LOG_LEVEL takes precedence");
     }
 
     LogLevel parsed_level = current_level_.load();
     bool disable_logging = false;
     if (!parse_log_level(env_level, parsed_level, disable_logging)) {
-      set_error("Invalid UNILINK_LOG_LEVEL: " + std::string(env_level));
+      set_error("Invalid " + std::string(env_name) + ": " + std::string(env_level));
       return;
     }
 

--- a/wirestead/unilink.hpp
+++ b/wirestead/unilink.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Wirestead entrypoint header. The library, its namespace, and its symbols
+// are still named unilink (see docs/migration-from-unilink.md for why) - this
+// header exists so `#include <wirestead/unilink.hpp>` works for consumers who
+// found the library through its new name, without duplicating any code.
+#include <unilink/unilink.hpp>


### PR DESCRIPTION
## Summary
Second half of Stage 4 of the migration plan (see #533 for the CMake package/target half — this stacks on top of it and should merge after). Per `docs/migration-from-unilink.md`'s compatibility table: adds `<wirestead/unilink.hpp>`, `WIRESTEAD_*` CMake option mirrors, `WIRESTEAD_LOG_LEVEL` precedence, and the `WIRESTEAD_API` export macro.

**Note**: this branch was cut from `main` before #533 merged, so it doesn't yet include #533's `wiresteadConfig.cmake`/`wirestead.pc` generation. Rebasing onto `main` once #533 lands before this one merges.

## Changes
- `wirestead/unilink.hpp` (new): forwarding entrypoint header — `#include <wirestead/unilink.hpp>` → `#include <unilink/unilink.hpp>`. Only the documented public entrypoint gets a forward; deep `<unilink/...>` includes aren't part of the compatibility guarantee (`docs/api_stability.md`), so they don't get wirestead equivalents either.
- `unilink/base/visibility.hpp`: `WIRESTEAD_API` defined as a plain alias of `UNILINK_API` — mirrors whatever dllexport/dllimport/visibility `UNILINK_API` resolved to, no duplicated logic.
- `cmake/UnilinkOptions.cmake`: `WIRESTEAD_<X>` mirrors `UNILINK_<X>` for all 17 existing options. Explicit conflicting values (`-DUNILINK_ENABLE_CONFIG=ON -DWIRESTEAD_ENABLE_CONFIG=OFF`) are a hard `FATAL_ERROR`; otherwise whichever one was explicitly set forwards onto the other, so `UNILINK_<X>` (what the rest of the build actually reads) is always the effective value either way.
- `unilink/diagnostics/logger.cc`: `WIRESTEAD_LOG_LEVEL` takes precedence over `UNILINK_LOG_LEVEL` when both are set, with a startup log line so the choice is discoverable rather than silent. `UNILINK_LOG_LEVEL` alone still works unchanged.
- `cmake/UnilinkPackaging.cmake`: installs `wirestead/unilink.hpp` to `include/wirestead/`.
- `test/unit/common/test_logger_behaviors.cc`: new test covering `UNILINK_LOG_LEVEL`-only, `WIRESTEAD_LOG_LEVEL`-only, and both-set-different-values precedence.

## Compatibility
`namespace unilink`, `UnilinkException` and its subclasses, `UNILINK_API`, `UNILINK_LOG_LEVEL`, and every `UNILINK_*` option are untouched — this is additive only, per the migration doc's explicit recommendation *not* to rename the C++ symbol surface (unlike the packaging-identity changes, that would be a source break for every existing consumer).

## Validation
Ran locally (Boost 1.83.0 + spdlog were available in this environment, so this wasn't just a syntax read-through):
- Built the library and ran a real `cmake --install`.
- Compiled and linked a consumer using only `#include <wirestead/unilink.hpp>` against the installed `unilink::` package — succeeded.
- Standalone check that `WIRESTEAD_API` is defined and usable on a function — compiled, linked, ran, returned the expected value.
- Exercised the `WIRESTEAD_<X>`/`UNILINK_<X>` reconciliation logic directly via `cmake -S . -B ...` with 5 scenarios: WIRESTEAD-only explicit (forwards correctly), UNILINK-only explicit (forwards correctly), both explicit matching (no error), both explicit conflicting (`FATAL_ERROR` as designed), neither explicit (both default consistently).
- Ran: `git diff --check` (clean)
- Not run locally: the new `WiresteadLogLevelTakesPrecedenceOverUnilinkLogLevel` gtest (needs the full gtest-linked test binary) — added as a real unit test, will run in CI.
- Tests: added (`test_logger_behaviors.cc`)

## Not Included
- `wirestead::wirestead` CMake target and `wiresteadConfig.cmake`/`wirestead.pc` generation — that's #533.
- Consumer-smoke CI coverage of `<wirestead/unilink.hpp>` specifically (#533 already added a `find_package(wirestead)` smoke consumer; extending it to also use the new header is reasonable follow-up once both PRs are on `main` together).

## Risks / Follow-up
- Needs a rebase onto `main` once #533 merges, then a final combined sanity check (the two PRs were validated independently, not together yet).
- Recurring flaky Windows test (`UdpClientWrapperLifecycleTest.RestartAfterStopResolvesFutureAndReinstallsHandlers`) has now shown up on #529, #532 (main branch), and #533 — unrelated to this PR, but worth its own investigation given the repeat appearances.