### PR TITLE
ci: verify installed exports and run install-consume on macOS

### DIFF
--- a/.github/workflows/ci-install-consume.yml
+++ b/.github/workflows/ci-install-consume.yml
@@ -20,18 +20,30 @@ on:
 
 jobs:
   build-test-install-consume:
-    runs-on: ubuntu-24.04
+    name: install & consume (${{ matrix.os }}, ${{ matrix.compiler }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        include:
+          - os: ubuntu-24.04
+            compiler: gcc
+            triplet: x64-linux
+          - os: ubuntu-24.04
+            compiler: clang
+            triplet: x64-linux
+          - os: macos-15
+            compiler: clang
+            triplet: arm64-osx
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up C++ toolchain
+      - name: Set up C++ toolchain (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build pkg-config
-          
+
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             echo "CC=gcc" >> $GITHUB_ENV
             echo "CXX=g++" >> $GITHUB_ENV
@@ -41,10 +53,17 @@ jobs:
             echo "CXX=clang++-18" >> $GITHUB_ENV
           fi
 
+      - name: Set up C++ toolchain (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install ninja pkg-config
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+
       - name: Install dependencies with vcpkg
         uses: ./.github/actions/setup-vcpkg
         with:
-          triplet: x64-linux
+          triplet: ${{ matrix.triplet }}
 
       - name: Configure
         run: |
@@ -64,6 +83,41 @@ jobs:
 
       - name: Install
         run: cmake --install build --prefix "$RUNNER_TEMP/wirestead-install"
+
+      # Guards the export restriction in cmake/wirestead.map and wirestead.exp.
+      # A wrong symbol pattern does not fail the link, it just exports nothing
+      # or everything, and the unit tests cannot notice because they link the
+      # static library. This is the only place that inspects the shared one.
+      - name: Verify shared library exports
+        shell: bash
+        run: |
+          set -euo pipefail
+          lib_dir="$RUNNER_TEMP/wirestead-install/lib"
+
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            lib="$(ls "$lib_dir"/libwirestead*.dylib | head -n 1)"
+            symbols="$(nm -gU "$lib")"
+          else
+            lib="$(ls "$lib_dir"/libwirestead.so.* | head -n 1)"
+            symbols="$(nm -D --defined-only "$lib")"
+          fi
+          echo "inspecting $lib"
+
+          owner() { printf '%s\n' "$symbols" | grep -cE "^[^ ]* [A-Za-z] _?_Z[A-Za-z]*$1" || true; }
+          ours="$(owner 9wirestead)"
+          foreign="$(( $(owner 5boost) + $(owner 6spdlog) + $(owner 3fmt) ))"
+          echo "wirestead symbols: $ours, third-party symbols: $foreign"
+
+          if [ "$ours" -eq 0 ]; then
+            echo "the shared library exports no wirestead symbols; the export list did not match"
+            exit 1
+          fi
+          if [ "$foreign" -ne 0 ]; then
+            echo "the shared library re-exports third-party symbols:"
+            offenders="$(printf '%s\n' "$symbols" | grep -E "^[^ ]* [A-Za-z] _?_Z[A-Za-z]*(5boost|6spdlog|3fmt)" || true)"
+            printf '%s\n' "$offenders" | head -20 || true
+            exit 1
+          fi
 
       - name: Consume canonical package (find_package)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and ABI policy.
 - Aligned the CMake project description with the GitHub repository
   description. This string is user-visible: it is carried into the CPack
   package metadata and the generated pkg-config description.
+- Extended the install-and-consume CI job to macOS. It previously ran on Linux
+  only, so the installed-package path was never exercised on any other
+  platform.
+- Added a CI check that inspects the installed shared library and fails if it
+  exports no Wirestead symbols or any third-party ones. The unit tests link the
+  static library, so nothing else looks at what the shared library exports.
 - Pinned the `microsoft/vcpkg` checkout used by CI, the CMake matrix, the
   release workflow, the vcpkg package test, and the `setup-vcpkg` composite
   action to a reviewed commit recorded in `VCPKG_BASELINE`, instead of cloning


### PR DESCRIPTION
## Description

Two gaps left over from #559, which restricted what the shared library exports.

**Nothing in CI looked at what the shared library exports.** The unit tests link the static library, so a version script that matched nothing would produce an empty `.so` and every job would still pass. The mistake would only surface for a consumer.

**The install-and-consume job ran on Linux only.** That meant `cmake/wirestead.exp`, the Mach-O exported-symbols list added in #559, had no coverage whatsoever. Its macOS jobs going green proved the linker accepted the flag, not that the patterns matched anything — precisely because the tests there link the static library too.

## Key Changes

- `.github/workflows/ci-install-consume.yml`:
  - Matrix restructured to `include` entries so macOS can join: `ubuntu-24.04`/gcc, `ubuntu-24.04`/clang, `macos-15`/clang, each carrying its own vcpkg triplet.
  - Toolchain setup split per platform; macOS installs `ninja` and `pkg-config` via Homebrew.
  - New **Verify shared library exports** step, right after install, that inspects the installed shared library and fails if it exports no Wirestead symbols or any third-party ones.
- `CHANGELOG.md`.

The export check runs on every platform in the job, so adding macOS gives the Mach-O list real coverage.

## Related Issues
- Follows #559.

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The check was tested in both directions against real artifacts, not just written.** That mattered, because the first two versions of it were wrong:

1. **False positive.** Matching `5boost` as a substring also counts our own symbols, since a function taking `std::shared_ptr<boost::asio::io_context>` carries `5boost` in its mangled parameter list. Run against a correctly restricted library, that version reported 325 "third-party" symbols and would have failed CI on a good build. The check now anchors on the *owning* namespace: Itanium mangling puts the owner right after the `_Z` prefix and its letter tags, and Mach-O only adds one leading underscore, so `^[^ ]* [A-Za-z] _?_Z[A-Za-z]*5boost` covers both platforms without demangling — which also sidesteps Apple's `nm` not supporting `-C`.
2. **Wrong exit code.** Piping `grep` into `head -20` under `set -o pipefail` made the step die with 141 (SIGPIPE) before reaching its `exit 1`. It failed, but for the wrong reason and with truncated output.

Final verification, against libraries actually built from this repository:

| library | wirestead symbols | third-party | exit |
|---|---:|---:|---:|
| restricted (built with `WIRESTEAD_LIMIT_EXPORTED_SYMBOLS=ON`) | 1534 | 0 | **0** |
| unrestricted (same tree, `=OFF`) | 1605 | 325 | **1** |

Also confirmed the workflow parses and the embedded shell passes `bash -n`.

**Not verified locally: the macOS leg.** I have no macOS machine, so the Homebrew setup, the `arm64-osx` vcpkg triplet, `nm -gU` output shape, and whether the installed `.dylib` resolves at runtime for the consumer are all first exercised by this PR's own CI. This is the job that is supposed to find those things, so a failure here is the feature working. If the `arm64-osx` vcpkg build turns out to be slow or flaky, dropping the macOS leg back out is a one-line matrix change.

**Not run.** `./scripts/verify.sh` builds the full core and test suite; this change touches only workflow YAML and Markdown. The behavior it adds was verified directly as described above.
