### PR TITLE
build: drive LTO through the CMake property and drop the MSVC workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and ABI policy.
 - Aligned the CMake project description with the GitHub repository
   description. This string is user-visible: it is carried into the CPack
   package metadata and the generated pkg-config description.
+- Drive link-time optimization through CMake's `INTERPROCEDURAL_OPTIMIZATION`
+  property instead of hand-written `/GL`, `/LTCG`, and `-flto` flags, applied
+  per library target and only to the optimized configurations.
+  `WIRESTEAD_ENABLE_LTO` now means the same thing on every compiler; it
+  previously gated `-flto` on GCC and Clang while MSVC received `/GL`
+  unconditionally in Release, so the option had no effect there.
+- Removed the MSVC workaround that forced `/GL-` and `/LTCG:OFF` onto the
+  library targets to avoid `link.exe` access violations. A CI run with the
+  override removed confirmed the underlying problem no longer reproduces, and
+  the flags it fought with are gone.
 - Documented that out-of-line functions declared in internal headers are not
   always exported from the shared library, so code calling them links against
   the static library but not the shared one. The documented public surface is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,34 +22,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/WiresteadSources.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/WiresteadTargets.cmake)
 wirestead_add_library_targets()
 
-# Disable MSVC LTCG for wirestead libraries to avoid link.exe access violations.
-# This is a known workaround. Future investigation should aim to resolve the
-# underlying conflict that causes these violations when LTCG is enabled.
-if(MSVC)
-  foreach(_target IN LISTS WIRESTEAD_LIBRARY_TARGETS)
-    target_compile_options(
-      ${_target}
-      PRIVATE "$<$<CONFIG:Release>:/GL->" "$<$<CONFIG:RelWithDebInfo>:/GL->"
-              "$<$<CONFIG:MinSizeRel>:/GL->"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_RELEASE " /LTCG:OFF"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG:OFF"
-    )
-    set_property(
-      TARGET ${_target}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS_MINSIZEREL " /LTCG:OFF"
-    )
-  endforeach()
-endif()
-
 # Export header generation
 if(WIRESTEAD_ENABLE_EXPORT_HEADER)
   include(GenerateExportHeader)

--- a/cmake/WiresteadCompiler.cmake
+++ b/cmake/WiresteadCompiler.cmake
@@ -53,17 +53,13 @@ if(MSVC)
 
   # MSVC-specific optimizations and debug information
   set(CMAKE_CXX_FLAGS_RELEASE
-      "${CMAKE_CXX_FLAGS_RELEASE} /O2 /Ob2 /Oi /Ot /Oy /GL /wd4251 /wd4275"
+      "${CMAKE_CXX_FLAGS_RELEASE} /O2 /Ob2 /Oi /Ot /Oy /wd4251 /wd4275"
   )
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
       "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /O2 /wd4251 /wd4275"
   )
   set(CMAKE_CXX_FLAGS_MINSIZEREL
       "${CMAKE_CXX_FLAGS_MINSIZEREL} /O1 /Os /wd4251 /wd4275"
-  )
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG")
-  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE
-      "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG"
   )
 
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -184,10 +180,6 @@ int main() {
   # Optimization flags
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(-O3 -DNDEBUG)
-    if(WIRESTEAD_ENABLE_LTO)
-      add_compile_options(-flto)
-      add_link_options(-flto)
-    endif()
   elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-g -O0)
   endif()

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -87,6 +87,23 @@ option(WIRESTEAD_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
 option(WIRESTEAD_ENABLE_TSAN "Enable ThreadSanitizer" OFF)
 
 option(WIRESTEAD_ENABLE_LTO "Enable Link Time Optimization" OFF)
+
+# Resolved once here so the target helpers can just read it. Asking the
+# toolchain beats guessing: it covers MSVC /GL plus /LTCG and GCC/Clang -flto
+# behind one property, and reports rather than fails when unavailable.
+set(WIRESTEAD_IPO_SUPPORTED OFF)
+if(WIRESTEAD_ENABLE_LTO)
+  include(CheckIPOSupported)
+  check_ipo_supported(
+    RESULT WIRESTEAD_IPO_SUPPORTED OUTPUT _wirestead_ipo_error
+  )
+  if(NOT WIRESTEAD_IPO_SUPPORTED)
+    message(
+      WARNING "WIRESTEAD_ENABLE_LTO is ON but this toolchain does not support "
+              "interprocedural optimization: ${_wirestead_ipo_error}"
+    )
+  endif()
+endif()
 option(WIRESTEAD_ENABLE_PCH "Enable Precompiled Headers" OFF)
 
 foreach(_suffix IN LISTS _wirestead_option_suffixes)

--- a/cmake/WiresteadTargets.cmake
+++ b/cmake/WiresteadTargets.cmake
@@ -4,7 +4,23 @@
 # at whatever listfile happens to call the functions below.
 set(WIRESTEAD_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
+# Only the optimized configurations; enabling it for Debug would slow builds
+# down for no benefit. Applied per target so it does not reach tests, examples
+# or anything consuming this project.
+function(wirestead_enable_ipo target)
+  if(NOT WIRESTEAD_ENABLE_LTO OR NOT WIRESTEAD_IPO_SUPPORTED)
+    return()
+  endif()
+  set_target_properties(
+    ${target}
+    PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
+               INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE
+               INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE
+  )
+endfunction()
+
 function(wirestead_configure_library_target target)
+  wirestead_enable_ipo(${target})
   target_link_libraries(${target} PUBLIC wirestead_dependencies)
   target_compile_features(${target} PUBLIC cxx_std_20)
   target_include_directories(


### PR DESCRIPTION
## Description

Three settings were fighting each other:

- `cmake/WiresteadCompiler.cmake` put `/GL` and `/LTCG` on **every** MSVC Release build.
- `CMakeLists.txt` then forced `/GL-` and `/LTCG:OFF` back onto the library targets.
- `WIRESTEAD_ENABLE_LTO` (default `OFF`) gated `-flto` for GCC and Clang, and **did nothing at all on MSVC**.

The net effect was that test and example targets compiled with `/GL` and linked against libraries built without LTCG. Mixing `/GL` objects with non-LTCG linking is a documented way to upset `link.exe` — so the override may have been sustaining the access violations it was added for in #92, rather than avoiding them.

This asks CMake instead of hand-writing flags.

## Key Changes

- `cmake/WiresteadCompiler.cmake` — removed the hand-written `/GL`, `/LTCG`, and `-flto`.
- `cmake/WiresteadOptions.cmake` — `check_ipo_supported()` resolves toolchain support once and warns instead of failing when `WIRESTEAD_ENABLE_LTO` is on but unsupported.
- `cmake/WiresteadTargets.cmake` — `wirestead_enable_ipo()` sets `INTERPROCEDURAL_OPTIMIZATION` per library target, on `Release`, `RelWithDebInfo`, and `MinSizeRel` only.
- `CMakeLists.txt` — the 28-line MSVC override is gone.
- `CHANGELOG.md`.

`WIRESTEAD_ENABLE_LTO` now means the same thing on every compiler and still defaults to `OFF`, so a default build gets no LTO anywhere. Applying it per target also keeps it off tests, examples, and anything consuming this project.

## Related Issues
- Resolves the question left open by #92 and probed in #562.

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Why removing the override is safe.** #562 is the evidence: with the override removed, all three Windows jobs passed — `Windows (windows-2022)`, `Windows (windows-11-arm)`, and `C++ (Windows, MSVC)`. Critically, LTCG was genuinely active in that run rather than silently skipped; the linker log shows repeated `Generating code` / `Finished generating code` phases, which only appear when LTCG runs. Build time rose accordingly, from ~27m30s to 35m15s on `windows-2022` and ~31m59s to 44m10s on `windows-11-arm`.

**That cost does not land here.** Because `WIRESTEAD_ENABLE_LTO` defaults to `OFF` and now actually applies to MSVC, the default build does *less* optimization work than today's `main`, where MSVC Release gets `/GL` unconditionally. Windows CI times should return to the ~27–32m baseline rather than the ~35–44m the probe showed.

**Verified locally on Linux, both directions:**

| configuration | `-flto` in compile flags | `-flto` at link | tests |
|---|---|---|---|
| default (`WIRESTEAD_ENABLE_LTO=OFF`) | none | none | **733/733 pass** |
| `WIRESTEAD_ENABLE_LTO=ON` | `-flto=auto` on `wirestead_shared` and `wirestead_static` | `-flto=auto` | **733/733 pass** |

The LTO-on run is worth calling out: `-flto` has been available behind this option for a while, but since it defaults to off it is unlikely to have been exercised in CI. This is a real build-and-test pass with it enabled.

**Not verified locally: MSVC.** No toolchain here. #562 proved the override is removable; it did not exercise this PR's rewiring, which changes where the flags come from. The Windows jobs on this PR are the first run of the combination, and they are the ones to watch.

**A method slip worth recording**, since it briefly looked like the property was not applying: I first checked flags in `CMakeFiles/wirestead.dir/`, which does not exist — the targets are `wirestead_shared` and `wirestead_static`. Reading a non-existent path reported zero `-flto` occurrences for both configurations. The table above comes from the real target directories.

**Not run.** `./scripts/verify.sh` runs formatting plus build plus tests; the build and test halves were run directly for both configurations above, and `cmake-format` is idempotent on all four edited `.cmake`/`CMakeLists.txt` files.

Once this lands, #562 can be closed — it was a diagnostic branch and was never meant to merge.
