### PR TITLE
docs: update vcpkg references now that the wirestead port is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _Wirestead is the successor to UniLink._
 Serial · TCP · UDP · UDS
 
 ![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20Windows%20%7C%20macOS-informational)
-![vcpkg](https://img.shields.io/badge/vcpkg-jwsung91--unilink%20legacy/current-0078D6)
+![vcpkg](https://img.shields.io/badge/vcpkg-wirestead-0078D6)
 [![Coverage](https://img.shields.io/endpoint?url=https://wirestead.github.io/wirestead/coverage/badges/coverage.json)](https://wirestead.github.io/wirestead/coverage/)
 
 ## Description
@@ -41,14 +41,16 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 ### vcpkg (recommended)
 
 ```bash
-vcpkg install jwsung91-unilink
+vcpkg install wirestead
 ```
 
-The `wirestead` vcpkg port is planned after the v0.9.0 release. Until then,
-`jwsung91-unilink` is the legacy/current port.
+`jwsung91-unilink` is now a deprecated compatibility alias that depends on
+`wirestead` and installs nothing itself; use `wirestead` directly.
 
 External documentation, examples, Python bindings, and container repositories
-are still in their legacy locations until they are moved.
+have moved to the `wirestead` organization as `wirestead-docs`,
+`wirestead-python`, `wirestead-examples`, `wirestead-benchmarks`, and
+`wirestead-container`.
 
 ### Contributor Development Setup
 
@@ -79,9 +81,9 @@ Core repository entrypoints:
 
 Useful external repositories:
 
-* [Python bindings](https://github.com/wirestead/wirestead-python) (legacy/current)
-* [Examples](https://github.com/wirestead/wirestead-examples) (legacy/current)
-* [Containers](https://github.com/wirestead/wirestead-container) (legacy/current)
+* [Python bindings](https://github.com/wirestead/wirestead-python)
+* [Examples](https://github.com/wirestead/wirestead-examples)
+* [Containers](https://github.com/wirestead/wirestead-container)
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,11 +17,11 @@ gate and rejects Boost versions older than the configured minimum.
 ## vcpkg
 
 ```bash
-vcpkg install jwsung91-unilink
+vcpkg install wirestead
 ```
 
-The `wirestead` vcpkg port is planned after the v0.9.0 release. Until then,
-`jwsung91-unilink` is the legacy/current port.
+`jwsung91-unilink` is now a deprecated compatibility alias that depends on
+`wirestead` and installs nothing itself; use `wirestead` directly.
 
 ## Minimal CMake find_package consumer
 

--- a/docs/migration-from-unilink.md
+++ b/docs/migration-from-unilink.md
@@ -25,7 +25,7 @@ be rebuilt.
 | Library file | `libwirestead` | no `libunilink` binary compatibility shim |
 | SONAME | `libwirestead.so.0` on Linux | no `libunilink` SONAME |
 | Release assets | `wirestead-<version>-*` | old `unilink-<version>-*` asset names are not produced |
-| vcpkg port | planned `wirestead` port after v0.9.0 | existing `jwsung91-unilink` port remains the legacy/current route until deprecated |
+| vcpkg port | `wirestead` (live in the vcpkg registry) | `jwsung91-unilink` is a deprecated alias depending on `wirestead` |
 
 ## Source Compatibility
 
@@ -77,10 +77,10 @@ and the logger emits a diagnostic line so the precedence is visible.
 
 ## vcpkg Status
 
-The canonical vcpkg port will be `wirestead` after a validated v0.9.0 release is
-available. Until that PR lands, existing vcpkg instructions that reference
-`jwsung91-unilink` describe the legacy/current port. That port is expected to
-become a deprecated compatibility port depending on `wirestead`.
+The canonical vcpkg port is `wirestead`, merged into the vcpkg registry in
+[microsoft/vcpkg#52984](https://github.com/microsoft/vcpkg/pull/52984).
+`jwsung91-unilink` is now a deprecated compatibility port that installs
+nothing itself and only depends on `wirestead`.
 
 ## External Repositories
 


### PR DESCRIPTION
## Summary
- README.md, docs/installation.md, and docs/migration-from-unilink.md still said the `wirestead` vcpkg port was "planned" and pointed installation instructions at `jwsung91-unilink`.
- microsoft/vcpkg#52984 already merged the canonical `wirestead` port and turned `jwsung91-unilink` into a deprecated alias that installs nothing itself.

## Changes
- README.md: vcpkg badge and install snippet now reference `wirestead`; corrected the external-repos sentence (docs/python/examples/benchmarks/container repos have already moved, not "still in legacy locations"); dropped stale "(legacy/current)" tags on external repo links.
- docs/installation.md: install snippet updated to `vcpkg install wirestead`; status text updated.
- docs/migration-from-unilink.md: compatibility table's vcpkg row and "vcpkg Status" section rewritten to state the port is live, linking microsoft/vcpkg#52984.

## Test plan
- [x] `git diff --check` clean
- [x] `grep` sweep confirms no remaining stale `jwsung91-unilink` "legacy/current"/"planned after" phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJG9XmyLLHzqzUH8Lsu4Ex