### PR TITLE
fix: match consumer sample MSVC runtime to the vcpkg static triplet

### DIFF
--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -224,6 +224,16 @@ jobs:
           cmake_minimum_required(VERSION 3.15)
           project(wirestead_consumer LANGUAGES CXX)
           set(CMAKE_CXX_STANDARD 20)
+
+          # vcpkg's static triplets build wirestead and its dependencies
+          # (spdlog, fmt) against the static MSVC runtime. Without this, the
+          # consumer executable defaults to the dynamic runtime and link
+          # fails with LNK2038/LNK2005 runtime-library mismatches.
+          cmake_policy(SET CMP0091 NEW)
+          if(VCPKG_TARGET_TRIPLET MATCHES "-static`$")
+            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded`$<`$<CONFIG:Debug>:Debug>")
+          endif()
+
           find_package(wirestead CONFIG REQUIRED)
 
           add_executable(vcpkg_consumer main.cpp)


### PR DESCRIPTION
## Description
The `Vcpkg Package Test` workflow's `windows-2022 - x64-windows-static` leg failed on the v0.9.1 tag push (it passed on v0.9.0 and every prior tag): https://github.com/wirestead/wirestead/actions/runs/30203376101

The consumer sample's generated `CMakeLists.txt` never set `CMAKE_MSVC_RUNTIME_LIBRARY`, so the consumer executable's own `main.obj` compiled against the dynamic CRT (`/MD`) while `wirestead.lib`, `spdlog.lib`, and `fmt.lib` (installed via vcpkg for the `x64-windows-static` triplet) are built against the static CRT (`/MT`). Linking failed with `LNK2038`/`LNK2005` runtime-library mismatches. This isn't a bug in `wirestead` itself — the library built correctly with the static CRT; only the test harness's own consumer executable had the wrong setting. It likely regressed because this workflow clones vcpkg's unpinned `master` branch on every run, and something in the toolchain's CRT-linkage defaults appears to have changed upstream between the v0.9.0 and v0.9.1 test runs.

## Key Changes
- Windows consumer sample `CMakeLists.txt` template (generated inline in `vcpkg-package-test.yml`): added `cmake_policy(SET CMP0091 NEW)` and set `CMAKE_MSVC_RUNTIME_LIBRARY` to the static CRT when `VCPKG_TARGET_TRIPLET` ends in `-static`, matching what vcpkg already builds the dependencies with.

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [ ] My changes follow the project's coding style and conventions.

## Additional Context
- Change is confined to a CI workflow file (a generated test-harness `CMakeLists.txt`), not library code — `scripts/verify.sh` doesn't cover this path.
- Verified the exact PowerShell here-string renders correctly (literal `` ` `` escapes produce literal `$` characters, not stray backslashes) by running the extracted snippet through `mcr.microsoft.com/powershell` in Docker and inspecting the emitted `CMakeLists.txt` content.
- Couldn't build-test on real Windows locally; this is `cmake_policy(SET CMP0091 NEW)` + `CMAKE_MSVC_RUNTIME_LIBRARY`, the standard documented fix for this exact CMake/MSVC/vcpkg static-CRT mismatch class of error. Real validation is the next `Vcpkg Package Test` run (triggers on `v*` tag push or `workflow_dispatch`).