### PR TITLE
docs: point external repo links at wirestead org, not unilink-lab

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -338,7 +338,7 @@ jobs:
           EOF
           echo "✅ Custom index page created with coverage: ${COVERAGE}"
 
-      # API docs (Doxygen) still live in the legacy unilink-lab/unilink-docs
+      # API docs (Doxygen) still live in the legacy wirestead/unilink-docs
       # repository until the external docs repo is moved.
       # since docs generation moved out of this one. GitHub's native
       # actions/deploy-pages can only publish to the Pages site of the repo
@@ -350,7 +350,7 @@ jobs:
       - name: Checkout legacy docs source
         uses: actions/checkout@v7
         with:
-          repository: unilink-lab/unilink-docs
+          repository: wirestead/unilink-docs
           path: docs-src
 
       - name: Checkout Wirestead core for docs generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ lowercase, imperative mood, no trailing period.
   model, callback lifetime, API stability, security model. Full tutorials
   and runnable examples still live in legacy locations until those
   repositories are moved:
-  [unilink-docs](https://github.com/unilink-lab/unilink-docs) and
-  [unilink-examples](https://github.com/unilink-lab/unilink-examples).
+  [unilink-docs](https://github.com/wirestead/unilink-docs) and
+  [unilink-examples](https://github.com/wirestead/unilink-examples).
 - Bug reports and feature requests: open a GitHub issue in this repository.
 - Security issues: see `docs/security.md` before filing a public issue.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Core repository entrypoints:
 
 Useful external repositories:
 
-* [Python bindings](https://github.com/unilink-lab/unilink-python) (legacy/current)
-* [Examples](https://github.com/unilink-lab/unilink-examples) (legacy/current)
-* [Containers](https://github.com/unilink-lab/unilink-containers) (legacy/current)
+* [Python bindings](https://github.com/wirestead/unilink-python) (legacy/current)
+* [Examples](https://github.com/wirestead/unilink-examples) (legacy/current)
+* [Containers](https://github.com/wirestead/unilink-container) (legacy/current)
 
 ---
 

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -45,7 +45,7 @@ if(DEFINED BUILD_PYTHON_BINDINGS AND BUILD_PYTHON_BINDINGS)
   message(
     FATAL_ERROR
       "BUILD_PYTHON_BINDINGS has been removed. "
-      "Python bindings live at https://github.com/unilink-lab/unilink-python."
+      "Python bindings live at https://github.com/wirestead/unilink-python."
   )
 endif()
 
@@ -53,7 +53,7 @@ if(DEFINED WIRESTEAD_BUILD_EXAMPLES AND WIRESTEAD_BUILD_EXAMPLES)
   message(
     FATAL_ERROR
       "WIRESTEAD_BUILD_EXAMPLES has been removed. "
-      "Examples live at https://github.com/unilink-lab/unilink-examples."
+      "Examples live at https://github.com/wirestead/unilink-examples."
   )
 endif()
 
@@ -61,7 +61,7 @@ if(DEFINED UNILINK_BUILD_EXAMPLES AND UNILINK_BUILD_EXAMPLES)
   message(
     FATAL_ERROR
       "UNILINK_BUILD_EXAMPLES has been removed. "
-      "Examples live at https://github.com/unilink-lab/unilink-examples."
+      "Examples live at https://github.com/wirestead/unilink-examples."
   )
 endif()
 

--- a/docs/migration-from-unilink.md
+++ b/docs/migration-from-unilink.md
@@ -85,8 +85,9 @@ become a deprecated compatibility port depending on `wirestead`.
 ## External Repositories
 
 External documentation, Python binding, example, and container repositories are
-outside this source-tree rename. Links to legacy `unilink-lab/*` repositories
-remain historical/current until those repositories are moved or replaced.
+outside this source-tree rename. Those repositories already moved from the
+`unilink-lab` organization to `wirestead`, but still keep their legacy
+`unilink-*` names until each one is individually renamed or replaced.
 
 ## Version Policy
 


### PR DESCRIPTION
## Summary
- The `unilink-lab` organization was renamed to `wirestead` a while ago, but several files still referenced the old org name in external-repo links.

## Changes
- `README.md`: Python bindings / Examples / Containers links now point at `wirestead/...` (Containers also corrected from the already-renamed plural `unilink-containers` to `unilink-container`)
- `CONTRIBUTING.md`: unilink-docs / unilink-examples links updated to `wirestead/...`
- `cmake/WiresteadOptions.cmake`: three removed-option error messages now point at `wirestead/...`
- `.github/workflows/coverage.yml`: the Doxygen cross-repo checkout step's `repository:` input (a functional CI dependency, not just a doc link) now checks out `wirestead/unilink-docs` instead of `unilink-lab/unilink-docs`; accompanying comment updated to match
- `docs/migration-from-unilink.md`: corrected the "External Repositories" note, which still described the satellite repos as living under `unilink-lab`

## Validation
- [x] Ran: `git diff --check`
- [ ] Not run: `cmake --build build -j2` because this is a docs/CI-config-only change with no source impact
- Tests: not needed — no behavior change, only which org the referenced/checked-out URLs point at
- Documentation: updated (this PR is the documentation update)

## Not Included
- Renaming `unilink-docs`, `unilink-examples`, or `unilink-python` themselves — those repository renames are still pending and tracked separately.

## Follow-up
- Once those satellite repos are renamed, the same links (and this coverage.yml checkout) will need a second pass to match their new names.