### PR TITLE
ci: cache vcpkg binaries through actions/cache

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -15,9 +15,43 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: cache-key
+      shell: bash
+      run: |
+        set -euo pipefail
+        # vcpkg names each archive after a package ABI hash that folds in the
+        # compiler, so jobs on different compilers share no archives at all. Cache
+        # keys are write-once, so one key spanning compilers would let whichever
+        # job saves first lock every other compiler out of caching anything.
+        if command -v sha256sum >/dev/null 2>&1; then
+          sha256() { sha256sum; }
+        else
+          sha256() { shasum -a 256; }
+        fi
+        cc_id="$( { "${CC:-cc}" --version 2>/dev/null || echo unknown-compiler; } | head -n 1 )"
+        fingerprint="$(printf '%s\n%s\n%s\n' \
+          "${cc_id}" '${{ inputs.triplet }}' '${{ inputs.packages }}' | sha256 | cut -c1-16)"
+        # The baseline is only in the key, not the prefix, so a baseline bump can
+        # still reuse the archives of every port whose ABI did not actually move.
+        prefix="vcpkg-${{ runner.os }}-${{ runner.arch }}-${fingerprint}-"
+        echo "prefix=${prefix}" >> "${GITHUB_OUTPUT}"
+        echo "key=${prefix}${{ hashFiles('VCPKG_BASELINE') }}" >> "${GITHUB_OUTPUT}"
+
+    - name: Restore the vcpkg binary cache
+      uses: actions/cache@v6
+      with:
+        path: ${{ runner.temp }}/vcpkg-archives
+        key: ${{ steps.cache-key.outputs.key }}
+        restore-keys: ${{ steps.cache-key.outputs.prefix }}
+
     - shell: bash
       run: |
         set -euo pipefail
+        # vcpkg's own x-gha backend was removed upstream, so binary caching runs
+        # through the plain files provider pointed at the actions/cache path above.
+        VCPKG_DEFAULT_BINARY_CACHE="${RUNNER_TEMP}/vcpkg-archives"
+        export VCPKG_DEFAULT_BINARY_CACHE
+        mkdir -p "${VCPKG_DEFAULT_BINARY_CACHE}"
         VCPKG_ROOT="${{ inputs.vcpkg-root }}"
         if [ -z "${VCPKG_ROOT}" ]; then
           VCPKG_ROOT="${GITHUB_WORKSPACE}/vcpkg"
@@ -77,5 +111,5 @@ runs:
           echo "VCPKG_ROOT=${VCPKG_ROOT}"
           echo "VCPKG_TARGET_TRIPLET=${{ inputs.triplet }}"
           echo "CMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-          echo "VCPKG_BINARY_SOURCES=clear;x-gha,readwrite"
+          echo "VCPKG_DEFAULT_BINARY_CACHE=${VCPKG_DEFAULT_BINARY_CACHE}"
         } >> "$GITHUB_ENV"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,20 +69,12 @@ jobs:
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
       VCPKG_TARGET_TRIPLET: ${{ matrix.triplet }}
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       BUILD_TYPE: ${{ matrix.build_type }}
       VCPKG_USE_SYSTEM_BINARIES: "1"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Export GitHub Actions Cache Environment Variables
-        uses: actions/github-script@v9
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install Build Dependencies (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/vcpkg-package-test.yml
+++ b/.github/workflows/vcpkg-package-test.yml
@@ -38,18 +38,10 @@ jobs:
 
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Export GitHub Actions Cache Environment Variables
-        uses: actions/github-script@v9
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Cache vcpkg
         id: cache-vcpkg


### PR DESCRIPTION
## Description

vcpkg **removed its `x-gha` binary caching backend** upstream. Every job that configured it has been running with no binary cache at all, and the warning has been sitting in the logs unread:

```
$VCPKG_BINARY_SOURCES: warning: The 'x-gha' binary caching backend has been removed.
  Consider using a NuGet-based binary caching provider instead
```

The consequence is visible in any job log:

```
Restored 0 package(s) from /home/runner/.cache/vcpkg/archives in 74.6 us
→ 57 ports built from source, 0 restored
```

Measured on #568's run: **52 vcpkg steps, 2434s ≈ 41 minutes of runner time per CI run**, spent rebuilding byte-identical dependencies. The worst offenders are Windows (`Set up vcpkg (x64)` 276s, ARM64 252s) and macOS (101s).

A second bug hid the first: `setup-vcpkg` wrote `VCPKG_BINARY_SOURCES` to `$GITHUB_ENV` **after** running `vcpkg install`. `$GITHUB_ENV` only applies to *later* steps, so the install never saw the setting even back when the backend still worked. Only `cmake.yml` and `vcpkg-package-test.yml` set it at workflow level; the other eight workflows never set it anywhere.

## Key Changes

- Point vcpkg's plain `files` provider at `${{ runner.temp }}/vcpkg-archives` via `VCPKG_DEFAULT_BINARY_CACHE`, and wrap that directory in `actions/cache`.
- **Cache key folds in the compiler.** vcpkg names each archive after a package ABI hash that includes the compiler, and GHA cache keys are write-once — a single key spanning compilers would let whichever job saves first lock every other compiler out of caching anything. The key is derived at runtime from `$CC --version`, so it tracks the real toolchain rather than a matrix label.
- **Baseline hash is in the key but not in the restore-key prefix**, so a baseline bump still reuses the archives of every port whose ABI did not actually move.
- Drop the dead `x-gha` settings and the `github-script` steps that existed solely to export `ACTIONS_CACHE_URL` for them.

## Related Issues

- Follow-up to #568. No issue to close.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [x] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass. — **not run**: touches only GitHub Actions YAML, no C++. Narrower relevant checks were run instead, below.
- [ ] I have added or updated tests to verify my changes. — **not applicable**: CI configuration.
- [x] I have updated the documentation to reflect the changes (if applicable). — not applicable.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Validation performed locally:

- `git diff --check` → clean; all three YAML files parse; both shell steps pass `bash -n` after substituting the Actions expressions
- **The mechanism was verified end-to-end against real vcpkg** at the current baseline (`39344dff`), in a throwaway worktree:
  - cold run → `Restored 0 package(s)`, archives written to the custom `VCPKG_DEFAULT_BINARY_CACHE` path (ABI-hash-named `.zip` files)
  - `installed/ packages/ buildtrees/` wiped to imitate a fresh runner that restored only the cache → **`Restored 3 package(s)`, zero `Building` lines, 7.11s**
- Cache-key derivation executed for real: `CC=gcc`, `CC=clang`, and `CC=cc` each yield a distinct fingerprint (this is the property that keeps compilers from locking each other out); a nonexistent `$CC` degrades to `unknown-compiler` instead of tripping `set -euo pipefail`
- macOS `shasum` fallback exercised under a synthesised `PATH` that genuinely lacks `sha256sum`; produces a key identical to the `sha256sum` branch

Not verified locally: actual cache hit rates on GitHub's cache service, and the first run on this PR will necessarily be a cold miss — **the saving shows up on the second run onward.** Worth re-checking a job log after this merges for `Restored N package(s)` with N > 0.

Windows still sets vcpkg up inline in `ci.yml` and `release.yml`, so it is **not** covered by this change and keeps rebuilding from source. Folding those five duplicated inline blocks into this action is the natural next step and would collapse the repo's three separate retry implementations at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue
