### PR TITLE
docs: correct Unilink capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and ABI policy.
 
 ### Added
 
-- Documented the UniLink to Wirestead migration path and compatibility policy.
+- Documented the Unilink to Wirestead migration path and compatibility policy.
 
 ### Changed
 
@@ -19,7 +19,7 @@ and ABI policy.
 
 ### Deprecated
 
-- UniLink compatibility names remain deprecated compatibility surfaces for the
+- Unilink compatibility names remain deprecated compatibility surfaces for the
   v0.9.x line.
 
 ### Removed
@@ -57,21 +57,21 @@ and ABI policy.
 ### Compatibility
 
 - No intentional public API removal was made in v0.9.1.
-- Known limitations remain the pre-1.0 ABI policy and the v0.9.x UniLink
+- Known limitations remain the pre-1.0 ABI policy and the v0.9.x Unilink
   compatibility layer described in `docs/migration-from-unilink.md`.
 
 ## v0.9.0 - 2026-07-19
 
 ### Changed
 
-- Renamed the canonical project identity from UniLink to Wirestead.
+- Renamed the canonical project identity from Unilink to Wirestead.
 - Changed the canonical C++ namespace from `unilink` to `wirestead`.
 - Changed canonical include paths from `<unilink/...>` to `<wirestead/...>`.
 - Changed the canonical CMake package from `unilink` to `wirestead`.
 - Changed the canonical CMake target from `unilink::unilink` to
   `wirestead::wirestead`.
 - Changed generated library names, release archive names, CPack metadata, and
-  pkg-config metadata from UniLink names to Wirestead names.
+  pkg-config metadata from Unilink names to Wirestead names.
 - Changed canonical CMake options, compile definitions, export macros, and
   runtime environment variables from `UNILINK_*` names to `WIRESTEAD_*` names.
 - Changed package identity to the `wirestead` vcpkg port. The former
@@ -87,7 +87,7 @@ and ABI policy.
   compatibility surfaces that forward to the Wirestead package and target.
 - `UNILINK_*` CMake inputs are accepted as compatibility aliases for matching
   `WIRESTEAD_*` options. Conflicting old/new values fail at configure time.
-- `UNILINK_API`, `UNILINK_EXPORT`, `UNILINK_NO_EXPORT`, and UniLink logging
+- `UNILINK_API`, `UNILINK_EXPORT`, `UNILINK_NO_EXPORT`, and Unilink logging
   macros are compatibility aliases for the Wirestead macros.
 - `UNILINK_LOG_LEVEL` is read only when `WIRESTEAD_LOG_LEVEL` is unset or empty.
 - A `libunilink` filename or SONAME compatibility shim is not provided because

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Wirestead™
 
-_Wirestead is the successor to UniLink._
+_Wirestead is the successor to Unilink._
 
 **Robust, simple async communication for modern C++20.**
 
@@ -44,8 +44,8 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 vcpkg install wirestead
 ```
 
-For UniLink migration details and compatibility aliases, see
-[Migrating from UniLink](./docs/migration-from-unilink.md).
+For Unilink migration details and compatibility aliases, see
+[Migrating from Unilink](./docs/migration-from-unilink.md).
 
 External documentation, examples, Python bindings, and container repositories
 have moved to the `wirestead` organization as `wirestead-docs`,
@@ -73,7 +73,7 @@ Core repository entrypoints:
 - [Quick Start](https://github.com/wirestead/wirestead/blob/main/docs/quickstart.md)
 - [Installation](https://github.com/wirestead/wirestead/blob/main/docs/installation.md)
 - [API Stability Summary](https://github.com/wirestead/wirestead/blob/main/docs/api_stability.md)
-- [UniLink Migration Guide](https://github.com/wirestead/wirestead/blob/main/docs/migration-from-unilink.md)
+- [Unilink Migration Guide](https://github.com/wirestead/wirestead/blob/main/docs/migration-from-unilink.md)
 - [Changelog](https://github.com/wirestead/wirestead/blob/main/CHANGELOG.md)
 - [Error Model](https://github.com/wirestead/wirestead/blob/main/docs/error_model.md)
 - [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md)

--- a/cmake/unilink.pc.in
+++ b/cmake/unilink.pc.in
@@ -4,7 +4,7 @@ libdir=${pcfiledir}/..
 includedir=${prefix}/@WIRESTEAD_PKGCONFIG_INCLUDEDIR_FROM_PREFIX@
 
 Name: unilink
-Description: Legacy UniLink compatibility package for Wirestead
+Description: Legacy Unilink compatibility package for Wirestead
 URL: https://github.com/wirestead/wirestead
 Version: @PROJECT_VERSION@
 Requires: @PKGCONFIG_REQUIRES@

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,5 @@ package consumers, migration users, and release maintainers.
 - [Quick Start](quickstart.md)
 - [Installation](installation.md)
 - [API Stability Summary](api_stability.md)
-- [Migrating from UniLink](migration-from-unilink.md)
+- [Migrating from Unilink](migration-from-unilink.md)
 - [Release Checklist](release_checklist.md)

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -61,7 +61,7 @@ changes should be documented in `CHANGELOG.md` and migration notes.
 
 Deprecated APIs and compatibility aliases should remain for at least the current
 minor line unless a security or correctness issue makes that impossible. The
-v0.9.x UniLink compatibility aliases are documented in
+v0.9.x Unilink compatibility aliases are documented in
 `docs/migration-from-unilink.md`.
 
 ## Diagnostics

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,8 +20,8 @@ gate and rejects Boost versions older than the configured minimum.
 vcpkg install wirestead
 ```
 
-For UniLink migration details and compatibility aliases, see
-[Migrating from UniLink](migration-from-unilink.md).
+For Unilink migration details and compatibility aliases, see
+[Migrating from Unilink](migration-from-unilink.md).
 
 ## Minimal CMake find_package consumer
 

--- a/docs/migration-from-unilink.md
+++ b/docs/migration-from-unilink.md
@@ -1,7 +1,7 @@
-# Migrating from UniLink to Wirestead
+# Migrating from Unilink to Wirestead
 
 Wirestead is the canonical project, package, build, and C++ API identity
-starting with v0.9.0. UniLink names are kept only as a v0.9.x source and build
+starting with v0.9.0. Unilink names are kept only as a v0.9.x source and build
 compatibility layer for existing consumers.
 
 The rename changes C++ mangled symbols, library filenames, and shared library
@@ -10,7 +10,7 @@ be rebuilt.
 
 ## Name Mapping
 
-| Area | UniLink | Wirestead |
+| Area | Unilink | Wirestead |
 |---|---|---|
 | Header | `<unilink/unilink.hpp>` and `<unilink/...>` | `<wirestead/wirestead.hpp>` and `<wirestead/...>` |
 | Namespace | `unilink` | `wirestead` |
@@ -78,7 +78,7 @@ be rebuilt.
 6. Do a clean rebuild.
 
    Delete CMake build directories, CMake package caches, generated build-system
-   files, and any installed v0.8.x UniLink artifacts from the prefix you plan to
+   files, and any installed v0.8.x Unilink artifacts from the prefix you plan to
    use. Do not rely on an incremental relink across the rename.
 
 7. Run tests.
@@ -100,7 +100,7 @@ unilink::builder::TcpClientBuilderDefault builder("127.0.0.1", 8080);
 ```
 
 The compatibility layer is intentionally narrow. It does not support reopening
-`namespace unilink { ... }`, direct forward declarations of internal UniLink
+`namespace unilink { ... }`, direct forward declarations of internal Unilink
 symbols, undocumented internal headers, checks that hard-code mangled symbol
 names, or old shared library filenames.
 
@@ -121,9 +121,9 @@ Provided compatibility surfaces:
 If both old and new CMake options are explicitly set to different values,
 configure fails with `FATAL_ERROR`.
 
-The UniLink compatibility layer is guaranteed for the v0.9.x line. Its removal
+The Unilink compatibility layer is guaranteed for the v0.9.x line. Its removal
 version is not fixed; removal will be decided later from real usage data and
-will not make UniLink the canonical identity again.
+will not make Unilink the canonical identity again.
 
 ## ABI and Install Prefixes
 
@@ -132,9 +132,9 @@ libraries that link to Wirestead. A `libunilink` symlink is intentionally not
 provided because the C++ symbols now live under `wirestead::`; a filename-only
 shim would hide the ABI break without making old binaries work.
 
-Do not install UniLink v0.8.x and Wirestead v0.9.x into the same prefix. The
+Do not install Unilink v0.8.x and Wirestead v0.9.x into the same prefix. The
 v0.9.x install includes legacy `<unilink/...>` forwarding headers and
-`unilinkConfig.cmake` for source compatibility, so an old UniLink install in
+`unilinkConfig.cmake` for source compatibility, so an old Unilink install in
 the same prefix can create ambiguous headers, package configs, or stale binary
 artifacts. Use separate prefixes while migrating, or remove the old install
 before validating Wirestead.

--- a/wirestead/base/visibility.hpp
+++ b/wirestead/base/visibility.hpp
@@ -56,7 +56,7 @@
 #define WIRESTEAD_NO_EXPORT WIRESTEAD_LOCAL
 #endif
 
-// Legacy UniLink export macros are source compatibility aliases for v0.9.x.
+// Legacy Unilink export macros are source compatibility aliases for v0.9.x.
 #ifndef UNILINK_API
 #define UNILINK_API WIRESTEAD_API
 #endif


### PR DESCRIPTION
## Summary

- Corrects the former project name from `UniLink` to its official spelling, `Unilink`.
- Updates changelog, migration, installation, compatibility, pkg-config description, and source comments.
- Leaves compatibility identifiers such as `unilink`, `UNILINK_*`, filenames, CMake package names, and paths unchanged.

## Validation

- Confirmed no `UniLink` text remains in the current core documentation, CMake metadata, or source tree.
- Ran `git diff --check`.