### PR TITLE
docs: link wirestead-docs in README external repositories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Core repository entrypoints:
 
 Useful external repositories:
 
+* [Documentation](https://github.com/wirestead/wirestead-docs)
 * [Python bindings](https://github.com/wirestead/wirestead-python)
 * [Examples](https://github.com/wirestead/wirestead-examples)
 * [Containers](https://github.com/wirestead/wirestead-container)


### PR DESCRIPTION
## Summary
- The "Useful external repositories" list in README.md was missing a link to `wirestead-docs`.

## Changes
- README.md: added a `Documentation` bullet linking to https://github.com/wirestead/wirestead-docs, alongside the existing Python bindings/Examples/Containers links.

## Test plan
- [x] Link points to the existing `wirestead-docs` repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJG9XmyLLHzqzUH8Lsu4Ex