### PR TITLE
ci: run install-and-consume on Windows

### DIFF
--- a/.github/workflows/ci-install-consume.yml
+++ b/.github/workflows/ci-install-consume.yml
@@ -35,6 +35,9 @@ jobs:
           - os: macos-15
             compiler: clang
             triplet: arm64-osx
+          - os: windows-2022
+            compiler: msvc
+            triplet: x64-windows
     steps:
       - uses: actions/checkout@v7
 
@@ -61,11 +64,27 @@ jobs:
           echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Install dependencies with vcpkg
+        if: runner.os != 'Windows'
         uses: ./.github/actions/setup-vcpkg
         with:
           triplet: ${{ matrix.triplet }}
 
+      # The composite action bootstraps through bootstrap-vcpkg.sh, which the
+      # Windows runners cannot use. They ship vcpkg preinstalled, which the
+      # existing `windows` job in ci.yml already relies on.
+      - name: Install dependencies with vcpkg (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          "/c/vcpkg/vcpkg.exe" install boost-asio:${{ matrix.triplet }} boost-system:${{ matrix.triplet }} spdlog:${{ matrix.triplet }}
+          {
+            echo "VCPKG_ROOT=C:/vcpkg"
+            echo "VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}"
+            echo "CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+          } >> "$GITHUB_ENV"
+
       - name: Configure
+        if: runner.os != 'Windows'
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -78,17 +97,46 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
             -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
 
+      # Visual Studio is a multi-config generator, so the configuration is
+      # chosen at build and install time rather than at configure time.
+      - name: Configure (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 \
+            -DCMAKE_INSTALL_PREFIX="$RUNNER_TEMP/wirestead-install" \
+            -DWIRESTEAD_ENABLE_INSTALL=ON \
+            -DWIRESTEAD_ENABLE_EXPORT_HEADER=ON \
+            -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" \
+            -DVCPKG_TARGET_TRIPLET="$VCPKG_TARGET_TRIPLET"
+
       - name: Build
+        if: runner.os != 'Windows'
         run: cmake --build build --config Release -- -v
 
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: cmake --build build --config Release
+
       - name: Install
+        if: runner.os != 'Windows'
         run: cmake --install build --prefix "$RUNNER_TEMP/wirestead-install"
+
+      - name: Install (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: cmake --install build --config Release --prefix "$RUNNER_TEMP/wirestead-install"
 
       # Guards the export restriction in cmake/wirestead.map and wirestead.exp.
       # A wrong symbol pattern does not fail the link, it just exports nothing
       # or everything, and the unit tests cannot notice because they link the
       # static library. This is the only place that inspects the shared one.
+      # Skipped on Windows on purpose: DLL exports are opt-in through
+      # __declspec(dllexport), so a DLL cannot re-export what it links
+      # against, and there is no version script or symbols list to get wrong.
       - name: Verify shared library exports
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
@@ -120,6 +168,7 @@ jobs:
           fi
 
       - name: Consume canonical package (find_package)
+        shell: bash
         run: |
           install_prefix="$RUNNER_TEMP/wirestead-install"
           mkdir -p "$RUNNER_TEMP/consumer" && cd "$RUNNER_TEMP/consumer"
@@ -144,14 +193,23 @@ jobs:
             return 0;
           }
           EOF
-          cmake -S . -B build -G Ninja \
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            generator=(-G "Visual Studio 17 2022" -A x64)
+            binary="./build/Release/consumer.exe"
+            export PATH="$install_prefix/bin:/c/vcpkg/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
+          else
+            generator=(-G Ninja)
+            binary="./build/consumer"
+          fi
+          cmake -S . -B build "${generator[@]}" \
             -DCMAKE_PREFIX_PATH="$install_prefix" \
             -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
             -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
           cmake --build build --config Release
-          ./build/consumer
+          "$binary"
 
       - name: Consume legacy package (find_package)
+        shell: bash
         run: |
           install_prefix="$RUNNER_TEMP/wirestead-install"
           mkdir -p "$RUNNER_TEMP/consumer-legacy" && cd "$RUNNER_TEMP/consumer-legacy"
@@ -176,14 +234,25 @@ jobs:
             return 0;
           }
           EOF
-          cmake -S . -B build -G Ninja \
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            generator=(-G "Visual Studio 17 2022" -A x64)
+            binary="./build/Release/legacy_consumer.exe"
+            export PATH="$install_prefix/bin:/c/vcpkg/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
+          else
+            generator=(-G Ninja)
+            binary="./build/legacy_consumer"
+          fi
+          cmake -S . -B build "${generator[@]}" \
             -DCMAKE_PREFIX_PATH="$install_prefix" \
             -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
             -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
           cmake --build build --config Release
-          ./build/legacy_consumer
+          "$binary"
 
+      # pkg-config is not part of the MSVC consumption story, and the Windows
+      # runners have no pkg-config to test with.
       - name: Test pkg-config
+        if: runner.os != 'Windows'
         run: |
           # wirestead.pc and unilink.pc both need vcpkg's pkg-config modules
           # when dependencies such as spdlog are external.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and ABI policy.
   always exported from the shared library, so code calling them links against
   the static library but not the shared one. The documented public surface is
   exported from both.
-- Extended the install-and-consume CI job to macOS. It previously ran on Linux
+- Extended the install-and-consume CI job to macOS and Windows. It previously
+  ran on Linux only, so the installed-package path was never exercised on any
+  other platform. It previously ran on Linux
   only, so the installed-package path was never exercised on any other
   platform.
 - Added a CI check that inspects the installed shared library and fails if it


### PR DESCRIPTION
## Description

#560 gave the install-and-consume job macOS coverage. Windows still had none, which left the MSVC consumption path completely unverified — and that is the platform where consumption differs most: a multi-config generator, DLLs that must be locatable at run time, and an import library rather than a version-scripted shared object.

Nothing in CI has ever confirmed that an installed Wirestead package can be consumed from a separate CMake project on Windows.

## Key Changes

- `.github/workflows/ci-install-consume.yml`:
  - `windows-2022` / `msvc` / `x64-windows` added to the matrix.
  - **vcpkg**: Windows uses the preinstalled `C:\vcpkg` instead of the composite action, which bootstraps through `bootstrap-vcpkg.sh`. This matches what the existing `windows` job in `ci.yml` already does.
  - **Configure/build/install**: Visual Studio is a multi-config generator, so the configuration is selected at build and install time rather than at configure time.
  - **Consume steps**: parameterised on generator and binary path rather than duplicated, so Linux and macOS behavior is byte-for-byte unchanged. Windows additionally puts the install `bin` and the vcpkg `bin` on `PATH` so the DLLs resolve at run time.
- `CHANGELOG.md`.

Two steps are skipped on Windows, for reasons rather than convenience:

- **Export verification** does not apply. DLL exports are opt-in through `__declspec(dllexport)`, so a DLL cannot re-export what it links against, and there is no version script or symbols list that could be wrong. The check exists to guard `cmake/wirestead.map` and `wirestead.exp`, neither of which Windows uses.
- **pkg-config** is not part of the MSVC consumption story, and the runners have none installed.

## Related Issues
- Completes the platform coverage started in #560.

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified locally, to the extent a Windows-targeting workflow can be without Windows:**

- The workflow parses, and every `run:` block passes `bash -n` with GitHub expressions stubbed.
- The generator/binary branch was executed both ways: `RUNNER_OS=Linux` yields `-G Ninja` and `./build/consumer`; `RUNNER_OS=Windows` yields `-G "Visual Studio 17 2022" -A x64` and `./build/Release/consumer.exe`. This is what confirms the existing platforms are unaffected — the shared step is the same one they already ran.
- Step gating was checked against the parsed workflow rather than by reading: 5 steps are Windows-only, 6 are non-Windows, and the rest run everywhere.

**Windows steps use `shell: bash` deliberately.** My first attempt wrote them in PowerShell, which broke the YAML outright: a pwsh here-string terminator (`'@`) must sit at column 0, and that is incompatible with a YAML block scalar. Git Bash is present on the Windows runners, so the existing heredoc-based steps work there unchanged, and using one shell keeps the consume steps shared rather than forked.

**Not verified: everything Windows-specific actually running.** No Windows machine here, so the `x64-windows` vcpkg install, the Visual Studio generator invocation, DLL resolution through `PATH`, and `find_package` against the installed package are all first exercised by this PR's own CI. That is the point of the job — a failure here is it doing its work, not a surprise.

**One thing worth flagging separately.** Windows x64 takes vcpkg from the runner image, so `VCPKG_BASELINE` — the pin added in #556 — does not apply to it. That is pre-existing and matches `ci.yml`, and the runner image is at least a slower-moving pin than cloning the default branch, but it does mean the pin's coverage has a hole. Worth deciding on separately rather than folding into this PR.
