### PR TITLE
ci: propose vcpkg baseline bumps automatically

### DIFF
--- a/.github/workflows/vcpkg-baseline-bump.yml
+++ b/.github/workflows/vcpkg-baseline-bump.yml
@@ -1,0 +1,118 @@
+name: vcpkg baseline bump
+
+# VCPKG_BASELINE pins the microsoft/vcpkg commit every job builds against.
+# Pinning stops upstream drift from breaking builds, but it also means the
+# pin goes stale until somebody moves it, and dependabot does not track raw
+# git checkouts. This opens that bump as a reviewable PR on a schedule.
+#
+# The PR is a proposal, not a verdict. A candidate is only good once this
+# repository's CI has built against it -- including the Linux ARM64 jobs,
+# which is where a bad candidate showed up last time.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Propose a vcpkg baseline bump
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve candidate commit
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(cat VCPKG_BASELINE)"
+          candidate="$(git ls-remote https://github.com/microsoft/vcpkg.git HEAD | cut -f1)"
+
+          if ! printf '%s' "${candidate}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "could not resolve the vcpkg default branch: '${candidate}'"
+            exit 1
+          fi
+
+          echo "current:   ${current}"
+          echo "candidate: ${candidate}"
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+          echo "candidate=${candidate}" >> "$GITHUB_OUTPUT"
+
+          if [ "${current}" = "${candidate}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # A candidate without the port would fail every consuming job, so reject
+      # it here rather than spending a CI run to find out.
+      - name: Verify the candidate carries the wirestead port
+        if: steps.candidate.outputs.changed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE: ${{ steps.candidate.outputs.candidate }}
+        run: |
+          set -euo pipefail
+          gh api "repos/microsoft/vcpkg/contents/ports/wirestead/vcpkg.json?ref=${CANDIDATE}" --jq '.name' > /dev/null
+          echo "wirestead port is present at the candidate commit"
+
+      - name: Open or update the bump pull request
+        if: steps.candidate.outputs.changed == 'true'
+        shell: bash
+        env:
+          # A PR opened with GITHUB_TOKEN does not trigger workflow runs, so
+          # prefer a PAT when one is configured. Without it the PR still opens,
+          # but CI has to be kicked by hand before the bump means anything.
+          GH_TOKEN: ${{ secrets.VCPKG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          CURRENT: ${{ steps.candidate.outputs.current }}
+          CANDIDATE: ${{ steps.candidate.outputs.candidate }}
+          HAS_PAT: ${{ secrets.VCPKG_BUMP_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          branch="automation/vcpkg-baseline"
+          short="${CANDIDATE:0:12}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "${branch}"
+          printf '%s\n' "${CANDIDATE}" > VCPKG_BASELINE
+          git add VCPKG_BASELINE
+          git commit -m "ci: bump the vcpkg baseline to ${short}"
+          git push --force origin "${branch}"
+
+          {
+            printf 'Moves `VCPKG_BASELINE` from `%s` to [`%s`](https://github.com/microsoft/vcpkg/commit/%s).\n\n' \
+              "${CURRENT}" "${short}" "${CANDIDATE}"
+            printf 'Opened automatically because the pin had drifted behind vcpkg default branch. The `wirestead` port was confirmed present at the candidate commit.\n\n'
+            printf 'CI must be green on this branch before merging. The Linux ARM64 jobs matter most: a baseline can build everywhere else and still fail there.\n\n'
+            if [ "${HAS_PAT}" != "true" ]; then
+              printf 'This PR was opened with `GITHUB_TOKEN`, so GitHub will not start workflow runs for it. Close and reopen it, or push any commit, to trigger CI. Configure a `VCPKG_BUMP_TOKEN` secret to have that happen automatically.\n\n'
+            fi
+            printf 'If CI fails, do not merge: pick an older commit that this repository has built against instead of taking the default branch tip.\n'
+          } > vcpkg-bump-body.md
+
+          existing="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" --body-file vcpkg-bump-body.md
+            echo "updated existing PR #${existing}"
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "ci: bump the vcpkg baseline to ${short}" \
+              --body-file vcpkg-bump-body.md
+          fi
+
+      - name: Report no change
+        if: steps.candidate.outputs.changed != 'true'
+        run: echo "VCPKG_BASELINE already matches the vcpkg default branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and ABI policy.
   release workflow, the vcpkg package test, and the `setup-vcpkg` composite
   action to a reviewed commit recorded in `VCPKG_BASELINE`, instead of cloning
   whatever is on its default branch at build time.
+- Added a weekly `vcpkg baseline bump` workflow that proposes a
+  `VCPKG_BASELINE` update as a reviewable pull request, so the pin can be kept
+  current without relying on someone remembering to move it.
 
 ### Deprecated
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -19,7 +19,9 @@ CI, CPack, and consumer smoke workflows live here.
 
 ## Packaging
 
-- [ ] `VCPKG_BASELINE` is current, and CI passed against that commit.
+- [ ] `VCPKG_BASELINE` is current, and CI passed against that commit. The weekly
+      `vcpkg baseline bump` workflow proposes this as a pull request; a bump is
+      only good once CI is green on it, the Linux ARM64 jobs included.
 - [ ] Release workflow dry-run completed.
 - [ ] CPack package was generated.
 - [ ] Package contains headers.


### PR DESCRIPTION
## Description

Pinning the vcpkg checkout (#556) stopped upstream drift, but it traded that for staleness: the pin sits where it is until somebody moves it, and dependabot does not track raw git checkouts. This adds the maintenance path that pin created a need for.

A weekly workflow opens the bump as a reviewable pull request instead of leaving it to be remembered.

## Key Changes

- `.github/workflows/vcpkg-baseline-bump.yml`: weekly (and `workflow_dispatch`) job that compares `VCPKG_BASELINE` against vcpkg's default branch and opens or updates a PR on `automation/vcpkg-baseline` when they differ.
- `docs/release_checklist.md`: notes that the workflow proposes the bump, and that a bump counts only once CI is green on it.
- `CHANGELOG.md`: entry under `Changed`.

Two things the workflow does deliberately, both learned from #556:

- **It rejects a candidate lacking the `wirestead` port** before opening the PR, rather than spending a full CI run to discover it.
- **The generated PR body says the Linux ARM64 jobs are the ones that matter.** The first baseline in #556 built everywhere else and failed exactly there, so that is where a bad candidate shows up.

## Related Issues
- Follows #556.

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

(Also Build/CI — the template has no such option; the substantive change is a workflow file.)

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified.** A scheduled workflow cannot be proven by CI on its own PR, so the pieces were exercised directly:

- YAML parses; every `run:` block passes `bash -n` with GitHub expressions stubbed out.
- `git ls-remote https://github.com/microsoft/vcpkg.git HEAD` was run live and resolves to a valid 40-character SHA, which is what the change detection compares against.
- The port guard was run against the live API at a real candidate commit and correctly finds `ports/wirestead/vcpkg.json`.
- The PR-body construction was executed and the output checked to contain **zero indented lines**. That matters: the first draft embedded a multi-line shell string starting at column 0 and broke the YAML block scalar outright. Rebuilding the body with `printf` fixed it, and that check is what confirms it renders as prose rather than a Markdown code block.

**Known caveat, stated in the PR body the workflow generates.** GitHub does not start workflow runs for pull requests opened with `GITHUB_TOKEN`. An unvalidated baseline PR is precisely the failure this whole effort exists to prevent, so the workflow prefers a `VCPKG_BUMP_TOKEN` secret when one is configured, and when it is not, it says plainly in the generated PR body that CI must be kicked by hand and that the PR should not be merged without a green run. It works with no secret setup; it just cannot auto-validate.

**Not run.** `./scripts/verify.sh` builds the full C++ core and test suite; this change touches only workflow YAML and Markdown, with no C++, CMake, or source file involved. No tests were added because a scheduled workflow has no runtime surface in this repository.

**Companion PR.** `wirestead-python#49` adds the matching workflow there. It syncs from this repository's `VCPKG_BASELINE` rather than tracking vcpkg directly, because its CI never builds `arm64-linux` while its release workflow builds manylinux aarch64 wheels on that triplet — so this repository's CI clearing a commit first is the cheaper check.
