### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   wirestead
-  VERSION 0.9.0
+  VERSION 0.9.1
   DESCRIPTION
     "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"


### PR DESCRIPTION
## Description
Cutting a v0.9.1 patch release. There's real content since v0.9.0 (11 commits): a correctness/concurrency review fix (#548) plus several docs/CI cleanups. This also aligns the core version number with wirestead-python's upcoming 0.9.1 release (PyPI distribution, unilink/unilink_py shim removal).

## Key Changes
- Bump `project(wirestead VERSION ...)` in `CMakeLists.txt` from 0.9.0 to 0.9.1.

## Related Issues
- N/A

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [ ] My changes follow the project's coding style and conventions.

## Additional Context
- Ran a CMake configure (`-DWIRESTEAD_BUILD_TESTS=OFF -DWIRESTEAD_BUILD_DOCS=OFF -DWIRESTEAD_BUILD_EXAMPLES=OFF`) to confirm the version-only change doesn't break configuration. Didn't run the full test suite since no functional code changed.
- No public API or ABI changes; this is a version-number-only diff.