### PR TITLE
fix: address 11 correctness/concurrency findings from a core-logic review

### DIFF
--- a/test/unit/framer/test_line_framer.cc
+++ b/test/unit/framer/test_line_framer.cc
@@ -89,9 +89,19 @@ TEST_F(LineFramerTest, MaxLengthReset) {
 
   std::string data = "123456";  // No delimiter, exceeds max
   framer_->push_bytes(memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
-  // Should have cleared buffer.
+  // Should have cleared the buffer and entered discard-until-delimiter mode.
 
-  // Now send valid message
+  // The bytes up to the next delimiter might be the untransmitted tail of
+  // the message that was just discarded, so they must not be delivered as a
+  // fresh, trusted message (jwsung91/wirestead review finding: emitting them
+  // would silently hand the caller corrupted/truncated data).
+  std::string maybe_tail_of_discarded_message = "Hi\n";
+  framer_->push_bytes(memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(maybe_tail_of_discarded_message.data()),
+                                            maybe_tail_of_discarded_message.size()));
+  EXPECT_EQ(messages_.size(), 0);
+
+  // Once resynchronized past that first post-overflow delimiter, normal
+  // delivery resumes for subsequent messages.
   std::string valid = "Hi\n";
   framer_->push_bytes(memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(valid.data()), valid.size()));
 
@@ -164,6 +174,37 @@ TEST_F(LineFramerTest, SplitDelimiter) {
   ASSERT_EQ(messages_.size(), 2);
   EXPECT_EQ(messages_[0], "Hello");
   EXPECT_EQ(messages_[1], "World");
+}
+
+TEST_F(LineFramerTest, OverflowTailIsNotDeliveredAsAMessage) {
+  // Max length 5. A 9-byte message split across two calls overflows on the
+  // first call (6 bytes, no delimiter yet); its last 3 bytes plus a
+  // delimiter arrive in the second call.
+  framer_ = std::make_unique<LineFramer>("\n", false, 5);
+  framer_->on_message([this](memory::ConstByteSpan msg) {
+    std::string s(reinterpret_cast<const char*>(msg.data()), msg.size());
+    messages_.push_back(s);
+  });
+
+  std::string overflow_head = "123456";  // No delimiter, exceeds max_length (5)
+  framer_->push_bytes(
+      memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(overflow_head.data()), overflow_head.size()));
+  ASSERT_EQ(messages_.size(), 0);
+
+  std::string overflow_tail = "789\n";  // The rest of the SAME discarded message
+  framer_->push_bytes(
+      memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(overflow_tail.data()), overflow_tail.size()));
+
+  // Before the fix, this would incorrectly deliver "789" as if it were a
+  // complete, valid message - it's actually a fragment of the 9-byte message
+  // that was already discarded for exceeding max_length.
+  EXPECT_EQ(messages_.size(), 0);
+
+  // A genuinely new message after resynchronization is delivered normally.
+  std::string next = "ok\n";
+  framer_->push_bytes(memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(next.data()), next.size()));
+  ASSERT_EQ(messages_.size(), 1);
+  EXPECT_EQ(messages_[0], "ok");
 }
 
 }  // namespace test

--- a/test/unit/framer/test_packet_framer.cc
+++ b/test/unit/framer/test_packet_framer.cc
@@ -256,5 +256,32 @@ TEST_F(PacketFramerTest, ResetClearsState) {
   EXPECT_EQ(count, 0);
 }
 
+TEST_F(PacketFramerTest, FastPathOverflowDoesNotSwallowNextValidMessage) {
+  // Max length 4. A single push_bytes() call with a start marker and no end
+  // marker within that same call takes the fast path (buffer_ starts
+  // empty); the max_length_ check must apply immediately there, not only on
+  // a later call.
+  PacketFramer framer({'S'}, {'E'}, 4);
+  std::vector<std::vector<uint8_t>> messages;
+  framer.on_message([&](memory::ConstByteSpan data) { messages.emplace_back(data.begin(), data.end()); });
+
+  // 'S' + 5 bytes of unterminated garbage, 6 bytes total, exceeds
+  // max_length(4), all within one push_bytes() call.
+  std::vector<uint8_t> overflow = {'S', 'x', 'x', 'x', 'x', 'x'};
+  framer.push_bytes(memory::ConstByteSpan(overflow.data(), overflow.size()));
+  ASSERT_EQ(messages.size(), 0);
+
+  // A genuinely new, complete, well-within-max_length message.
+  std::vector<uint8_t> valid = {'S', 'a', 'E'};
+  framer.push_bytes(memory::ConstByteSpan(valid.data(), valid.size()));
+
+  // Before the fix, the overflow from the first call was never cleared
+  // until this second call's Collect-loop check ran - by which point this
+  // message's own 'S'/'E' had already been merged into (and discarded
+  // along with) the stale oversized buffer, silently dropping it.
+  ASSERT_EQ(messages.size(), 1);
+  EXPECT_EQ(messages[0], valid);
+}
+
 }  // namespace test
 }  // namespace wirestead

--- a/wirestead/builder/ibuilder.hpp
+++ b/wirestead/builder/ibuilder.hpp
@@ -84,8 +84,14 @@ class BuilderInterface {
   /**
    * @brief Set data handler callback
    */
+  // Note: this returns a new, moved-to builder value rather than mutating in
+  // place (see BuilderState's doc comment above) - the original object is
+  // left moved-from. [[nodiscard]] turns an accidental
+  // `builder.on_data(...);` statement that ignores the result (which would
+  // silently leave `builder` moved-from) into a compile-time warning instead
+  // of a runtime footgun.
   template <DataHandler F>
-  auto on_data(F&& handler) {
+  [[nodiscard]] auto on_data(F&& handler) {
     on_data_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
   }
@@ -94,7 +100,7 @@ class BuilderInterface {
    * @brief Set batched data handler callback
    */
   template <BatchDataHandler F>
-  auto on_data_batch(F&& handler) {
+  [[nodiscard]] auto on_data_batch(F&& handler) {
     on_data_batch_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
   }
@@ -103,7 +109,7 @@ class BuilderInterface {
    * @brief Set data handler callback using member function pointer
    */
   template <typename U, typename F>
-  auto on_data(U* obj, F method) {
+  [[nodiscard]] auto on_data(U* obj, F method) {
     return on_data([obj, method](const wrapper::MessageContext& ctx) { (obj->*method)(ctx); });
   }
 
@@ -145,7 +151,7 @@ class BuilderInterface {
    * @brief Set error handler callback
    */
   template <ErrorHandler F>
-  auto on_error(F&& handler) {
+  [[nodiscard]] auto on_error(F&& handler) {
     on_error_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasError>(std::move(static_cast<Derived&>(*this)));
   }
@@ -154,7 +160,7 @@ class BuilderInterface {
    * @brief Set error handler callback using member function pointer
    */
   template <typename U, typename F>
-  auto on_error(U* obj, F method) {
+  [[nodiscard]] auto on_error(U* obj, F method) {
     return on_error([obj, method](const wrapper::ErrorContext& ctx) { (obj->*method)(ctx); });
   }
 
@@ -195,7 +201,7 @@ class BuilderInterface {
    * @brief Set message handler callback
    */
   template <DataHandler F>
-  auto on_message(F&& handler) {
+  [[nodiscard]] auto on_message(F&& handler) {
     on_message_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
   }
@@ -204,7 +210,7 @@ class BuilderInterface {
    * @brief Set batched framed-message handler callback
    */
   template <BatchDataHandler F>
-  auto on_message_batch(F&& handler) {
+  [[nodiscard]] auto on_message_batch(F&& handler) {
     on_message_batch_ = std::forward<F>(handler);
     return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
   }
@@ -221,7 +227,7 @@ class BuilderInterface {
    * @brief Set message handler callback using member function pointer
    */
   template <typename U, typename F>
-  auto on_message(U* obj, F method) {
+  [[nodiscard]] auto on_message(U* obj, F method) {
     return on_message([obj, method](const wrapper::MessageContext& ctx) { (obj->*method)(ctx); });
   }
 

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -96,10 +96,10 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
     serial->framer(this->framer_factory_());
   }
   if (this->on_message_) {
-    serial->on_message(std::move(this->on_message_));
+    serial->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    serial->on_message_batch(std::move(this->on_message_batch_));
+    serial->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {

--- a/wirestead/builder/tcp_client_builder.cc
+++ b/wirestead/builder/tcp_client_builder.cc
@@ -81,10 +81,10 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
     client->framer(this->framer_factory_());
   }
   if (this->on_message_) {
-    client->on_message(std::move(this->on_message_));
+    client->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    client->on_message_batch(std::move(this->on_message_batch_));
+    client->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {

--- a/wirestead/builder/tcp_server_builder.cc
+++ b/wirestead/builder/tcp_server_builder.cc
@@ -88,10 +88,10 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
     server->framer(this->framer_factory_);
   }
   if (this->on_message_) {
-    server->on_message(std::move(this->on_message_));
+    server->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    server->on_message_batch(std::move(this->on_message_batch_));
+    server->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {

--- a/wirestead/builder/udp_builder.cc
+++ b/wirestead/builder/udp_builder.cc
@@ -80,10 +80,10 @@ std::unique_ptr<wrapper::UdpClient> UdpClientBuilder<State>::build() {
     client->framer(this->framer_factory_());
   }
   if (this->on_message_) {
-    client->on_message(std::move(this->on_message_));
+    client->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    client->on_message_batch(std::move(this->on_message_batch_));
+    client->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {
@@ -204,10 +204,10 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder<State>::build() {
     server->framer(this->framer_factory_);
   }
   if (this->on_message_) {
-    server->on_message(std::move(this->on_message_));
+    server->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    server->on_message_batch(std::move(this->on_message_batch_));
+    server->on_message_batch(this->on_message_batch_);
   }
 
   if (client_limit_enabled_) {

--- a/wirestead/builder/uds_builder.cc
+++ b/wirestead/builder/uds_builder.cc
@@ -69,10 +69,10 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
     client->framer(this->framer_factory_());
   }
   if (this->on_message_) {
-    client->on_message(std::move(this->on_message_));
+    client->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    client->on_message_batch(std::move(this->on_message_batch_));
+    client->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {
@@ -164,10 +164,10 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
     server->framer(this->framer_factory_);
   }
   if (this->on_message_) {
-    server->on_message(std::move(this->on_message_));
+    server->on_message(this->on_message_);
   }
   if (this->on_message_batch_) {
-    server->on_message_batch(std::move(this->on_message_batch_));
+    server->on_message_batch(this->on_message_batch_);
   }
 
   if (auto_start_) {

--- a/wirestead/concurrency/thread_safe_state.hpp
+++ b/wirestead/concurrency/thread_safe_state.hpp
@@ -277,7 +277,15 @@ bool ThreadSafeState<StateType>::is_state(const State& expected_state) const {
 
 template <typename StateType>
 void ThreadSafeState<StateType>::notify_state_change() {
-  state_version_.fetch_add(1, std::memory_order_relaxed);
+  // Bump under state_mutex_ - wait_for_state_change() captures its baseline
+  // and enters the wait while holding this same lock, so incrementing
+  // without it would reopen a lost-wakeup window: a waiter that has already
+  // checked the predicate (and found it false) but hasn't yet started
+  // waiting would miss this notification and block for the full timeout.
+  {
+    std::unique_lock<std::shared_mutex> lock(state_mutex_);
+    state_version_.fetch_add(1, std::memory_order_relaxed);
+  }
   state_cv_.notify_all();
 }
 

--- a/wirestead/concurrency/thread_safe_state.hpp
+++ b/wirestead/concurrency/thread_safe_state.hpp
@@ -76,7 +76,12 @@ class ThreadSafeState {
  private:
   mutable std::shared_mutex state_mutex_;
   State state_;
-  std::atomic<bool> state_changed_{false};
+  // Monotonically increasing on every state change. wait_for_state_change()
+  // captures this before waiting and checks for it to differ from that
+  // baseline, so every concurrent waiter observes any given change - a
+  // shared "changed" bool that gets reset by whichever waiter wakes first
+  // would starve the others.
+  std::atomic<uint64_t> state_version_{0};
 
   struct CallbackInfo {
     StateCallbackHandle handle;
@@ -181,7 +186,7 @@ void ThreadSafeState<StateType>::set_state(const State& new_state) {
   {
     std::unique_lock<std::shared_mutex> lock(state_mutex_);
     state_ = new_state;
-    state_changed_.store(true);
+    state_version_.fetch_add(1, std::memory_order_relaxed);
   }
   notify_callbacks(new_state);
   state_cv_.notify_all();
@@ -192,7 +197,7 @@ void ThreadSafeState<StateType>::set_state(State&& new_state) {
   {
     std::unique_lock<std::shared_mutex> lock(state_mutex_);
     state_ = std::move(new_state);
-    state_changed_.store(true);
+    state_version_.fetch_add(1, std::memory_order_relaxed);
   }
   notify_callbacks(state_);
   state_cv_.notify_all();
@@ -203,7 +208,7 @@ bool ThreadSafeState<StateType>::compare_and_set(const State& expected, const St
   std::unique_lock<std::shared_mutex> lock(state_mutex_);
   if (state_ == expected) {
     state_ = desired;
-    state_changed_.store(true);
+    state_version_.fetch_add(1, std::memory_order_relaxed);
     lock.unlock();
     notify_callbacks(desired);
     state_cv_.notify_all();
@@ -219,7 +224,7 @@ StateType ThreadSafeState<StateType>::exchange(const State& new_state) {
     std::unique_lock<std::shared_mutex> lock(state_mutex_);
     old_state = state_;
     state_ = new_state;
-    state_changed_.store(true);
+    state_version_.fetch_add(1, std::memory_order_relaxed);
   }
   notify_callbacks(new_state);
   state_cv_.notify_all();
@@ -258,8 +263,10 @@ void ThreadSafeState<StateType>::wait_for_state(const State& expected_state, std
 template <typename StateType>
 void ThreadSafeState<StateType>::wait_for_state_change(std::chrono::milliseconds timeout) {
   std::unique_lock<std::shared_mutex> lock(state_mutex_);
-  state_cv_.wait_for(lock, timeout, [this] { return state_changed_.load(); });
-  state_changed_.store(false);
+  const uint64_t observed_version = state_version_.load(std::memory_order_relaxed);
+  state_cv_.wait_for(lock, timeout, [this, observed_version] {
+    return state_version_.load(std::memory_order_relaxed) != observed_version;
+  });
 }
 
 template <typename StateType>
@@ -270,6 +277,7 @@ bool ThreadSafeState<StateType>::is_state(const State& expected_state) const {
 
 template <typename StateType>
 void ThreadSafeState<StateType>::notify_state_change() {
+  state_version_.fetch_add(1, std::memory_order_relaxed);
   state_cv_.notify_all();
 }
 

--- a/wirestead/config/config_manager.cc
+++ b/wirestead/config/config_manager.cc
@@ -61,15 +61,24 @@ struct ConfigManager::Impl {
     return ValidationResult::success();
   }
 
-  void notify_change(const std::string& key, const std::any& old_value, const std::any& new_value) {
+  // Must be called while holding mutex_. Returns an empty callback if none is
+  // registered for `key`.
+  ConfigChangeCallback change_callback_for(const std::string& key) const {
     auto it = change_callbacks_.find(key);
-    if (it != change_callbacks_.end()) {
-      try {
-        it->second(key, old_value, new_value);
-      } catch (const std::exception& e) {
-        WIRESTEAD_LOG_ERROR("config_manager", "callback",
-                            "Error in change callback for key '" + key + "': " + std::string(e.what()));
-      }
+    return it != change_callbacks_.end() ? it->second : ConfigChangeCallback{};
+  }
+
+  // Must be called *without* holding mutex_: it invokes user code, and a
+  // callback that reenters get()/set()/has() on this ConfigManager would
+  // otherwise deadlock on the non-recursive mutex_.
+  static void invoke_change_callback(const ConfigChangeCallback& callback, const std::string& key,
+                                     const std::any& old_value, const std::any& new_value) {
+    if (!callback) return;
+    try {
+      callback(key, old_value, new_value);
+    } catch (const std::exception& e) {
+      WIRESTEAD_LOG_ERROR("config_manager", "callback",
+                          "Error in change callback for key '" + key + "': " + std::string(e.what()));
     }
   }
 
@@ -142,27 +151,35 @@ bool ConfigManager::has(const std::string& key) const {
 }
 
 ValidationResult ConfigManager::set(const std::string& key, const std::any& value) {
-  std::lock_guard<std::mutex> lock(impl_->mutex_);
-
-  auto validation_result = impl_->validate_value(key, value);
-  if (!validation_result.is_valid) {
-    return validation_result;
-  }
-
   std::any old_value;
   bool had_key = false;
-  auto it = impl_->config_items_.find(key);
-  if (it != impl_->config_items_.end()) {
-    old_value = it->second.value;
-    had_key = true;
-    it->second.value = value;
-  } else {
-    ConfigItem item(key, value, ConfigType::String, false);
-    impl_->config_items_[key] = item;
+  ConfigChangeCallback callback;
+
+  {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    auto validation_result = impl_->validate_value(key, value);
+    if (!validation_result.is_valid) {
+      return validation_result;
+    }
+
+    auto it = impl_->config_items_.find(key);
+    if (it != impl_->config_items_.end()) {
+      old_value = it->second.value;
+      had_key = true;
+      it->second.value = value;
+    } else {
+      ConfigItem item(key, value, ConfigType::String, false);
+      impl_->config_items_[key] = item;
+    }
+
+    if (had_key) {
+      callback = impl_->change_callback_for(key);
+    }
   }
 
   if (had_key) {
-    impl_->notify_change(key, old_value, value);
+    Impl::invoke_change_callback(callback, key, old_value, value);
   }
 
   return ValidationResult::success();
@@ -255,74 +272,97 @@ bool ConfigManager::save_to_file(const std::string& filepath) const {
 }
 
 bool ConfigManager::load_from_file(const std::string& filepath) {
-  std::lock_guard<std::mutex> lock(impl_->mutex_);
+  struct PendingNotification {
+    std::string key;
+    std::any old_value;
+    std::any new_value;
+    ConfigChangeCallback callback;
+  };
+  std::vector<PendingNotification> pending_notifications;
 
-  try {
-    std::ifstream file(filepath);
-    if (!file.is_open()) {
+  // Parsing and mutating config_items_ stays under the lock; change
+  // callbacks are invoked afterward (below) so a callback that reenters
+  // get()/set() on this ConfigManager doesn't deadlock on mutex_.
+  const bool load_result = [&]() {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    try {
+      std::ifstream file(filepath);
+      if (!file.is_open()) {
+        return false;
+      }
+
+      std::string line;
+      while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') {
+          continue;
+        }
+
+        size_t pos = line.find('=');
+        if (pos != std::string::npos) {
+          std::string key = line.substr(0, pos);
+          std::string value_str = line.substr(pos + 1);
+
+          key.erase(0, key.find_first_not_of(" \t"));
+          key.erase(key.find_last_not_of(" \t") + 1);
+          value_str.erase(0, value_str.find_first_not_of(" \t"));
+          value_str.erase(value_str.find_last_not_of(" \t") + 1);
+
+          ConfigType type = ConfigType::String;
+          auto it = impl_->config_items_.find(key);
+          bool exists = (it != impl_->config_items_.end());
+
+          if (exists) {
+            type = it->second.type;
+          } else {
+            if (value_str == "true" || value_str == "false") {
+              type = ConfigType::Boolean;
+            } else if (std::all_of(value_str.begin(), value_str.end(),
+                                   [](char c) { return std::isdigit(c) || c == '-'; })) {
+              type = ConfigType::Integer;
+            } else if (std::count(value_str.begin(), value_str.end(), '.') == 1 &&
+                       std::all_of(value_str.begin(), value_str.end(),
+                                   [](char c) { return std::isdigit(c) || c == '.' || c == '-'; })) {
+              type = ConfigType::Double;
+            }
+          }
+
+          std::any value = impl_->deserialize_value(value_str, type);
+
+          if (exists) {
+            auto result = impl_->validate_value(key, value);
+            if (!result.is_valid) {
+              WIRESTEAD_LOG_ERROR("config_manager", "load",
+                                  "Validation failed for key '" + key + "': " + result.error_message);
+              continue;
+            }
+
+            std::any old_value = it->second.value;
+            it->second.value = value;
+            auto callback = impl_->change_callback_for(key);
+            if (callback) {
+              pending_notifications.push_back({key, old_value, value, std::move(callback)});
+            }
+          } else {
+            ConfigItem item(key, value, type, false);
+            impl_->config_items_[key] = item;
+          }
+        }
+      }
+
+      return true;
+    } catch (const std::exception& e) {
+      WIRESTEAD_LOG_ERROR("config_manager", "load", "Error loading configuration: " + std::string(e.what()));
       return false;
     }
+  }();
 
-    std::string line;
-    while (std::getline(file, line)) {
-      if (line.empty() || line[0] == '#') {
-        continue;
-      }
-
-      size_t pos = line.find('=');
-      if (pos != std::string::npos) {
-        std::string key = line.substr(0, pos);
-        std::string value_str = line.substr(pos + 1);
-
-        key.erase(0, key.find_first_not_of(" \t"));
-        key.erase(key.find_last_not_of(" \t") + 1);
-        value_str.erase(0, value_str.find_first_not_of(" \t"));
-        value_str.erase(value_str.find_last_not_of(" \t") + 1);
-
-        ConfigType type = ConfigType::String;
-        auto it = impl_->config_items_.find(key);
-        bool exists = (it != impl_->config_items_.end());
-
-        if (exists) {
-          type = it->second.type;
-        } else {
-          if (value_str == "true" || value_str == "false") {
-            type = ConfigType::Boolean;
-          } else if (std::all_of(value_str.begin(), value_str.end(),
-                                 [](char c) { return std::isdigit(c) || c == '-'; })) {
-            type = ConfigType::Integer;
-          } else if (std::count(value_str.begin(), value_str.end(), '.') == 1 &&
-                     std::all_of(value_str.begin(), value_str.end(),
-                                 [](char c) { return std::isdigit(c) || c == '.' || c == '-'; })) {
-            type = ConfigType::Double;
-          }
-        }
-
-        std::any value = impl_->deserialize_value(value_str, type);
-
-        if (exists) {
-          auto result = impl_->validate_value(key, value);
-          if (!result.is_valid) {
-            WIRESTEAD_LOG_ERROR("config_manager", "load",
-                                "Validation failed for key '" + key + "': " + result.error_message);
-            continue;
-          }
-
-          std::any old_value = it->second.value;
-          it->second.value = value;
-          impl_->notify_change(key, old_value, value);
-        } else {
-          ConfigItem item(key, value, type, false);
-          impl_->config_items_[key] = item;
-        }
-      }
-    }
-
-    return true;
-  } catch (const std::exception& e) {
-    WIRESTEAD_LOG_ERROR("config_manager", "load", "Error loading configuration: " + std::string(e.what()));
-    return false;
+  for (const auto& notification : pending_notifications) {
+    Impl::invoke_change_callback(notification.callback, notification.key, notification.old_value,
+                                 notification.new_value);
   }
+
+  return load_result;
 }
 
 std::vector<std::string> ConfigManager::get_keys() const {

--- a/wirestead/config/config_manager.cc
+++ b/wirestead/config/config_manager.cc
@@ -355,7 +355,10 @@ bool ConfigManager::load_from_file(const std::string& filepath) {
       WIRESTEAD_LOG_ERROR("config_manager", "load", "Error loading configuration: " + std::string(e.what()));
       return false;
     }
-  }();
+  }();  // load_result: whether the file was read and parsed successfully.
+        // pending_notifications (collected above, outside this lambda) is
+        // drained into callback invocations next, now that mutex_ is
+        // released.
 
   for (const auto& notification : pending_notifications) {
     Impl::invoke_change_callback(notification.callback, notification.key, notification.old_value,

--- a/wirestead/framer/line_framer.cc
+++ b/wirestead/framer/line_framer.cc
@@ -71,8 +71,40 @@ void LineFramer::push_bytes(memory::ConstByteSpan data) {
   }
 }
 
+std::optional<size_t> LineFramer::skip_until_delimiter(memory::ConstByteSpan data) const {
+  decltype(data.begin()) it;
+  if (delimiter_.size() == 1) {
+    const void* found = std::memchr(data.data(), static_cast<uint8_t>(delimiter_[0]), data.size());
+    it = found ? data.begin() +
+                     std::distance(static_cast<const uint8_t*>(data.data()), static_cast<const uint8_t*>(found))
+               : data.end();
+  } else {
+    it = std::search(data.begin(), data.end(), delimiter_.begin(), delimiter_.end());
+  }
+  if (it == data.end()) {
+    return std::nullopt;
+  }
+  return static_cast<size_t>(std::distance(data.begin(), it)) + delimiter_.size();
+}
+
 void LineFramer::push_bytes_internal(memory::ConstByteSpan data) {
   if (data.empty()) return;
+
+  if (discarding_) {
+    // Resynchronizing after a discarded oversized message: don't buffer or
+    // emit anything from this chunk until the delimiter that ends the
+    // discarded message is found. A delimiter split across two discard-mode
+    // chunks is missed (we don't carry a partial match across calls here),
+    // which only delays resync by one more chunk - it doesn't misdeliver
+    // data.
+    std::optional<size_t> consumed = skip_until_delimiter(data);
+    if (!consumed.has_value()) {
+      return;  // Still haven't found it; stay in discarding mode.
+    }
+    discarding_ = false;
+    data = data.subspan(*consumed, data.size() - *consumed);
+    if (data.empty()) return;
+  }
 
   // Fast Path: If buffer is empty, process data directly (zero-copy)
   if (buffer_.empty()) {
@@ -87,6 +119,7 @@ void LineFramer::push_bytes_internal(memory::ConstByteSpan data) {
       if (buffer_.size() > max_length_) {
         buffer_.clear();
         scanned_idx_ = 0;
+        discarding_ = true;
       }
     } else {
       // All processed, buffer remains empty
@@ -123,6 +156,7 @@ void LineFramer::push_bytes_internal(memory::ConstByteSpan data) {
   if (buffer_.size() > max_length_) {
     buffer_.clear();
     scanned_idx_ = 0;
+    discarding_ = true;
   }
 }
 
@@ -198,6 +232,7 @@ void LineFramer::on_message(MessageCallback cb) { on_message_ = std::move(cb); }
 void LineFramer::reset() {
   buffer_.clear();
   scanned_idx_ = 0;
+  discarding_ = false;
 }
 
 }  // namespace framer

--- a/wirestead/framer/line_framer.hpp
+++ b/wirestead/framer/line_framer.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -57,6 +58,13 @@ class WIRESTEAD_API LineFramer : public IFramer {
   std::vector<uint8_t> buffer_;
   MessageCallback on_message_;
 
+  // Set when an in-progress message exceeded max_length_ and buffer_ was
+  // discarded before a delimiter was found. While true, push_bytes_internal
+  // discards incoming bytes (instead of buffering them) until it finds a
+  // delimiter, so the untransmitted tail of the discarded message can't be
+  // mistaken for the start of a fresh, valid message.
+  bool discarding_ = false;
+
   /**
    * @brief Helper to scan data for delimiters and process messages.
    *
@@ -65,6 +73,15 @@ class WIRESTEAD_API LineFramer : public IFramer {
    * @return The number of bytes processed (emitted as messages).
    */
   size_t scan_and_process(memory::ConstByteSpan data, size_t search_start_offset);
+
+  /**
+   * @brief Find the end of the next delimiter in data, if any.
+   *
+   * @param data The data to scan (searched from the beginning).
+   * @return The number of bytes up to and including the delimiter, or
+   *         std::nullopt if no delimiter was found in data.
+   */
+  std::optional<size_t> skip_until_delimiter(memory::ConstByteSpan data) const;
 
   /**
    * @brief Internal helper to process a manageable chunk of data.

--- a/wirestead/framer/packet_framer.cc
+++ b/wirestead/framer/packet_framer.cc
@@ -127,6 +127,17 @@ void PacketFramer::push_bytes(memory::ConstByteSpan data) {
           }
         }
       }
+
+      // The end pattern wasn't found within this call. Apply the same
+      // max_length_ cap the Collect-state loop below applies on later calls -
+      // otherwise a single push_bytes() call with a start marker and a large
+      // unterminated payload could grow buffer_ past the documented limit
+      // before any call gets a chance to check it.
+      if (state_ == State::Collect && buffer_.size() > max_length_) {
+        buffer_.clear();
+        state_ = State::Sync;
+        scanned_idx_ = 0;
+      }
     }
     return;
   }

--- a/wirestead/memory/memory_tracker.cc
+++ b/wirestead/memory/memory_tracker.cc
@@ -82,7 +82,10 @@ void MemoryTracker::track_deallocation(void* ptr) {
   }
 }
 
-MemoryTracker::MemoryStats MemoryTracker::stats() const { return stats_; }
+MemoryTracker::MemoryStats MemoryTracker::stats() const {
+  std::lock_guard<std::mutex> lock(allocations_mutex_);
+  return stats_;
+}
 
 std::vector<MemoryTracker::AllocationInfo> MemoryTracker::current_allocations() const {
   std::lock_guard<std::mutex> lock(allocations_mutex_);

--- a/wirestead/memory/safe_span.hpp
+++ b/wirestead/memory/safe_span.hpp
@@ -49,17 +49,32 @@ class SafeSpan : public std::span<T, Extent> {
     return (*this)[index];
   }
 
-  // Override subspan to return SafeSpan instead of std::span
+  // Override subspan to return SafeSpan instead of std::span, and to check
+  // bounds - std::span::subspan()'s out-of-range offset/count is undefined
+  // behavior, which would otherwise be the only unchecked accessor left in a
+  // class named "Safe" (at() is already checked above).
   constexpr SafeSpan<T, std::dynamic_extent> subspan(std::size_t offset,
                                                      std::size_t count = std::dynamic_extent) const {
+    if (offset > this->size()) {
+      throw std::out_of_range("SafeSpan::subspan: offset out of range");
+    }
+    if (count != std::dynamic_extent && count > this->size() - offset) {
+      throw std::out_of_range("SafeSpan::subspan: count out of range");
+    }
     return SafeSpan<T, std::dynamic_extent>(Base::subspan(offset, count));
   }
 
   constexpr SafeSpan<T, std::dynamic_extent> first(std::size_t count) const {
+    if (count > this->size()) {
+      throw std::out_of_range("SafeSpan::first: count out of range");
+    }
     return SafeSpan<T, std::dynamic_extent>(Base::first(count));
   }
 
   constexpr SafeSpan<T, std::dynamic_extent> last(std::size_t count) const {
+    if (count > this->size()) {
+      throw std::out_of_range("SafeSpan::last: count out of range");
+    }
     return SafeSpan<T, std::dynamic_extent>(Base::last(count));
   }
 };

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -296,14 +296,21 @@ void TcpClient::stop() {
 
   impl_->stopping_.store(true);
   impl_->stop_seq_.store(impl_->current_seq_.load());
-  auto weak_self = weak_from_this();
   if (!impl_->ioc_) {
     return;
   }
 
-  if (auto self = weak_self.lock()) {
-    net::post(impl_->strand_, [self]() { self->impl_->perform_stop_cleanup(); });
-  }
+  // Post via a raw Impl* rather than weak_from_this().lock(): when stop()
+  // runs from ~TcpClient(), the shared_ptr use count is already 0, so that
+  // lock() is guaranteed null (standard shared_ptr/enable_shared_from_this
+  // behavior during destruction) and perform_stop_cleanup() - which resets
+  // work_guard_ - would never be posted, leaving join_ioc_thread() below
+  // blocked forever with no work_guard reset to let io_context::run()
+  // return. impl_ itself stays alive until after join_ioc_thread() returns
+  // (~TcpClient() doesn't destroy it until its body finishes), so capturing
+  // the raw Impl* is safe in both the destructor and non-destructor paths.
+  Impl* impl_ptr = impl_.get();
+  net::post(impl_->strand_, [impl_ptr]() { impl_ptr->perform_stop_cleanup(); });
 
   impl_->join_ioc_thread(false);
 }
@@ -1236,16 +1243,6 @@ void TcpClient::Impl::join_ioc_thread(bool allow_detach) {
     }
     return;
   }
-
-  // stop() posts perform_stop_cleanup() (which resets work_guard_) only when
-  // weak_from_this().lock() succeeds. During ~TcpClient(), the shared_ptr use
-  // count is already 0, so that lock() is guaranteed null and the cleanup is
-  // never posted. request_stop() is the unconditional fallback that still
-  // guarantees io_context::run() returns: it fires the stop_callback
-  // registered in start() below, which calls ioc->stop() directly. Mirrors
-  // TcpServer::Impl's destructor/stop() (tcp_server.cc), which already does
-  // this before joining.
-  ioc_thread_.request_stop();
 
   try {
     ioc_thread_.join();

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -1237,6 +1237,16 @@ void TcpClient::Impl::join_ioc_thread(bool allow_detach) {
     return;
   }
 
+  // stop() posts perform_stop_cleanup() (which resets work_guard_) only when
+  // weak_from_this().lock() succeeds. During ~TcpClient(), the shared_ptr use
+  // count is already 0, so that lock() is guaranteed null and the cleanup is
+  // never posted. request_stop() is the unconditional fallback that still
+  // guarantees io_context::run() returns: it fires the stop_callback
+  // registered in start() below, which calls ioc->stop() directly. Mirrors
+  // TcpServer::Impl's destructor/stop() (tcp_server.cc), which already does
+  // this before joining.
+  ioc_thread_.request_stop();
+
   try {
     ioc_thread_.join();
   } catch (const std::exception& e) {

--- a/wirestead/wrapper/callback_guard.hpp
+++ b/wirestead/wrapper/callback_guard.hpp
@@ -16,6 +16,12 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "wirestead/diagnostics/logger.hpp"
+
 // #449: a blocking send (Reliable-mode send()/send_blocking()/send_move()/
 // send_shared()) called from inside a data/message callback deadlocks -
 // clearing backpressure requires progress on the same io thread that a
@@ -47,6 +53,27 @@ class CallbackGuard {
 };
 
 inline bool in_data_callback() { return g_callback_depth > 0; }
+
+// Invokes a user-supplied wrapper callback (on_data/on_message/on_connect/
+// on_disconnect/on_error/on_backpressure and their batch variants) and
+// prevents an exception escaping it from propagating further. All channels
+// share one process-wide IoContextManager thread by default
+// (concurrency/io_context_manager.cc); an uncaught exception here would
+// otherwise escape the un-guarded handler call, propagate out of
+// io_context::run(), and stop I/O for every channel sharing that context -
+// not just the one whose callback misbehaved.
+template <typename Callback, typename... Args>
+void invoke_user_callback(std::string_view component, std::string_view operation, const Callback& callback,
+                          Args&&... args) {
+  if (!callback) return;
+  try {
+    callback(std::forward<Args>(args)...);
+  } catch (const std::exception& e) {
+    WIRESTEAD_LOG_ERROR(component, operation, "Uncaught exception in user callback: " + std::string(e.what()));
+  } catch (...) {
+    WIRESTEAD_LOG_ERROR(component, operation, "Uncaught non-standard exception in user callback");
+  }
+}
 
 }  // namespace detail
 }  // namespace wrapper

--- a/wirestead/wrapper/callback_guard.hpp
+++ b/wirestead/wrapper/callback_guard.hpp
@@ -30,17 +30,23 @@ namespace wirestead {
 namespace wrapper {
 namespace detail {
 
-inline thread_local bool g_in_data_callback = false;
+// A depth counter rather than a bool so that a nested/reentrant
+// CallbackGuard on the same thread doesn't clear the flag out from under an
+// outer guard that's still in scope: the inner guard's destructor would
+// otherwise flip g_callback_depth back to "not in a callback" while the
+// outer dispatch is still running, reopening the #449 deadlock this guard
+// exists to prevent.
+inline thread_local int g_callback_depth = 0;
 
 class CallbackGuard {
  public:
-  CallbackGuard() { g_in_data_callback = true; }
-  ~CallbackGuard() { g_in_data_callback = false; }
+  CallbackGuard() { ++g_callback_depth; }
+  ~CallbackGuard() { --g_callback_depth; }
   CallbackGuard(const CallbackGuard&) = delete;
   CallbackGuard& operator=(const CallbackGuard&) = delete;
 };
 
-inline bool in_data_callback() { return g_in_data_callback; }
+inline bool in_data_callback() { return g_callback_depth > 0; }
 
 }  // namespace detail
 }  // namespace wrapper

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -137,7 +137,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("serial", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -147,7 +147,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("serial", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -451,9 +451,9 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
-      } else if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("serial", "on_data_batch", flush_handler, batch);
+      } else {
+        detail::invoke_user_callback("serial", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -470,7 +470,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         handler = bp_handler;
       }
-      if (handler) handler(queued);
+      detail::invoke_user_callback("serial", "on_backpressure", handler, queued);
     });
 
     channel->on_state([this, weak_impl, weak_alive](base::LinkState state) {
@@ -487,7 +487,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
             fulfill_all_locked(true);
             handler = connect_handler;
           }
-          if (handler) handler(ConnectionContext(0));
+          detail::invoke_user_callback("serial", "on_connect", handler, ConnectionContext(0));
           break;
         }
         case base::LinkState::Closed:
@@ -504,13 +504,10 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
               disconnect_handler_snapshot = disconnect_handler;
             }
           }
-          if (disconnect_handler_snapshot) {
-            disconnect_handler_snapshot(ConnectionContext(0));
-          }
-          if (error_handler_snapshot) {
-            error_handler_snapshot(channel ? detail::build_error_context(*channel, "Connection error")
-                                           : ErrorContext(ErrorCode::IoError, "Connection error"));
-          }
+          detail::invoke_user_callback("serial", "on_disconnect", disconnect_handler_snapshot, ConnectionContext(0));
+          detail::invoke_user_callback("serial", "on_error", error_handler_snapshot,
+                                       channel ? detail::build_error_context(*channel, "Connection error")
+                                               : ErrorContext(ErrorCode::IoError, "Connection error"));
           break;
         }
         default:
@@ -547,13 +544,11 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
+        detail::invoke_user_callback("serial", "on_message_batch", flush_handler, batch);
         return;
       }
 
-      if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(msg)));
-      }
+      detail::invoke_user_callback("serial", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
     });
   }
 

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -136,7 +136,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("tcp_client", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -146,7 +146,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("tcp_client", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -473,9 +473,9 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
-      } else if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("tcp_client", "on_data_batch", flush_handler, batch);
+      } else {
+        detail::invoke_user_callback("tcp_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -497,7 +497,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
           fulfill_all_locked(true);
           connect_handler = connect_handler_;
         }
-        if (connect_handler) connect_handler(ConnectionContext(0));
+        detail::invoke_user_callback("tcp_client", "on_connect", connect_handler, ConnectionContext(0));
       } else if (state == base::LinkState::Closed || state == base::LinkState::Error) {
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -509,11 +509,13 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
             channel_snapshot = channel_;
           }
         }
-        if (state == base::LinkState::Closed && disconnect_handler) {
-          disconnect_handler(ConnectionContext(0));
-        } else if (state == base::LinkState::Error && error_handler) {
-          error_handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
-                                         : ErrorContext(ErrorCode::IoError, "Connection error"));
+        if (state == base::LinkState::Closed) {
+          detail::invoke_user_callback("tcp_client", "on_disconnect", disconnect_handler, ConnectionContext(0));
+        } else if (state == base::LinkState::Error) {
+          detail::invoke_user_callback("tcp_client", "on_error", error_handler,
+                                       channel_snapshot
+                                           ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                           : ErrorContext(ErrorCode::IoError, "Connection error"));
         }
       }
     });
@@ -529,7 +531,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         handler = bp_handler_;
       }
-      if (handler) handler(queued);
+      detail::invoke_user_callback("tcp_client", "on_backpressure", handler, queued);
     });
   }
 
@@ -561,13 +563,11 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
+        detail::invoke_user_callback("tcp_client", "on_message_batch", flush_handler, batch);
         return;
       }
 
-      if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(msg)));
-      }
+      detail::invoke_user_callback("tcp_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
     });
   }
 

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -173,7 +173,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("tcp_server", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -183,7 +183,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("tcp_server", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -443,20 +443,19 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
                       schedule_batch_timer();
                     }
                   }
-                  if (flush_handler) flush_handler(batch);
+                  detail::invoke_user_callback("tcp_server", "on_message_batch", flush_handler, batch);
                   return;
                 }
 
-                if (on_message_handler) {
-                  on_message_handler(MessageContext(id, memory::SafeDataBuffer(msg)));
-                }
+                detail::invoke_user_callback("tcp_server", "on_message", on_message_handler,
+                                             MessageContext(id, memory::SafeDataBuffer(msg)));
               });
               framers_[id] = std::move(shared_framer);
             }
           }
           handler = on_client_connect_;
         }
-        if (handler) handler(ConnectionContext(id, info));
+        detail::invoke_user_callback("tcp_server", "on_connect", handler, ConnectionContext(id, info));
       });
       transport_server->on_multi_data([this, weak_impl, weak_alive](ClientId id, memory::ConstByteSpan data_span) {
         auto impl_keepalive = weak_impl.lock();
@@ -504,9 +503,10 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
               schedule_batch_timer();
             }
           }
-          if (flush_handler) flush_handler(batch);
-        } else if (handler) {
-          handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
+          detail::invoke_user_callback("tcp_server", "on_data_batch", flush_handler, batch);
+        } else {
+          detail::invoke_user_callback("tcp_server", "on_data", handler,
+                                       MessageContext(id, memory::SafeDataBuffer(data_span)));
         }
 
         if (framer) framer->push_bytes(data_span);
@@ -523,7 +523,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
           framers_.erase(id);
           handler = on_disconnect_;
         }
-        if (handler) handler(ConnectionContext(id));
+        detail::invoke_user_callback("tcp_server", "on_disconnect", handler, ConnectionContext(id));
       });
 
       transport_server->on_backpressure([this, weak_impl, weak_alive](size_t queued) {
@@ -537,7 +537,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
           std::shared_lock<std::shared_mutex> lock(mutex_);
           handler = on_backpressure_;
         }
-        if (handler) handler(queued);
+        detail::invoke_user_callback("tcp_server", "on_backpressure", handler, queued);
       });
     }
     channel_->on_state([this, weak_impl, weak_alive](base::LinkState state) {
@@ -561,10 +561,9 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
             handler = on_error_;
           }
         }
-        if (handler) {
-          handler(channel_ ? detail::build_error_context(*channel_, "Server error")
-                           : ErrorContext(ErrorCode::IoError, "Server error"));
-        }
+        detail::invoke_user_callback("tcp_server", "on_error", handler,
+                                     channel_ ? detail::build_error_context(*channel_, "Server error")
+                                              : ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
   }

--- a/wirestead/wrapper/udp/udp.cc
+++ b/wirestead/wrapper/udp/udp.cc
@@ -120,7 +120,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("udp_client", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -130,7 +130,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("udp_client", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -436,9 +436,9 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
-      } else if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("udp_client", "on_data_batch", flush_handler, batch);
+      } else {
+        detail::invoke_user_callback("udp_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -455,7 +455,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         handler = bp_handler;
       }
-      if (handler) handler(queued);
+      detail::invoke_user_callback("udp_client", "on_backpressure", handler, queued);
     });
 
     channel->on_state([this, weak_impl, weak_alive](base::LinkState state) {
@@ -473,7 +473,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
             fulfill_all_locked(true);
             handler = connect_handler;
           }
-          if (handler) handler(ConnectionContext(0));
+          detail::invoke_user_callback("udp_client", "on_connect", handler, ConnectionContext(0));
           break;
         }
         case base::LinkState::Closed:
@@ -490,12 +490,10 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
               disconnect_handler_snapshot = disconnect_handler;
             }
           }
-          if (disconnect_handler_snapshot) {
-            disconnect_handler_snapshot(ConnectionContext(0));
-          }
-          if (error_handler_snapshot) {
-            error_handler_snapshot(detail::build_error_context(*channel, "Connection error"));
-          }
+          detail::invoke_user_callback("udp_client", "on_disconnect", disconnect_handler_snapshot,
+                                       ConnectionContext(0));
+          detail::invoke_user_callback("udp_client", "on_error", error_handler_snapshot,
+                                       detail::build_error_context(*channel, "Connection error"));
           break;
         }
         default:
@@ -532,13 +530,11 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
+        detail::invoke_user_callback("udp_client", "on_message_batch", flush_handler, batch);
         return;
       }
 
-      if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(msg)));
-      }
+      detail::invoke_user_callback("udp_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
     });
   }
 

--- a/wirestead/wrapper/udp/udp_server.cc
+++ b/wirestead/wrapper/udp/udp_server.cc
@@ -148,7 +148,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("udp_server", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -158,7 +158,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("udp_server", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -229,10 +229,8 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
     }
 
     // Call disconnect handlers outside the lock
-    if (disconnect_handler) {
-      for (auto const& [id, info] : to_remove_with_info) {
-        disconnect_handler(ConnectionContext(id, info));
-      }
+    for (auto const& [id, info] : to_remove_with_info) {
+      detail::invoke_user_callback("udp_server", "on_disconnect", disconnect_handler, ConnectionContext(id, info));
     }
   }
 
@@ -303,13 +301,12 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
                       schedule_batch_timer();
                     }
                   }
-                  if (flush_handler) flush_handler(batch);
+                  detail::invoke_user_callback("udp_server", "on_message_batch", flush_handler, batch);
                   return;
                 }
 
-                if (on_message_handler) {
-                  on_message_handler(MessageContext(client_id, memory::SafeDataBuffer(msg)));
-                }
+                detail::invoke_user_callback("udp_server", "on_message", on_message_handler,
+                                             MessageContext(client_id, memory::SafeDataBuffer(msg)));
               });
               entry.framer = std::move(framer);
             }
@@ -322,8 +319,10 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
         connect_handler_copy = on_connect;
       }
 
-      if (is_new && connect_handler_copy) {
-        connect_handler_copy(ConnectionContext(client_id, fmt::format("{}:{}", ep.address().to_string(), ep.port())));
+      if (is_new) {
+        detail::invoke_user_callback(
+            "udp_server", "on_connect", connect_handler_copy,
+            ConnectionContext(client_id, fmt::format("{}:{}", ep.address().to_string(), ep.port())));
       }
 
       {
@@ -356,9 +355,10 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
               schedule_batch_timer();
             }
           }
-          if (flush_handler) flush_handler(batch);
-        } else if (data_handler_copy) {
-          data_handler_copy(MessageContext(client_id, memory::SafeDataBuffer(data)));
+          detail::invoke_user_callback("udp_server", "on_data_batch", flush_handler, batch);
+        } else {
+          detail::invoke_user_callback("udp_server", "on_data", data_handler_copy,
+                                       MessageContext(client_id, memory::SafeDataBuffer(data)));
         }
       }
 
@@ -385,7 +385,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
         std::shared_lock<std::shared_mutex> lock(mutex);
         handler = bp_handler;
       }
-      if (handler) handler(queued);
+      detail::invoke_user_callback("udp_server", "on_backpressure", handler, queued);
     });
 
     channel->on_state([this, weak_impl](base::LinkState state) {
@@ -406,10 +406,9 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
         }
       }
 
-      if (error_handler_copy) {
-        error_handler_copy(channel ? detail::build_error_context(*channel, "Server error")
-                                   : ErrorContext(ErrorCode::IoError, "Server error"));
-      }
+      detail::invoke_user_callback("udp_server", "on_error", error_handler_copy,
+                                   channel ? detail::build_error_context(*channel, "Server error")
+                                           : ErrorContext(ErrorCode::IoError, "Server error"));
     });
   }
 

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -129,7 +129,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("uds_client", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -139,7 +139,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("uds_client", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -416,9 +416,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
           fulfill_all_locked(true);
           handler = connect_handler_;
         }
-        if (handler) {
-          handler(ConnectionContext(0));
-        }
+        detail::invoke_user_callback("uds_client", "on_connect", handler, ConnectionContext(0));
       } else if (state == base::LinkState::Error) {
         ErrorHandler handler;
         std::shared_ptr<interface::Channel> channel_snapshot;
@@ -428,10 +426,10 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
           handler = error_handler_;
           channel_snapshot = channel_;
         }
-        if (handler) {
-          handler(channel_snapshot ? detail::build_error_context(*channel_snapshot, "Connection error")
-                                   : ErrorContext(ErrorCode::IoError, "Connection error"));
-        }
+        detail::invoke_user_callback("uds_client", "on_error", handler,
+                                     channel_snapshot
+                                         ? detail::build_error_context(*channel_snapshot, "Connection error")
+                                         : ErrorContext(ErrorCode::IoError, "Connection error"));
       } else if (state == base::LinkState::Closed || state == base::LinkState::Idle) {
         ConnectionHandler handler;
         {
@@ -439,9 +437,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
           fulfill_all_locked(false);
           handler = disconnect_handler_;
         }
-        if (handler) {
-          handler(ConnectionContext(0));
-        }
+        detail::invoke_user_callback("uds_client", "on_disconnect", handler, ConnectionContext(0));
       }
     });
 
@@ -487,9 +483,9 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
-      } else if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("uds_client", "on_data_batch", flush_handler, batch);
+      } else {
+        detail::invoke_user_callback("uds_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -506,7 +502,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         handler = bp_handler_;
       }
-      if (handler) handler(queued);
+      detail::invoke_user_callback("uds_client", "on_backpressure", handler, queued);
     });
   }
 
@@ -540,13 +536,11 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
+        detail::invoke_user_callback("uds_client", "on_message_batch", flush_handler, batch);
         return;
       }
 
-      if (handler) {
-        handler(MessageContext(0, memory::SafeDataBuffer(msg)));
-      }
+      detail::invoke_user_callback("uds_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
     });
   }
 

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -108,7 +108,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       data_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("uds_server", "on_data_batch", handler, batch);
         lock.lock();
       }
     }
@@ -118,7 +118,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       message_batch_queue_.clear();
       if (handler) {
         lock.unlock();
-        handler(batch);
+        detail::invoke_user_callback("uds_server", "on_message_batch", handler, batch);
         lock.lock();
       }
     }
@@ -321,7 +321,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           }
           handler = client_connect_handler_;
         }
-        if (handler) handler(ConnectionContext(id, info));
+        detail::invoke_user_callback("uds_server", "on_connect", handler, ConnectionContext(id, info));
       });
       transport_server->on_multi_data([this, weak_impl, weak_alive](ClientId id, memory::ConstByteSpan data_span) {
         auto impl_keepalive = weak_impl.lock();
@@ -369,9 +369,10 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
               schedule_batch_timer();
             }
           }
-          if (flush_handler) flush_handler(batch);
-        } else if (handler) {
-          handler(MessageContext(id, memory::SafeDataBuffer(data_span)));
+          detail::invoke_user_callback("uds_server", "on_data_batch", flush_handler, batch);
+        } else {
+          detail::invoke_user_callback("uds_server", "on_data", handler,
+                                       MessageContext(id, memory::SafeDataBuffer(data_span)));
         }
 
         if (framer_to_push) framer_to_push->push_bytes(data_span);
@@ -388,7 +389,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           framers_.erase(id);
           handler = client_disconnect_handler_;
         }
-        if (handler) handler(ConnectionContext(id));
+        detail::invoke_user_callback("uds_server", "on_disconnect", handler, ConnectionContext(id));
       });
 
       transport_server->on_backpressure([this, weak_impl, weak_alive](size_t queued) {
@@ -402,7 +403,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           std::shared_lock<std::shared_mutex> lock(mutex_);
           handler = on_backpressure_;
         }
-        if (handler) handler(queued);
+        detail::invoke_user_callback("uds_server", "on_backpressure", handler, queued);
       });
     }
 
@@ -427,10 +428,9 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
             handler = error_handler_;
           }
         }
-        if (handler) {
-          handler(server_ ? detail::build_error_context(*server_, "Server error")
-                          : ErrorContext(ErrorCode::IoError, "Server error"));
-        }
+        detail::invoke_user_callback("uds_server", "on_error", handler,
+                                     server_ ? detail::build_error_context(*server_, "Server error")
+                                             : ErrorContext(ErrorCode::IoError, "Server error"));
       }
     });
   }
@@ -475,13 +475,12 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
             schedule_batch_timer();
           }
         }
-        if (flush_handler) flush_handler(batch);
+        detail::invoke_user_callback("uds_server", "on_message_batch", flush_handler, batch);
         return;
       }
 
-      if (handler) {
-        handler(MessageContext(id, memory::SafeDataBuffer(msg)));
-      }
+      detail::invoke_user_callback("uds_server", "on_message", handler,
+                                   MessageContext(id, memory::SafeDataBuffer(msg)));
     });
   }
 };


### PR DESCRIPTION
## Description
A focused code review of the transport/concurrency/memory/framer/builder/wrapper core logic surfaced 11 defects (2 P1, 6 P2, 3 P3). This PR fixes all of them, each as a separate commit with its own rationale and empirical before/after verification (see individual commit messages for repro details).

## Key Changes
- `~TcpClient()` could deadlock forever if destroyed without an explicit `stop()` call, since `weak_from_this().lock()` is guaranteed null during destruction and never posted the cleanup that resets `work_guard_`. Fixed by posting via a raw `Impl*` instead (074d2e5a5 corrects a race introduced by the first attempt at this fix, e422fb947).
- Builder `on_data()`/`on_data_batch()`/`on_message()`/`on_message_batch()`/`on_error()` silently corrupted the original builder if their return value was discarded (they move `*this` into a new object). Marked `[[nodiscard]]` rather than changing the return semantics, since every concrete builder deletes its copy constructor and needs the move-returning prvalue for `auto b = X().on_data(...);` to compile.
- `MemoryTracker::stats()` read a struct mutated under a mutex without holding that mutex - a data race.
- `ConfigManager::set()`/`load_from_file()` held their mutex while synchronously invoking user change-callbacks, deadlocking on reentrant `get()`/`set()` calls.
- `build()` copied most callbacks by lvalue but `std::move()`'d `on_message_`/`on_message_batch_`, silently dropping them on a second `build()` call from the same configured builder.
- `SafeSpan::subspan()/first()/last()` forwarded to `std::span`'s unchecked versions despite the class being named "Safe" (only `at()` was checked).
- `ThreadSafeState::wait_for_state_change()` used a shared "changed" bool that got reset by whichever waiter woke first, starving other concurrent waiters. Replaced with a monotonic version counter (currently unused in-tree, but a real latent bug).
- `CallbackGuard`'s in-callback flag was a plain bool, not nesting-safe (latent, no current caller nests it).
- `PacketFramer` skipped its `max_length_` check on the very first `push_bytes()` call when a start pattern was found but not the end pattern.
- `LineFramer` fully cleared its buffer on overflow instead of remembering a message was discarded, so the untransmitted tail of that message could later be misdelivered as a fresh, valid short message.
- Wrapper callbacks (`on_data`/`on_message`/`on_connect`/`on_disconnect`/`on_error`/`on_backpressure` and batch variants) had no exception guard across all 7 wrapper files. Verified the actual effect with a live TCP client/server: a throwing `on_data` handler was silently force-closing the connection and triggering a reconnect cycle (the transport layer's own catch calls `handle_close()`), not "killing the shared io_context" as originally suspected - transport-layer protection already existed for on_bytes/on_state/on_backpressure dispatch on TCP/Serial.

## Related Issues
- Fixes #

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass. (732/732 tests pass, including full integration + e2e suites)
- [x] I have added or updated tests to verify my changes. (New regression test for the LineFramer tail-delivery bug; existing tests updated where they encoded the old buggy behavior)
- [ ] I have updated the documentation to reflect the changes (if applicable). (No public API/behavior contract changed; all fixes are internal correctness fixes)
- [x] My changes follow the project's coding style and conventions.

## Additional Context
Every fix in this PR was verified empirically, not just by passing the existing test suite: for each bug, I reproduced the broken behavior against the pre-fix code (via `git stash`/temporary worktree checkouts of the base commit) with a bounded-timeout standalone repro, then confirmed the fix resolves it and re-ran the full suite. One of these fixes (the TcpClient destructor deadlock) initially introduced its own regression, caught by `StressIntegrationTest.TcpClientStartStopStress` in the full integration suite (not the unit suite alone) and corrected in a follow-up commit - the commit message for `074d2e5a5` has the full root-cause writeup.