### PR TITLE
docs: add changelog and Unilink migration guidance

### DIFF
--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -77,8 +77,8 @@ jobs:
         run: |
           set -euo pipefail
           if ! "${VCPKG_ROOT}/vcpkg" search wirestead | grep -q "^wirestead"; then
-            echo "wirestead port not found in vcpkg registry yet. Skipping package test."
-            echo "VCPKG_SKIP_PACKAGE_TEST=1" >> "$GITHUB_ENV"
+            echo "wirestead port not found in the vcpkg registry."
+            exit 1
           fi
 
       - name: Check wirestead port availability (Windows)
@@ -87,25 +87,25 @@ jobs:
         run: |
           $searchOutput = & "${env:VCPKG_ROOT}\vcpkg.exe" search wirestead
           if (-not ($searchOutput -match "^wirestead")) {
-            Write-Host "wirestead port not found in vcpkg registry yet. Skipping package test."
-            "VCPKG_SKIP_PACKAGE_TEST=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            Write-Error "wirestead port not found in the vcpkg registry."
+            exit 1
           }
 
       - name: Install wirestead via vcpkg (Unix)
-        if: runner.os != 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os != 'Windows'
         run: |
           "${VCPKG_ROOT}/vcpkg" install "wirestead:${{ matrix.triplet }}" \
             --clean-after-build
 
       - name: Install wirestead via vcpkg (Windows)
-        if: runner.os == 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           & "${env:VCPKG_ROOT}\vcpkg.exe" install "wirestead:${{ matrix.triplet }}" `
             --clean-after-build
 
       - name: Verify installation layout (Unix)
-        if: runner.os != 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os != 'Windows'
         run: |
           set -euo pipefail
           INSTALL_ROOT="${VCPKG_ROOT}/installed/${{ matrix.triplet }}"
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Verify installation layout (Windows)
-        if: runner.os == 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $installRoot = "$env:VCPKG_ROOT\installed\${{ matrix.triplet }}"
@@ -171,7 +171,7 @@ jobs:
           $libs + $dlls | ForEach-Object { Write-Host "  $_" }
 
       - name: Build and run consumer sample (Unix)
-        if: runner.os != 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os != 'Windows'
         run: |
           set -euo pipefail
           WORKDIR=$(mktemp -d)
@@ -214,7 +214,7 @@ jobs:
           "${WORKDIR}/build/vcpkg_consumer"
 
       - name: Build and run consumer sample (Windows)
-        if: runner.os == 'Windows' && env.VCPKG_SKIP_PACKAGE_TEST != '1'
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $workDir = Join-Path $env:RUNNER_TEMP "wirestead-consumer"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+All notable changes to Wirestead are documented in this file.
+
+This project follows the Keep a Changelog section names where practical. The
+core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
+and ABI policy.
+
+## Unreleased
+
+### Added
+
+- Documented the UniLink to Wirestead migration path and compatibility policy.
+
+### Changed
+
+- Clarified that the official vcpkg port is the canonical package-consumer
+  install path.
+
+### Deprecated
+
+- UniLink compatibility names remain deprecated compatibility surfaces for the
+  v0.9.x line.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+### Security
+
+- Nothing.
+
+## v0.9.1 - 2026-07-26
+
+### Changed
+
+- Linked the published `wirestead-docs` site from the README and updated
+  satellite repository links to the `wirestead` organization.
+- Updated vcpkg references after the `wirestead` port became available from the
+  vcpkg registry.
+- Moved docs and coverage Pages ownership to `wirestead-docs`.
+- Updated GitHub Actions dependency pins, including `actions/setup-python`.
+
+### Fixed
+
+- Addressed correctness and concurrency findings in builders, configuration
+  management, framers, callback guards, TCP/UDP/UDS wrappers, serial wrapper,
+  and related tests.
+- Fixed Doxygen checkout path handling so generated API reference content is
+  produced in the docs workflow.
+- Fixed dependabot auto-merge strategy.
+
+### Compatibility
+
+- No intentional public API removal was made in v0.9.1.
+- Known limitations remain the pre-1.0 ABI policy and the v0.9.x UniLink
+  compatibility layer described in `docs/migration-from-unilink.md`.
+
+## v0.9.0 - 2026-07-19
+
+### Changed
+
+- Renamed the canonical project identity from UniLink to Wirestead.
+- Changed the canonical C++ namespace from `unilink` to `wirestead`.
+- Changed canonical include paths from `<unilink/...>` to `<wirestead/...>`.
+- Changed the canonical CMake package from `unilink` to `wirestead`.
+- Changed the canonical CMake target from `unilink::unilink` to
+  `wirestead::wirestead`.
+- Changed generated library names, release archive names, CPack metadata, and
+  pkg-config metadata from UniLink names to Wirestead names.
+- Changed canonical CMake options, compile definitions, export macros, and
+  runtime environment variables from `UNILINK_*` names to `WIRESTEAD_*` names.
+- Changed package identity to the `wirestead` vcpkg port. The former
+  `jwsung91-unilink` port is a deprecated compatibility alias.
+
+### Compatibility
+
+- v0.9.0 is an ABI break from v0.8.x. Consumers must rebuild binaries and
+  libraries that link to the C++ core.
+- `namespace unilink = wirestead` is provided for source compatibility.
+- `<unilink/...>` forwarding headers are installed for the v0.9.x line.
+- `find_package(unilink CONFIG REQUIRED)` and `unilink::unilink` remain as
+  compatibility surfaces that forward to the Wirestead package and target.
+- `UNILINK_*` CMake inputs are accepted as compatibility aliases for matching
+  `WIRESTEAD_*` options. Conflicting old/new values fail at configure time.
+- `UNILINK_API`, `UNILINK_EXPORT`, `UNILINK_NO_EXPORT`, and UniLink logging
+  macros are compatibility aliases for the Wirestead macros.
+- `UNILINK_LOG_LEVEL` is read only when `WIRESTEAD_LOG_LEVEL` is unset or empty.
+- A `libunilink` filename or SONAME compatibility shim is not provided because
+  old v0.8.x binaries are not ABI-compatible with v0.9.x symbols.
+
+### Fixed
+
+- Stabilized UDP client restart lifecycle coverage before the v0.9.0 final tag.
+- Made pkg-config files relocatable.
+- Fixed release workflow permissions and retry behavior during the v0.9.0
+  release candidate cycle.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 vcpkg install wirestead
 ```
 
-`jwsung91-unilink` is now a deprecated compatibility alias that depends on
-`wirestead` and installs nothing itself; use `wirestead` directly.
+For UniLink migration details and compatibility aliases, see
+[Migrating from UniLink](./docs/migration-from-unilink.md).
 
 External documentation, examples, Python bindings, and container repositories
 have moved to the `wirestead` organization as `wirestead-docs`,
@@ -73,6 +73,8 @@ Core repository entrypoints:
 - [Quick Start](https://github.com/wirestead/wirestead/blob/main/docs/quickstart.md)
 - [Installation](https://github.com/wirestead/wirestead/blob/main/docs/installation.md)
 - [API Stability Summary](https://github.com/wirestead/wirestead/blob/main/docs/api_stability.md)
+- [UniLink Migration Guide](https://github.com/wirestead/wirestead/blob/main/docs/migration-from-unilink.md)
+- [Changelog](https://github.com/wirestead/wirestead/blob/main/CHANGELOG.md)
 - [Error Model](https://github.com/wirestead/wirestead/blob/main/docs/error_model.md)
 - [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md)
 - [Callback Data Lifetime](https://github.com/wirestead/wirestead/blob/main/docs/callbacks.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 # Wirestead Core Documentation
 
 This core repository keeps minimal documentation entrypoints for source users,
-package consumers, and release maintainers. External documentation remains in
-its legacy repository location until it is moved.
+package consumers, migration users, and release maintainers.
 
 ## Core entrypoints
 
 - [Quick Start](quickstart.md)
 - [Installation](installation.md)
 - [API Stability Summary](api_stability.md)
+- [Migrating from UniLink](migration-from-unilink.md)
 - [Release Checklist](release_checklist.md)

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -4,6 +4,9 @@
 
 `wirestead` is currently pre-1.0.
 
+The project tries to keep documented user-facing behavior stable within a minor
+line, but C++ API and ABI compatibility are not frozen before v1.0.
+
 ## Stable user-facing surface
 
 Prefer:
@@ -37,6 +40,30 @@ C++ ABI stability is not guaranteed before v1.0. The v0.9.0 Wirestead rename
 changes C++ symbols, library filenames, and SONAMEs; consumers moving from
 v0.8.x must rebuild.
 
+Patch releases may require relinking and retesting. Applications should not
+mix headers from one minor line with libraries from another.
+
+## Release Compatibility Policy
+
+Patch releases should avoid:
+
+- removing public include paths
+- removing public APIs
+- changing existing default behavior
+- removing compatibility shims
+- reducing supported platforms without prior notice
+
+Patch releases may include bug fixes, packaging fixes, CI fixes,
+documentation updates, test additions, and compatible implementation changes.
+
+Minor releases before v1.0 may introduce API changes when needed, but breaking
+changes should be documented in `CHANGELOG.md` and migration notes.
+
+Deprecated APIs and compatibility aliases should remain for at least the current
+minor line unless a security or correctness issue makes that impossible. The
+v0.9.x UniLink compatibility aliases are documented in
+`docs/migration-from-unilink.md`.
+
 ## Diagnostics
 
 `RuntimeStats` is a user-facing diagnostics snapshot. It is not a
@@ -64,3 +91,10 @@ Compatibility is not guaranteed for deep includes under:
 These headers are installed for implementation and advanced integration needs,
 but application code should include `<wirestead/wirestead.hpp>` unless a documented
 advanced API requires otherwise.
+
+## Python Binding Compatibility
+
+The Python binding follows the C++ core minor release line. Python package
+0.9.x targets Wirestead C++ core 0.9.x. Patch versions may differ when the
+Python package contains packaging, CI, binding, or documentation fixes that do
+not require a matching C++ core patch release.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,8 @@ gate and rejects Boost versions older than the configured minimum.
 vcpkg install wirestead
 ```
 
-`jwsung91-unilink` is now a deprecated compatibility alias that depends on
-`wirestead` and installs nothing itself; use `wirestead` directly.
+For UniLink migration details and compatibility aliases, see
+[Migrating from UniLink](migration-from-unilink.md).
 
 ## Minimal CMake find_package consumer
 

--- a/docs/migration-from-unilink.md
+++ b/docs/migration-from-unilink.md
@@ -5,29 +5,90 @@ starting with v0.9.0. UniLink names are kept only as a v0.9.x source and build
 compatibility layer for existing consumers.
 
 The rename changes C++ mangled symbols, library filenames, and shared library
-SONAMEs. Existing v0.8.x binaries are not ABI-compatible with v0.9.0 and must
+SONAMEs. Existing v0.8.x binaries are not ABI-compatible with v0.9.x and must
 be rebuilt.
 
-## Compatibility Table
+## Name Mapping
 
-| Area | Wirestead canonical surface | UniLink compatibility surface |
+| Area | UniLink | Wirestead |
 |---|---|---|
-| C++ namespace | `namespace wirestead` | `namespace unilink = wirestead` |
-| Base exception | `wirestead::diagnostics::WiresteadException` | `wirestead::diagnostics::UnilinkException` type alias |
-| Header path | `<wirestead/wirestead.hpp>` and `<wirestead/...>` | `<unilink/...>` forwarding headers |
-| CMake project | `project(wirestead)` | legacy cache variables documented here |
-| CMake package | `find_package(wirestead CONFIG REQUIRED)` | `find_package(unilink CONFIG REQUIRED)` loads Wirestead and adds legacy targets |
-| CMake target | `wirestead::wirestead` | `unilink::unilink` links to `wirestead::wirestead` |
-| CMake options | `WIRESTEAD_*` | `UNILINK_*` inputs are forwarded during configure |
-| Environment variable | `WIRESTEAD_LOG_LEVEL` | `UNILINK_LOG_LEVEL` fallback when the Wirestead variable is absent |
-| Export macro | `WIRESTEAD_API` | `UNILINK_API` alias |
-| pkg-config | `wirestead.pc` with `-lwirestead` | `unilink.pc` with `-lwirestead` |
-| Library file | `libwirestead` | no `libunilink` binary compatibility shim |
-| SONAME | `libwirestead.so.0` on Linux | no `libunilink` SONAME |
-| Release assets | `wirestead-<version>-*` | old `unilink-<version>-*` asset names are not produced |
-| vcpkg port | `wirestead` (live in the vcpkg registry) | `jwsung91-unilink` is a deprecated alias depending on `wirestead` |
+| Header | `<unilink/unilink.hpp>` and `<unilink/...>` | `<wirestead/wirestead.hpp>` and `<wirestead/...>` |
+| Namespace | `unilink` | `wirestead` |
+| CMake package | `find_package(unilink CONFIG REQUIRED)` | `find_package(wirestead CONFIG REQUIRED)` |
+| CMake target | `unilink::unilink` | `wirestead::wirestead` |
+| Shared/static targets | `unilink::unilink_shared`, `unilink::unilink_static` | `wirestead::wirestead_shared`, `wirestead::wirestead_static` |
+| Library | `libunilink` in v0.8.x | `libwirestead` in v0.9.x |
+| SONAME | `libunilink.so.0` in v0.8.x | `libwirestead.so.0` in v0.9.x |
+| Export macro | `UNILINK_API` | `WIRESTEAD_API` |
+| Build macros | `UNILINK_BUILD_*`, `UNILINK_ENABLE_*` | `WIRESTEAD_BUILD_*`, `WIRESTEAD_ENABLE_*` |
+| Logging macros | `UNILINK_LOG_*` | `WIRESTEAD_LOG_*` |
+| Environment variable | `UNILINK_LOG_LEVEL` | `WIRESTEAD_LOG_LEVEL` |
+| pkg-config | `unilink.pc`, `pkg-config --libs unilink` | `wirestead.pc`, `pkg-config --libs wirestead` |
+| vcpkg port | `jwsung91-unilink` compatibility alias | `wirestead` |
+| Release assets | `unilink-<version>-*` | `wirestead-<version>-*` |
+| Python distribution | `unilink` | `wirestead` |
+| Python import | `unilink`, `unilink_py` | `wirestead` |
 
-## Source Compatibility
+## Migration Steps
+
+1. Change dependency declarations.
+
+   For vcpkg consumers, use the official port:
+
+   ```bash
+   vcpkg install wirestead
+   ```
+
+   For CMake consumers, depend on the Wirestead package:
+
+   ```cmake
+   find_package(wirestead CONFIG REQUIRED)
+   ```
+
+2. Change include paths.
+
+   ```cpp
+   #include <wirestead/wirestead.hpp>
+   ```
+
+   Prefer the public facade include for application code. Deep includes under
+   `transport/`, `interface/`, `memory/`, `concurrency/`, and `factory/` are
+   not part of the pre-1.0 compatibility promise.
+
+3. Change namespaces.
+
+   ```cpp
+   auto client = wirestead::tcp_client("127.0.0.1", 9000)
+       .auto_start(false)
+       .build();
+   ```
+
+4. Change CMake package and target usage.
+
+   ```cmake
+   find_package(wirestead CONFIG REQUIRED)
+   target_link_libraries(my_app PRIVATE wirestead::wirestead)
+   ```
+
+5. Change macros and environment variables.
+
+   Use `WIRESTEAD_*` CMake options, compile definitions, export macros, and
+   logging macros. Use `WIRESTEAD_LOG_LEVEL` instead of `UNILINK_LOG_LEVEL`.
+
+6. Do a clean rebuild.
+
+   Delete CMake build directories, CMake package caches, generated build-system
+   files, and any installed v0.8.x UniLink artifacts from the prefix you plan to
+   use. Do not rely on an incremental relink across the rename.
+
+7. Run tests.
+
+   At minimum, run a build of a small external consumer with
+   `find_package(wirestead CONFIG REQUIRED)`, include
+   `<wirestead/wirestead.hpp>`, link `wirestead::wirestead`, and execute a local
+   loopback smoke test for the transports your application uses.
+
+## Compatibility Surface
 
 Existing documented source usage continues to compile when rebuilt against
 v0.9.x:
@@ -40,58 +101,69 @@ unilink::builder::TcpClientBuilderDefault builder("127.0.0.1", 8080);
 
 The compatibility layer is intentionally narrow. It does not support reopening
 `namespace unilink { ... }`, direct forward declarations of internal UniLink
-symbols, undocumented internal headers, or checks that hard-code mangled symbol
-names or old shared library filenames.
+symbols, undocumented internal headers, checks that hard-code mangled symbol
+names, or old shared library filenames.
 
-## ABI Compatibility
+Provided compatibility surfaces:
+
+- `namespace unilink = wirestead`
+- `<unilink/...>` forwarding headers
+- `find_package(unilink CONFIG REQUIRED)`
+- `unilink::unilink`, `unilink::unilink_shared`, and
+  `unilink::unilink_static`
+- `UNILINK_*` CMake option inputs for matching `WIRESTEAD_*` options
+- `UNILINK_API`, `UNILINK_EXPORT`, `UNILINK_NO_EXPORT`, and `UNILINK_LOG_*`
+  macro aliases
+- `UNILINK_LOG_LEVEL` fallback when `WIRESTEAD_LOG_LEVEL` is unset or empty
+- `unilink.pc` forwarding pkg-config metadata
+
+`WIRESTEAD_LOG_LEVEL` takes precedence when both environment variables are set.
+If both old and new CMake options are explicitly set to different values,
+configure fails with `FATAL_ERROR`.
+
+The UniLink compatibility layer is guaranteed for the v0.9.x line. Its removal
+version is not fixed; removal will be decided later from real usage data and
+will not make UniLink the canonical identity again.
+
+## ABI and Install Prefixes
 
 v0.9.0 is an ABI break from v0.8.x. Consumers must rebuild all binaries and
 libraries that link to Wirestead. A `libunilink` symlink is intentionally not
 provided because the C++ symbols now live under `wirestead::`; a filename-only
 shim would hide the ABI break without making old binaries work.
 
-## Build Compatibility
+Do not install UniLink v0.8.x and Wirestead v0.9.x into the same prefix. The
+v0.9.x install includes legacy `<unilink/...>` forwarding headers and
+`unilinkConfig.cmake` for source compatibility, so an old UniLink install in
+the same prefix can create ambiguous headers, package configs, or stale binary
+artifacts. Use separate prefixes while migrating, or remove the old install
+before validating Wirestead.
 
-`WIRESTEAD_*` CMake options are canonical. `UNILINK_*` options are accepted as
-v0.9.x compatibility inputs and forwarded to the matching `WIRESTEAD_*` option
-early in configure. If both names are explicitly set to the same value, configure
-continues. If both names are explicitly set to different values, configure fails
-with `FATAL_ERROR`.
+## Python Users
 
-`WIRESTEAD_LOG_LEVEL` is read first at runtime. `UNILINK_LOG_LEVEL` is read only
-when `WIRESTEAD_LOG_LEVEL` is unset or empty. When both are set, Wirestead wins
-and the logger emits a diagnostic line so the precedence is visible.
+New code should install and import Wirestead:
 
-## Migration Examples
+```bash
+python -m pip uninstall -y unilink unilink_py
+python -m pip install wirestead
+```
 
-| Old | New |
-|---|---|
-| `find_package(unilink CONFIG REQUIRED)` | `find_package(wirestead CONFIG REQUIRED)` |
-| `target_link_libraries(app PRIVATE unilink::unilink)` | `target_link_libraries(app PRIVATE wirestead::wirestead)` |
-| `#include <unilink/unilink.hpp>` | `#include <wirestead/wirestead.hpp>` |
-| `unilink::tcp_client(...)` | `wirestead::tcp_client(...)` |
-| `catch (const unilink::diagnostics::UnilinkException&)` | `catch (const wirestead::diagnostics::WiresteadException&)` |
-| `-DUNILINK_ENABLE_CONFIG=ON` | `-DWIRESTEAD_ENABLE_CONFIG=ON` |
-| `UNILINK_LOG_LEVEL=DEBUG` | `WIRESTEAD_LOG_LEVEL=DEBUG` |
-| `pkg-config --libs unilink` | `pkg-config --libs wirestead` |
+```python
+import wirestead
+```
 
-## vcpkg Status
+The `wirestead` Python package does not require the C++ source tree when a
+prebuilt wheel exists for your Python version and platform. Python package and
+core versions track the same minor line: `wirestead` Python 0.9.x targets
+Wirestead C++ core 0.9.x.
 
-The canonical vcpkg port is `wirestead`, merged into the vcpkg registry in
-[microsoft/vcpkg#52984](https://github.com/microsoft/vcpkg/pull/52984).
-`jwsung91-unilink` is now a deprecated compatibility port that installs
-nothing itself and only depends on `wirestead`.
+Avoid mechanical `unilink` to `wirestead` replacement in generated files,
+vendored code, historical changelog entries, issue URLs, or code that still
+intentionally exercises the v0.9.x compatibility layer.
 
 ## External Repositories
 
 External documentation, Python binding, example, benchmark, and container
-repositories are outside this source-tree rename. Those repositories already
-moved from the `unilink-lab` organization to `wirestead`, and have since been
-renamed to `wirestead-docs`, `wirestead-python`, `wirestead-examples`,
-`wirestead-benchmarks`, and `wirestead-container` respectively.
-
-## Version Policy
-
-The UniLink compatibility layer is guaranteed for the v0.9.x line. Its removal
-version is not fixed; removal will be decided later from real usage data and
-will not make UniLink the canonical identity again.
+repositories moved from the `unilink-lab` organization to `wirestead`, and have
+since been renamed to `wirestead-docs`, `wirestead-python`,
+`wirestead-examples`, `wirestead-benchmarks`, and `wirestead-container`.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -33,6 +33,8 @@ CI, CPack, and consumer smoke workflows live here.
 
 - [ ] Core README links to `wirestead-docs`.
 - [ ] Core README and docs repo links were checked.
+- [ ] `CHANGELOG.md` and migration guidance are current for compatibility
+      changes.
 - [ ] Core minimal docs are present:
   - [ ] `docs/installation.md`
   - [ ] `docs/quickstart.md`


### PR DESCRIPTION
## Summary

- Adds a root `CHANGELOG.md` covering v0.9.0, v0.9.1, and `Unreleased` with compatibility notes.
- Reworks `docs/migration-from-unilink.md` into an actionable old-to-new mapping and migration procedure.
- Clarifies pre-1.0 API/ABI, patch/minor release, deprecated API, compatibility alias, and Python/core compatibility policy.
- Keeps README and installation docs focused on the official `vcpkg install wirestead` path and links compatibility details to the migration guide.
- Updates the vcpkg package workflow so the official port is required rather than skipped as pending.

## UniLink Residuals

Remaining `unilink`/`UNILINK` references are intentional compatibility or history:

- `unilink/**` forwarding headers.
- `cmake/UnilinkConfig.cmake.in`, `unilink.pc`, and legacy CMake/pkg-config validation.
- `UNILINK_*` compatibility aliases and runtime fallback handling.
- Release/vcpkg workflow checks ensuring legacy headers/configs exist but no `libunilink` binary shim is produced.
- Migration/changelog historical documentation.

## Migration Mapping

The migration guide now covers headers, namespace, CMake package/targets, library and SONAME rename, macros, environment variables, pkg-config, vcpkg port, release assets, Python distribution, and Python imports.

## Compatibility Policy

- v0.9.0 is documented as an ABI break from v0.8.x.
- UniLink compatibility aliases are guaranteed for the v0.9.x line.
- Removal timing remains undecided and is not stated as fixed policy.
- Patch releases should avoid public include/API removal, default behavior changes, compatibility shim removal, and unannounced support reductions.

## Validation

- `git diff --check`
- `rg` search for `unilink`, `UNILINK`, old org/repo references, vcpkg pending language, and overlay/registry guidance
- `/home/rain/workspace/wirestead/vcpkg/vcpkg search wirestead`
- `/home/rain/workspace/wirestead/vcpkg/vcpkg install wirestead:x64-linux --clean-after-build`
- `cmake -S /tmp/wirestead-vcpkg-consumer -B /tmp/wirestead-vcpkg-consumer/build -DCMAKE_TOOLCHAIN_FILE=/home/rain/workspace/wirestead/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/wirestead-vcpkg-consumer/build --config Release`
- `/tmp/wirestead-vcpkg-consumer/build/wirestead_vcpkg_consumer`

## Follow-up

- If the separate docs site has migration/install pages outside this repository, sync the same migration/changelog links there.
- Keep the v0.9.2 release candidate validation focused on real clean consumer environments before moving to v1.0 API freeze.
