### PR TITLE
docs: correct the visibility comment and record the shared/static gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and ABI policy.
 - Aligned the CMake project description with the GitHub repository
   description. This string is user-visible: it is carried into the CPack
   package metadata and the generated pkg-config description.
+- Documented that out-of-line functions declared in internal headers are not
+  always exported from the shared library, so code calling them links against
+  the static library but not the shared one. The documented public surface is
+  exported from both.
 - Extended the install-and-consume CI job to macOS. It previously ran on Linux
   only, so the installed-package path was never exercised on any other
   platform.

--- a/cmake/WiresteadCompiler.cmake
+++ b/cmake/WiresteadCompiler.cmake
@@ -175,8 +175,11 @@ int main() {
     endif()
   endif()
 
-  # Visibility settings (disabled for now to avoid linking issues)
-  # add_compile_options(-fvisibility=hidden -fvisibility-inlines-hidden)
+  # Visibility is not set globally here on purpose. The library targets set it
+  # per target in WiresteadTargets.cmake through CXX_VISIBILITY_PRESET and
+  # VISIBILITY_INLINES_HIDDEN, which also keeps it off consumers of this
+  # project. Adding -fvisibility=hidden here would be redundant, and it would
+  # apply to test and example targets that do not want it.
 
   # Optimization flags
   if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -105,6 +105,13 @@ Compatibility is not guaranteed for deep includes under:
 - `concurrency/*`
 - `factory/*`
 
+A further consequence applies to the shared library. Out-of-line functions
+declared in those headers are not always exported from it, because they carry
+no export annotation and hidden visibility keeps them internal. Code that
+includes an internal header and calls such a function links against the static
+library but not the shared one. The documented public surface is unaffected;
+it is exported from both.
+
 These headers are installed for implementation and advanced integration needs,
 but application code should include `<wirestead/wirestead.hpp>` unless a documented
 advanced API requires otherwise.


### PR DESCRIPTION
## Description

Two follow-ups from the export work in #559 and #560. Both turned out to be documentation problems rather than code problems, and the investigation behind the second one is the substance of this PR.

**The comment was wrong.** `cmake/WiresteadCompiler.cmake` said visibility was *"disabled for now to avoid linking issues"*. It is not disabled — `WiresteadTargets.cmake` sets `CXX_VISIBILITY_PRESET hidden` and `VISIBILITY_INLINES_HIDDEN` per target. The global flag would merely be redundant, and would additionally reach test and example targets that do not want it. This comment is what led me to report, wrongly, that the project shipped with visibility off; replacing it with what is actually true.

**There is a real static/shared difference, and it is now written down.** 31 non-template functions exist as globals in the static library but are not exported from the shared one: they are declared in internal headers without an export annotation, so hidden visibility keeps them internal. Code including such a header and calling one of them links against the static library and fails against the shared one.

## Key Changes

- `cmake/WiresteadCompiler.cmake` — comment corrected to describe where visibility is actually set and why it is not set globally.
- `docs/api_stability.md` — records the shared/static consequence in the internal-headers section.
- `CHANGELOG.md`.

No behavior changes.

## Related Issues
- Follows #559, #560.

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The decisive check: the documented public surface is fine.** Rather than reason from symbol lists, I built the TCP client example from `docs/quickstart.md` — unmodified, with the CMake shown there — against the installed shared package. It links and runs. `start_sync()` had looked at risk because `wrapper::ChannelInterface::start_sync` is among the unexported symbols, but the concrete override on `TcpClient` is exported, so a consumer never needs the base one.

**Where the 31 sit:** transport 9, diagnostics 8, memory 3, interface 3, config 3, wrapper 2, framer 2, base 1. Every one of those namespaces is already listed in `api_stability.md` as carrying no compatibility guarantee, which is why this documents the consequence instead of exporting them. Adding export annotations would widen the ABI surface — the opposite of what #559 set out to do — and should be a deliberate decision per symbol, not a sweep.

**Method note, because I got this wrong twice before landing on a number I trust.** My first comparison read `libwirestead.a`, which does not exist — the static target's `OUTPUT_NAME` makes it `libwirestead_static.a` — and with stderr discarded that silently produced "0 missing". My second used `readelf` on the archive, whose per-member output shifts the column the symbol name lands in, and it reported symbols as missing that are in fact exported. The figure above comes from `nm` on both artifacts, and I validated the method by checking two known cases through it: `IoContextManager::instance`, which is exported, does not appear in the missing set, and `safe_buffer_factory::from_c_string`, which is not exported, does.

**Not run.** `./scripts/verify.sh` builds the full core and test suite; this PR changes a comment and two Markdown files. `cmake-format` reports no reformatting needed on the edited `.cmake` file, and `git diff --check` is clean.
