### PR TITLE
ci: pin the Windows x64 vcpkg checkout too

### DIFF
--- a/.github/workflows/ci-install-consume.yml
+++ b/.github/workflows/ci-install-consume.yml
@@ -70,17 +70,23 @@ jobs:
           triplet: ${{ matrix.triplet }}
 
       # The composite action bootstraps through bootstrap-vcpkg.sh, which the
-      # Windows runners cannot use. They ship vcpkg preinstalled, which the
-      # existing `windows` job in ci.yml already relies on.
+      # Windows runners cannot use, so the pinned checkout is done inline here
+      # to keep this job on the same VCPKG_BASELINE as every other one.
       - name: Install dependencies with vcpkg (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          "/c/vcpkg/vcpkg.exe" install boost-asio:${{ matrix.triplet }} boost-system:${{ matrix.triplet }} spdlog:${{ matrix.triplet }}
+          sha="$(cat VCPKG_BASELINE)"
+          git init C:/vcpkg-pinned
+          git -C C:/vcpkg-pinned remote add origin https://github.com/microsoft/vcpkg.git
+          git -C C:/vcpkg-pinned fetch --depth 1 origin "$sha"
+          git -C C:/vcpkg-pinned checkout FETCH_HEAD
+          "C:/vcpkg-pinned/bootstrap-vcpkg.bat"
+          "C:/vcpkg-pinned/vcpkg.exe" install boost-asio:${{ matrix.triplet }} boost-system:${{ matrix.triplet }} spdlog:${{ matrix.triplet }}
           {
-            echo "VCPKG_ROOT=C:/vcpkg"
+            echo "VCPKG_ROOT=C:/vcpkg-pinned"
             echo "VCPKG_TARGET_TRIPLET=${{ matrix.triplet }}"
-            echo "CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+            echo "CMAKE_TOOLCHAIN_FILE=C:/vcpkg-pinned/scripts/buildsystems/vcpkg.cmake"
           } >> "$GITHUB_ENV"
 
       - name: Configure
@@ -196,7 +202,7 @@ jobs:
           if [ "$RUNNER_OS" = "Windows" ]; then
             generator=(-G "Visual Studio 17 2022" -A x64)
             binary="./build/Release/consumer.exe"
-            export PATH="$install_prefix/bin:/c/vcpkg/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
+            export PATH="$install_prefix/bin:/c/vcpkg-pinned/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
           else
             generator=(-G Ninja)
             binary="./build/consumer"
@@ -237,7 +243,7 @@ jobs:
           if [ "$RUNNER_OS" = "Windows" ]; then
             generator=(-G "Visual Studio 17 2022" -A x64)
             binary="./build/Release/legacy_consumer.exe"
-            export PATH="$install_prefix/bin:/c/vcpkg/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
+            export PATH="$install_prefix/bin:/c/vcpkg-pinned/installed/$VCPKG_TARGET_TRIPLET/bin:$PATH"
           else
             generator=(-G Ninja)
             binary="./build/legacy_consumer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,14 @@ jobs:
         shell: pwsh
         run: |
           choco install ninja --no-progress -y
-          & "C:\vcpkg\vcpkg.exe" install boost-asio:x64-windows boost-system:x64-windows spdlog:x64-windows
-          echo "VCPKG_ROOT=C:/vcpkg" >> $env:GITHUB_ENV
+          $sha = (Get-Content VCPKG_BASELINE -Raw).Trim()
+          git init C:/vcpkg-pinned
+          git -C C:/vcpkg-pinned remote add origin https://github.com/microsoft/vcpkg.git
+          git -C C:/vcpkg-pinned fetch --depth 1 origin $sha
+          git -C C:/vcpkg-pinned checkout FETCH_HEAD
+          & "C:/vcpkg-pinned/bootstrap-vcpkg.bat"
+          & "C:/vcpkg-pinned/vcpkg.exe" install boost-asio:x64-windows boost-system:x64-windows spdlog:x64-windows
+          echo "VCPKG_ROOT=C:/vcpkg-pinned" >> $env:GITHUB_ENV
 
       - name: Set up vcpkg (ARM64)
         if: matrix.cmake_arch == 'ARM64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,14 @@ jobs:
         shell: pwsh
         run: |
           choco install ninja --no-progress -y
-          & "C:\vcpkg\vcpkg.exe" install boost-asio:x64-windows boost-system:x64-windows spdlog:x64-windows
-          echo "VCPKG_ROOT=C:/vcpkg" >> $env:GITHUB_ENV
+          $sha = (Get-Content VCPKG_BASELINE -Raw).Trim()
+          git init C:/vcpkg-pinned
+          git -C C:/vcpkg-pinned remote add origin https://github.com/microsoft/vcpkg.git
+          git -C C:/vcpkg-pinned fetch --depth 1 origin $sha
+          git -C C:/vcpkg-pinned checkout FETCH_HEAD
+          & "C:/vcpkg-pinned/bootstrap-vcpkg.bat"
+          & "C:/vcpkg-pinned/vcpkg.exe" install boost-asio:x64-windows boost-system:x64-windows spdlog:x64-windows
+          echo "VCPKG_ROOT=C:/vcpkg-pinned" >> $env:GITHUB_ENV
 
       - name: Set up C++ toolchain (Windows ARM64)
         if: runner.os == 'Windows' && matrix.cmake_arch == 'ARM64'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,13 @@ and ABI policy.
 - Added a CI check that inspects the installed shared library and fails if it
   exports no Wirestead symbols or any third-party ones. The unit tests link the
   static library, so nothing else looks at what the shared library exports.
-- Pinned the `microsoft/vcpkg` checkout used by CI, the CMake matrix, the
-  release workflow, the vcpkg package test, and the `setup-vcpkg` composite
-  action to a reviewed commit recorded in `VCPKG_BASELINE`, instead of cloning
-  whatever is on its default branch at build time.
+- Pinned every `microsoft/vcpkg` checkout to a reviewed commit recorded in
+  `VCPKG_BASELINE`, instead of cloning whatever is on its default branch at
+  build time. This covers CI, the CMake matrix, the release workflow, the
+  vcpkg package test, the install-and-consume job, and the `setup-vcpkg`
+  composite action. The Windows x64 legs previously used the vcpkg that ships
+  in the runner image, which meant release binaries depended on whichever
+  version that image happened to carry.
 - Added a weekly `vcpkg baseline bump` workflow that proposes a
   `VCPKG_BASELINE` update as a reviewable pull request, so the pin can be kept
   current without relying on someone remembering to move it.


### PR DESCRIPTION
## Description

#556 pinned every `microsoft/vcpkg` checkout to `VCPKG_BASELINE` — but it only fixed the places that *cloned* vcpkg. The Windows x64 legs never cloned it; they used the vcpkg that ships in the runner image, so the pin simply did not reach them.

That left three jobs outside the baseline, and one of them is `release.yml`. The Windows release binaries were built against whichever vcpkg version the runner image happened to carry, not against a commit anyone reviewed. That is the exact class of problem #556 set out to close, in the workflow where it matters most.

## Key Changes

- `.github/workflows/ci.yml` — the `Set up vcpkg (x64)` step now fetches the pinned commit into `C:/vcpkg-pinned`.
- `.github/workflows/release.yml` — same, for the Windows x64 release leg.
- `.github/workflows/ci-install-consume.yml` — same, done inline in bash because the composite action bootstraps with a shell script Windows cannot run. Both consume steps had their `PATH` updated to the new vcpkg location.
- `CHANGELOG.md`.

This mirrors what the ARM64 legs have been doing since #556. Every vcpkg checkout in the repository now comes from `VCPKG_BASELINE`.

## Related Issues
- Completes #556.

## Type of Change
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The cost was measured before making the change, not assumed.** On the last completed `main` CI run:

| leg | vcpkg step | approach |
|---|---:|---|
| `Windows (windows-2022)` | 216s | runner image, unpinned |
| `Windows (windows-11-arm)` | 252s | pinned clone |

Roughly half a minute per Windows job. Different machine classes, so not a controlled A/B, but close enough to show pinning is not expensive here — which is what decided this was worth doing rather than documenting as a known gap. This PR's own CI gives the real number for x64.

**Verified locally:** all three workflows parse; every non-pwsh `run:` block passes `bash -n` with GitHub expressions stubbed; a sweep for `C:\vcpkg`, `C:/vcpkg/`, and `/c/vcpkg/` finds no remaining references to the runner-image copy; each of the three workflows now references `VCPKG_BASELINE` twice, matching the ARM64 legs.

**Not verified locally: that any of this runs.** No Windows machine here. The pwsh steps in `ci.yml` and `release.yml` are excluded from the `bash -n` check by definition, and the pinned fetch, bootstrap, and `vcpkg install` on Windows are all first exercised by this PR's CI. The pattern itself is not new — it is copied from the ARM64 legs that have been running since #556 — but the x64 triplet and the `C:/vcpkg-pinned` path are.

**Watch the Windows job durations on this run.** If the x64 vcpkg step lands far above the ~250s the ARM leg takes, the trade may be worse than the numbers above suggest and this is worth reconsidering.
