### PR TITLE
experiment: drop the MSVC LTCG workaround to see if it is still needed (do not merge)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,34 +22,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/WiresteadSources.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/WiresteadTargets.cmake)
 wirestead_add_library_targets()
 
-# Disable MSVC LTCG for wirestead libraries to avoid link.exe access violations.
-# This is a known workaround. Future investigation should aim to resolve the
-# underlying conflict that causes these violations when LTCG is enabled.
-if(MSVC)
-  foreach(_target IN LISTS WIRESTEAD_LIBRARY_TARGETS)
-    target_compile_options(
-      ${_target}
-      PRIVATE "$<$<CONFIG:Release>:/GL->" "$<$<CONFIG:RelWithDebInfo>:/GL->"
-              "$<$<CONFIG:MinSizeRel>:/GL->"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_RELEASE " /LTCG:OFF"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG:OFF"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_MINSIZEREL " /LTCG:OFF"
-    )
-  endforeach()
-endif()
-
 # Export header generation
 if(WIRESTEAD_ENABLE_EXPORT_HEADER)
   include(GenerateExportHeader)


### PR DESCRIPTION
## Description

**Draft, and not for merging.** This exists to get an answer out of CI that cannot be obtained locally, because none of us has an MSVC toolchain here.

`CMakeLists.txt` forces `/GL-` and `/LTCG:OFF` onto the library targets, undoing the `/GL` and `/LTCG` that `cmake/WiresteadCompiler.cmake` applies globally for MSVC Release. It arrived in #92 (2025-11-23) as *"disable MSVC LTCG for unilink libraries to prevent link.exe access violations"*, and its own comment asks for exactly this: *"Future investigation should aim to resolve the underlying conflict."*

Nothing has re-checked it in the ~8 months since. That matters because the same period produced a comment claiming visibility was disabled when it was not — corrected in #561 — and both came out of the same packaging rework. A stale workaround is a real possibility.

This branch removes the override so the global settings apply uniformly, and lets the Windows jobs answer.

## What the result means

- **Windows Release green** → the workaround has outlived its cause. The follow-up is to stop hand-writing `/GL`, `/LTCG`, and `-flto` and drive it through CMake's `INTERPROCEDURAL_OPTIMIZATION` property, which removes the override entirely and makes `WIRESTEAD_ENABLE_LTO` mean the same thing on every compiler.
- **Windows Release fails** → the workaround is still load-bearing. The error text is then the input for a targeted fix, and the comment in `CMakeLists.txt` should be updated to record that it was re-verified rather than left open-ended.

Either outcome closes a question that has been open since November.

## Key Changes

- `CMakeLists.txt` — removes the 28-line `if(MSVC)` override block. Nothing else.

## Related Issues
- Investigates the open question left by #92.

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

(None of these fit well — this is a diagnostic branch, not a change to land.)

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Confirmed the experiment can actually answer the question.** The override only applies to `Release`, `RelWithDebInfo`, and `MinSizeRel`, so it would prove nothing if CI built Windows in Debug. Checked the workflows: `ci.yml`'s `windows` job, `release.yml`, and `vcpkg-package-test.yml` all build `Release` on Windows. The job to watch is **`Windows (windows-2022)`**, with `Windows (windows-11-arm)` alongside it.

**What the current arrangement actually does**, which is worth stating because it may be the cause rather than a victim: `/GL` and `/LTCG` are applied globally, then removed from the library targets only. Test and example targets therefore still compile with `/GL` while linking against libraries built without LTCG. Mixing `/GL` objects with non-LTCG linking is a documented source of MSVC linker trouble, so the override may be sustaining the very inconsistency it was added to work around.

**A related asymmetry, not addressed here.** `WIRESTEAD_ENABLE_LTO` defaults to `OFF` and gates `-flto` for GCC and Clang, but MSVC gets `/GL` unconditionally in Release. The option currently has no effect on MSVC.

`cmake-format` reports no reformatting needed after the removal.
