### PR TITLE
docs: update satellite repo links for wirestead-* rename

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -338,19 +338,19 @@ jobs:
           EOF
           echo "✅ Custom index page created with coverage: ${COVERAGE}"
 
-      # API docs (Doxygen) still live in the legacy wirestead/unilink-docs
+      # API docs (Doxygen) still live in the legacy wirestead/wirestead-docs
       # repository until the external docs repo is moved.
       # since docs generation moved out of this one. GitHub's native
       # actions/deploy-pages can only publish to the Pages site of the repo
-      # the workflow is running in, so unilink-docs can't deploy here itself
-      # (no supported cross-repo path) - this job checks unilink-docs out as
+      # the workflow is running in, so wirestead-docs can't deploy here itself
+      # (no supported cross-repo path) - this job checks wirestead-docs out as
       # a source dependency instead and generates docs from *this* exact
       # commit, then combines them with the coverage report into one
       # artifact before the single deploy-pages call below.
       - name: Checkout legacy docs source
         uses: actions/checkout@v7
         with:
-          repository: wirestead/unilink-docs
+          repository: wirestead/wirestead-docs
           path: docs-src
 
       - name: Checkout Wirestead core for docs generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ lowercase, imperative mood, no trailing period.
   model, callback lifetime, API stability, security model. Full tutorials
   and runnable examples still live in legacy locations until those
   repositories are moved:
-  [unilink-docs](https://github.com/wirestead/unilink-docs) and
-  [unilink-examples](https://github.com/wirestead/unilink-examples).
+  [wirestead-docs](https://github.com/wirestead/wirestead-docs) and
+  [wirestead-examples](https://github.com/wirestead/wirestead-examples).
 - Bug reports and feature requests: open a GitHub issue in this repository.
 - Security issues: see `docs/security.md` before filing a public issue.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Core repository entrypoints:
 
 Useful external repositories:
 
-* [Python bindings](https://github.com/wirestead/unilink-python) (legacy/current)
-* [Examples](https://github.com/wirestead/unilink-examples) (legacy/current)
-* [Containers](https://github.com/wirestead/unilink-container) (legacy/current)
+* [Python bindings](https://github.com/wirestead/wirestead-python) (legacy/current)
+* [Examples](https://github.com/wirestead/wirestead-examples) (legacy/current)
+* [Containers](https://github.com/wirestead/wirestead-container) (legacy/current)
 
 ---
 

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -45,7 +45,7 @@ if(DEFINED BUILD_PYTHON_BINDINGS AND BUILD_PYTHON_BINDINGS)
   message(
     FATAL_ERROR
       "BUILD_PYTHON_BINDINGS has been removed. "
-      "Python bindings live at https://github.com/wirestead/unilink-python."
+      "Python bindings live at https://github.com/wirestead/wirestead-python."
   )
 endif()
 
@@ -53,7 +53,7 @@ if(DEFINED WIRESTEAD_BUILD_EXAMPLES AND WIRESTEAD_BUILD_EXAMPLES)
   message(
     FATAL_ERROR
       "WIRESTEAD_BUILD_EXAMPLES has been removed. "
-      "Examples live at https://github.com/wirestead/unilink-examples."
+      "Examples live at https://github.com/wirestead/wirestead-examples."
   )
 endif()
 
@@ -61,7 +61,7 @@ if(DEFINED UNILINK_BUILD_EXAMPLES AND UNILINK_BUILD_EXAMPLES)
   message(
     FATAL_ERROR
       "UNILINK_BUILD_EXAMPLES has been removed. "
-      "Examples live at https://github.com/wirestead/unilink-examples."
+      "Examples live at https://github.com/wirestead/wirestead-examples."
   )
 endif()
 

--- a/docs/migration-from-unilink.md
+++ b/docs/migration-from-unilink.md
@@ -84,10 +84,11 @@ become a deprecated compatibility port depending on `wirestead`.
 
 ## External Repositories
 
-External documentation, Python binding, example, and container repositories are
-outside this source-tree rename. Those repositories already moved from the
-`unilink-lab` organization to `wirestead`, but still keep their legacy
-`unilink-*` names until each one is individually renamed or replaced.
+External documentation, Python binding, example, benchmark, and container
+repositories are outside this source-tree rename. Those repositories already
+moved from the `unilink-lab` organization to `wirestead`, and have since been
+renamed to `wirestead-docs`, `wirestead-python`, `wirestead-examples`,
+`wirestead-benchmarks`, and `wirestead-container` respectively.
 
 ## Version Policy
 


### PR DESCRIPTION
## Summary
unilink-docs, unilink-examples, unilink-python, and unilink-container were just renamed to wirestead-docs, wirestead-examples, wirestead-python, and wirestead-container. This repo still referenced them by their old names.

## Changes
- README.md: Python bindings / Examples / Containers links updated
- CONTRIBUTING.md: unilink-docs / unilink-examples links updated
- cmake/WiresteadOptions.cmake: three removed-option error messages updated
- .github/workflows/coverage.yml: the Doxygen cross-repo checkout step's `repository:` input (a functional CI dependency) now checks out `wirestead/wirestead-docs`; accompanying comments updated to match
- docs/migration-from-unilink.md: "External Repositories" note now names the actual current repo names instead of describing them as still using legacy `unilink-*` names

## Validation
- [x] Ran: `git diff --check`
- [ ] Not run: `cmake --build build -j2` because this is a docs/CI-config-only change with no source impact
- Tests: not needed
- Documentation: updated (this PR is the documentation update)

## Not Included
- unilink-benchmarks was also renamed to wirestead-benchmarks, but no file in this repo referenced it by name, so no change was needed for that one.

## Follow-up
N/A