### PR TITLE
test: wait for retry attempts instead of racing a fixed timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and ABI policy.
 
 ### Fixed
 
+- Made the TCP client retry tests wait for the attempts they assert on instead
+  of running for a fixed duration and hoping. They raced anything that slowed
+  the machine down, and one of them failed a coverage run on a resolve that
+  took longer than the window allowed.
 - Stopped the shared library from re-exporting `boost::asio::detail` symbols it
   merely links against. Those are weak and unique symbols that hidden
   visibility does not remove, so a consumer loading a different Boost into the

--- a/test/integration/transport/transport_tcp_client.cc
+++ b/test/integration/transport/transport_tcp_client.cc
@@ -38,6 +38,32 @@
 
 using namespace wirestead;
 using namespace wirestead::transport;
+
+namespace {
+
+// Drives the io_context in slices until `predicate` holds, or the timeout
+// expires. The retry tests below used to run for a fixed duration and then
+// assert on how many attempts had happened, which races anything that slows
+// the machine down: a slow resolver, a loaded runner, coverage
+// instrumentation. Waiting on the condition instead makes them finish as soon
+// as the attempts arrive and tolerate the cases where they arrive late.
+template <typename Predicate>
+bool run_until(boost::asio::io_context& ioc, Predicate predicate,
+               std::chrono::milliseconds timeout = std::chrono::seconds(5)) {
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!predicate()) {
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return false;
+    }
+    if (ioc.stopped()) {
+      ioc.restart();
+    }
+    ioc.run_for(std::chrono::milliseconds(10));
+  }
+  return true;
+}
+
+}  // namespace
 using namespace wirestead::test;
 using namespace std::chrono_literals;
 namespace net = boost::asio;
@@ -252,7 +278,7 @@ TEST_F(TransportTcpClientTest, OnBytesExceptionTriggersReconnect) {
   client_->start();
 
   // Run enough to connect, receive, throw, and schedule a retry
-  ioc.run_for(150ms);
+  run_until(ioc, [&] { return connecting_events.load() >= 2; });
 
   EXPECT_EQ(error_events.load(), 0);
   // At least two Connecting states: initial + post-exception reconnect attempt
@@ -374,7 +400,7 @@ TEST_F(TransportTcpClientTest, ConnectionRefusedTriggersRetry) {
 
   // Run enough time for initial attempt + at least one retry
   // Initial (0ms) + Timeout(100ms) + Interval(50ms) + Retry(0ms) = ~150ms minimum
-  ioc.run_for(std::chrono::milliseconds(500));
+  run_until(ioc, [&] { return connecting_count.load() >= 2; });
 
   EXPECT_GE(connecting_count.load(), 2);
 
@@ -401,7 +427,7 @@ TEST_F(TransportTcpClientTest, ResolveFailureTriggersRetry) {
   client_->start();
 
   // Run enough time for initial attempt + retry. Resolve might take time, give it margin.
-  ioc.run_for(std::chrono::milliseconds(500));
+  run_until(ioc, [&] { return connecting_count.load() >= 2; });
 
   EXPECT_GE(connecting_count.load(), 2);
 
@@ -493,7 +519,7 @@ TEST_F(TransportTcpClientTest, ConnectionTimeoutTriggersRetry) {
   client_->start();
 
   // Run enough for initial + 2 retries (timeout 50ms + retry interval 50ms = 100ms per attempt)
-  ioc.run_for(std::chrono::milliseconds(500));
+  run_until(ioc, [&] { return connecting_count.load() >= 3; });
 
   EXPECT_GE(connecting_count.load(), 3);
 
@@ -524,7 +550,7 @@ TEST_F(TransportTcpClientTest, UnlimitedRetriesKeepsConnecting) {
   // Run for enough time to get 5 attempts.
   // Each attempt: Timeout(50) + Interval(50) = 100ms.
   // 5 attempts needs ~500ms. Give it 1000ms.
-  ioc.run_for(std::chrono::milliseconds(1000));
+  run_until(ioc, [&] { return connecting_count.load() >= 5; });
 
   EXPECT_GE(connecting_count.load(), 5);
 
@@ -749,7 +775,7 @@ TEST_F(TransportTcpClientTest, UnknownOnBytesExceptionTriggersReconnect) {
   client_->on_bytes([](memory::ConstByteSpan) { throw 7; });
 
   client_->start();
-  ioc.run_for(200ms);
+  run_until(ioc, [&] { return connecting_events.load() >= 2; });
 
   EXPECT_GE(connecting_events.load(), 2);
 


### PR DESCRIPTION
## Description

`TransportTcpClientTest.ResolveFailureTriggersRetry` failed the Code Coverage job on #564:

```
test/integration/transport/transport_tcp_client.cc:406: Failure
Expected: (connecting_count.load()) >= (2), actual: 1 vs 2
```

The test ran the io_context for a fixed 500ms and then asserted that two connection attempts had happened. That assumes resolving `invalid.host.name.that.does.not.exist` fails quickly. Under coverage instrumentation, or on a loaded runner, or against a slow resolver, a single attempt can fill the whole window — so the test was racing the machine, not testing the retry logic.

## Key Changes

- `test/integration/transport/transport_tcp_client.cc` — added a `run_until` helper that drives the io_context in 10ms slices until a predicate holds, with a 5s ceiling, and converted the six tests that used the fixed-duration pattern.
- `CHANGELOG.md`.

**Six tests, not one.** The failing test is not special; five siblings differ only in the duration and the expected count, and every one of them is the same race:

| test | was | now |
|---|---|---|
| `OnBytesExceptionTriggersReconnect` | 150ms → `>= 2` | wait for `>= 2` |
| `ConnectionRefusedTriggersRetry` | 500ms → `>= 2` | wait for `>= 2` |
| `ResolveFailureTriggersRetry` | 500ms → `>= 2` | wait for `>= 2` |
| `ConnectionTimeoutTriggersRetry` | 500ms → `>= 3` | wait for `>= 3` |
| `UnlimitedRetriesKeepsConnecting` | 1000ms → `>= 5` | wait for `>= 5` |
| `UnknownOnBytesExceptionTriggersReconnect` | 200ms → `>= 2` | wait for `>= 2` |

Fixing only the one that lost first would have left the other five to fail on other days.

The assertions themselves are unchanged — `run_until` returns early when satisfied, and the `EXPECT_GE` still does the checking, so a genuine regression still fails the test rather than silently passing.

## Related Issues
- Fixes the flake observed on #564.

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**A single green run proves nothing about a flake, so it was run 30 times.** The six converted tests passed 30 consecutive times with zero failures. The full suite also passes: 733/733.

**Faster, not just steadier.** The six tests previously waited at least 2850ms of fixed sleeps between them (150 + 500 + 500 + 500 + 1000 + 200). They now complete in about 750ms, because each one stops as soon as the attempts it is waiting for arrive.

**One test was deliberately left alone.** `QueueLimitDropsMessage` matches the same textual pattern — a `run_for` followed by an `EXPECT_GE` — but its `failed_sends` assertion is satisfied synchronously by the rejected `async_write_copy` *before* the `run_for`, which is only draining. There is no race there, so changing it would be churn without evidence.

**Note on what this does not fix.** `run_until` bounds the wait at 5s and ignores its own return value; if the attempts never arrive, the subsequent `EXPECT_GE` fails as before, just 5s later instead of 500ms later. That is intentional — the assertion, not the helper, decides the verdict.

**Not run.** `./scripts/verify.sh` runs formatting plus build plus tests as one pipeline; the build and test halves were run directly as above, and `clang-format` (18.1.3, matching `code-formatting.yml`) reports no reformatting needed.
