### PR TITLE
ci: give vcpkg its pinned cmake on arm64 linux and retry bootstrap

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -22,6 +22,21 @@ runs:
         if [ -z "${VCPKG_ROOT}" ]; then
           VCPKG_ROOT="${GITHUB_WORKSPACE}/vcpkg"
         fi
+        retry() {
+          local what="$1"
+          shift
+          local attempt
+          for attempt in 1 2 3; do
+            if "$@"; then
+              return 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              return 1
+            fi
+            echo "${what} failed; retrying attempt $((attempt + 1)) of 3..."
+            sleep $((attempt * 10))
+          done
+        }
         if [ ! -d "${VCPKG_ROOT}/.git" ]; then
           VCPKG_BASELINE_SHA="$(cat "${GITHUB_WORKSPACE}/VCPKG_BASELINE")"
           git init "${VCPKG_ROOT}"
@@ -29,21 +44,35 @@ runs:
           git -C "${VCPKG_ROOT}" fetch --depth 1 origin "${VCPKG_BASELINE_SHA}"
           git -C "${VCPKG_ROOT}" checkout FETCH_HEAD
         fi
-        "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
-        retry_vcpkg_install() {
-          local attempt
-          for attempt in 1 2 3; do
-            if "${VCPKG_ROOT}/vcpkg" install ${{ inputs.packages }} --triplet "${{ inputs.triplet }}" --clean-after-build; then
-              return 0
-            fi
-            if [ "${attempt}" -eq 3 ]; then
-              return 1
-            fi
-            echo "vcpkg install failed; retrying attempt $((attempt + 1)) of 3..."
-            sleep $((attempt * 10))
-          done
-        }
-        retry_vcpkg_install
+        # vcpkg's SBOM scripts need the CMake version vcpkg itself pins (4.x uses
+        # string(JSON ... STRING_ENCODE), which the apt CMake 3.28 does not have).
+        # On x64 vcpkg acquires that CMake itself; on arm64-linux it silently falls
+        # back to the system one, so put the pinned build on PATH for vcpkg only.
+        # The project's own configure step keeps using the system CMake, as on x64.
+        TOOLS_JSON="${VCPKG_ROOT}/scripts/vcpkg-tools.json"
+        if [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "aarch64" ] \
+          && command -v jq >/dev/null 2>&1 && [ -f "${TOOLS_JSON}" ]; then
+          CMAKE_ENTRY='.tools[] | select(.name == "cmake" and .os == "linux" and .arch == "arm64")'
+          CMAKE_URL="$(jq -r "${CMAKE_ENTRY} | .url // empty" "${TOOLS_JSON}")"
+          CMAKE_SHA512="$(jq -r "${CMAKE_ENTRY} | .sha512 // empty" "${TOOLS_JSON}")"
+          CMAKE_EXE="$(jq -r "${CMAKE_ENTRY} | .executable // empty" "${TOOLS_JSON}")"
+          if [ -n "${CMAKE_URL}" ] && [ -n "${CMAKE_SHA512}" ] && [ -n "${CMAKE_EXE}" ]; then
+            CMAKE_DIR="${RUNNER_TEMP}/vcpkg-cmake"
+            CMAKE_ARCHIVE="${RUNNER_TEMP}/$(basename "${CMAKE_URL}")"
+            mkdir -p "${CMAKE_DIR}"
+            retry "cmake download" curl -fsSL "${CMAKE_URL}" -o "${CMAKE_ARCHIVE}"
+            echo "${CMAKE_SHA512}  ${CMAKE_ARCHIVE}" | sha512sum -c -
+            tar -xzf "${CMAKE_ARCHIVE}" -C "${CMAKE_DIR}"
+            PATH="$(dirname "${CMAKE_DIR}/${CMAKE_EXE}"):${PATH}"
+            export PATH
+            echo "vcpkg will use $(cmake --version | head -n 1)"
+          else
+            echo "no linux/arm64 cmake entry in ${TOOLS_JSON}; using the system cmake"
+          fi
+        fi
+        retry "vcpkg bootstrap" "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
+        retry "vcpkg install" \
+          "${VCPKG_ROOT}/vcpkg" install ${{ inputs.packages }} --triplet "${{ inputs.triplet }}" --clean-after-build
         {
           echo "VCPKG_ROOT=${VCPKG_ROOT}"
           echo "VCPKG_TARGET_TRIPLET=${{ inputs.triplet }}"


### PR DESCRIPTION
## Description

`#558` (vcpkg baseline bump) fails on all three arm64-linux jobs. It was previously recorded as an upstream `boost-cmake:arm64-linux` regression, but it is not — it is a CMake version mismatch that we can fix on our side.

Baselines newer than `6d9d7df` add `scripts/cmake/z_vcpkg_spdx.cmake`, which uses `string(JSON ... STRING_ENCODE)`. The apt CMake 3.28.3 has no such mode, so any port going through the SBOM path dies:

```
CMake Error at scripts/cmake/z_vcpkg_spdx.cmake:15 (string):
  string sub-command JSON got an invalid mode 'STRING_ENCODE', expected one
  of GET, TYPE, MEMBER, LENGTH, REMOVE, SET, EQUAL.
→ error: building boost-cmake:arm64-linux failed with: BUILD_FAILED
```

On x64 this is invisible — vcpkg logs `A suitable version of cmake was not found (required v4.4.0).` and acquires that build itself, so the same `boost-cmake@1.91.0` compiles fine. On arm64-linux vcpkg emits no such line and silently falls back to the system CMake, even though `scripts/vcpkg-tools.json` **does** carry a `linux`/`arm64` cmake 4.4.0 entry. Both runners `apt-get install` the identical 3.28.3, so only ARM fails.

The same PR run also lost both macOS jobs to an unrelated transient: `bootstrap-vcpkg.sh` got `curl: (56) The requested URL returned error: 500` downloading the vcpkg binary. `bootstrap` sat outside the retry wrapper — only `vcpkg install` was retried — so one blip killed the job.

Both fixes land in `.github/actions/setup-vcpkg`, the single choke point that all 16 workflow call sites route through.

## Key Changes

- On aarch64 Linux, read the cmake `url` / `sha512` / `executable` out of the checked-out `${VCPKG_ROOT}/scripts/vcpkg-tools.json`, download and sha512-verify it, and prepend it to `PATH` **for the vcpkg calls only**. Deriving the version from `tools.json` instead of hardcoding `4.4.0` keeps the weekly baseline automation from silently desyncing the pin.
- `PATH` is deliberately not exported to `GITHUB_ENV`/`GITHUB_PATH`, so the project's own configure step keeps using the system CMake — exactly what x64 does today. This avoids putting only ARM on CMake 4.x while the project declares `cmake_minimum_required(VERSION 3.12)`.
- Generalise `retry_vcpkg_install()` into `retry <label> <cmd...>` and apply it to `bootstrap-vcpkg.sh` as well as `vcpkg install`.
- Guarded fallback: if `jq`, `tools.json`, or the `linux`/`arm64` entry is missing, log a line and keep the previous behaviour. This matters for the self-hosted aarch64 benchmark runner, which also uses this action.

No workflow files changed; no other platform's behaviour changes apart from bootstrap now being retried.

## Related Issues

- Unblocks #558 (vcpkg baseline bump). Not a `Fixes` — #558 needs a rebase on this to be re-validated.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass. — **not run**: this change touches only GitHub Actions YAML and no C++; the narrowest relevant checks were run instead (see below).
- [ ] I have added or updated tests to verify my changes. — **not applicable**: CI configuration; validation is the CI run itself.
- [x] I have updated the documentation to reflect the changes (if applicable). — not applicable.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Validation performed locally:

- `git diff --check` → clean
- YAML parses (`yaml.safe_load`); embedded script passes `bash -n` after substituting the Actions expressions
- jq queries verified against three real `vcpkg-tools.json` revisions — `6d9d7df` (schema v1) and `8586ecbf` / `b10f846` (schema v2) all yield the correct url/sha512/executable; a nonexistent arch yields empty, exercising the fallback path
- Full download → `sha512sum -c` → extract → PATH resolution exercised end-to-end (run with the `amd64` entry, since the local machine is x86_64) → checksum OK, resolves to `cmake version 4.4.0`
- Root cause reproduced and confirmed resolved: `string(JSON out STRING_ENCODE "boost-cmake")` produces the exact CI error under CMake 3.28.3 and succeeds under 4.4.0

**Not verified locally: the real arm64-linux path.** No ARM hardware here, so the ARM branch of the script has never executed as written — CI on this PR is the first real exercise of it. Worth watching the ARM jobs' logs for the `vcpkg will use cmake version 4.4.0` line.

Possible follow-up, left out to keep this scoped: `git fetch --depth 1` is the same class of flaky network call as `bootstrap` and is still unretried; it is a one-line change with the new `retry` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue
