### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
-## Unreleased
+## v0.9.2 - 2026-08-01
 
 ### Added
 
@@ -35,9 +35,7 @@ and ABI policy.
   exported from both.
 - Extended the install-and-consume CI job to macOS and Windows. It previously
   ran on Linux only, so the installed-package path was never exercised on any
-  other platform. It previously ran on Linux
-  only, so the installed-package path was never exercised on any other
-  platform.
+  other platform.
 - Added a CI check that inspects the installed shared library and fails if it
   exports no Wirestead symbols or any third-party ones. The unit tests link the
   static library, so nothing else looks at what the shared library exports.
@@ -57,10 +55,6 @@ and ABI policy.
 - Unilink compatibility names remain deprecated compatibility surfaces for the
   v0.9.x line.
 
-### Removed
-
-- Nothing.
-
 ### Fixed
 
 - Made the TCP client retry tests wait for the attempts they assert on instead
@@ -78,9 +72,17 @@ and ABI policy.
   than the static vcpkg triplet its dependencies were built with, which
   surfaced as LNK2038 and LNK2005 errors after upstream vcpkg drift.
 
-### Security
+### Compatibility
 
-- Nothing.
+- The shared library no longer exports symbols this project does not own.
+  Every `wirestead` symbol is still exported, including those from internal
+  namespaces and the typeinfo and vtables that exceptions thrown across the
+  library boundary need, so no Wirestead API was removed. Code that resolved a
+  `boost`, `spdlog`, or `fmt` symbol out of `libwirestead` rather than linking
+  it directly must now link it directly; that was never a supported use.
+- No intentional public API removal was made in v0.9.2.
+- Known limitations remain the pre-1.0 ABI policy and the v0.9.x Unilink
+  compatibility layer described in `docs/migration-from-unilink.md`.
 
 ## v0.9.1 - 2026-07-26
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   wirestead
-  VERSION 0.9.1
+  VERSION 0.9.2
   DESCRIPTION "Robust, simple, cross-platform async C++ communication library"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"
   LANGUAGES CXX


### PR DESCRIPTION
## Description

Bumps the project version to 0.9.2 and closes the unreleased changelog section.

When a core release was last weighed, the recommendation was **not** to cut one: the only library change since v0.9.1 was a comment capitalization, so a release would have asked every consumer to relink and retest for nothing. That has changed.

**#559 is the reason.** The shared library used to re-export `boost::asio::detail` internals it merely links against — weak and unique symbols that hidden visibility does not remove. A consumer loading a different Boost into the same process can have stateful internals such as `epoll_reactor` merged into one, which is an ODR violation that surfaces as runtime misbehavior rather than a link error. Anyone on v0.9.1 still has that `.so`, and the fix only reaches them through a release.

## Key Changes

- `CMakeLists.txt` — project version 0.9.1 → 0.9.2.
- `CHANGELOG.md` — `## Unreleased` becomes `## v0.9.2 - 2026-08-01`, plus a `Compatibility` section matching what v0.9.1 records.

Two cleanups in the same file:

- Dropped the empty `Removed` and `Security` placeholders. "Nothing." is useful while a section is accumulating; it is noise in a released one.
- Fixed a sentence duplicated when the macOS install-and-consume entry was extended to cover Windows — my own error from #564, caught while reading the section end to end.

## What is actually in this release

Of the 13 commits since v0.9.1, one changes what consumers receive:

| commit | reaches consumers? |
|---|---|
| **#559** third-party symbol re-export | **yes** — exported symbols 2139 → 1534 |
| #553 CMake description, #555 `.pc` description casing | packaging metadata only |
| #563 LTO rewiring | **no** — see below |
| #552, #556, #557, #560, #564, #565, #566 | CI and tests only |
| #554, #561 | docs only |

**#563 deserves the explicit "no".** Rewiring LTO looks like it changes optimization, but the shipped library is unaffected: MSVC Release previously applied `/GL` globally and then forced `/GL-` and `/LTCG:OFF` back onto the library targets, so the library had no LTCG. It still has none, because `WIRESTEAD_ENABLE_LTO` defaults off. Only test and example targets changed, and those are not shipped.

## Related Issues
- Releases the fix from #559.

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

(Plus the version bump itself, which the template has no category for.)

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified that the bump reaches the build**, rather than assuming a string edit is enough: a fresh configure reports `CMAKE_PROJECT_VERSION=0.9.2`, and `PROJECT_VERSION` feeds `CPACK_PACKAGE_VERSION`, the installer display names, and the library `VERSION`/`SOVERSION` properties. `cmake-format` needs no reformatting and `git diff --check` is clean.

**On calling this a patch.** The exported symbol set narrowed, which sounds like it belongs in a minor. It does not: `docs/api_stability.md` asks patch releases to avoid removing public APIs, and none were removed — every `wirestead` symbol is still exported, internal namespaces and the typeinfo and vtables that cross-boundary exception catching needs included. What disappeared was never this project's to export. The Compatibility section says so plainly, including the one way it could bite: code that resolved a `boost`, `spdlog`, or `fmt` symbol out of `libwirestead` instead of linking it directly.

**Not run.** `./scripts/verify.sh` builds the full core and test suite; this PR edits a version string and a changelog. The full suite passed on `main` at #565 and #566, and CI covers it here.

**Sequencing.** Nothing else should merge into this release line before the tag. After merge, `v0.9.2` needs to be tagged and the release checklist run — worth doing by hand, since the tag drives the release workflow and is awkward to undo. `wirestead-python` cannot move to `WIRESTEAD_CORE_REF=v0.9.2` until that tag exists, or its CI will fail checking out a ref that is not there.
