### PR TITLE
release: bump to v0.9.0 and rename release archives to wirestead-*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             cmake_generator: "Ninja"
             cpack_generator: "TGZ"
             release_files: |
-              build/package/unilink-*.tar.gz
+              build/package/wirestead-*.tar.gz
 
           - os: ubuntu-22.04-arm
             label: Linux ARM64 (Ubuntu 22.04)
@@ -44,7 +44,7 @@ jobs:
             cmake_generator: "Ninja"
             cpack_generator: "TGZ"
             release_files: |
-              build/package/unilink-*.tar.gz
+              build/package/wirestead-*.tar.gz
 
           - os: ubuntu-24.04
             label: Linux (Ubuntu 24.04)
@@ -53,7 +53,7 @@ jobs:
             cmake_generator: "Ninja"
             cpack_generator: "TGZ"
             release_files: |
-              build/package/unilink-*.tar.gz
+              build/package/wirestead-*.tar.gz
 
           - os: ubuntu-24.04-arm
             label: Linux ARM64 (Ubuntu 24.04)
@@ -62,7 +62,7 @@ jobs:
             cmake_generator: "Ninja"
             cpack_generator: "TGZ"
             release_files: |
-              build/package/unilink-*.tar.gz
+              build/package/wirestead-*.tar.gz
 
           - os: macos-15
             label: macOS 15
@@ -71,8 +71,8 @@ jobs:
             cmake_generator: "Ninja"
             cpack_generator: "TGZ;DragNDrop"
             release_files: |
-              build/package/unilink-*.tar.gz
-              build/package/unilink-*.dmg
+              build/package/wirestead-*.tar.gz
+              build/package/wirestead-*.dmg
 
           - os: windows-2022
             label: Windows (VS 2022)
@@ -82,7 +82,7 @@ jobs:
             triplet: x64-windows
             cpack_generator: "ZIP"
             release_files: |
-              build/package/unilink-*.zip
+              build/package/wirestead-*.zip
 
           - os: windows-11-arm
             label: Windows ARM64
@@ -92,7 +92,7 @@ jobs:
             triplet: arm64-windows
             cpack_generator: "ZIP"
             release_files: |
-              build/package/unilink-*.zip
+              build/package/wirestead-*.zip
 
     steps:
       - uses: actions/checkout@v7
@@ -221,20 +221,20 @@ jobs:
           echo "Package directory:"
           ls -la build/package
 
-          count=$(find build/package -maxdepth 1 -type f \( -name "unilink-*.tar.gz" -o -name "unilink-*.zip" -o -name "unilink-*.dmg" \) | wc -l | tr -d ' ')
+          count=$(find build/package -maxdepth 1 -type f \( -name "wirestead-*.tar.gz" -o -name "wirestead-*.zip" -o -name "wirestead-*.dmg" \) | wc -l | tr -d ' ')
           if [ "$count" -eq 0 ]; then
             echo "No release package files found"
             exit 1
           fi
 
           echo "Release package files:"
-          find build/package -maxdepth 1 -type f \( -name "unilink-*.tar.gz" -o -name "unilink-*.zip" -o -name "unilink-*.dmg" \) -print | sort
+          find build/package -maxdepth 1 -type f \( -name "wirestead-*.tar.gz" -o -name "wirestead-*.zip" -o -name "wirestead-*.dmg" \) -print | sort
 
       - name: Verify package contents (TGZ)
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          pkg=$(find build/package -maxdepth 1 -name 'unilink-*.tar.gz' | head -n1)
+          pkg=$(find build/package -maxdepth 1 -name 'wirestead-*.tar.gz' | head -n1)
           if [ -z "$pkg" ]; then
             echo "No TGZ package found"
             exit 1
@@ -247,6 +247,8 @@ jobs:
           grep -E '/lib/(lib)?unilink[^/]*\.(a|so|dylib)(\.[0-9.]+)?$|/bin/unilink[^/]*\.(dll|exe)$' package-files.txt
           grep -E '/unilinkConfig\.cmake$' package-files.txt
           grep -E '/unilinkTargets\.cmake$' package-files.txt
+          grep -E '/include/wirestead/unilink.hpp$' package-files.txt
+          grep -E '/wiresteadConfig\.cmake$' package-files.txt
           grep -E '/LICENSE$' package-files.txt
           grep -E '/NOTICE$' package-files.txt
           grep -E '/README\.md$' package-files.txt
@@ -255,7 +257,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $pkg = Get-ChildItem build/package -Filter "unilink-*.zip" | Select-Object -First 1
+          $pkg = Get-ChildItem build/package -Filter "wirestead-*.zip" | Select-Object -First 1
           if (-not $pkg) {
             Write-Error "No ZIP package found"
             exit 1
@@ -289,6 +291,14 @@ jobs:
             Write-Error "Missing unilinkTargets.cmake"
             exit 1
           }
+          if (-not (Get-ChildItem -Recurse $dest -Filter "unilink.hpp" | Where-Object { $_.FullName -match '[\\/]wirestead[\\/]' })) {
+            Write-Error "Missing wirestead/unilink.hpp"
+            exit 1
+          }
+          if (-not (Get-ChildItem -Recurse $dest -Filter "wiresteadConfig.cmake")) {
+            Write-Error "Missing wiresteadConfig.cmake"
+            exit 1
+          }
           if (-not (Get-ChildItem -Recurse $dest -Filter "LICENSE")) {
             Write-Error "Missing LICENSE"
             exit 1
@@ -312,7 +322,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Package files" >> $GITHUB_STEP_SUMMARY
           echo '```text' >> $GITHUB_STEP_SUMMARY
-          find build/package -maxdepth 1 -type f -name "unilink-*" -print | sort >> $GITHUB_STEP_SUMMARY
+          find build/package -maxdepth 1 -type f -name "wirestead-*" -print | sort >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Release Asset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   unilink
-  VERSION 0.8.9
+  VERSION 0.9.0
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -1,8 +1,11 @@
 # Unilink packaging configuration This file handles all packaging-related
 # settings
 
-# Basic package information
-set(CPACK_PACKAGE_NAME "unilink")
+# Basic package information. CPACK_PACKAGE_NAME drives the release archive
+# filename (wirestead-<version>-<os>-<arch>.tar.gz/.zip) - it does not rename
+# the installed library, unilink:: CMake package, or unilink.pc, which stay
+# unilink-named per docs/migration-from-unilink.md's compatibility policy.
+set(CPACK_PACKAGE_NAME "wirestead")
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
     "Cross-platform async C++ communication library for Serial, TCP, UDP, and UDS"
@@ -55,8 +58,8 @@ set(CPACK_SOURCE_PACKAGE_FILE_NAME
 # Platform-specific settings
 if(WIN32)
   set(CPACK_GENERATOR "ZIP;NSIS;WIX")
-  set(CPACK_NSIS_DISPLAY_NAME "Unilink ${PROJECT_VERSION}")
-  set(CPACK_NSIS_PACKAGE_NAME "Unilink")
+  set(CPACK_NSIS_DISPLAY_NAME "Wirestead ${PROJECT_VERSION}")
+  set(CPACK_NSIS_PACKAGE_NAME "Wirestead")
   set(CPACK_NSIS_CONTACT "${CPACK_PACKAGE_CONTACT}")
   set(CPACK_NSIS_URL_INFO_ABOUT "${CPACK_PACKAGE_HOMEPAGE_URL}")
   set(CPACK_NSIS_MODIFY_PATH ON)
@@ -67,7 +70,7 @@ if(WIN32)
 
 elseif(APPLE)
   set(CPACK_GENERATOR "TGZ;DragNDrop")
-  set(CPACK_DMG_VOLUME_NAME "Unilink ${PROJECT_VERSION}")
+  set(CPACK_DMG_VOLUME_NAME "Wirestead ${PROJECT_VERSION}")
   set(CPACK_DMG_FORMAT "UDZO")
 
 elseif(UNIX)
@@ -151,11 +154,11 @@ set(CPACK_COMPONENTS_ALL libraries headers cmake pkgconfig documentation)
 
 # Component descriptions
 set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries")
-set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION "Unilink shared and static libraries")
+set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION "Wirestead shared and static libraries")
 set(CPACK_COMPONENT_LIBRARIES_REQUIRED TRUE)
 
 set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Header Files")
-set(CPACK_COMPONENT_HEADERS_DESCRIPTION "Unilink C++ header files")
+set(CPACK_COMPONENT_HEADERS_DESCRIPTION "Wirestead C++ header files")
 set(CPACK_COMPONENT_HEADERS_REQUIRED TRUE)
 
 set(CPACK_COMPONENT_CMAKE_DISPLAY_NAME "CMake Files")

--- a/cmake/UnilinkPackaging.cmake
+++ b/cmake/UnilinkPackaging.cmake
@@ -154,7 +154,9 @@ set(CPACK_COMPONENTS_ALL libraries headers cmake pkgconfig documentation)
 
 # Component descriptions
 set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries")
-set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION "Wirestead shared and static libraries")
+set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION
+    "Wirestead shared and static libraries"
+)
 set(CPACK_COMPONENT_LIBRARIES_REQUIRED TRUE)
 
 set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "Header Files")


### PR DESCRIPTION
## Summary
Stage 5 prep of the migration plan (docs/migration-from-unilink.md): version bump to v0.9.0 and rename the release archive filename from `unilink-*` to `wirestead-*`. This is the last change needed before tagging `v0.9.0-rc.1`.

## Changes
- `CMakeLists.txt`: `VERSION 0.8.9` → `0.9.0`.
- `cmake/UnilinkPackaging.cmake`: `CPACK_PACKAGE_NAME` `"unilink"` → `"wirestead"` (drives `CPACK_PACKAGE_FILE_NAME`, i.e. the outer archive name only). NSIS/DMG display names and component descriptions updated to say Wirestead for consistency — these are cosmetic installer-UI strings, not identifiers.
- `.github/workflows/release.yml`: every `unilink-*` archive glob (`release_files` per platform, package-existence check, package-content verification, job summary) updated to `wirestead-*`. Added explicit checks that `wirestead/unilink.hpp` and `wiresteadConfig.cmake` are present inside the package, alongside the existing `unilink.hpp`/`unilinkConfig.cmake` checks (both TGZ/bash and ZIP/PowerShell paths).

## Compatibility
Only the outer release archive's filename changes. Everything inside it is unchanged: the installed library is still `libunilink.so`/`.a`, the CMake package is still `unilink::unilink` via `unilinkConfig.cmake`, and `unilink.pc` is untouched. `wiresteadConfig.cmake`/`wirestead::wirestead`/`wirestead/unilink.hpp` (from #533/#534) ship inside the same archive alongside them.

## Validation
- Ran locally: full Release build, then `cpack -C Release -B package -G TGZ` — produced `wirestead-0.9.0-linux-amd64.tar.gz` (confirms the rename works, not just reads correctly).
- Ran the exact grep checks from release.yml's "Verify package contents (TGZ)" step against the real tarball — all 9 checks passed, including both the unilink and wirestead header/config files coexisting inside it.
- Ran: `git diff --check` (clean), `python3 -c "import yaml; yaml.safe_load(...)"` (release.yml syntax valid)
- Not run locally: the Windows ZIP / PowerShell verification path, or the actual GitHub Actions release matrix (macOS/Windows toolchains not available here) — that's what this PR's own CI, and the eventual `v0.9.0-rc.1` tag push, will exercise.

## Not Included
- The actual `v0.9.0-rc.1` tag — planned as the next step once this merges, to trigger `release.yml` for real across all 6 platforms.
- vcpkg port changes (Stage 6) — blocked on a real v0.9.0 tag existing first.

## Risks / Follow-up
- This is the first real end-to-end test of the Stage 2 macOS `gtest_discover_tests` fix (`DISCOVERY_MODE PRE_TEST`) at release-workflow scale, not just `ci.yml` scale — worth watching closely once the RC tag triggers `release.yml`.
- Anyone with existing automation that downloads `unilink-*.tar.gz`/`.zip` release assets by name will need to switch to `wirestead-*` starting with this release — worth calling out in the v0.9.0 release notes.