### PR TITLE
fix: stop the shared library re-exporting third-party symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and ABI policy.
 
 ### Fixed
 
+- Stopped the shared library from re-exporting `boost::asio::detail` symbols it
+  merely links against. Those are weak and unique symbols that hidden
+  visibility does not remove, so a consumer loading a different Boost into the
+  same process could have them merged, which is an ODR violation. No
+  `wirestead` symbol changed: the export surface this project owns, including
+  the typeinfo and vtables needed to catch exceptions across the library
+  boundary, is unchanged.
 - Fixed the Windows consumer sample linking against a different MSVC runtime
   than the static vcpkg triplet its dependencies were built with, which
   surfaced as LNK2038 and LNK2005 errors after upstream vcpkg drift.

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -33,6 +33,9 @@ foreach(_suffix IN LISTS _wirestead_option_suffixes)
 endforeach()
 
 option(WIRESTEAD_BUILD_SHARED "Build shared library" ON)
+option(WIRESTEAD_LIMIT_EXPORTED_SYMBOLS
+       "Restrict shared library exports to wirestead symbols" ON
+)
 option(WIRESTEAD_BUILD_STATIC "Build static library" ON)
 option(WIRESTEAD_BUILD_TESTS "Build tests" ON)
 option(

--- a/cmake/WiresteadTargets.cmake
+++ b/cmake/WiresteadTargets.cmake
@@ -1,11 +1,44 @@
 # Wirestead library target construction and shared target utilities.
 
+# Resolved while this file is being included, so it points at cmake/ rather than
+# at whatever listfile happens to call the functions below.
+set(WIRESTEAD_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
 function(wirestead_configure_library_target target)
   target_link_libraries(${target} PUBLIC wirestead_dependencies)
   target_compile_features(${target} PUBLIC cxx_std_20)
   target_include_directories(
     ${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                      $<INSTALL_INTERFACE:include>
+  )
+endfunction()
+
+# Hidden visibility alone does not stop the shared library from re-exporting
+# symbols it links against, because weak and unique symbols survive it. Ask the
+# linker for the wirestead symbols and nothing else. MSVC needs no equivalent:
+# exports there are already opt-in through __declspec(dllexport).
+function(wirestead_limit_exported_symbols target)
+  if(NOT WIRESTEAD_LIMIT_EXPORTED_SYMBOLS)
+    return()
+  endif()
+
+  if(APPLE)
+    set(_script "${WIRESTEAD_CMAKE_DIR}/wirestead.exp")
+    target_link_options(
+      ${target} PRIVATE "LINKER:-exported_symbols_list,${_script}"
+    )
+  elseif(UNIX)
+    set(_script "${WIRESTEAD_CMAKE_DIR}/wirestead.map")
+    target_link_options(${target} PRIVATE "LINKER:--version-script,${_script}")
+  else()
+    return()
+  endif()
+
+  # Relink when the script changes; it is an input to the link step.
+  set_property(
+    TARGET ${target}
+    APPEND
+    PROPERTY LINK_DEPENDS "${_script}"
   )
 endfunction()
 
@@ -24,6 +57,7 @@ function(wirestead_configure_shared_target target output_name)
     PUBLIC WIRESTEAD_BUILD_SHARED UNILINK_BUILD_SHARED
     PRIVATE WIRESTEAD_BUILDING_LIBRARY UNILINK_BUILDING_LIBRARY
   )
+  wirestead_limit_exported_symbols(${target})
   wirestead_configure_library_target(${target})
 endfunction()
 

--- a/cmake/wirestead.exp
+++ b/cmake/wirestead.exp
@@ -1,0 +1,8 @@
+# Mach-O exported symbols list, the Darwin counterpart to wirestead.map.
+# Mach-O prefixes mangled C++ symbols with an extra underscore.
+__ZN9wirestead*
+__ZNK9wirestead*
+__ZTIN9wirestead*
+__ZTSN9wirestead*
+__ZTVN9wirestead*
+__ZTHN9wirestead*

--- a/cmake/wirestead.map
+++ b/cmake/wirestead.map
@@ -1,0 +1,22 @@
+# Linker version script: export only symbols this project owns.
+#
+# Without it the shared library also exports symbols it merely links against,
+# including boost::asio::detail internals. Those are weak and unique symbols,
+# so a consumer that loads a different Boost into the same process can have
+# them merged, which is an ODR violation that surfaces as hard-to-diagnose
+# runtime behavior rather than a link error.
+#
+# Every wirestead symbol stays exported, including typeinfo and vtables, which
+# exceptions thrown across the library boundary need in order to be caught by
+# type. This is not a reduction of the wirestead ABI surface.
+{
+  global:
+    _ZN9wirestead*;
+    _ZNK9wirestead*;
+    _ZTIN9wirestead*;
+    _ZTSN9wirestead*;
+    _ZTVN9wirestead*;
+    _ZTHN9wirestead*;
+  local:
+    *;
+};

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -74,6 +74,23 @@ synchronization primitive.
 `SendResult` is currently design-only unless explicitly implemented in a future
 release. It is not part of the runtime API in the current release line.
 
+## Exported symbols
+
+The shared library exports the symbols this project owns and nothing else.
+Hidden visibility alone does not achieve that, because weak and unique symbols
+survive it: before this was enforced, `libwirestead.so` also re-exported
+`boost::asio::detail` internals it merely linked against. A consumer loading a
+different Boost into the same process could have those merged, which is an ODR
+violation that shows up as runtime misbehavior rather than a link error.
+
+This restricts what leaks out, not what Wirestead offers. Every `wirestead`
+symbol stays exported, including the typeinfo and vtables that exceptions
+thrown across the library boundary need in order to be caught by type. The
+lists live in `cmake/wirestead.map` (ELF) and `cmake/wirestead.exp` (Mach-O);
+MSVC needs no equivalent because exports there are already opt-in through
+`__declspec(dllexport)`. Set `WIRESTEAD_LIMIT_EXPORTED_SYMBOLS=OFF` to fall
+back to the previous behavior.
+
 ## Internal headers
 
 Internal headers are not part of the compatibility guarantee before v1.0.


### PR DESCRIPTION
## Description

`libwirestead.so` exported 2139 symbols. Only 1534 were ours. Of the remaining 605, **35 came from `boost::asio::detail`** and the rest were standard library instantiations the library merely links against.

Hidden visibility — which the shared target already sets via `CXX_VISIBILITY_PRESET hidden` — does not remove them, because they are weak and unique symbols. The unique ones matter most: `STB_GNU_UNIQUE` forces a single instance process-wide, so a consumer loading a different Boost alongside this library can have stateful internals merged into one. Examples actually found in the export table:

```
boost::asio::detail::epoll_reactor::descriptor_state::perform_io
boost::asio::detail::keyword_tss_ptr<...>::value_
boost::asio::detail::execution_context_service_base<...>::id
boost::asio::detail::posix_serial_port_service::open
```

Merging an `epoll_reactor` or a thread-local pointer across two different Boost versions is an ODR violation that surfaces as runtime misbehavior, not a link error — the kind that is very expensive to diagnose.

## Key Changes

- `cmake/wirestead.map` — ELF version script.
- `cmake/wirestead.exp` — Mach-O exported symbols list.
- `cmake/WiresteadTargets.cmake` — `wirestead_limit_exported_symbols()`, applied to the shared target, with `LINK_DEPENDS` so editing a script triggers a relink.
- `cmake/WiresteadOptions.cmake` — `WIRESTEAD_LIMIT_EXPORTED_SYMBOLS` (default `ON`) as an escape hatch.
- `docs/api_stability.md`, `CHANGELOG.md`.

**This is not an ABI reduction.** Every `wirestead` symbol stays exported — including the 394 from `transport/`, `interface/`, `memory/`, `concurrency/`, and `factory/`, and the typeinfo and vtables that exceptions thrown across the boundary need to be caught by type. Only symbols that were never ours are removed.

| | before | after |
|---|---:|---:|
| exported total | 2139 | **1534** |
| ours | 1534 | **1534** |
| foreign | 605 | **0** |
| boost/spdlog/fmt | 35 | **0** |

## Related Issues
- N/A

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified on Linux (GCC, Release):**

- Default configuration (shared + static, tests on) builds, and **733/733 tests pass**.
- The shared library from that same build exports 1534 symbols, **all of them ours**, with zero `boost`/`spdlog`/`fmt`.
- Installed the shared-only build and consumed it from a separate project through `find_package(wirestead CONFIG REQUIRED)` + `wirestead::wirestead`: it links, runs, and **catches a library exception by type across the `.so` boundary** — the failure mode this change could plausibly have introduced, since hiding typeinfo breaks `catch` silently.
- `cmake-format` (cmakelang 0.6.13, matching `code-formatting.yml`) is idempotent on the edited files.

**Not verified locally: the Mach-O path.** `cmake/wirestead.exp` uses the extra leading underscore Mach-O adds to mangled C++ symbols, but I have no macOS machine here. The macOS CI jobs are the check. If `-exported_symbols_list` is wrong, the failure will be loud (link error), not silent.

**Two mistakes made and corrected while doing this, recorded so review can weigh them:**

1. My first report claimed visibility was disabled entirely, based on the commented-out `add_compile_options(-fvisibility=hidden ...)` in `WiresteadCompiler.cmake:178`. That was wrong — `WiresteadTargets.cmake` already sets it as a target property. The supporting number I gave was also wrong: I counted `nm` ` T ` entries, and `nm` does not show ELF visibility, so hidden symbols were included. `readelf -sW` gives the real split.
2. The first draft resolved the script path with `CMAKE_CURRENT_LIST_DIR` inside a function, which resolves against the *calling* listfile, so it looked for `wirestead.map` at the repository root. Now captured at include time into `WIRESTEAD_CMAKE_DIR`. The scratch experiment could not have caught this, because it passed an absolute path through `CMAKE_SHARED_LINKER_FLAGS`; only wiring it into the repository exposed it.

**Separate pre-existing issue, deliberately not addressed here.** A shared-only build with tests enabled fails to link: `wirestead::memory::safe_buffer_factory` has no `WIRESTEAD_API`, so hidden visibility keeps it out of the `.so` while the tests reference it directly. I confirmed by control build that this happens with `WIRESTEAD_LIMIT_EXPORTED_SYMBOLS=OFF` too, so it predates this change. Nothing builds that combination today — `scripts/verify_installed_consumer.sh` uses `WIRESTEAD_BUILD_TESTS=OFF` for its shared mode — so it is latent rather than shipping. It does mean symbol availability differs between the static and shared libraries, which may be worth a separate look.

**Not run.** `./scripts/verify.sh` runs the full formatting-plus-build-plus-test pipeline; the build and test halves were run directly as described above, and `cmake-format` was checked against the same version CI pins.
