### PR TITLE
ci: pin VCPKG_BASELINE to LF in the working tree

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# VCPKG_BASELINE holds a bare git SHA that shell steps read and hand straight to
+# git. Without this, checkout on Windows rewrites it to CRLF, $( ) keeps the
+# trailing CR, and every consumer has to strip it. Pin the working-tree ending so
+# the file is byte-identical on every platform.
+VCPKG_BASELINE text eol=lf


### PR DESCRIPTION
## Description

`VCPKG_BASELINE` holds a bare git SHA that shell steps read and hand straight to git. Checkout on Windows was rewriting it to CRLF, `$( )` keeps the trailing CR, and git only tolerates that inside a refspec by luck.

#570 stripped the CR at the point of use. This removes the split at the source, so the file is byte-identical on every platform.

The repo had no `.gitattributes` at all until now, and the blob is already LF in the index — `git ls-files --eol` reports `i/lf w/lf` before and after, so **nothing is renormalised**. This only changes what Windows checks out.

## Key Changes

- New `.gitattributes` with a single entry: `VCPKG_BASELINE text eol=lf`.
- Deliberately narrow. No `* text=auto`, which would be a repo-wide policy change with renormalisation risk across the whole tree.
- The `tr -d '\r'` in `setup-vcpkg` **stays**. It costs nothing and keeps the action correct on a checkout that does not honour these attributes.

## Related Issues

- Follows up the CRLF finding in #570. No issue to close.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass. — **not run**: adds one git attribute, no C++ and no workflow logic.
- [ ] I have added or updated tests to verify my changes. — **not applicable**.
- [x] I have updated the documentation to reflect the changes (if applicable). — the rationale is in the file itself.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Verified locally:

- `git check-attr text eol -- VCPKG_BASELINE` → `text: set`, `eol: lf`
- `git ls-files --eol VCPKG_BASELINE` → `i/lf w/lf attr/text eol=lf`, unchanged from before
- `git status` after staging shows only the new file; no pending content change for `VCPKG_BASELINE`

**One-time CI effect worth expecting:** `hashFiles('VCPKG_BASELINE')` on Windows moves from `44f2b7ab…` to the `a965b144…` that Linux and macOS already produce. The three Windows vcpkg cache entries are orphaned by that, so the next Windows run is a cold miss (~180–220s per job) before settling back to the warm ~36–57s measured in #570. Unix caches are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue
