### PR TITLE
fix: use squash merge strategy in dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,7 +29,7 @@ jobs:
         # escalating their own permissions). Those PRs -- i.e. GitHub Actions
         # version bumps -- must be merged manually. All other Dependabot PRs
         # auto-merge fine.
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `gh pr merge --auto --merge` requests a merge-commit strategy, but this repo only allows squash merges (`allow_merge_commit: false`, `allow_squash_merge: true`).
- After the org's "Allow GitHub Actions to create and approve pull requests" setting was enabled (fixing the earlier approve-step failure), the merge step started failing with `GraphQL: Merge commits are not allowed on this repository.`
- Switches the merge step to `--squash` to match the repo's allowed strategy.

## Test plan
- [ ] Re-run the `Dependabot Auto-Merge` workflow on PR #541 (`actions/setup-python` bump) and confirm the "Enable auto-merge for Dependabot PRs" step succeeds.

https://claude.ai/code/session_01F7gZRccj88EJrvcUrJY73D