### PR TITLE
docs: link the published wirestead-docs site from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Core repository entrypoints:
 
 Useful external repositories:
 
-* [Documentation](https://github.com/wirestead/wirestead-docs)
+* [Documentation](https://github.com/wirestead/wirestead-docs) ([published site](https://wirestead.github.io/wirestead-docs/))
 * [Python bindings](https://github.com/wirestead/wirestead-python)
 * [Examples](https://github.com/wirestead/wirestead-examples)
 * [Containers](https://github.com/wirestead/wirestead-container)


### PR DESCRIPTION
## Summary
Small follow-up to #549 — the external-repositories list linked only to
the `wirestead-docs` GitHub repo, not the live Pages site it now builds
and deploys.

## Changes
- `README.md`: added a link to https://wirestead.github.io/wirestead-docs/
  next to the existing `wirestead-docs` repo link.

## Validation
- [x] Ran: visual diff review (single-line Markdown link addition).
- Tests: not needed — documentation only.
- Documentation: this change is the documentation update.

## Not Included
Nothing else changed.

## Follow-up
None.