### PR TITLE
ci: fix docs checkout path so Doxygen API reference actually generates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -338,16 +338,15 @@ jobs:
           EOF
           echo "✅ Custom index page created with coverage: ${COVERAGE}"
 
-      # API docs (Doxygen) still live in the legacy wirestead/wirestead-docs
-      # repository until the external docs repo is moved.
-      # since docs generation moved out of this one. GitHub's native
-      # actions/deploy-pages can only publish to the Pages site of the repo
-      # the workflow is running in, so wirestead-docs can't deploy here itself
-      # (no supported cross-repo path) - this job checks wirestead-docs out as
-      # a source dependency instead and generates docs from *this* exact
-      # commit, then combines them with the coverage report into one
+      # API docs (Doxygen) live in the separate wirestead/wirestead-docs
+      # repository, since docs generation moved out of this one. GitHub's
+      # native actions/deploy-pages can only publish to the Pages site of the
+      # repo the workflow is running in, so wirestead-docs can't deploy here
+      # itself (no supported cross-repo path) - this job checks wirestead-docs
+      # out as a source dependency instead and generates docs from *this*
+      # exact commit, then combines them with the coverage report into one
       # artifact before the single deploy-pages call below.
-      - name: Checkout legacy docs source
+      - name: Checkout docs source
         uses: actions/checkout@v7
         with:
           repository: wirestead/wirestead-docs
@@ -356,7 +355,7 @@ jobs:
       - name: Checkout Wirestead core for docs generation
         uses: actions/checkout@v7
         with:
-          path: docs-src/external/unilink
+          path: docs-src/external/wirestead
 
       - name: Install Doxygen
         run: |


### PR DESCRIPTION
## Summary
- `coverage.yml` checked the core repo out to `docs-src/external/unilink` for Doxygen generation, but `wirestead-docs`'s Doxyfile (`INPUT = external/wirestead/wirestead`) and `generate_docs.sh` expect `external/wirestead`. Confirmed on the live site: `annotated.html`, `classes.html`, `namespaces.html`, `files.html`, and `hierarchy.html` all return 404 even though the workflow reports success.

## Changes
- `.github/workflows/coverage.yml`: checkout path for the core repo changed from `docs-src/external/unilink` to `docs-src/external/wirestead`.
- Dropped stale "legacy docs"/"legacy wirestead/wirestead-docs...until moved" wording now that `wirestead-docs` is the current, already-renamed repo.

## Test plan
- [x] Verified live 404s on the deployed Pages site before this fix (`annotated.html`, `classes.html`, `namespaces.html`, `files.html`, `hierarchy.html`)
- [ ] Confirm the next `Code Coverage` workflow run on `main` publishes a populated API reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJG9XmyLLHzqzUH8Lsu4Ex