### PR TITLE
test: stabilize udp client restart lifecycle test

### DIFF
--- a/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.hpp"
 #include "wirestead/framer/line_framer.hpp"
 #include "wirestead/interface/channel.hpp"
 #include "wirestead/wrapper/udp/udp.hpp"
@@ -331,14 +332,14 @@ TEST(UdpClientWrapperLifecycleTest, RestartAfterStopResolvesFutureAndReinstallsH
   auto first = client.start();
   ASSERT_EQ(first.wait_for(std::chrono::seconds(1)), std::future_status::ready);
   EXPECT_TRUE(first.get());
-  EXPECT_EQ(connect_count.load(), 1);
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return connect_count.load() == 1; }, 1000));
 
   client.stop();
 
   auto second = client.start();
   ASSERT_EQ(second.wait_for(std::chrono::seconds(1)), std::future_status::ready);
   EXPECT_TRUE(second.get());
-  EXPECT_EQ(connect_count.load(), 2);
+  EXPECT_TRUE(TestUtils::waitForCondition([&]() { return connect_count.load() == 2; }, 1000));
 
   client.stop();
 }


### PR DESCRIPTION
## Summary
Stabilizes the UDP client restart lifecycle regression test that failed on the Windows MSVC CMake workflow.

## Root Cause
`UdpClient::Impl::setup_internal_handlers()` fulfills the `start()` future before invoking the user `on_connect` handler from the same state callback. The test treated future readiness as proof that the connect handler had already completed, which exposes a scheduler race on Windows.

## Changes
- Include the shared `TestUtils` wait helper.
- Keep the same assertions about first and second connect callbacks, but wait boundedly for the handler count after each `start()` future resolves.

## Validation
- `cmake --build build/wirestead-rename-tests -j2 --target run_integration_test_udp_client_wrapper_lifecycle`
- `ctest --test-dir build/wirestead-rename-tests -R '^UdpClientWrapperLifecycleTest\.RestartAfterStopResolvesFutureAndReinstallsHandlers$' --output-on-failure --repeat until-fail:20`
- `ctest --test-dir build/wirestead-rename-tests -R '^UdpClientWrapperLifecycleTest\.' --output-on-failure`
- `clang-format -i -style=file test/integration/wrapper/test_udp_client_wrapper_lifecycle.cc`
- `git diff --check`
