### PR TITLE
perf: make the receive path allocation-free and batch queued writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and ABI policy.
 
 ### Changed
 
+- Stream transports now drain several queued buffers into one scatter-gather
+  write instead of one send syscall per queued message. Measured on a TCP
+  loopback burst of 16386 small messages, send syscalls drop from 16386 to
+  1025. The socket interfaces gained a buffer-sequence `async_write` overload
+  with a correct default implementation, so existing implementations keep
+  working unchanged.
 - Removed the per-chunk heap allocation and copy from the receive path.
   `MessageContext` now borrows the payload for the single-shot `on_data()` and
   `on_message()` dispatch instead of copying it into an owned buffer; only the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
+## Unreleased
+
+### Changed
+
+- Removed the per-chunk heap allocation and copy from the receive path.
+  `MessageContext` now borrows the payload for the single-shot `on_data()` and
+  `on_message()` dispatch instead of copying it into an owned buffer; only the
+  batch handlers, whose contexts are queued until the batch is flushed, still
+  own their data. Measured on a TCP loopback echo, allocations on the receiving
+  io thread drop from 3 to 2 per callback. The documented callback contract is
+  unchanged - `docs/callbacks.md` already scoped the view to the callback - and
+  copying a `MessageContext` still takes ownership, so keeping one past the
+  callback remains safe.
+- `MessageContext::safe_data()` materializes its buffer on demand when the
+  context borrows its payload. It is now the only accessor that copies; prefer
+  `data()`, `data_as_string()`, or `data_as_vector()`.
+
 ## v0.9.2 - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and ABI policy.
 
 ## Unreleased
 
+### Added
+
+- `read_buffer_size` on the TCP and UDS configs, wrappers, and builders. This
+  is the userspace buffer each read fills, and it was previously a
+  compile-time-fixed 4 KiB `std::array` per connection with no way to change
+  it — `receive_buffer_size` only ever set the kernel's `SO_RCVBUF`. Raising it
+  cuts read completions and callback dispatches on bulk transfers. The default
+  is unchanged at 4 KiB, and values are clamped to
+  `[MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]` (512 B to 1 MiB). The ceiling
+  is far below `MAX_SOCKET_BUFFER_SIZE` because this buffer is per connection
+  and a server multiplies it by `max_connections`.
+
 ### Changed
 
 - Removed the per-chunk heap allocation and copy from the receive path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ and ABI policy.
 - `MessageContext::safe_data()` materializes its buffer on demand when the
   context borrows its payload. It is now the only accessor that copies; prefer
   `data()`, `data_as_string()`, or `data_as_vector()`.
+- Transports and wrappers now snapshot their callbacks through a shared pointer
+  instead of copying a `std::function` on every dispatch. A `std::function`
+  copy heap-allocates whenever the target outgrows its small-object buffer, and
+  the receive path took one such copy per chunk at each layer. Storage
+  discipline is unchanged - the same mutex guards the member and the callback
+  is still invoked outside the lock. Together with the change above, the TCP
+  client receive path goes from 5.06 to 0.06 allocations per callback, measured
+  on a loopback echo with a handler capturing 64 bytes; receiving is now
+  allocation-free.
+
+### Fixed
+
+- `UdpChannel::on_bytes_from()` now takes `callback_mtx_` when installing the
+  callback. It assigned without the lock while the strand-confined read site
+  took it, against the member's own documented invariant, so replacing the
+  callback on a running channel raced with the receive path.
 
 ## v0.9.2 - 2026-08-01
 

--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -28,6 +28,20 @@ client->on_data([](const wirestead::MessageContext& ctx) {
 
 For binary payloads, use `data_as_vector()` before the callback returns.
 
+Copying the context object itself is also safe. A `MessageContext` delivered to
+`on_data`/`on_message` borrows the transport's receive buffer so the callback
+costs no allocation, but a copy always takes ownership of the payload, so a
+copy stays valid after the callback returns:
+
+```cpp
+client->on_data([&](const wirestead::MessageContext& ctx) {
+    queue.push_back(ctx);  // copy — owns its payload, safe to keep
+});
+```
+
+Only the view returned by `data()` is callback-scoped. Contexts delivered to
+the batch handlers (`on_data_batch`/`on_message_batch`) always own their data.
+
 ## Do not call a blocking send from within a callback
 
 `on_data`/`on_message` (and every other) callback runs on the channel's own

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -59,6 +59,7 @@ foreach(
   test_tcp_nodelay_default.cc
   test_read_buffer_size.cc
   test_gather_write.cc
+  test_receive_allocations.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -57,6 +57,7 @@ foreach(
   test_tcp_abort.cc
   test_tcp_cancel.cc
   test_tcp_nodelay_default.cc
+  test_read_buffer_size.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -58,6 +58,7 @@ foreach(
   test_tcp_cancel.cc
   test_tcp_nodelay_default.cc
   test_read_buffer_size.cc
+  test_gather_write.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/tcp/test_gather_write.cc
+++ b/test/integration/tcp/test_gather_write.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "wirestead/wirestead.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Enough queued at once that do_write() gathers many buffers per write, which
+// is the path these tests exist to pin down.
+constexpr int kMessages = 2000;
+
+}  // namespace
+
+// A gather write must put exactly the queued bytes on the wire - no more, no
+// less. An earlier implementation handed asio a non-owning view of the buffer
+// sequence; asio's partial-write bookkeeping did not survive that, and queued
+// buffers were silently duplicated on the wire or left stuck in the queue.
+// Byte counts alone catch both, so assert them directly.
+TEST(GatherWriteTest, SendsExactlyWhatWasAccepted) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+  std::atomic<size_t> received{0};
+
+  auto server = wirestead::tcp_server(port).build();
+  server->on_data([&](const wirestead::MessageContext& ctx) { received.fetch_add(ctx.data().size()); });
+  ASSERT_TRUE(server->start_sync());
+
+  auto client = wirestead::tcp_client("127.0.0.1", port).max_retries(50).build();
+  ASSERT_TRUE(client->start_sync());
+
+  const std::string payload(1024, 'x');
+  size_t accepted_by_app = 0;
+  for (int i = 0; i < kMessages; ++i) {
+    if (client->try_send(payload)) accepted_by_app += payload.size();
+  }
+  ASSERT_GT(accepted_by_app, 0u);
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return received.load() >= accepted_by_app; }, 10000))
+      << "only " << received.load() << " of " << accepted_by_app << " bytes arrived - queued buffers were lost";
+
+  const auto stats = client->stats();
+  EXPECT_EQ(stats.bytes_sent, stats.bytes_accepted) << "bytes on the wire must match what the queue accepted";
+  EXPECT_EQ(received.load(), accepted_by_app) << "receiver must see exactly the accepted bytes, never a duplicate";
+
+  client->stop();
+  server->stop();
+}
+
+// The same guarantee for the ownership-transfer path, whose queued buffers are
+// plain vectors rather than pooled buffers - a different variant alternative
+// feeding the same gather.
+TEST(GatherWriteTest, SendMovePreservesByteCountAndOrder) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+  std::mutex mtx;
+  std::vector<uint8_t> assembled;
+
+  auto server = wirestead::tcp_server(port).build();
+  server->on_data([&](const wirestead::MessageContext& ctx) {
+    const auto bytes = ctx.data_as_vector();
+    std::lock_guard<std::mutex> lock(mtx);
+    assembled.insert(assembled.end(), bytes.begin(), bytes.end());
+  });
+  ASSERT_TRUE(server->start_sync());
+
+  auto client = wirestead::tcp_client("127.0.0.1", port).max_retries(50).build();
+  ASSERT_TRUE(client->start_sync());
+
+  // Each message is a distinct byte value, so a duplicated or reordered
+  // buffer shows up as a mismatch rather than just a wrong total.
+  std::vector<uint8_t> expected;
+  int sent_messages = 0;
+  for (int i = 0; i < 512; ++i) {
+    std::vector<uint8_t> msg(256, static_cast<uint8_t>(i % 256));
+    auto copy = msg;
+    if (client->send_move(std::move(msg))) {
+      expected.insert(expected.end(), copy.begin(), copy.end());
+      ++sent_messages;
+    }
+  }
+  ASSERT_GT(sent_messages, 0);
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        std::lock_guard<std::mutex> lock(mtx);
+        return assembled.size() >= expected.size();
+      },
+      10000));
+
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    EXPECT_EQ(assembled.size(), expected.size());
+    EXPECT_EQ(assembled, expected) << "gathered buffers must reach the peer in order, exactly once";
+  }
+
+  client->stop();
+  server->stop();
+}

--- a/test/integration/tcp/test_read_buffer_size.cc
+++ b/test/integration/tcp/test_read_buffer_size.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "test_utils.hpp"
+#include "wirestead/wirestead.hpp"
+
+using namespace wirestead;
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr size_t kPayloadBytes = 512 * 1024;
+constexpr size_t kLargeReadBuffer = 64 * 1024;
+
+struct ReceiveTally {
+  std::mutex mtx;
+  size_t total = 0;
+  size_t largest_chunk = 0;
+
+  void record(size_t n) {
+    std::lock_guard<std::mutex> lock(mtx);
+    total += n;
+    if (n > largest_chunk) largest_chunk = n;
+  }
+};
+
+struct TransferResult {
+  size_t total = 0;
+  size_t largest_chunk = 0;
+};
+
+// Drives kPayloadBytes from a client into a server configured with
+// `read_buffer_size`, and reports what the server saw.
+TransferResult run_transfer(uint16_t port, size_t read_buffer_size) {
+  auto tally = std::make_shared<ReceiveTally>();
+
+  auto server = wirestead::tcp_server(port).read_buffer_size(read_buffer_size).build();
+  server->on_data([tally](const wirestead::MessageContext& ctx) { tally->record(ctx.data().size()); });
+  EXPECT_TRUE(server->start_sync());
+
+  auto client = wirestead::tcp_client("127.0.0.1", port).max_retries(50).build();
+  EXPECT_TRUE(client->start_sync());
+
+  const std::string chunk(16 * 1024, 'x');
+  size_t sent = 0;
+  while (sent < kPayloadBytes) {
+    if (client->send_blocking(chunk)) {
+      sent += chunk.size();
+    } else {
+      std::this_thread::sleep_for(1ms);
+    }
+  }
+
+  for (int i = 0; i < 400; ++i) {
+    {
+      std::lock_guard<std::mutex> lock(tally->mtx);
+      if (tally->total >= kPayloadBytes) break;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+
+  client->stop();
+  server->stop();
+
+  std::lock_guard<std::mutex> lock(tally->mtx);
+  return TransferResult{tally->total, tally->largest_chunk};
+}
+
+}  // namespace
+
+// The whole point of making the read buffer configurable: a bulk transfer
+// should be delivered in chunks larger than the old fixed 4 KiB array, which
+// is what cuts read completions and callback dispatches.
+TEST(ReadBufferSizeIntegrationTest, LargerBufferDeliversLargerChunks) {
+  const uint16_t port = test::TestUtils::getAvailableTestPort();
+  auto result = run_transfer(port, kLargeReadBuffer);
+
+  EXPECT_EQ(result.total, kPayloadBytes) << "all bytes must still arrive intact";
+  EXPECT_GT(result.largest_chunk, base::constants::DEFAULT_READ_BUFFER_SIZE)
+      << "a 64 KiB read buffer must be able to deliver more than the old fixed 4 KiB";
+  EXPECT_LE(result.largest_chunk, kLargeReadBuffer) << "must never exceed the configured buffer";
+}
+
+// The default must keep behaving exactly as before: no chunk larger than the
+// 4 KiB the fixed array used to provide.
+TEST(ReadBufferSizeIntegrationTest, DefaultBufferCapsChunksAtTheOldSize) {
+  const uint16_t port = test::TestUtils::getAvailableTestPort();
+  auto result = run_transfer(port, base::constants::DEFAULT_READ_BUFFER_SIZE);
+
+  EXPECT_EQ(result.total, kPayloadBytes);
+  EXPECT_LE(result.largest_chunk, base::constants::DEFAULT_READ_BUFFER_SIZE);
+}
+
+// An out-of-range request must be clamped rather than honoured or rejected.
+TEST(ReadBufferSizeIntegrationTest, OversizedRequestIsClampedNotHonoured) {
+  const uint16_t port = test::TestUtils::getAvailableTestPort();
+  auto result = run_transfer(port, base::constants::MAX_READ_BUFFER_SIZE * 8);
+
+  EXPECT_EQ(result.total, kPayloadBytes);
+  EXPECT_LE(result.largest_chunk, base::constants::MAX_READ_BUFFER_SIZE);
+}

--- a/test/integration/tcp/test_receive_allocations.cc
+++ b/test/integration/tcp/test_receive_allocations.cc
@@ -87,11 +87,15 @@ void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
 void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
 void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }
 
-// The receive path must not allocate once per delivered message. It used to
+// The receive path must not add an allocation per delivered message. It used to
 // allocate three times per callback - the chunk was copied into the context and
 // each std::function handler was copied on the way out. Both are gone; this
 // pins that down, because the cost is invisible in latency and only shows up as
 // allocator pressure under load.
+//
+// Measured on the parent commit vs here: 3.0 -> 0.0 on Linux and macOS,
+// 7.0 -> 3.0 and 3.0 -> 1.0 on the two Windows job configurations. What is left
+// on Windows is asio's, not ours; see the bound below.
 TEST(ReceiveAllocationsTest, DoesNotAllocatePerDeliveredMessage) {
   const uint16_t port = TestUtils::getAvailableTestPort();
 
@@ -135,13 +139,32 @@ TEST(ReceiveAllocationsTest, DoesNotAllocatePerDeliveredMessage) {
   const size_t allocations = g_probe.allocs_at_last_callback - g_probe.allocs_at_first_callback;
   const double per_callback = static_cast<double>(allocations) / static_cast<double>(callbacks - 1);
 
-  // The steady state measures 0.0 exactly, and the regression this guards
-  // against sits at 3.0. The bound is deliberately loose rather than == 0: the
-  // claim worth pinning is "does not allocate per message", and a stray
-  // allocation from an unrelated io-thread wakeup should not fail the build.
-  EXPECT_LT(per_callback, 0.5) << "receive path allocated " << per_callback << " times per callback (" << allocations
-                               << " allocations across " << callbacks
-                               << " callbacks) - something on the receive path is allocating per message again";
+  // On Linux and macOS the steady state measures 0.0 exactly, so the bound only
+  // has to be loose enough that a stray allocation from an unrelated io-thread
+  // wakeup does not fail the build.
+  //
+  // Windows has a non-zero floor that is not ours to remove. asio's backend
+  // there is IOCP, a proactor that allocates per async operation, and this
+  // project binds no custom handler allocator, so those allocations land in the
+  // same counter. The floor also depends on how the test binary is linked -
+  // measured 1.0 for the x64-windows jobs and 3.0 for x64-windows-static-md -
+  // so a single tight bound would either fail on one or go blind on the other.
+  //
+  // 3.5 clears the higher floor and still catches the regression this exists
+  // for: three allocations per message coming back reads 4.0 against the 1.0
+  // floor and 7.0 against the 3.0 floor, both measured on the parent commit.
+  // The margin over the 3.0 floor is thin. If this starts flaking on Windows,
+  // raising the bound is the wrong fix - re-measure the floor on the parent
+  // commit first, because a floor that moved on its own is the finding.
+#ifdef _WIN32
+  constexpr double kMaxAllocationsPerCallback = 3.5;
+#else
+  constexpr double kMaxAllocationsPerCallback = 0.5;
+#endif
+
+  EXPECT_LT(per_callback, kMaxAllocationsPerCallback)
+      << "receive path allocated " << per_callback << " times per callback (" << allocations << " allocations across "
+      << callbacks << " callbacks) - something on the receive path is allocating per message again";
 
   client->stop();
   server->stop();

--- a/test/integration/tcp/test_receive_allocations.cc
+++ b/test/integration/tcp/test_receive_allocations.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+#include <string>
+
+#include "test_utils.hpp"
+#include "wirestead/wirestead.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace std::chrono_literals;
+
+// docs/performance_validation.md gates on "unexpected allocation-count
+// increase". Unlike throughput, allocation count is deterministic: counting
+// global operator new on the receiving io thread gives byte-identical numbers
+// across runs, which is what makes it usable as a regression gate at all.
+//
+// This file must stay its own executable. The counter below replaces global
+// operator new for the whole binary, and the integration CMakeLists builds one
+// executable per test file, so nothing else is affected.
+
+namespace {
+
+// thread_local so the receiving io thread is counted in isolation - gtest and
+// the main thread allocate freely and are never read.
+thread_local size_t t_allocs = 0;
+
+struct ReceiveProbe {
+  size_t allocs_at_first_callback = 0;
+  size_t allocs_at_last_callback = 0;
+  std::atomic<size_t> callbacks{0};
+  std::atomic<size_t> bytes{0};
+};
+
+ReceiveProbe g_probe;
+
+constexpr int kMessages = 1000;
+constexpr size_t kPayload = 256;
+
+// A handler must capture more than std::function's small-buffer budget for the
+// shared-pointer snapshot to be observable at all: a small lambda fits the SBO
+// and its copy never allocated, so a trivial handler measures nothing and looks
+// like the snapshot change did nothing.
+constexpr size_t kCaptureBytes = 64;
+
+}  // namespace
+
+void* operator new(std::size_t n) {
+  ++t_allocs;
+  void* p = std::malloc(n ? n : 1);
+  if (!p) throw std::bad_alloc();
+  return p;
+}
+void* operator new[](std::size_t n) { return ::operator new(n); }
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
+  ++t_allocs;
+  return std::malloc(n ? n : 1);
+}
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept { return ::operator new(n, std::nothrow); }
+
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
+void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }
+
+// The receive path must not allocate once per delivered message. It used to
+// allocate three times per callback - the chunk was copied into the context and
+// each std::function handler was copied on the way out. Both are gone; this
+// pins that down, because the cost is invisible in latency and only shows up as
+// allocator pressure under load.
+TEST(ReceiveAllocationsTest, DoesNotAllocatePerDeliveredMessage) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = wirestead::tcp_server(port).build();
+  server->on_data([](const wirestead::MessageContext&) {});
+  ASSERT_TRUE(server->start_sync());
+
+  std::array<char, kCaptureBytes> padding{};
+  padding.fill('x');
+
+  auto client = wirestead::tcp_client("127.0.0.1", port).max_retries(50).build();
+  client->on_data([padding](const wirestead::MessageContext& ctx) {
+    // Read the capture so it cannot be optimised out of the closure.
+    if (padding[0] == 'y') return;
+    if (g_probe.callbacks.load(std::memory_order_relaxed) == 0) g_probe.allocs_at_first_callback = t_allocs;
+    g_probe.callbacks.fetch_add(1, std::memory_order_relaxed);
+    g_probe.bytes.fetch_add(ctx.data().size(), std::memory_order_relaxed);
+    g_probe.allocs_at_last_callback = t_allocs;
+  });
+  ASSERT_TRUE(client->start_sync());
+
+  const std::string payload(kPayload, 'a');
+  // broadcast() is a non-blocking fan-out, so a tight loop legitimately drops
+  // once the queue fills. Count what it accepted rather than what was offered -
+  // exact byte accounting is test_gather_write's job, not this test's.
+  size_t accepted_bytes = 0;
+  for (int i = 0; i < kMessages; ++i) {
+    if (server->broadcast(payload)) accepted_bytes += payload.size();
+  }
+  ASSERT_GT(accepted_bytes, 0u) << "server accepted nothing to send";
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] { return g_probe.bytes.load(std::memory_order_relaxed) >= accepted_bytes; }, 15000))
+      << "only " << g_probe.bytes.load() << " of " << accepted_bytes << " accepted bytes arrived";
+
+  const size_t callbacks = g_probe.callbacks.load(std::memory_order_relaxed);
+  ASSERT_GT(callbacks, 1u) << "need at least two callbacks to measure the steady state";
+
+  // Measured between the first and last callback so connection setup, which
+  // legitimately allocates, is excluded.
+  const size_t allocations = g_probe.allocs_at_last_callback - g_probe.allocs_at_first_callback;
+  const double per_callback = static_cast<double>(allocations) / static_cast<double>(callbacks - 1);
+
+  // The steady state measures 0.0 exactly, and the regression this guards
+  // against sits at 3.0. The bound is deliberately loose rather than == 0: the
+  // claim worth pinning is "does not allocate per message", and a stray
+  // allocation from an unrelated io-thread wakeup should not fail the build.
+  EXPECT_LT(per_callback, 0.5) << "receive path allocated " << per_callback << " times per callback (" << allocations
+                               << " allocations across " << callbacks
+                               << " callbacks) - something on the receive path is allocating per message again";
+
+  client->stop();
+  server->stop();
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -140,6 +140,7 @@ foreach(
   test_file
   test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
   test_runtime_stats.cc test_send_buffer_apis.cc test_error_context_builder.cc
+  test_message_context.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -110,7 +110,7 @@ endforeach()
 
 # Config tests (separate executables)
 foreach(test_file test_config.cc test_config_security.cc
-                  test_config_failure.cpp
+                  test_config_failure.cpp test_read_buffer_size.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
   wirestead_add_unit_gtest(

--- a/test/unit/config/test_read_buffer_size.cc
+++ b/test/unit/config/test_read_buffer_size.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "wirestead/base/constants.hpp"
+#include "wirestead/config/tcp_client_config.hpp"
+#include "wirestead/config/tcp_server_config.hpp"
+#include "wirestead/config/uds_config.hpp"
+
+using namespace wirestead;
+using namespace wirestead::config;
+namespace k = wirestead::base::constants;
+
+namespace {
+
+// Every config carrying a read buffer clamps it the same way, so run the same
+// checks over each rather than letting one drift.
+template <typename Config>
+void expect_read_buffer_clamped() {
+  Config cfg;
+  EXPECT_EQ(cfg.read_buffer_size, k::DEFAULT_READ_BUFFER_SIZE) << "default must not change silently";
+
+  cfg.read_buffer_size = 1;
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.validate_and_clamp();
+  EXPECT_EQ(cfg.read_buffer_size, k::MIN_READ_BUFFER_SIZE);
+  EXPECT_TRUE(cfg.is_valid());
+
+  cfg.read_buffer_size = k::MAX_READ_BUFFER_SIZE * 4;
+  EXPECT_FALSE(cfg.is_valid());
+  cfg.validate_and_clamp();
+  EXPECT_EQ(cfg.read_buffer_size, k::MAX_READ_BUFFER_SIZE);
+  EXPECT_TRUE(cfg.is_valid());
+
+  // A value already in range must survive untouched.
+  cfg.read_buffer_size = 32 * 1024;
+  cfg.validate_and_clamp();
+  EXPECT_EQ(cfg.read_buffer_size, 32u * 1024u);
+}
+
+}  // namespace
+
+TEST(ReadBufferSizeConfigTest, TcpClientConfigClampsToRange) { expect_read_buffer_clamped<TcpClientConfig>(); }
+
+TEST(ReadBufferSizeConfigTest, TcpServerConfigClampsToRange) { expect_read_buffer_clamped<TcpServerConfig>(); }
+
+TEST(ReadBufferSizeConfigTest, UdsClientConfigClampsToRange) { expect_read_buffer_clamped<UdsClientConfig>(); }
+
+TEST(ReadBufferSizeConfigTest, UdsServerConfigClampsToRange) { expect_read_buffer_clamped<UdsServerConfig>(); }
+
+TEST(ReadBufferSizeConfigTest, BoundsAreOrdered) {
+  EXPECT_LT(k::MIN_READ_BUFFER_SIZE, k::MAX_READ_BUFFER_SIZE);
+  EXPECT_GE(k::DEFAULT_READ_BUFFER_SIZE, k::MIN_READ_BUFFER_SIZE);
+  EXPECT_LE(k::DEFAULT_READ_BUFFER_SIZE, k::MAX_READ_BUFFER_SIZE);
+  // The read buffer is per connection and a server multiplies it by
+  // max_connections, so it must stay well under the kernel socket-buffer cap.
+  EXPECT_LT(k::MAX_READ_BUFFER_SIZE, k::MAX_SOCKET_BUFFER_SIZE);
+}

--- a/test/unit/wrapper/test_message_context.cc
+++ b/test/unit/wrapper/test_message_context.cc
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "wirestead/wrapper/context.hpp"
+
+using namespace wirestead;
+using namespace wirestead::wrapper;
+
+namespace {
+
+std::vector<uint8_t> make_payload(const std::string& text) { return std::vector<uint8_t>(text.begin(), text.end()); }
+
+}  // namespace
+
+// The borrowing constructor exists to keep the single-shot on_data()/
+// on_message() dispatch allocation-free. Pointer identity is the only direct
+// evidence that no copy happened, so assert it - a future change that
+// reintroduces a per-chunk copy has to fail here.
+TEST(MessageContextTest, ViewConstructorDoesNotCopyThePayload) {
+  auto payload = make_payload("borrowed");
+  const MessageContext ctx(7, memory::ConstByteSpan(payload.data(), payload.size()));
+
+  EXPECT_EQ(ctx.client_id(), 7u);
+  EXPECT_EQ(ctx.data(), "borrowed");
+  EXPECT_EQ(static_cast<const void*>(ctx.data().data()), static_cast<const void*>(payload.data()));
+}
+
+TEST(MessageContextTest, OwningConstructorCopiesThePayload) {
+  auto payload = make_payload("owned");
+  const MessageContext ctx(3, memory::SafeDataBuffer(memory::ConstByteSpan(payload.data(), payload.size())));
+
+  EXPECT_EQ(ctx.data(), "owned");
+  EXPECT_NE(static_cast<const void*>(ctx.data().data()), static_cast<const void*>(payload.data()));
+
+  // Mutating the source must not be visible through an owning context.
+  payload[0] = static_cast<uint8_t>('X');
+  EXPECT_EQ(ctx.data(), "owned");
+}
+
+TEST(MessageContextTest, AccessorsAgreeAcrossBothConstructors) {
+  auto payload = make_payload("hello wirestead");
+  const MessageContext view_ctx(1, memory::ConstByteSpan(payload.data(), payload.size()));
+  const MessageContext owned_ctx(1, memory::SafeDataBuffer(memory::ConstByteSpan(payload.data(), payload.size())));
+
+  EXPECT_EQ(view_ctx.data(), owned_ctx.data());
+  EXPECT_EQ(view_ctx.data_as_string(), owned_ctx.data_as_string());
+  EXPECT_EQ(view_ctx.data_as_vector(), owned_ctx.data_as_vector());
+  EXPECT_EQ(view_ctx.data_as_string(), "hello wirestead");
+  EXPECT_EQ(view_ctx.data_as_vector(), payload);
+}
+
+// safe_data() is the one accessor that still has to hand back a real
+// SafeDataBuffer, so a borrowing context materializes one on demand.
+TEST(MessageContextTest, SafeDataMaterializesForABorrowingContext) {
+  auto payload = make_payload("materialize me");
+  const MessageContext ctx(0, memory::ConstByteSpan(payload.data(), payload.size()));
+
+  const auto& buffer = ctx.safe_data();
+  EXPECT_EQ(buffer.size(), payload.size());
+  EXPECT_EQ(buffer.as_string(), "materialize me");
+
+  // Cached: a second call returns the same object, and the other accessors
+  // keep agreeing with it afterwards.
+  EXPECT_EQ(&buffer, &ctx.safe_data());
+  EXPECT_EQ(ctx.data(), "materialize me");
+  EXPECT_EQ(ctx.data_as_vector(), payload);
+}
+
+TEST(MessageContextTest, SafeDataReturnsTheOwnedBufferDirectly) {
+  auto payload = make_payload("already owned");
+  const MessageContext ctx(0, memory::SafeDataBuffer(memory::ConstByteSpan(payload.data(), payload.size())));
+
+  EXPECT_EQ(ctx.safe_data().as_string(), "already owned");
+  EXPECT_EQ(static_cast<const void*>(ctx.data().data()), static_cast<const void*>(ctx.safe_data().data()));
+}
+
+// The batch handlers move contexts into a queue and then move the whole queue
+// out to flush it, so moving must not leave a context reading from relocated
+// storage.
+TEST(MessageContextTest, MovingAnOwningContextKeepsItsPayload) {
+  auto payload = make_payload("survives the move");
+  MessageContext ctx(11, memory::SafeDataBuffer(memory::ConstByteSpan(payload.data(), payload.size())));
+
+  std::vector<MessageContext> queue;
+  queue.emplace_back(std::move(ctx));
+  std::vector<MessageContext> flushed = std::move(queue);
+
+  ASSERT_EQ(flushed.size(), 1u);
+  EXPECT_EQ(flushed[0].client_id(), 11u);
+  EXPECT_EQ(flushed[0].data(), "survives the move");
+  EXPECT_EQ(flushed[0].data_as_vector(), payload);
+}
+
+// Copying is the only way a caller can keep a context past the callback (it is
+// handed out as a const reference), so a copy of a borrowing context has to
+// take ownership rather than carry the soon-to-dangle view.
+TEST(MessageContextTest, CopyOfABorrowingContextOutlivesTheSourceBuffer) {
+  MessageContext copy(0, memory::ConstByteSpan{});
+  {
+    auto payload = make_payload("source goes away");
+    const MessageContext borrowed(5, memory::ConstByteSpan(payload.data(), payload.size()), "peer");
+    copy = borrowed;
+    EXPECT_NE(static_cast<const void*>(copy.data().data()), static_cast<const void*>(payload.data()));
+  }
+  EXPECT_EQ(copy.client_id(), 5u);
+  EXPECT_EQ(copy.data(), "source goes away");
+  EXPECT_EQ(copy.client_info(), "peer");
+}
+
+TEST(MessageContextTest, CopyConstructingABorrowingContextTakesOwnership) {
+  std::vector<MessageContext> kept;
+  {
+    auto payload = make_payload("kept past the callback");
+    const MessageContext borrowed(9, memory::ConstByteSpan(payload.data(), payload.size()));
+    kept.push_back(borrowed);  // copy, not move
+  }
+  ASSERT_EQ(kept.size(), 1u);
+  EXPECT_EQ(kept[0].data(), "kept past the callback");
+}
+
+// The batch queues rely on moves staying noexcept, otherwise vector
+// reallocation silently downgrades to the deep-copying copy constructor.
+TEST(MessageContextTest, MovesAreNoexcept) {
+  EXPECT_TRUE(std::is_nothrow_move_constructible_v<MessageContext>);
+  EXPECT_TRUE(std::is_nothrow_move_assignable_v<MessageContext>);
+}
+
+TEST(MessageContextTest, CopyingAMaterializedContextKeepsItsPayload) {
+  auto payload = make_payload("copied");
+  const MessageContext ctx(0, memory::ConstByteSpan(payload.data(), payload.size()));
+  ASSERT_EQ(ctx.safe_data().as_string(), "copied");
+
+  const MessageContext copy = ctx;
+  EXPECT_EQ(copy.data(), "copied");
+  EXPECT_EQ(copy.safe_data().as_string(), "copied");
+}
+
+TEST(MessageContextTest, EmptyPayloadIsSafeForBothConstructors) {
+  const MessageContext view_ctx(0, memory::ConstByteSpan{});
+  EXPECT_TRUE(view_ctx.data().empty());
+  EXPECT_TRUE(view_ctx.data_as_string().empty());
+  EXPECT_TRUE(view_ctx.data_as_vector().empty());
+  EXPECT_TRUE(view_ctx.safe_data().empty());
+
+  const MessageContext owned_ctx(0, memory::SafeDataBuffer(memory::ConstByteSpan{}));
+  EXPECT_TRUE(owned_ctx.data().empty());
+  EXPECT_TRUE(owned_ctx.data_as_string().empty());
+  EXPECT_TRUE(owned_ctx.data_as_vector().empty());
+}
+
+TEST(MessageContextTest, ClientInfoIsCarriedByBothConstructors) {
+  auto payload = make_payload("x");
+  const MessageContext view_ctx(2, memory::ConstByteSpan(payload.data(), payload.size()), "127.0.0.1:9000");
+  const MessageContext owned_ctx(2, memory::SafeDataBuffer(memory::ConstByteSpan(payload.data(), payload.size())),
+                                 "127.0.0.1:9000");
+
+  EXPECT_EQ(view_ctx.client_info(), "127.0.0.1:9000");
+  EXPECT_EQ(owned_ctx.client_info(), "127.0.0.1:9000");
+}

--- a/wirestead/base/constants.hpp
+++ b/wirestead/base/constants.hpp
@@ -53,6 +53,14 @@ constexpr size_t DEFAULT_BACKPRESSURE_THRESHOLD = DEFAULT_THRESHOLD_RELIABLE;
 constexpr size_t MIN_BACKPRESSURE_THRESHOLD = 1024;       // 1 KiB minimum
 constexpr size_t MAX_BACKPRESSURE_THRESHOLD = 100 << 20;  // 100 MiB maximum
 constexpr size_t DEFAULT_READ_BUFFER_SIZE = 4096;         // 4 KiB
+// Bounds for the per-connection userspace read buffer (the buffer each
+// async_read_some() fills, sized by *Config::read_buffer_size). A larger
+// buffer means fewer read completions and fewer callback dispatches for bulk
+// transfers. The ceiling is far below MAX_SOCKET_BUFFER_SIZE below because
+// this buffer is allocated per connection and a server multiplies it by
+// max_connections, whereas SO_RCVBUF is charged to the kernel per socket.
+constexpr size_t MIN_READ_BUFFER_SIZE = 512;          // 512 B
+constexpr size_t MAX_READ_BUFFER_SIZE = 1024 * 1024;  // 1 MiB
 
 // Retry and timeout constants
 constexpr unsigned DEFAULT_RETRY_INTERVAL_MS = 1000;      // 1 second

--- a/wirestead/builder/tcp_client_builder.cc
+++ b/wirestead/builder/tcp_client_builder.cc
@@ -39,7 +39,8 @@ TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port
       tcp_no_delay_(true),
       keep_alive_(false),
       send_buffer_size_(0),
-      receive_buffer_size_(0) {
+      receive_buffer_size_(0),
+      read_buffer_size_(base::constants::DEFAULT_READ_BUFFER_SIZE) {
   if (port == 0) throw diagnostics::BuilderException("Invalid port number: 0");
   if (host.empty()) throw diagnostics::BuilderException("Host cannot be empty");
 
@@ -73,6 +74,7 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   if (keep_alive_set_) client->keep_alive(keep_alive_);
   if (send_buffer_size_set_) client->send_buffer_size(send_buffer_size_);
   if (receive_buffer_size_set_) client->receive_buffer_size(receive_buffer_size_);
+  if (read_buffer_size_set_) client->read_buffer_size(read_buffer_size_);
 
   if (this->bp_strategy_set_) client->backpressure_strategy(this->bp_strategy_);
   client->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -166,6 +168,13 @@ template <uint32_t State>
 TcpClientBuilder<State>& TcpClientBuilder<State>::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   receive_buffer_size_set_ = true;
+  return *this;
+}
+
+template <uint32_t State>
+TcpClientBuilder<State>& TcpClientBuilder<State>::read_buffer_size(size_t bytes) {
+  read_buffer_size_ = bytes;
+  read_buffer_size_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/tcp_client_builder.hpp
+++ b/wirestead/builder/tcp_client_builder.hpp
@@ -68,7 +68,9 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
         send_buffer_size_(other.send_buffer_size_),
         send_buffer_size_set_(other.send_buffer_size_set_),
         receive_buffer_size_(other.receive_buffer_size_),
-        receive_buffer_size_set_(other.receive_buffer_size_set_) {
+        receive_buffer_size_set_(other.receive_buffer_size_set_),
+        read_buffer_size_(other.read_buffer_size_),
+        read_buffer_size_set_(other.read_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -115,6 +117,15 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
   TcpClientBuilder<State>& send_buffer_size(size_t bytes);
   TcpClientBuilder<State>& receive_buffer_size(size_t bytes);
 
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
+   */
+  TcpClientBuilder<State>& read_buffer_size(size_t bytes);
+
  private:
   template <uint32_t S>
   friend class TcpClientBuilder;
@@ -142,6 +153,8 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
   bool send_buffer_size_set_{false};
   size_t receive_buffer_size_;
   bool receive_buffer_size_set_{false};
+  size_t read_buffer_size_;
+  bool read_buffer_size_set_{false};
 };
 
 using TcpClientBuilderDefault = TcpClientBuilder<BuilderState::None>;

--- a/wirestead/builder/tcp_server_builder.cc
+++ b/wirestead/builder/tcp_server_builder.cc
@@ -41,7 +41,8 @@ TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
       tcp_no_delay_(true),
       keep_alive_(false),
       send_buffer_size_(0),
-      receive_buffer_size_(0) {
+      receive_buffer_size_(0),
+      read_buffer_size_(base::constants::DEFAULT_READ_BUFFER_SIZE) {
   if (port == 0) throw diagnostics::BuilderException("Invalid port number: 0");
 
   // Ensure background IO service is running
@@ -80,6 +81,7 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
   if (keep_alive_set_) server->keep_alive(keep_alive_);
   if (send_buffer_size_set_) server->send_buffer_size(send_buffer_size_);
   if (receive_buffer_size_set_) server->receive_buffer_size(receive_buffer_size_);
+  if (read_buffer_size_set_) server->read_buffer_size(read_buffer_size_);
 
   if (this->bp_strategy_set_) server->backpressure_strategy(this->bp_strategy_);
   server->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -179,6 +181,13 @@ template <uint32_t State>
 TcpServerBuilder<State>& TcpServerBuilder<State>::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   receive_buffer_size_set_ = true;
+  return *this;
+}
+
+template <uint32_t State>
+TcpServerBuilder<State>& TcpServerBuilder<State>::read_buffer_size(size_t bytes) {
+  read_buffer_size_ = bytes;
+  read_buffer_size_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/tcp_server_builder.hpp
+++ b/wirestead/builder/tcp_server_builder.hpp
@@ -70,7 +70,9 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
         send_buffer_size_(other.send_buffer_size_),
         send_buffer_size_set_(other.send_buffer_size_set_),
         receive_buffer_size_(other.receive_buffer_size_),
-        receive_buffer_size_set_(other.receive_buffer_size_set_) {
+        receive_buffer_size_set_(other.receive_buffer_size_set_),
+        read_buffer_size_(other.read_buffer_size_),
+        read_buffer_size_set_(other.read_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -108,6 +110,15 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
   TcpServerBuilder<State>& keep_alive(bool enable = true);
   TcpServerBuilder<State>& send_buffer_size(size_t bytes);
   TcpServerBuilder<State>& receive_buffer_size(size_t bytes);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
+   */
+  TcpServerBuilder<State>& read_buffer_size(size_t bytes);
 
   // Backward compatibility methods
   TcpServerBuilder<State>& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
@@ -153,6 +164,8 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
   bool send_buffer_size_set_{false};
   size_t receive_buffer_size_;
   bool receive_buffer_size_set_{false};
+  size_t read_buffer_size_;
+  bool read_buffer_size_set_{false};
 };
 
 using TcpServerBuilderDefault = TcpServerBuilder<BuilderState::None>;

--- a/wirestead/builder/uds_builder.cc
+++ b/wirestead/builder/uds_builder.cc
@@ -34,7 +34,8 @@ UdsClientBuilder<State>::UdsClientBuilder(const std::string& socket_path)
       independent_context_(false),
       retry_interval_(base::constants::DEFAULT_RETRY_INTERVAL_MS),
       max_retries_(base::constants::DEFAULT_MAX_RETRIES),
-      connection_timeout_(base::constants::DEFAULT_CONNECTION_TIMEOUT_MS) {
+      connection_timeout_(base::constants::DEFAULT_CONNECTION_TIMEOUT_MS),
+      read_buffer_size_(base::constants::DEFAULT_READ_BUFFER_SIZE) {
   if (socket_path.empty()) throw diagnostics::BuilderException("Socket path cannot be empty");
 
   // Ensure background IO service is running
@@ -61,6 +62,7 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
   if (retry_interval_set_) client->retry_interval(retry_interval_);
   if (max_retries_set_) client->max_retries(max_retries_);
   if (connection_timeout_set_) client->connection_timeout(connection_timeout_);
+  if (read_buffer_size_set_) client->read_buffer_size(read_buffer_size_);
 
   if (this->bp_strategy_set_) client->backpressure_strategy(this->bp_strategy_);
   client->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -110,6 +112,13 @@ UdsClientBuilder<State>& UdsClientBuilder<State>::connection_timeout(std::chrono
 }
 
 template <uint32_t State>
+UdsClientBuilder<State>& UdsClientBuilder<State>::read_buffer_size(size_t bytes) {
+  read_buffer_size_ = bytes;
+  read_buffer_size_set_ = true;
+  return *this;
+}
+
+template <uint32_t State>
 UdsClientBuilder<State>& UdsClientBuilder<State>::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
@@ -125,7 +134,8 @@ UdsServerBuilder<State>::UdsServerBuilder(const std::string& socket_path)
       max_clients_(0),
       client_limit_enabled_(false),
       idle_timeout_(0),
-      idle_timeout_set_(false) {
+      idle_timeout_set_(false),
+      read_buffer_size_(base::constants::DEFAULT_READ_BUFFER_SIZE) {
   if (socket_path.empty()) throw diagnostics::BuilderException("Socket path cannot be empty");
 
   // Ensure background IO service is running
@@ -155,6 +165,7 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
   if (idle_timeout_set_) {
     server->idle_timeout(idle_timeout_);
   }
+  if (read_buffer_size_set_) server->read_buffer_size(read_buffer_size_);
 
   if (this->bp_strategy_set_) server->backpressure_strategy(this->bp_strategy_);
   server->backpressure_threshold(this->get_effective_backpressure_threshold());
@@ -193,6 +204,13 @@ template <uint32_t State>
 UdsServerBuilder<State>& UdsServerBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
   idle_timeout_set_ = true;
+  return *this;
+}
+
+template <uint32_t State>
+UdsServerBuilder<State>& UdsServerBuilder<State>::read_buffer_size(size_t bytes) {
+  read_buffer_size_ = bytes;
+  read_buffer_size_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/uds_builder.hpp
+++ b/wirestead/builder/uds_builder.hpp
@@ -57,7 +57,9 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
         max_retries_(other.max_retries_),
         max_retries_set_(other.max_retries_set_),
         connection_timeout_(other.connection_timeout_),
-        connection_timeout_set_(other.connection_timeout_set_) {
+        connection_timeout_set_(other.connection_timeout_set_),
+        read_buffer_size_(other.read_buffer_size_),
+        read_buffer_size_set_(other.read_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -83,6 +85,15 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
   UdsClientBuilder<State>& retry_interval(std::chrono::milliseconds interval);
   UdsClientBuilder<State>& max_retries(int max_retries);
   UdsClientBuilder<State>& connection_timeout(std::chrono::milliseconds timeout);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
+   */
+  UdsClientBuilder<State>& read_buffer_size(size_t bytes);
   UdsClientBuilder<State>& independent_context(bool use_independent = true);
 
  private:
@@ -99,6 +110,8 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
   bool max_retries_set_{false};
   std::chrono::milliseconds connection_timeout_;
   bool connection_timeout_set_{false};
+  size_t read_buffer_size_;
+  bool read_buffer_size_set_{false};
 };
 
 using UdsClientBuilderDefault = UdsClientBuilder<BuilderState::None>;
@@ -123,7 +136,9 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
         max_clients_(other.max_clients_),
         client_limit_enabled_(other.client_limit_enabled_),
         idle_timeout_(other.idle_timeout_),
-        idle_timeout_set_(other.idle_timeout_set_) {
+        idle_timeout_set_(other.idle_timeout_set_),
+        read_buffer_size_(other.read_buffer_size_),
+        read_buffer_size_set_(other.read_buffer_size_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -148,6 +163,15 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
   UdsServerBuilder<State>& auto_start(bool auto_start = true) override;
   UdsServerBuilder<State>& independent_context(bool use_independent = true);
   UdsServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
+   */
+  UdsServerBuilder<State>& read_buffer_size(size_t bytes);
   UdsServerBuilder<State>& max_clients(uint32_t max_clients);
   [[deprecated("Use max_clients(1) instead")]]
   UdsServerBuilder<State>& single_client();
@@ -166,6 +190,8 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
   bool client_limit_enabled_;
   std::chrono::milliseconds idle_timeout_;
   bool idle_timeout_set_;
+  size_t read_buffer_size_;
+  bool read_buffer_size_set_{false};
 };
 
 using UdsServerBuilderDefault = UdsServerBuilder<BuilderState::None>;

--- a/wirestead/config/tcp_client_config.hpp
+++ b/wirestead/config/tcp_client_config.hpp
@@ -40,6 +40,12 @@ struct TcpClientConfig {
   bool keep_alive = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;
+  // Size of the per-connection userspace read buffer that each
+  // async_read_some() fills. Distinct from receive_buffer_size, which is the
+  // kernel's SO_RCVBUF. Raising this reduces read completions and callback
+  // dispatches on bulk transfers, at the cost of that much memory per
+  // connection.
+  size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE;
 
   TcpClientConfig() = default;
   TcpClientConfig(const TcpClientConfig&) = default;
@@ -49,8 +55,9 @@ struct TcpClientConfig {
 
   // Validation methods
   bool is_valid() const {
-    return util::InputValidator::is_valid_host(host) && port > 0 &&
-           retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
+    return read_buffer_size >= base::constants::MIN_READ_BUFFER_SIZE &&
+           read_buffer_size <= base::constants::MAX_READ_BUFFER_SIZE && util::InputValidator::is_valid_host(host) &&
+           port > 0 && retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
            connection_timeout_ms >= base::constants::MIN_CONNECTION_TIMEOUT_MS &&
            connection_timeout_ms <= base::constants::MAX_CONNECTION_TIMEOUT_MS &&
@@ -67,6 +74,11 @@ struct TcpClientConfig {
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
+    if (read_buffer_size < base::constants::MIN_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MIN_READ_BUFFER_SIZE;
+    } else if (read_buffer_size > base::constants::MAX_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MAX_READ_BUFFER_SIZE;
+    }
     if (retry_interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
       retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
     } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {

--- a/wirestead/config/tcp_server_config.hpp
+++ b/wirestead/config/tcp_server_config.hpp
@@ -46,6 +46,12 @@ struct TcpServerConfig {
   bool keep_alive = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size = 0;
   size_t receive_buffer_size = 0;
+  // Size of the per-connection userspace read buffer that each
+  // async_read_some() fills. Distinct from receive_buffer_size, which is the
+  // kernel's SO_RCVBUF. Raising this reduces read completions and callback
+  // dispatches on bulk transfers, at the cost of that much memory per
+  // connection.
+  size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE;
 
   // Opt into the shared IoContextManager singleton instead of a dedicated
   // io_context + thread (the default since #440). Only meaningful for
@@ -55,7 +61,9 @@ struct TcpServerConfig {
 
   // Validation methods
   bool is_valid() const {
-    return (util::InputValidator::is_valid_ipv4(bind_address) || util::InputValidator::is_valid_ipv6(bind_address)) &&
+    return read_buffer_size >= base::constants::MIN_READ_BUFFER_SIZE &&
+           read_buffer_size <= base::constants::MAX_READ_BUFFER_SIZE &&
+           (util::InputValidator::is_valid_ipv4(bind_address) || util::InputValidator::is_valid_ipv6(bind_address)) &&
            port > 0 && backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections >= 0 &&
            (idle_timeout_ms == 0 || (idle_timeout_ms >= static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS) &&
@@ -68,6 +76,11 @@ struct TcpServerConfig {
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
+    if (read_buffer_size < base::constants::MIN_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MIN_READ_BUFFER_SIZE;
+    } else if (read_buffer_size > base::constants::MAX_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MAX_READ_BUFFER_SIZE;
+    }
     if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
       backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
     } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {

--- a/wirestead/config/uds_config.hpp
+++ b/wirestead/config/uds_config.hpp
@@ -36,11 +36,18 @@ struct UdsClientConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
+  // Size of the per-connection userspace read buffer that each
+  // async_read_some() fills. Raising this reduces read completions and
+  // callback dispatches on bulk transfers, at the cost of that much memory
+  // per connection.
+  size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE;
 
   UdsClientConfig() = default;
 
   bool is_valid() const {
-    return util::InputValidator::is_valid_uds_path(socket_path) &&
+    return read_buffer_size >= base::constants::MIN_READ_BUFFER_SIZE &&
+           read_buffer_size <= base::constants::MAX_READ_BUFFER_SIZE &&
+           util::InputValidator::is_valid_uds_path(socket_path) &&
            retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
            connection_timeout_ms >= base::constants::MIN_CONNECTION_TIMEOUT_MS &&
@@ -51,6 +58,11 @@ struct UdsClientConfig {
   }
 
   void validate_and_clamp() {
+    if (read_buffer_size < base::constants::MIN_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MIN_READ_BUFFER_SIZE;
+    } else if (read_buffer_size > base::constants::MAX_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MAX_READ_BUFFER_SIZE;
+    }
     if (retry_interval_ms < base::constants::MIN_RETRY_INTERVAL_MS) {
       retry_interval_ms = base::constants::MIN_RETRY_INTERVAL_MS;
     } else if (retry_interval_ms > base::constants::MAX_RETRY_INTERVAL_MS) {
@@ -83,6 +95,11 @@ struct UdsServerConfig {
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
+  // Size of the per-connection userspace read buffer that each
+  // async_read_some() fills. Raising this reduces read completions and
+  // callback dispatches on bulk transfers, at the cost of that much memory
+  // per connection.
+  size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE;
   // #437: 0 (unlimited) used to be the default, risking unbounded memory
   // growth from a large number of slow/malicious clients. 0 still means
   // unlimited for callers who explicitly opt into it.
@@ -95,7 +112,9 @@ struct UdsServerConfig {
   int socket_permissions = -1;
 
   bool is_valid() const {
-    return util::InputValidator::is_valid_uds_path(socket_path) &&
+    return read_buffer_size >= base::constants::MIN_READ_BUFFER_SIZE &&
+           read_buffer_size <= base::constants::MAX_READ_BUFFER_SIZE &&
+           util::InputValidator::is_valid_uds_path(socket_path) &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD && max_connections >= 0 &&
            (idle_timeout_ms == 0 || (idle_timeout_ms >= static_cast<int>(base::constants::MIN_IDLE_TIMEOUT_MS) &&
@@ -104,6 +123,11 @@ struct UdsServerConfig {
   }
 
   void validate_and_clamp() {
+    if (read_buffer_size < base::constants::MIN_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MIN_READ_BUFFER_SIZE;
+    } else if (read_buffer_size > base::constants::MAX_READ_BUFFER_SIZE) {
+      read_buffer_size = base::constants::MAX_READ_BUFFER_SIZE;
+    }
     if (backpressure_threshold < base::constants::MIN_BACKPRESSURE_THRESHOLD) {
       backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
     } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {

--- a/wirestead/interface/channel.hpp
+++ b/wirestead/interface/channel.hpp
@@ -77,5 +77,27 @@ class WIRESTEAD_API Channel {
   virtual void on_state(OnState cb) = 0;
   virtual void on_backpressure(OnBackpressure cb) = 0;
 };
+
+// Snapshot type for a callback an implementation hands out to its io thread.
+//
+// The storage discipline above is unchanged - the mutex still guards the
+// member, and the callback is still invoked outside the lock. What changes is
+// the cost of the snapshot: copying a std::function heap-allocates whenever
+// the target does not fit its small-object buffer, and the receive path takes
+// one such copy per received chunk. Sharing an immutable copy turns that into
+// a refcount bump. The pointed-to callback is const, so a snapshot taken by
+// the io thread stays valid and unchanged even while a setter installs a
+// replacement, which is the same guarantee the copy provided (#436).
+template <typename Callback>
+using SharedCallback = std::shared_ptr<const Callback>;
+
+// Returns null for an empty callback, so a non-null SharedCallback always
+// holds something invocable and callers need only the pointer check.
+// Call this outside the lock - it allocates.
+template <typename Callback>
+SharedCallback<Callback> share_callback(Callback cb) {
+  if (!cb) return {};
+  return std::make_shared<const Callback>(std::move(cb));
+}
 }  // namespace interface
 }  // namespace wirestead

--- a/wirestead/interface/iserial_port.hpp
+++ b/wirestead/interface/iserial_port.hpp
@@ -18,7 +18,9 @@
 
 #include <boost/asio.hpp>
 #include <functional>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "wirestead/base/platform.hpp"
 #include "wirestead/base/visibility.hpp"
@@ -50,7 +52,40 @@ class WIRESTEAD_API SerialPortInterface {
                                std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
   virtual void async_write(const net::const_buffer& buffer,
                            std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
+
+  // Scatter-gather write: sends every buffer in `buffers` as one operation,
+  // completing once with the total byte count or the first error. Draining
+  // several queued messages this way turns N send syscalls into one.
+  //
+  // The memory the buffers point at must stay valid until the handler runs.
+  //
+  // The default flattens into one buffer and delegates to the single-buffer
+  // overload above: correct, but it copies, so implementations backed by a real
+  // socket override it. Test doubles can rely on the default.
+  virtual void async_write(const std::vector<net::const_buffer>& buffers,
+                           std::function<void(const boost::system::error_code&, std::size_t)> handler);
 };
+
+// Flattens into one contiguous buffer and delegates. Copies, which is why a
+// socket-backed implementation overrides this; kept here so test doubles and
+// any not-yet-converted implementation stay correct for free. `flat` is
+// owned by the completion lambda, so it outlives the delegated write.
+inline void SerialPortInterface::async_write(
+    const std::vector<net::const_buffer>& buffers,
+    std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  auto flat = std::make_shared<std::vector<unsigned char>>();
+  std::size_t total = 0;
+  for (const auto& b : buffers) total += b.size();
+  flat->reserve(total);
+  for (const auto& b : buffers) {
+    const auto* p = static_cast<const unsigned char*>(b.data());
+    flat->insert(flat->end(), p, p + b.size());
+  }
+  async_write(net::const_buffer(flat->data(), flat->size()),
+              [flat, handler = std::move(handler)](const boost::system::error_code& ec, std::size_t n) {
+                if (handler) handler(ec, n);
+              });
+}
 
 }  // namespace interface
 }  // namespace wirestead

--- a/wirestead/interface/itcp_socket.hpp
+++ b/wirestead/interface/itcp_socket.hpp
@@ -18,6 +18,8 @@
 
 #include <boost/asio.hpp>
 #include <functional>
+#include <memory>
+#include <vector>
 
 #include "wirestead/base/platform.hpp"
 #include "wirestead/base/visibility.hpp"
@@ -39,10 +41,43 @@ class WIRESTEAD_API TcpSocketInterface {
                                std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
   virtual void async_write(const net::const_buffer& buffer,
                            std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
+
+  // Scatter-gather write: sends every buffer in `buffers` as one operation,
+  // completing once with the total byte count or the first error. Draining
+  // several queued messages this way turns N send syscalls into one.
+  //
+  // The memory the buffers point at must stay valid until the handler runs.
+  //
+  // The default flattens into one buffer and delegates to the single-buffer
+  // overload above: correct, but it copies, so implementations backed by a real
+  // socket override it. Test doubles can rely on the default.
+  virtual void async_write(const std::vector<net::const_buffer>& buffers,
+                           std::function<void(const boost::system::error_code&, std::size_t)> handler);
   virtual void shutdown(net::ip::tcp::socket::shutdown_type what, boost::system::error_code& ec) = 0;
   virtual void close(boost::system::error_code& ec) = 0;
   virtual net::ip::tcp::endpoint remote_endpoint(boost::system::error_code& ec) const = 0;
 };
+
+// Flattens into one contiguous buffer and delegates. Copies, which is why a
+// socket-backed implementation overrides this; kept here so test doubles and
+// any not-yet-converted implementation stay correct for free. `flat` is
+// owned by the completion lambda, so it outlives the delegated write.
+inline void TcpSocketInterface::async_write(
+    const std::vector<net::const_buffer>& buffers,
+    std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  auto flat = std::make_shared<std::vector<unsigned char>>();
+  std::size_t total = 0;
+  for (const auto& b : buffers) total += b.size();
+  flat->reserve(total);
+  for (const auto& b : buffers) {
+    const auto* p = static_cast<const unsigned char*>(b.data());
+    flat->insert(flat->end(), p, p + b.size());
+  }
+  async_write(net::const_buffer(flat->data(), flat->size()),
+              [flat, handler = std::move(handler)](const boost::system::error_code& ec, std::size_t n) {
+                if (handler) handler(ec, n);
+              });
+}
 
 }  // namespace interface
 }  // namespace wirestead

--- a/wirestead/interface/iuds_socket.hpp
+++ b/wirestead/interface/iuds_socket.hpp
@@ -18,6 +18,8 @@
 
 #include <boost/asio.hpp>
 #include <functional>
+#include <memory>
+#include <vector>
 
 #include "wirestead/base/platform.hpp"
 #include "wirestead/base/visibility.hpp"
@@ -39,12 +41,45 @@ class WIRESTEAD_API UdsSocketInterface {
                                std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
   virtual void async_write(const net::const_buffer& buffer,
                            std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
+
+  // Scatter-gather write: sends every buffer in `buffers` as one operation,
+  // completing once with the total byte count or the first error. Draining
+  // several queued messages this way turns N send syscalls into one.
+  //
+  // The memory the buffers point at must stay valid until the handler runs.
+  //
+  // The default flattens into one buffer and delegates to the single-buffer
+  // overload above: correct, but it copies, so implementations backed by a real
+  // socket override it. Test doubles can rely on the default.
+  virtual void async_write(const std::vector<net::const_buffer>& buffers,
+                           std::function<void(const boost::system::error_code&, std::size_t)> handler);
   virtual void async_connect(const net::local::stream_protocol::endpoint& endpoint,
                              std::function<void(const boost::system::error_code&)> handler) = 0;
   virtual void shutdown(net::local::stream_protocol::socket::shutdown_type what, boost::system::error_code& ec) = 0;
   virtual void close(boost::system::error_code& ec) = 0;
   virtual net::local::stream_protocol::endpoint remote_endpoint(boost::system::error_code& ec) const = 0;
 };
+
+// Flattens into one contiguous buffer and delegates. Copies, which is why a
+// socket-backed implementation overrides this; kept here so test doubles and
+// any not-yet-converted implementation stay correct for free. `flat` is
+// owned by the completion lambda, so it outlives the delegated write.
+inline void UdsSocketInterface::async_write(
+    const std::vector<net::const_buffer>& buffers,
+    std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  auto flat = std::make_shared<std::vector<unsigned char>>();
+  std::size_t total = 0;
+  for (const auto& b : buffers) total += b.size();
+  flat->reserve(total);
+  for (const auto& b : buffers) {
+    const auto* p = static_cast<const unsigned char*>(b.data());
+    flat->insert(flat->end(), p, p + b.size());
+  }
+  async_write(net::const_buffer(flat->data(), flat->size()),
+              [flat, handler = std::move(handler)](const boost::system::error_code& ec, std::size_t n) {
+                if (handler) handler(ec, n);
+              });
+}
 
 }  // namespace interface
 }  // namespace wirestead

--- a/wirestead/transport/base/bp_state_machine.hpp
+++ b/wirestead/transport/base/bp_state_machine.hpp
@@ -102,7 +102,8 @@ inline EnqueueDecision decide_enqueue(BackpressureFields& f, size_t added, Deque
 // bytes moved; `kick_write` is called if the OFF transition leaves anything
 // in tx_ and nothing is currently being written.
 template <typename FlushFn, typename KickFn>
-inline void report_backpressure(BackpressureFields& f, size_t queued_bytes, interface::Channel::OnBackpressure& on_bp,
+inline void report_backpressure(BackpressureFields& f, size_t queued_bytes,
+                                const interface::Channel::OnBackpressure& on_bp,
                                 diagnostics::RuntimeStatsCounters& stats, FlushFn&& flush_pending_into_tx,
                                 KickFn&& kick_write) {
   if (!f.backpressure_active.load(std::memory_order_relaxed) && queued_bytes >= f.bp_high) {
@@ -154,7 +155,7 @@ inline void report_backpressure(BackpressureFields& f, size_t queued_bytes, inte
 // do_write() again (jwsung91/wirestead#427, #452). `clear_queues` must clear
 // every transport-specific queue (tx_, pending_, and their byte counters).
 template <typename ClearFn>
-inline void drain_and_clear_backpressure(BackpressureFields& f, interface::Channel::OnBackpressure& on_bp,
+inline void drain_and_clear_backpressure(BackpressureFields& f, const interface::Channel::OnBackpressure& on_bp,
                                          ClearFn&& clear_queues) {
   clear_queues();
   const bool had_backpressure = f.backpressure_active.load(std::memory_order_relaxed);

--- a/wirestead/transport/base/bp_utils.hpp
+++ b/wirestead/transport/base/bp_utils.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <boost/asio/buffer.hpp>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -150,6 +151,81 @@ inline size_t variant_buffer_size(const T& buf) {
   } else {
     return buf.size();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Gather writes
+// ---------------------------------------------------------------------------
+//
+// Stream transports used to hand exactly one queued buffer to async_write(),
+// so a backlog of N queued messages cost N send syscalls even though they were
+// all ready at once. Draining several into one scatter-gather write collapses
+// those into one.
+//
+// Caps on how much of tx_ a single gather write may take. These matter for
+// BestEffort: buffers moved into the in-flight batch have left tx_ and can no
+// longer be dropped by maybe_flush_for_keep_latest(), so an unbounded batch
+// would let stale data survive a keep-latest trim that was supposed to discard
+// it. They also bound how much gets re-queued when a write fails.
+// 16, not an arbitrary round number: asio fills at most 16 buffers per
+// prepared_buffers (detail/consuming_buffers.hpp, max_buffers), which is also
+// the iovec count a single sendmsg gets. Staying at or under it keeps each
+// gather write inside one prepare. Larger batches were measured to corrupt the
+// stream - at 64 buffers, queued messages came out of order on the wire while
+// byte counts still matched, so only an ordering check catches it. Anything
+// above this needs that verified again, not assumed.
+inline constexpr size_t kMaxGatherBuffers = 16;
+inline constexpr size_t kMaxGatherBytes = 256 * 1024;
+
+// Returns a const_buffer over a BufferVariant alternative.
+template <typename T>
+inline ::boost::asio::const_buffer variant_const_buffer(const T& buf) {
+  if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
+    return buf ? ::boost::asio::const_buffer(buf->data(), buf->size()) : ::boost::asio::const_buffer();
+  } else {
+    return ::boost::asio::const_buffer(buf.data(), buf.size());
+  }
+}
+// Moves buffers from the front of `tx` into `batch` (which is cleared first)
+// up to the caps above, filling `views` with the matching const_buffers.
+// Returns the total byte count, which is what the caller must subtract from
+// queue_bytes_ once the write completes.
+//
+// Must run on the strand, with no write already in flight: `views` describes
+// memory owned by `batch`, so neither may be touched until the write completes.
+//
+// `views` is handed to asio as an ordinary ConstBufferSequence, which asio
+// copies into the composed operation. An earlier version passed a non-owning
+// view to dodge that copy; asio's partial-write bookkeeping does not survive
+// an aliasing sequence, and it silently duplicated or stalled queued buffers.
+// One small copy per gather write is the right trade - it replaces N syscalls,
+// and with several messages per write it is fewer allocations than before.
+template <typename Deque, typename Batch>
+inline size_t take_gather_batch(Deque& tx, Batch& batch, std::vector<::boost::asio::const_buffer>& views) {
+  batch.clear();
+  views.clear();
+  size_t total = 0;
+  while (!tx.empty() && batch.size() < kMaxGatherBuffers && total < kMaxGatherBytes) {
+    const size_t n = std::visit([](const auto& b) { return variant_buffer_size(b); }, tx.front());
+    batch.push_back(std::move(tx.front()));
+    tx.pop_front();
+    total += n;
+  }
+  views.reserve(batch.size());
+  for (const auto& b : batch) {
+    views.push_back(std::visit([](const auto& x) { return variant_const_buffer(x); }, b));
+  }
+  return total;
+}
+
+// Returns a failed batch to the front of `tx` in its original order, so a
+// retry/teardown sees the queue exactly as it was.
+template <typename Deque, typename Batch>
+inline void return_gather_batch(Deque& tx, Batch& batch) {
+  for (auto it = batch.rbegin(); it != batch.rend(); ++it) {
+    tx.push_front(std::move(*it));
+  }
+  batch.clear();
 }
 
 // Identity projection: the default for maybe_flush_for_keep_latest()'s `project`

--- a/wirestead/transport/serial/boost_serial_port.hpp
+++ b/wirestead/transport/serial/boost_serial_port.hpp
@@ -58,6 +58,13 @@ class WIRESTEAD_API BoostSerialPort : public interface::SerialPortInterface {
     net::async_write(port_, buffer, std::move(handler));
   }
 
+  // Real scatter-gather write: hands the sequence to asio, which issues one
+  // sendmsg/writev instead of one send per queued buffer.
+  void async_write(const std::vector<net::const_buffer>& buffers,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    net::async_write(port_, buffers, std::move(handler));
+  }
+
  private:
   net::serial_port port_;
 };

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -79,7 +79,10 @@ struct Serial::Impl {
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
-  std::optional<BufferVariant> current_write_buffer_;
+  // Buffers handed to the in-flight gather write; current_write_views_
+  // points into the batch, so neither is touched while a write is in flight.
+  std::vector<BufferVariant> current_write_batch_;
+  std::vector<net::const_buffer> current_write_views_;
   bool writing_ = false;
   std::atomic<size_t> queued_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
@@ -372,14 +375,14 @@ struct Serial::Impl {
     }
     writing_ = true;
 
-    current_write_buffer_ = std::move(tx_.front());
-    tx_.pop_front();
-
-    auto& current = *current_write_buffer_;
+    // Drain several queued buffers into one scatter-gather write rather than
+    // one write syscall per message. `writing_` keeps do_write() from
+    // re-entering, so the batch and its views stay put for the whole operation.
+    queue_util::take_gather_batch(tx_, current_write_batch_, current_write_views_);
 
     auto on_write = [self](const boost::system::error_code& ec, std::size_t n) {
       auto impl = self->get_impl();
-      impl->current_write_buffer_.reset();
+      impl->current_write_batch_.clear();
 
       if (impl->queued_bytes_ >= n) {
         impl->queued_bytes_ -= n;
@@ -401,24 +404,7 @@ struct Serial::Impl {
       impl->do_write(self);
     };
 
-    std::visit(
-        [&](auto&& buf) {
-          using T = std::decay_t<decltype(buf)>;
-          auto* data_ptr = [&]() {
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>)
-              return buf->data();
-            else
-              return buf.data();
-          }();
-          auto size = [&]() {
-            if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>)
-              return buf->size();
-            else
-              return buf.size();
-          }();
-          port_->async_write(net::buffer(data_ptr, size), net::bind_executor(strand_, on_write));
-        },
-        current);
+    port_->async_write(current_write_views_, net::bind_executor(strand_, on_write));
   }
 
   void perform_cleanup() {

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -108,9 +108,12 @@ struct Serial::Impl {
   // and the strand-confined read sites both take this lock; readers copy
   // the callback under lock then invoke the copy outside the lock (#436).
   mutable std::mutex callback_mtx_;
-  OnBytes on_bytes_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots: the strand copies one out per received chunk, and a
+  // std::function copy allocates whenever the target outgrows its small-object
+  // buffer. See interface::SharedCallback.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
 
   std::atomic<bool> opened_{false};
   AtomicLinkState state_{LinkState::Idle};
@@ -320,14 +323,14 @@ struct Serial::Impl {
             return;
           }
           if (n > 0) impl->stats_.record_received(n);
-          OnBytes on_bytes;
+          interface::SharedCallback<OnBytes> on_bytes;
           {
             std::lock_guard<std::mutex> lock(impl->callback_mtx_);
             on_bytes = impl->on_bytes_;
           }
           if (on_bytes) {
             try {
-              on_bytes(memory::ConstByteSpan(impl->rx_.data(), n));
+              (*on_bytes)(memory::ConstByteSpan(impl->rx_.data(), n));
             } catch (const std::exception& e) {
               std::string msg = fmt::format("Exception in callback: {}", e.what());
               WIRESTEAD_LOG_ERROR("serial", "on_bytes", msg);
@@ -492,14 +495,14 @@ struct Serial::Impl {
 
   void notify_state() {
     if (stopping_.load()) return;
-    OnState on_state;
+    interface::SharedCallback<OnState> on_state;
     {
       std::lock_guard<std::mutex> lock(callback_mtx_);
       on_state = on_state_;
     }
     if (!on_state) return;
     try {
-      on_state(state_.get());
+      (*on_state)(state_.get());
     } catch (...) {
     }
   }
@@ -516,15 +519,16 @@ struct Serial::Impl {
     if (stopping_.load()) return;
     observe_queue();
 
-    OnBackpressure on_bp;
+    interface::SharedCallback<OnBackpressure> on_bp;
     {
       std::lock_guard<std::mutex> lock(callback_mtx_);
       on_bp = on_bp_;
     }
+    static const OnBackpressure kNoCallback;
 
     auto f = bp_fields();
     queue_util::report_backpressure(
-        f, qb, on_bp, stats_,
+        f, qb, on_bp ? *on_bp : kNoCallback, stats_,
         [&]() -> size_t {
           const size_t moved = pending_bytes_.exchange(0);
           while (!pending_.empty()) {
@@ -849,16 +853,19 @@ bool Serial::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>> 
 }
 
 void Serial::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 void Serial::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 void Serial::on_backpressure(OnBackpressure cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bp_ = std::move(cb);
+  impl_->on_bp_ = std::move(shared);
 }
 
 void Serial::set_backpressure_strategy(base::constants::BackpressureStrategy strategy) {

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -129,9 +129,12 @@ struct TcpClient::Impl {
   diagnostics::RuntimeStatsCounters stats_;
   unsigned first_retry_interval_ms_ = 100;
 
-  OnBytes on_bytes_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots rather than plain std::functions: the io thread copies
+  // one out per received chunk, and a std::function copy allocates whenever
+  // the target outgrows its small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
   mutable std::mutex callback_mtx_;
   std::atomic<bool> connected_{false};
   AtomicLinkState state_{LinkState::Idle};
@@ -571,17 +574,22 @@ bool TcpClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
   return true;
 }
 
+// Each setter builds the shared snapshot before taking the lock, so the
+// allocation stays outside the critical section the io thread contends on.
 void TcpClient::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 void TcpClient::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 void TcpClient::on_backpressure(OnBackpressure cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bp_ = std::move(cb);
+  impl_->on_bp_ = std::move(shared);
 }
 void TcpClient::set_backpressure_strategy(base::constants::BackpressureStrategy strategy) {
   impl_->bp_strategy_.store(strategy, std::memory_order_relaxed);
@@ -854,7 +862,7 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
     if (n > 0) {
       self->impl_->reset_idle_timer(self, seq);
     }
-    OnBytes on_bytes;
+    interface::SharedCallback<OnBytes> on_bytes;
     {
       std::lock_guard<std::mutex> lock(self->impl_->callback_mtx_);
       on_bytes = self->impl_->on_bytes_;
@@ -864,7 +872,7 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
 
     if (on_bytes) {
       try {
-        on_bytes(memory::ConstByteSpan(self->impl_->rx_.data(), n));
+        (*on_bytes)(memory::ConstByteSpan(self->impl_->rx_.data(), n));
       } catch (const std::exception& e) {
         WIRESTEAD_LOG_ERROR("tcp_client", "on_bytes", fmt::format("Exception in on_bytes callback: {}", e.what()));
         self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "on_bytes",
@@ -1129,15 +1137,16 @@ void TcpClient::Impl::report_backpressure(std::shared_ptr<TcpClient> self, size_
   if (stop_requested_.load() || stopping_.load()) return;
   observe_queue();
 
-  OnBackpressure on_bp;
+  interface::SharedCallback<OnBackpressure> on_bp;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     on_bp = on_bp_;
   }
+  static const OnBackpressure kNoCallback;
 
   auto f = bp_fields();
   queue_util::report_backpressure(
-      f, queued_bytes, on_bp, stats_,
+      f, queued_bytes, on_bp ? *on_bp : kNoCallback, stats_,
       [&]() -> size_t {
         const size_t moved = pending_bytes_.exchange(0);
         while (!pending_.empty()) {
@@ -1256,7 +1265,7 @@ void TcpClient::Impl::join_ioc_thread(bool allow_detach) {
 void TcpClient::Impl::notify_state() {
   if (stop_requested_.load() || stopping_.load()) return;
 
-  OnState on_state;
+  interface::SharedCallback<OnState> on_state;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     on_state = on_state_;
@@ -1264,7 +1273,7 @@ void TcpClient::Impl::notify_state() {
   if (!on_state) return;
 
   try {
-    on_state(state_.get());
+    (*on_state)(state_.get());
   } catch (const std::exception& e) {
     WIRESTEAD_LOG_ERROR("tcp_client", "on_state", "Exception in state callback: " + std::string(e.what()));
   } catch (...) {

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -112,7 +112,12 @@ struct TcpClient::Impl {
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
-  std::optional<BufferVariant> current_write_buffer_;
+  // Buffers handed to the in-flight write. Several at a time rather than one:
+  // a backlog of queued messages used to cost one send syscall each. `views_`
+  // points into `current_write_batch_`, so both stay untouched for the whole
+  // async_write - `writing_` is what guarantees that.
+  std::vector<BufferVariant> current_write_batch_;
+  std::vector<net::const_buffer> current_write_views_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
@@ -916,25 +921,11 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
   }
   writing_ = true;
 
-  current_write_buffer_ = std::move(tx_.front());
-  tx_.pop_front();
-
-  auto& current = *current_write_buffer_;
-
-  auto queued_bytes = std::visit(
-      [](auto&& buf) -> size_t {
-        using Buffer = std::decay_t<decltype(buf)>;
-        if constexpr (std::is_same_v<Buffer, std::shared_ptr<const std::vector<uint8_t>>>) {
-          return buf ? buf->size() : 0;
-        } else {
-          return buf.size();
-        }
-      },
-      current);
+  const auto queued_bytes = queue_util::take_gather_batch(tx_, current_write_batch_, current_write_views_);
 
   auto on_write = [self, queued_bytes, seq](auto ec, std::size_t bytes_written) {
     if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) {
-      self->impl_->current_write_buffer_.reset();
+      self->impl_->current_write_batch_.clear();
       self->impl_->queue_bytes_ =
           (self->impl_->queue_bytes_ > queued_bytes) ? (self->impl_->queue_bytes_ - queued_bytes) : 0;
       self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
@@ -943,10 +934,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
     }
 
     if (ec) {
-      if (self->impl_->current_write_buffer_) {
-        self->impl_->tx_.push_front(std::move(*self->impl_->current_write_buffer_));
-      }
-      self->impl_->current_write_buffer_.reset();
+      queue_util::return_gather_batch(self->impl_->tx_, self->impl_->current_write_batch_);
 
       WIRESTEAD_LOG_ERROR("tcp_client", "do_write", fmt::format("Write failed: {}", ec.message()));
       self->impl_->record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::COMMUNICATION, "write", ec,
@@ -956,7 +944,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
       return;
     }
 
-    self->impl_->current_write_buffer_.reset();
+    self->impl_->current_write_batch_.clear();
     self->impl_->stats_.record_sent(bytes_written);
     if (bytes_written > 0) {
       self->impl_->reset_idle_timer(self, seq);
@@ -974,16 +962,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
     self->impl_->do_write(self, seq);
   };
 
-  std::visit(
-      [&](const auto& buf) {
-        using T = std::decay_t<decltype(buf)>;
-        if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-          net::async_write(socket_, net::buffer(buf->data(), buf->size()), on_write);
-        } else {
-          net::async_write(socket_, net::buffer(buf.data(), buf.size()), on_write);
-        }
-      },
-      current);
+  net::async_write(socket_, current_write_views_, on_write);
 }
 
 void TcpClient::Impl::handle_close(std::shared_ptr<TcpClient> self, uint64_t seq, const boost::system::error_code& ec) {

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -105,7 +105,10 @@ struct TcpClient::Impl {
   std::atomic<bool> terminal_state_notified_{false};
   std::atomic<bool> reconnect_pending_{false};
 
-  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  // Sized from cfg_.read_buffer_size in init() rather than being a fixed
+  // std::array, so a bulk-transfer workload can trade memory for fewer read
+  // completions and callback dispatches.
+  std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
@@ -166,6 +169,7 @@ struct TcpClient::Impl {
     queue_bytes_ = 0;
     pending_bytes_ = 0;
     cfg_.validate_and_clamp();
+    rx_.resize(cfg_.read_buffer_size);
     recalculate_backpressure_bounds();
     first_retry_interval_ms_ = std::min(first_retry_interval_ms_, cfg_.retry_interval_ms);
   }

--- a/wirestead/transport/tcp_server/boost_tcp_socket.hpp
+++ b/wirestead/transport/tcp_server/boost_tcp_socket.hpp
@@ -42,6 +42,13 @@ class WIRESTEAD_API BoostTcpSocket : public interface::TcpSocketInterface {
                        std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
   void async_write(const net::const_buffer& buffer,
                    std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
+
+  // Real scatter-gather write: hands the sequence to asio, which issues one
+  // sendmsg/writev instead of one send per queued buffer.
+  void async_write(const std::vector<net::const_buffer>& buffers,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    net::async_write(socket_, buffers, std::move(handler));
+  }
   void shutdown(tcp::socket::shutdown_type what, boost::system::error_code& ec) override;
   void close(boost::system::error_code& ec) override;
   tcp::endpoint remote_endpoint(boost::system::error_code& ec) const override;

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -69,11 +69,15 @@ struct TcpServer::Impl {
   config::TcpServerConfig cfg_;
 
   concurrency::AtomicLinkState state_{base::LinkState::Idle};
-  OnBytes on_bytes_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots for the handlers the io thread copies out per received
+  // chunk - a std::function copy allocates whenever the target outgrows its
+  // small-object buffer. See interface::SharedCallback. The connect/disconnect
+  // handlers below stay plain: they fire once per connection, not per chunk.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
   MultiClientConnectHandler on_multi_connect_;
-  MultiClientDataHandler on_multi_data_;
+  interface::SharedCallback<MultiClientDataHandler> on_multi_data_;
   MultiClientDisconnectHandler on_multi_disconnect_;
   diagnostics::RuntimeStatsCounters stats_;
 
@@ -139,14 +143,14 @@ struct TcpServer::Impl {
 
   void notify_state() {
     if (stopping_.load()) return;
-    OnState cb;
+    interface::SharedCallback<OnState> cb;
     try {
       {
         std::lock_guard<std::mutex> lock(sessions_mutex_);
         cb = on_state_;
       }
       if (cb) {
-        cb(state_.get());
+        (*cb)(state_.get());
       }
     } catch (...) {
     }
@@ -331,25 +335,25 @@ struct TcpServer::Impl {
         if (!shared_self) return;
         auto* bytes_impl = shared_self->get_impl();
 
-        OnBytes cb;
-        MultiClientDataHandler multi_cb;
+        interface::SharedCallback<OnBytes> cb;
+        interface::SharedCallback<MultiClientDataHandler> multi_cb;
         {
           std::lock_guard<std::mutex> lock(bytes_impl->sessions_mutex_);
           cb = bytes_impl->on_bytes_;
           multi_cb = bytes_impl->on_multi_data_;
         }
-        if (cb) cb(data);
+        if (cb) (*cb)(data);
         if (multi_cb) {
-          multi_cb(client_id, data);
+          (*multi_cb)(client_id, data);
         }
       });
 
-      OnBackpressure bp_cb;
+      interface::SharedCallback<OnBackpressure> bp_cb;
       {
         std::lock_guard<std::mutex> lock(accept_impl->sessions_mutex_);
         bp_cb = accept_impl->on_bp_;
       }
-      if (bp_cb) new_session->on_backpressure(bp_cb);
+      if (bp_cb) new_session->on_backpressure(*bp_cb);
 
       new_session->on_close([weak_self, client_id, new_session] {
         auto shared_self = weak_self.lock();
@@ -769,26 +773,31 @@ bool TcpServer::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
   return false;
 }
 
+// Each setter builds the shared snapshot before taking the lock, so the
+// allocation stays outside the critical section the io thread contends on.
 void TcpServer::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 void TcpServer::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 void TcpServer::on_backpressure(OnBackpressure cb) {
   auto impl = get_impl();
+  auto shared = interface::share_callback(std::move(cb));
   std::shared_ptr<TcpServerSession> session;
-  OnBackpressure bp_cb;
+  interface::SharedCallback<OnBackpressure> bp_cb;
   {
     std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
-    impl->on_bp_ = std::move(cb);
+    impl->on_bp_ = std::move(shared);
     bp_cb = impl->on_bp_;
     session = impl->current_session_;
   }
 
-  if (session) session->on_backpressure(bp_cb);
+  if (session) session->on_backpressure(bp_cb ? *bp_cb : OnBackpressure{});
 }
 
 bool TcpServer::broadcast(std::string_view message) {
@@ -881,8 +890,9 @@ void TcpServer::on_multi_connect(MultiClientConnectHandler h) {
   impl_->on_multi_connect_ = std::move(h);
 }
 void TcpServer::on_multi_data(MultiClientDataHandler h) {
+  auto shared = interface::share_callback(std::move(h));
   std::lock_guard<std::mutex> l(impl_->sessions_mutex_);
-  impl_->on_multi_data_ = std::move(h);
+  impl_->on_multi_data_ = std::move(shared);
 }
 void TcpServer::on_multi_disconnect(MultiClientDisconnectHandler h) {
   std::lock_guard<std::mutex> l(impl_->sessions_mutex_);

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -324,7 +324,7 @@ struct TcpServer::Impl {
       auto new_session = std::make_shared<TcpServerSession>(
           accept_impl->ioc_, std::move(sock), accept_impl->cfg_.backpressure_threshold,
           accept_impl->cfg_.idle_timeout_ms, accept_impl->cfg_.backpressure_strategy,
-          accept_impl->cfg_.enable_memory_pool);
+          accept_impl->cfg_.enable_memory_pool, accept_impl->cfg_.read_buffer_size);
 
       ClientId client_id = accept_impl->next_client_id_.fetch_add(1);
 

--- a/wirestead/transport/tcp_server/tcp_server_session.cc
+++ b/wirestead/transport/tcp_server/tcp_server_session.cc
@@ -397,17 +397,14 @@ void TcpServerSession::do_write() {
   writing_ = true;
   auto self = shared_from_this();
 
-  // Move buffer out of queue immediately to ensure lifetime safety during async op
-  // Optimization: Move into current_write_buffer_ to keep it alive during async op
-  // without allocating a shared_ptr control block.
-  current_write_buffer_ = std::move(tx_.front());
-  tx_.pop_front();
-
-  auto& current = *current_write_buffer_;
+  // Drain several queued buffers into one scatter-gather write rather than one
+  // send syscall per message. The batch and its views stay alive for the whole
+  // operation because `writing_` keeps do_write() from re-entering.
+  queue_util::take_gather_batch(tx_, current_write_batch_, current_write_views_);
 
   auto on_write = [self](const boost::system::error_code& ec, std::size_t n) {
-    // Release the buffer immediately
-    self->current_write_buffer_.reset();
+    // Release the buffers immediately
+    self->current_write_batch_.clear();
 
     if (self->closing_ || !self->alive_) return;
     if (self->queue_bytes_ >= n) {
@@ -426,16 +423,7 @@ void TcpServerSession::do_write() {
     self->do_write();
   };
 
-  std::visit(
-      [&](const auto& buf) {
-        using T = std::decay_t<decltype(buf)>;
-        if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>) {
-          socket_->async_write(net::buffer(buf->data(), buf->size()), net::bind_executor(strand_, on_write));
-        } else {
-          socket_->async_write(net::buffer(buf.data(), buf.size()), net::bind_executor(strand_, on_write));
-        }
-      },
-      current);
+  socket_->async_write(current_write_views_, net::bind_executor(strand_, on_write));
 }
 
 void TcpServerSession::do_close() {

--- a/wirestead/transport/tcp_server/tcp_server_session.cc
+++ b/wirestead/transport/tcp_server/tcp_server_session.cc
@@ -28,7 +28,7 @@ namespace transport {
 
 TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_t backpressure_threshold,
                                    int idle_timeout_ms, base::constants::BackpressureStrategy strategy,
-                                   bool enable_memory_pool)
+                                   bool enable_memory_pool, size_t read_buffer_size)
     : ioc_(ioc),
       strand_(ioc.get_executor()),
       idle_timer_(ioc),
@@ -45,11 +45,14 @@ TcpServerSession::TcpServerSession(net::io_context& ioc, tcp::socket sock, size_
                        base::constants::MAX_BUFFER_SIZE);
   bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
   if (bp_low_ == 0) bp_low_ = 1;
+  rx_.resize(
+      std::clamp(read_buffer_size, base::constants::MIN_READ_BUFFER_SIZE, base::constants::MAX_READ_BUFFER_SIZE));
 }
 
 TcpServerSession::TcpServerSession(net::io_context& ioc, std::unique_ptr<interface::TcpSocketInterface> socket,
                                    size_t backpressure_threshold, int idle_timeout_ms,
-                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool)
+                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool,
+                                   size_t read_buffer_size)
     : ioc_(ioc),
       strand_(ioc.get_executor()),
       idle_timer_(ioc),
@@ -66,6 +69,8 @@ TcpServerSession::TcpServerSession(net::io_context& ioc, std::unique_ptr<interfa
                        base::constants::MAX_BUFFER_SIZE);
   bp_low_ = bp_high_ > 1 ? bp_high_ / 2 : bp_high_;
   if (bp_low_ == 0) bp_low_ = 1;
+  rx_.resize(
+      std::clamp(read_buffer_size, base::constants::MIN_READ_BUFFER_SIZE, base::constants::MAX_READ_BUFFER_SIZE));
 }
 
 void TcpServerSession::start() {

--- a/wirestead/transport/tcp_server/tcp_server_session.hpp
+++ b/wirestead/transport/tcp_server/tcp_server_session.hpp
@@ -61,13 +61,13 @@ class WIRESTEAD_API TcpServerSession : public std::enable_shared_from_this<TcpSe
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
                    base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
-                   bool enable_memory_pool = true);
+                   bool enable_memory_pool = true, size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE);
   // Constructor for testing with dependency injection
   TcpServerSession(net::io_context& ioc, std::unique_ptr<interface::TcpSocketInterface> socket,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
                    base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
-                   bool enable_memory_pool = true);
+                   bool enable_memory_pool = true, size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE);
 
   void start();
   bool async_write_copy(memory::ConstByteSpan data);
@@ -108,7 +108,10 @@ class WIRESTEAD_API TcpServerSession : public std::enable_shared_from_this<TcpSe
   // it's no longer amortized across every connected client in the process.
   memory::MemoryPool pool_{50, 200};
   bool enable_memory_pool_ = true;
-  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  // Sized from the server's read_buffer_size rather than being a fixed
+  // std::array: this buffer exists per connection, so a server trades memory
+  // against read completions here with max_connections as the multiplier.
+  std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};

--- a/wirestead/transport/tcp_server/tcp_server_session.hpp
+++ b/wirestead/transport/tcp_server/tcp_server_session.hpp
@@ -115,7 +115,10 @@ class WIRESTEAD_API TcpServerSession : public std::enable_shared_from_this<TcpSe
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
-  std::optional<BufferVariant> current_write_buffer_;
+  // Buffers handed to the in-flight gather write; `current_write_views_`
+  // points into the batch, so neither is touched while a write is in flight.
+  std::vector<BufferVariant> current_write_batch_;
+  std::vector<net::const_buffer> current_write_views_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the

--- a/wirestead/transport/udp/udp.cc
+++ b/wirestead/transport/udp/udp.cc
@@ -115,10 +115,13 @@ struct UdpChannel::Impl {
   // outside the lock, matching the pattern already used correctly by
   // TcpClient/UdsClient/both servers (see #436).
   mutable std::mutex callback_mtx_;
-  OnBytes on_bytes_;
-  UdpChannel::OnBytesFrom on_bytes_from_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots: the strand copies one out per received datagram, and a
+  // std::function copy allocates whenever the target outgrows its small-object
+  // buffer. See interface::SharedCallback.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<UdpChannel::OnBytesFrom> on_bytes_from_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
 
   ErrorInfoHolder error_info_holder_{"udp"};
 
@@ -307,8 +310,8 @@ struct UdpChannel::Impl {
 
     if (bytes > 0) {
       stats_.record_received(bytes);
-      OnBytes on_bytes;
-      UdpChannel::OnBytesFrom on_bytes_from;
+      interface::SharedCallback<OnBytes> on_bytes;
+      interface::SharedCallback<UdpChannel::OnBytesFrom> on_bytes_from;
       {
         std::lock_guard<std::mutex> lock(callback_mtx_);
         on_bytes = on_bytes_;
@@ -316,7 +319,7 @@ struct UdpChannel::Impl {
       }
       if (on_bytes && from_established_remote) {
         try {
-          on_bytes(memory::ConstByteSpan(rx_.data(), bytes));
+          (*on_bytes)(memory::ConstByteSpan(rx_.data(), bytes));
         } catch (const std::exception& e) {
           std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
           WIRESTEAD_LOG_ERROR("udp", "on_bytes", msg);
@@ -335,7 +338,7 @@ struct UdpChannel::Impl {
 
       if (on_bytes_from) {
         try {
-          on_bytes_from(memory::ConstByteSpan(rx_.data(), bytes), recv_endpoint_);
+          (*on_bytes_from)(memory::ConstByteSpan(rx_.data(), bytes), recv_endpoint_);
         } catch (const std::exception& e) {
           std::string msg = fmt::format("Exception in bytes callback: {}", e.what());
           WIRESTEAD_LOG_ERROR("udp", "on_bytes_from", msg);
@@ -373,13 +376,14 @@ struct UdpChannel::Impl {
   // which would leave a Reliable-mode sender blocked in send_blocking()'s bp_cv_ wait forever
   // since nothing will ever call do_write() again once the channel has stopped/errored (#427).
   void drain_queue_and_clear_backpressure() {
-    OnBackpressure on_bp;
+    interface::SharedCallback<OnBackpressure> on_bp;
     {
       std::lock_guard<std::mutex> lock(callback_mtx_);
       on_bp = on_bp_;
     }
+    static const OnBackpressure kNoCallback;
     auto f = bp_fields();
-    queue_util::drain_and_clear_backpressure(f, on_bp, [&]() {
+    queue_util::drain_and_clear_backpressure(f, on_bp ? *on_bp : kNoCallback, [&]() {
       tx_.clear();
       queue_bytes_ = 0;
       pending_.clear();
@@ -489,14 +493,14 @@ struct UdpChannel::Impl {
   }
 
   void notify_state() {
-    OnState on_state;
+    interface::SharedCallback<OnState> on_state;
     {
       std::lock_guard<std::mutex> lock(callback_mtx_);
       on_state = on_state_;
     }
     if (!on_state) return;
     try {
-      on_state(state_.get());
+      (*on_state)(state_.get());
     } catch (const std::exception& e) {
       WIRESTEAD_LOG_ERROR("udp", "on_state", fmt::format("Exception in state callback: {}", e.what()));
     } catch (...) {
@@ -508,15 +512,16 @@ struct UdpChannel::Impl {
     if (stop_requested_.load()) return;
     observe_queue();
 
-    OnBackpressure on_bp;
+    interface::SharedCallback<OnBackpressure> on_bp;
     {
       std::lock_guard<std::mutex> lock(callback_mtx_);
       on_bp = on_bp_;
     }
+    static const OnBackpressure kNoCallback;
 
     auto f = bp_fields();
     queue_util::report_backpressure(
-        f, queued_bytes, on_bp, stats_,
+        f, queued_bytes, on_bp ? *on_bp : kNoCallback, stats_,
         [&]() -> size_t {
           // Flush pending_ → tx_
           const size_t moved = pending_bytes_.exchange(0);
@@ -631,13 +636,14 @@ struct UdpChannel::Impl {
     try {
       close_socket();
       writing_ = false;
-      OnBackpressure on_bp;
+      interface::SharedCallback<OnBackpressure> on_bp;
       {
         std::lock_guard<std::mutex> lock(callback_mtx_);
         on_bp = on_bp_;
       }
+      static const OnBackpressure kNoCallback;
       auto f = bp_fields();
-      queue_util::drain_and_clear_backpressure(f, on_bp, [&]() {
+      queue_util::drain_and_clear_backpressure(f, on_bp ? *on_bp : kNoCallback, [&]() {
         tx_.clear();
         queue_bytes_ = 0;
         pending_.clear();
@@ -1043,18 +1049,21 @@ bool UdpChannel::async_try_write_shared(std::shared_ptr<const std::vector<uint8_
 }
 
 void UdpChannel::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 
 void UdpChannel::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 
 void UdpChannel::on_backpressure(OnBackpressure cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bp_ = std::move(cb);
+  impl_->on_bp_ = std::move(shared);
 }
 
 void UdpChannel::set_backpressure_strategy(base::constants::BackpressureStrategy strategy) {
@@ -1165,7 +1174,14 @@ bool UdpChannel::async_try_write_to(memory::ConstByteSpan data, const boost::asi
   return true;
 }
 
-void UdpChannel::on_bytes_from(OnBytesFrom cb) { impl_->on_bytes_from_ = std::move(cb); }
+// Takes callback_mtx_ like every other setter here. It previously assigned
+// without the lock while the strand-confined read site took it, which raced
+// against a concurrent on_bytes_from() replacement.
+void UdpChannel::on_bytes_from(OnBytesFrom cb) {
+  auto shared = interface::share_callback(std::move(cb));
+  std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
+  impl_->on_bytes_from_ = std::move(shared);
+}
 
 boost::asio::ip::udp::endpoint UdpChannel::local_endpoint() const { return get_impl()->local_endpoint_; }
 

--- a/wirestead/transport/uds/boost_uds_socket.hpp
+++ b/wirestead/transport/uds/boost_uds_socket.hpp
@@ -41,6 +41,13 @@ class WIRESTEAD_API BoostUdsSocket : public interface::UdsSocketInterface {
                        std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
   void async_write(const net::const_buffer& buffer,
                    std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
+
+  // Real scatter-gather write: hands the sequence to asio, which issues one
+  // sendmsg/writev instead of one send per queued buffer.
+  void async_write(const std::vector<net::const_buffer>& buffers,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
+    net::async_write(socket_, buffers, std::move(handler));
+  }
   void async_connect(const uds::endpoint& endpoint,
                      std::function<void(const boost::system::error_code&)> handler) override;
   void shutdown(uds::socket::shutdown_type what, boost::system::error_code& ec) override;

--- a/wirestead/transport/uds/uds_client.cc
+++ b/wirestead/transport/uds/uds_client.cc
@@ -87,7 +87,10 @@ struct UdsClient::Impl {
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
-  std::optional<BufferVariant> current_write_buffer_;
+  // Buffers handed to the in-flight gather write; current_write_views_
+  // points into the batch, so neither is touched while a write is in flight.
+  std::vector<BufferVariant> current_write_batch_;
+  std::vector<net::const_buffer> current_write_views_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the
@@ -644,41 +647,29 @@ void UdsClient::Impl::do_write(std::shared_ptr<UdsClient> self, uint64_t seq) {
     pending_.clear();
     queue_bytes_ = 0;
     pending_bytes_ = 0;
-    current_write_buffer_ = std::nullopt;
+    current_write_batch_.clear();
     writing_ = false;
     return;
   }
 
   if (tx_.empty() || writing_) return;
   writing_ = true;
-  current_write_buffer_ = std::move(tx_.front());
-  tx_.pop_front();
+  // Drain several queued buffers into one scatter-gather write rather than one
+  // send syscall per message. `writing_` keeps do_write() from re-entering, so
+  // the batch and its views stay put for the whole operation.
+  const size_t bytes_to_write = queue_util::take_gather_batch(tx_, current_write_batch_, current_write_views_);
 
-  net::const_buffer buffer;
-  std::visit(
-      [&buffer](auto&& arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, std::vector<uint8_t>>)
-          buffer = net::buffer(arg);
-        else if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>)
-          buffer = net::buffer(*arg);
-        else if constexpr (std::is_same_v<T, memory::PooledBuffer>)
-          buffer = net::buffer(arg.data(), arg.size());
-      },
-      *current_write_buffer_);
-
-  size_t bytes_to_write = buffer.size();
   socket_->async_write(
-      buffer,
+      current_write_views_,
       net::bind_executor(strand_, [self, seq, bytes_to_write](const boost::system::error_code& ec, size_t written) {
         if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) return;
         if (self->impl_->stop_requested_.load() || self->impl_->stopping_.load()) {
-          self->impl_->current_write_buffer_ = std::nullopt;
+          self->impl_->current_write_batch_.clear();
           self->impl_->writing_ = false;
           return;
         }
         self->impl_->writing_ = false;
-        self->impl_->current_write_buffer_ = std::nullopt;
+        self->impl_->current_write_batch_.clear();
         self->impl_->queue_bytes_ =
             (self->impl_->queue_bytes_ >= bytes_to_write) ? (self->impl_->queue_bytes_ - bytes_to_write) : 0;
         self->impl_->report_backpressure(self, self->impl_->queue_bytes_);
@@ -727,7 +718,7 @@ void UdsClient::Impl::perform_stop_cleanup(uint64_t seq) {
   queue_bytes_ = 0;
   pending_.clear();
   pending_bytes_ = 0;
-  current_write_buffer_ = std::nullopt;
+  current_write_batch_.clear();
   writing_ = false;
   connected_.store(false);
   backpressure_active_.store(false);

--- a/wirestead/transport/uds/uds_client.cc
+++ b/wirestead/transport/uds/uds_client.cc
@@ -80,7 +80,10 @@ struct UdsClient::Impl {
   std::atomic<bool> stop_requested_{false};
   std::atomic<bool> stopping_{false};
 
-  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  // Sized from cfg_.read_buffer_size in init() rather than being a fixed
+  // std::array, so a bulk-transfer workload can trade memory for fewer read
+  // completions and callback dispatches.
+  std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
@@ -142,6 +145,7 @@ struct UdsClient::Impl {
     queue_bytes_ = 0;
     pending_bytes_ = 0;
     cfg_.validate_and_clamp();
+    rx_.resize(cfg_.read_buffer_size);
     recalculate_backpressure_bounds();
   }
 
@@ -614,7 +618,7 @@ void UdsClient::Impl::start_read(std::shared_ptr<UdsClient> self, uint64_t seq) 
     return;
   }
 
-  socket_->async_read_some(net::buffer(rx_),
+  socket_->async_read_some(net::buffer(rx_.data(), rx_.size()),
                            net::bind_executor(strand_, [self, seq](const boost::system::error_code& ec, size_t bytes) {
                              if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) return;
                              if (self->impl_->stop_requested_.load() || self->impl_->stopping_.load()) return;

--- a/wirestead/transport/uds/uds_client.cc
+++ b/wirestead/transport/uds/uds_client.cc
@@ -103,9 +103,12 @@ struct UdsClient::Impl {
   std::atomic<bool> backpressure_active_{false};
   diagnostics::RuntimeStatsCounters stats_;
 
-  OnBytes on_bytes_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots: the io thread copies one out per received chunk, and a
+  // std::function copy allocates whenever the target outgrows its small-object
+  // buffer. See interface::SharedCallback.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
   mutable std::mutex callback_mtx_;
   std::atomic<bool> connected_{false};
   AtomicLinkState state_{LinkState::Idle};
@@ -467,18 +470,21 @@ bool UdsClient::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
 }
 
 void UdsClient::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 
 void UdsClient::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 
 void UdsClient::on_backpressure(OnBackpressure cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->callback_mtx_);
-  impl_->on_bp_ = std::move(cb);
+  impl_->on_bp_ = std::move(shared);
 }
 
 void UdsClient::set_backpressure_strategy(base::constants::BackpressureStrategy strategy) {
@@ -617,13 +623,13 @@ void UdsClient::Impl::start_read(std::shared_ptr<UdsClient> self, uint64_t seq) 
                                return;
                              }
 
-                             OnBytes cb;
+                             interface::SharedCallback<OnBytes> cb;
                              {
                                std::lock_guard<std::mutex> lock(self->impl_->callback_mtx_);
                                cb = self->impl_->on_bytes_;
                              }
                              if (bytes > 0) self->impl_->stats_.record_received(bytes);
-                             if (cb) cb(memory::ConstByteSpan(self->impl_->rx_.data(), bytes));
+                             if (cb) (*cb)(memory::ConstByteSpan(self->impl_->rx_.data(), bytes));
                              self->impl_->start_read(self, seq);
                            }));
 }
@@ -697,12 +703,12 @@ void UdsClient::Impl::handle_close(std::shared_ptr<UdsClient> self, uint64_t seq
 
 void UdsClient::Impl::transition_to(LinkState next, const boost::system::error_code&) {
   state_.set(next);
-  OnState cb;
+  interface::SharedCallback<OnState> cb;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     cb = on_state_;
   }
-  if (cb) cb(next);
+  if (cb) (*cb)(next);
 }
 
 void UdsClient::Impl::perform_stop_cleanup(uint64_t seq) {
@@ -790,15 +796,16 @@ void UdsClient::Impl::report_backpressure(std::shared_ptr<UdsClient> self, size_
   if (stop_requested_.load() || stopping_.load()) return;
   observe_queue();
 
-  OnBackpressure on_bp;
+  interface::SharedCallback<OnBackpressure> on_bp;
   {
     std::lock_guard<std::mutex> lock(callback_mtx_);
     on_bp = on_bp_;
   }
+  static const OnBackpressure kNoCallback;
 
   auto f = bp_fields();
   queue_util::report_backpressure(
-      f, queued_bytes, on_bp, stats_,
+      f, queued_bytes, on_bp ? *on_bp : kNoCallback, stats_,
       [&]() -> size_t {
         const size_t moved = pending_bytes_.exchange(0);
         while (!pending_.empty()) {

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -636,7 +636,7 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
       auto session = std::make_shared<UdsServerSession>(
           *self->impl_->ioc_, std::move(socket), self->impl_->cfg_.backpressure_threshold,
           self->impl_->cfg_.idle_timeout_ms, self->impl_->cfg_.backpressure_strategy,
-          self->impl_->cfg_.enable_memory_pool);
+          self->impl_->cfg_.enable_memory_pool, self->impl_->cfg_.read_buffer_size);
 
       std::weak_ptr<UdsServer> weak_self = self;
       session->on_bytes([weak_self, client_id](memory::ConstByteSpan data) {

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -116,11 +116,15 @@ struct UdsServer::Impl {
   config::UdsServerConfig cfg_;
 
   concurrency::AtomicLinkState state_{base::LinkState::Idle};
-  OnBytes on_bytes_;
-  OnState on_state_;
-  OnBackpressure on_bp_;
+  // Shared snapshots for the handlers the io thread copies out per received
+  // chunk - a std::function copy allocates whenever the target outgrows its
+  // small-object buffer. See interface::SharedCallback. The connect/disconnect
+  // handlers stay plain: they fire once per connection, not per chunk.
+  interface::SharedCallback<OnBytes> on_bytes_;
+  interface::SharedCallback<OnState> on_state_;
+  interface::SharedCallback<OnBackpressure> on_bp_;
   MultiClientConnectHandler on_multi_connect_;
-  MultiClientDataHandler on_multi_data_;
+  interface::SharedCallback<MultiClientDataHandler> on_multi_data_;
   MultiClientDisconnectHandler on_multi_disconnect_;
   diagnostics::RuntimeStatsCounters stats_;
 
@@ -507,18 +511,21 @@ bool UdsServer::async_try_write_shared(std::shared_ptr<const std::vector<uint8_t
 }
 
 void UdsServer::on_bytes(OnBytes cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_bytes_ = std::move(cb);
+  impl_->on_bytes_ = std::move(shared);
 }
 
 void UdsServer::on_state(OnState cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_state_ = std::move(cb);
+  impl_->on_state_ = std::move(shared);
 }
 
 void UdsServer::on_backpressure(OnBackpressure cb) {
+  auto shared = interface::share_callback(std::move(cb));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_bp_ = std::move(cb);
+  impl_->on_bp_ = std::move(shared);
 }
 
 bool UdsServer::broadcast(std::string_view message) {
@@ -595,8 +602,9 @@ void UdsServer::on_multi_connect(MultiClientConnectHandler handler) {
 }
 
 void UdsServer::on_multi_data(MultiClientDataHandler handler) {
+  auto shared = interface::share_callback(std::move(handler));
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
-  impl_->on_multi_data_ = std::move(handler);
+  impl_->on_multi_data_ = std::move(shared);
 }
 
 void UdsServer::on_multi_disconnect(MultiClientDisconnectHandler handler) {
@@ -634,15 +642,15 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
       session->on_bytes([weak_self, client_id](memory::ConstByteSpan data) {
         auto s = weak_self.lock();
         if (!s) return;
-        MultiClientDataHandler data_handler;
-        OnBytes bytes_handler;
+        interface::SharedCallback<MultiClientDataHandler> data_handler;
+        interface::SharedCallback<OnBytes> bytes_handler;
         {
           std::lock_guard<std::mutex> lock(s->impl_->sessions_mutex_);
           data_handler = s->impl_->on_multi_data_;
           bytes_handler = s->impl_->on_bytes_;
         }
-        if (data_handler) data_handler(client_id, data);
-        if (bytes_handler) bytes_handler(data);
+        if (data_handler) (*data_handler)(client_id, data);
+        if (bytes_handler) (*bytes_handler)(data);
       });
 
       session->on_close([weak_self, client_id]() {
@@ -708,12 +716,12 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
 }
 
 void UdsServer::Impl::notify_state() {
-  OnState cb;
+  interface::SharedCallback<OnState> cb;
   {
     std::lock_guard<std::mutex> lock(sessions_mutex_);
     cb = on_state_;
   }
-  if (cb) cb(state_.get());
+  if (cb) (*cb)(state_.get());
 }
 
 }  // namespace transport

--- a/wirestead/transport/uds/uds_server_session.cc
+++ b/wirestead/transport/uds/uds_server_session.cc
@@ -24,7 +24,7 @@ namespace transport {
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_t backpressure_threshold,
                                    int idle_timeout_ms, base::constants::BackpressureStrategy strategy,
-                                   bool enable_memory_pool)
+                                   bool enable_memory_pool, size_t read_buffer_size)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
       idle_timer_(ioc),
@@ -35,11 +35,15 @@ UdsServerSession::UdsServerSession(net::io_context& ioc, uds::socket sock, size_
       bp_low_(backpressure_threshold > 1 ? backpressure_threshold / 2 : backpressure_threshold),
       bp_limit_(std::min(std::max(backpressure_threshold * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
                          base::constants::MAX_BUFFER_SIZE)),
-      idle_timeout_ms_(idle_timeout_ms) {}
+      idle_timeout_ms_(idle_timeout_ms) {
+  rx_.resize(
+      std::clamp(read_buffer_size, base::constants::MIN_READ_BUFFER_SIZE, base::constants::MAX_READ_BUFFER_SIZE));
+}
 
 UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
                                    size_t backpressure_threshold, int idle_timeout_ms,
-                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool)
+                                   base::constants::BackpressureStrategy strategy, bool enable_memory_pool,
+                                   size_t read_buffer_size)
     : ioc_(ioc),
       strand_(net::make_strand(ioc_)),
       idle_timer_(ioc),
@@ -50,7 +54,10 @@ UdsServerSession::UdsServerSession(net::io_context& ioc, std::unique_ptr<interfa
       bp_low_(backpressure_threshold > 1 ? backpressure_threshold / 2 : backpressure_threshold),
       bp_limit_(std::min(std::max(backpressure_threshold * 4, base::constants::DEFAULT_BACKPRESSURE_THRESHOLD),
                          base::constants::MAX_BUFFER_SIZE)),
-      idle_timeout_ms_(idle_timeout_ms) {}
+      idle_timeout_ms_(idle_timeout_ms) {
+  rx_.resize(
+      std::clamp(read_buffer_size, base::constants::MIN_READ_BUFFER_SIZE, base::constants::MAX_READ_BUFFER_SIZE));
+}
 
 void UdsServerSession::start() {
   alive_ = true;
@@ -288,7 +295,7 @@ void UdsServerSession::on_close(OnClose cb) {
 
 void UdsServerSession::start_read() {
   socket_->async_read_some(
-      net::buffer(rx_),
+      net::buffer(rx_.data(), rx_.size()),
       net::bind_executor(strand_, [this, self = shared_from_this()](const boost::system::error_code& ec, size_t bytes) {
         if (closing_ || !alive_) return;
         if (ec) {

--- a/wirestead/transport/uds/uds_server_session.cc
+++ b/wirestead/transport/uds/uds_server_session.cc
@@ -312,28 +312,16 @@ void UdsServerSession::start_read() {
 void UdsServerSession::do_write() {
   if (tx_.empty() || writing_) return;
   writing_ = true;
-  current_write_buffer_ = std::move(tx_.front());
-  tx_.pop_front();
+  // Drain several queued buffers into one scatter-gather write rather than one
+  // send syscall per message. `writing_` keeps do_write() from re-entering.
+  const size_t bytes_to_write = queue_util::take_gather_batch(tx_, current_write_batch_, current_write_views_);
 
-  net::const_buffer buffer;
-  std::visit(
-      [&buffer](auto&& arg) {
-        using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, std::vector<uint8_t>>)
-          buffer = net::buffer(arg);
-        else if constexpr (std::is_same_v<T, std::shared_ptr<const std::vector<uint8_t>>>)
-          buffer = net::buffer(*arg);
-        else if constexpr (std::is_same_v<T, memory::PooledBuffer>)
-          buffer = net::buffer(arg.data(), arg.size());
-      },
-      *current_write_buffer_);
-
-  size_t bytes_to_write = buffer.size();
-  socket_->async_write(buffer, net::bind_executor(strand_, [this, self = shared_from_this(), bytes_to_write](
-                                                               const boost::system::error_code& ec, size_t written) {
+  socket_->async_write(current_write_views_,
+                       net::bind_executor(strand_, [this, self = shared_from_this(), bytes_to_write](
+                                                       const boost::system::error_code& ec, size_t written) {
                          if (closing_ || !alive_) return;
                          writing_ = false;
-                         current_write_buffer_ = std::nullopt;
+                         current_write_batch_.clear();
                          queue_bytes_ = (queue_bytes_ >= bytes_to_write) ? (queue_bytes_ - bytes_to_write) : 0;
                          report_backpressure(queue_bytes_);
 
@@ -365,7 +353,7 @@ void UdsServerSession::do_close() {
     auto f = bp_fields();
     queue_util::drain_and_clear_backpressure(f, on_bp_, [&]() {
       tx_.clear();
-      current_write_buffer_ = std::nullopt;
+      current_write_batch_.clear();
       queue_bytes_ = 0;
       pending_.clear();
       pending_bytes_ = 0;

--- a/wirestead/transport/uds/uds_server_session.hpp
+++ b/wirestead/transport/uds/uds_server_session.hpp
@@ -61,13 +61,13 @@ class WIRESTEAD_API UdsServerSession : public std::enable_shared_from_this<UdsSe
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
                    base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
-                   bool enable_memory_pool = true);
+                   bool enable_memory_pool = true, size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE);
 
   UdsServerSession(net::io_context& ioc, std::unique_ptr<interface::UdsSocketInterface> socket,
                    size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD,
                    int idle_timeout_ms = 0,
                    base::constants::BackpressureStrategy strategy = base::constants::BackpressureStrategy::Reliable,
-                   bool enable_memory_pool = true);
+                   bool enable_memory_pool = true, size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE);
 
   void start();
   bool async_write_copy(memory::ConstByteSpan data);
@@ -107,7 +107,10 @@ class WIRESTEAD_API UdsServerSession : public std::enable_shared_from_this<UdsSe
   // used to always heap-allocate a fresh std::vector).
   memory::MemoryPool pool_{50, 200};
   bool enable_memory_pool_ = true;
-  std::array<uint8_t, base::constants::DEFAULT_READ_BUFFER_SIZE> rx_{};
+  // Sized from the server's read_buffer_size rather than being a fixed
+  // std::array: this buffer exists per connection, so a server trades memory
+  // against read completions here with max_connections as the multiplier.
+  std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};

--- a/wirestead/transport/uds/uds_server_session.hpp
+++ b/wirestead/transport/uds/uds_server_session.hpp
@@ -114,7 +114,10 @@ class WIRESTEAD_API UdsServerSession : public std::enable_shared_from_this<UdsSe
   std::deque<BufferVariant> tx_;
   std::deque<BufferVariant> pending_;
   std::atomic<size_t> pending_bytes_{0};
-  std::optional<BufferVariant> current_write_buffer_;
+  // Buffers handed to the in-flight gather write; current_write_views_
+  // points into the batch, so neither is touched while a write is in flight.
+  std::vector<BufferVariant> current_write_batch_;
+  std::vector<net::const_buffer> current_write_views_;
   bool writing_ = false;
   std::atomic<size_t> queue_bytes_{0};
   // Bytes accepted by a plain async_write_* call but not yet routed onto the

--- a/wirestead/wrapper/callback_guard.hpp
+++ b/wirestead/wrapper/callback_guard.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -73,6 +74,16 @@ void invoke_user_callback(std::string_view component, std::string_view operation
   } catch (...) {
     WIRESTEAD_LOG_ERROR(component, operation, "Uncaught non-standard exception in user callback");
   }
+}
+
+// Overload for a handler snapshotted as a shared pointer rather than copied
+// out of its guarded member - see interface::SharedCallback. A null pointer
+// means "not registered", exactly as an empty std::function does above.
+template <typename Callback, typename... Args>
+void invoke_user_callback(std::string_view component, std::string_view operation,
+                          const std::shared_ptr<const Callback>& callback, Args&&... args) {
+  if (!callback) return;
+  invoke_user_callback(component, operation, *callback, std::forward<Args>(args)...);
 }
 
 }  // namespace detail

--- a/wirestead/wrapper/context.hpp
+++ b/wirestead/wrapper/context.hpp
@@ -34,8 +34,52 @@ namespace wrapper {
  */
 class MessageContext {
  public:
+  /**
+   * @brief Construct a context that owns a copy of the payload.
+   *
+   * Use this whenever the context outlives the callback that produced the
+   * data — the batch queues hold contexts until the batch is flushed, so they
+   * must own.
+   */
   MessageContext(ClientId client_id, memory::SafeDataBuffer data, std::string client_info = "")
-      : client_id_(client_id), data_(std::move(data)), client_info_(std::move(client_info)) {}
+      : client_id_(client_id), owned_(std::move(data)), client_info_(std::move(client_info)) {}
+
+  /**
+   * @brief Construct a context that borrows the payload without copying it.
+   *
+   * `data` must stay valid for the whole lifetime of this MessageContext. That
+   * holds for single-shot on_data()/on_message() dispatch, where the context is
+   * a temporary destroyed before the transport reuses its receive buffer, so
+   * those paths cost no per-chunk allocation at all. Do not use this
+   * constructor for a context that is queued or otherwise outlives the
+   * callback — use the SafeDataBuffer constructor above for those.
+   */
+  MessageContext(ClientId client_id, memory::ConstByteSpan data, std::string client_info = "")
+      : client_id_(client_id), view_(data), client_info_(std::move(client_info)) {}
+
+  // A copy always owns its payload, even when the source only borrows. The
+  // callback receives a `const MessageContext&`, so copying is the only way a
+  // caller can keep a context past the callback, and that is exactly when the
+  // borrowed bytes stop being valid. Doing this in the copy costs the hot path
+  // nothing: dispatch passes the context by reference and never copies it.
+  MessageContext(const MessageContext& other)
+      : client_id_(other.client_id_), owned_(other.cloned_payload()), client_info_(other.client_info_) {}
+
+  MessageContext& operator=(const MessageContext& other) {
+    if (this != &other) {
+      client_id_ = other.client_id_;
+      owned_ = other.cloned_payload();
+      view_ = {};
+      client_info_ = other.client_info_;
+    }
+    return *this;
+  }
+
+  // Moves stay cheap and noexcept so the batch queues keep using them on
+  // vector reallocation instead of falling back to the copy above.
+  MessageContext(MessageContext&&) noexcept = default;
+  MessageContext& operator=(MessageContext&&) noexcept = default;
+  ~MessageContext() = default;
 
   /** @brief Get the client identifier */
   ClientId client_id() const { return client_id_; }
@@ -46,26 +90,62 @@ class MessageContext {
    * The returned view is only valid for the lifetime of this MessageContext.
    * Do not store it past the callback's return — use data_as_string() instead.
    */
-  std::string_view data() const { return std::string_view(reinterpret_cast<const char*>(data_.data()), data_.size()); }
+  std::string_view data() const {
+    const auto size = payload_size();
+    if (size == 0) return {};
+    return std::string_view(reinterpret_cast<const char*>(payload_data()), size);
+  }
 
-  /** @brief Get the received data as a SafeDataBuffer reference */
-  const memory::SafeDataBuffer& safe_data() const { return data_; }
+  /**
+   * @brief Get the received data as a SafeDataBuffer reference.
+   *
+   * When this context borrows its payload (the single-shot callback paths),
+   * the buffer is materialized on first use and cached, so this accessor is
+   * the one place that still pays for a copy. Prefer data(), data_as_string(),
+   * or data_as_vector(). Materialization is not synchronized; like every other
+   * accessor here it assumes the single callback thread the context is
+   * delivered on (see docs/callbacks.md).
+   */
+  const memory::SafeDataBuffer& safe_data() const {
+    if (!owned_) owned_.emplace(view_);
+    return *owned_;
+  }
 
   /** @brief Get the received data as a std::string */
-  std::string data_as_string() const { return data_.as_string(); }
+  std::string data_as_string() const {
+    const auto size = payload_size();
+    if (size == 0) return {};
+    return std::string(reinterpret_cast<const char*>(payload_data()), size);
+  }
 
   /** @brief Get the received data as a std::vector<uint8_t> */
   std::vector<uint8_t> data_as_vector() const {
-    const auto* d = data_.data();
-    return std::vector<uint8_t>(d, d + data_.size());
+    const auto* d = payload_data();
+    return std::vector<uint8_t>(d, d + payload_size());
   }
 
   /** @brief Get the client information (e.g., endpoint address) */
   const std::string& client_info() const { return client_info_; }
 
  private:
+  const uint8_t* payload_data() const noexcept { return owned_ ? owned_->data() : view_.data(); }
+  size_t payload_size() const noexcept { return owned_ ? owned_->size() : view_.size(); }
+
+  // Payload for a copy: reuse the owned buffer when there is one, otherwise
+  // take a copy of the borrowed bytes.
+  std::optional<memory::SafeDataBuffer> cloned_payload() const {
+    if (owned_) return owned_;
+    return memory::SafeDataBuffer(view_);
+  }
+
   ClientId client_id_;
-  memory::SafeDataBuffer data_;
+  // Exactly one of these carries the payload: `owned_` when engaged, `view_`
+  // otherwise. `view_` is left default-constructed (and unread) on the owning
+  // path, which keeps the default copy/move operations correct — they never
+  // have to re-seat a pointer into relocated storage. `owned_` is mutable only
+  // so safe_data() can materialize a borrowed payload on demand.
+  mutable std::optional<memory::SafeDataBuffer> owned_;
+  memory::ConstByteSpan view_;
   std::string client_info_;
 };
 

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -64,14 +64,17 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
   // Event handlers (Context based)
-  MessageHandler data_handler{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the strand copies one out per received chunk, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> data_handler;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ConnectionHandler connect_handler{nullptr};
   ConnectionHandler disconnect_handler{nullptr};
   ErrorHandler error_handler{nullptr};
   std::function<void(size_t)> bp_handler{nullptr};
-  MessageHandler message_handler{nullptr};
-  BatchMessageHandler message_batch_handler_{nullptr};
+  interface::SharedCallback<MessageHandler> message_handler;
+  interface::SharedCallback<BatchMessageHandler> message_batch_handler_;
 
   std::shared_ptr<framer::IFramer> framer{nullptr};
 
@@ -424,7 +427,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       // unique_lock) - this is a pure read, matching try_send's locking
       // level so it no longer blocks concurrent sends even briefly.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -438,7 +441,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
         // lock is only held for the queue mutation itself, not the
         // allocation.
         MessageContext ctx(0, memory::SafeDataBuffer(data));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -522,7 +525,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       // #441: snapshot under a shared_lock (pure read), build the copy
       // before taking the exclusive lock for queue mutation.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         batch_mode = static_cast<bool>(message_batch_handler_);
@@ -531,7 +534,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
 
       if (batch_mode) {
         MessageContext ctx(0, memory::SafeDataBuffer(msg));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -560,13 +563,13 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
 
   void on_message(MessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_handler = std::move(handler);
+    message_handler = interface::share_callback(std::move(handler));
     if (framer) attach_framer_callback();
   }
 
   void on_message_batch(BatchMessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_batch_handler_ = std::move(handler);
+    message_batch_handler_ = interface::share_callback(std::move(handler));
     if (framer) attach_framer_callback();
   }
 
@@ -637,12 +640,12 @@ void Serial::reset_stats() { impl_->reset_stats(); }
 
 Serial& Serial::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_handler = std::move(h);
+  impl_->data_handler = interface::share_callback(std::move(h));
   return *this;
 }
 Serial& Serial::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(h);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 Serial& Serial::on_connect(ConnectionHandler h) {

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -453,7 +453,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
         }
         detail::invoke_user_callback("serial", "on_data_batch", flush_handler, batch);
       } else {
-        detail::invoke_user_callback("serial", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("serial", "on_data", handler, MessageContext(0, data));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -548,7 +548,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
         return;
       }
 
-      detail::invoke_user_callback("serial", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
+      detail::invoke_user_callback("serial", "on_message", handler, MessageContext(0, msg));
     });
   }
 

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -57,14 +57,17 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<bool> started_{false};
   std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
-  MessageHandler data_handler_{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the io thread copies one out per received chunk, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> data_handler_;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ConnectionHandler connect_handler_{nullptr};
   ConnectionHandler disconnect_handler_{nullptr};
   ErrorHandler error_handler_{nullptr};
   std::function<void(size_t)> bp_handler_{nullptr};
-  MessageHandler message_handler_{nullptr};
-  BatchMessageHandler message_batch_handler_{nullptr};
+  interface::SharedCallback<MessageHandler> message_handler_;
+  interface::SharedCallback<BatchMessageHandler> message_batch_handler_;
 
   std::shared_ptr<framer::IFramer> framer_{nullptr};
 
@@ -446,7 +449,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       // unique_lock) - this is a pure read, matching try_send's locking
       // level so it no longer blocks concurrent sends even briefly.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -460,7 +463,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
         // lock is only held for the queue mutation itself, not the
         // allocation.
         MessageContext ctx(0, memory::SafeDataBuffer(data));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -541,7 +544,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       // #441: snapshot under a shared_lock (pure read), build the copy
       // before taking the exclusive lock for queue mutation.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         batch_mode = static_cast<bool>(message_batch_handler_);
@@ -550,7 +553,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
 
       if (batch_mode) {
         MessageContext ctx(0, memory::SafeDataBuffer(msg));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -579,13 +582,13 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
 
   void on_message(MessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_handler_ = std::move(handler);
+    message_handler_ = interface::share_callback(std::move(handler));
     if (framer_) attach_framer_callback();
   }
 
   void on_message_batch(BatchMessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_batch_handler_ = std::move(handler);
+    message_batch_handler_ = interface::share_callback(std::move(handler));
     if (framer_) attach_framer_callback();
   }
 };
@@ -623,12 +626,12 @@ void TcpClient::reset_stats() { impl_->reset_stats(); }
 
 TcpClient& TcpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_handler_ = std::move(h);
+  impl_->data_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 TcpClient& TcpClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(h);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 TcpClient& TcpClient::on_connect(ConnectionHandler h) {

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -475,7 +475,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
         }
         detail::invoke_user_callback("tcp_client", "on_data_batch", flush_handler, batch);
       } else {
-        detail::invoke_user_callback("tcp_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("tcp_client", "on_data", handler, MessageContext(0, data));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -567,7 +567,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
         return;
       }
 
-      detail::invoke_user_callback("tcp_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
+      detail::invoke_user_callback("tcp_client", "on_message", handler, MessageContext(0, msg));
     });
   }
 

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -94,6 +94,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   bool keep_alive_ = base::constants::DEFAULT_KEEP_ALIVE;
   size_t send_buffer_size_ = 0;
   size_t receive_buffer_size_ = 0;
+  size_t read_buffer_size_ = base::constants::DEFAULT_READ_BUFFER_SIZE;
 
   Impl(const std::string& host, uint16_t port) : host_(host), port_(port), started_(false) {}
 
@@ -207,6 +208,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       config.keep_alive = keep_alive_;
       config.send_buffer_size = send_buffer_size_;
       config.receive_buffer_size = receive_buffer_size_;
+      config.read_buffer_size = read_buffer_size_;
       channel_ = factory::ChannelFactory::create(config, external_ioc_);
       setup_internal_handlers();
     }
@@ -776,6 +778,12 @@ TcpClient& TcpClient::send_buffer_size(size_t bytes) {
 TcpClient& TcpClient::receive_buffer_size(size_t bytes) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->receive_buffer_size_ = bytes;
+  return *this;
+}
+
+TcpClient& TcpClient::read_buffer_size(size_t bytes) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->read_buffer_size_ = bytes;
   return *this;
 }
 

--- a/wirestead/wrapper/tcp_client/tcp_client.hpp
+++ b/wirestead/wrapper/tcp_client/tcp_client.hpp
@@ -121,6 +121,17 @@ class WIRESTEAD_API TcpClient : public ChannelInterface {
   TcpClient& keep_alive(bool enable = true);
   TcpClient& send_buffer_size(size_t bytes);
   TcpClient& receive_buffer_size(size_t bytes);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Distinct from receive_buffer_size(), which sets the kernel's SO_RCVBUF.
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]; takes effect on the next
+   * start().
+   */
+  TcpClient& read_buffer_size(size_t bytes);
   TcpClient& manage_external_context(bool manage);
 
  private:

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -73,6 +73,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<bool> keep_alive_{base::constants::DEFAULT_KEEP_ALIVE};
   std::atomic<size_t> send_buffer_size_{0};
   std::atomic<size_t> receive_buffer_size_{0};
+  std::atomic<size_t> read_buffer_size_{base::constants::DEFAULT_READ_BUFFER_SIZE};
 
   ConnectionHandler on_client_connect_{nullptr};
   ConnectionHandler on_disconnect_{nullptr};
@@ -235,6 +236,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       config.keep_alive = keep_alive_.load();
       config.send_buffer_size = send_buffer_size_.load();
       config.receive_buffer_size = receive_buffer_size_.load();
+      config.read_buffer_size = read_buffer_size_.load();
       config.use_shared_context = shared_context_.load();
 
       channel_ = factory::ChannelFactory::create(config, external_ioc_);
@@ -745,6 +747,11 @@ TcpServer& TcpServer::send_buffer_size(size_t bytes) {
 
 TcpServer& TcpServer::receive_buffer_size(size_t bytes) {
   impl_->receive_buffer_size_.store(bytes);
+  return *this;
+}
+
+TcpServer& TcpServer::read_buffer_size(size_t bytes) {
+  impl_->read_buffer_size_.store(bytes);
   return *this;
 }
 

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -76,13 +76,16 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
 
   ConnectionHandler on_client_connect_{nullptr};
   ConnectionHandler on_disconnect_{nullptr};
-  MessageHandler on_data_{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the io thread copies one out per received chunk, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> on_data_;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ErrorHandler on_error_{nullptr};
   std::function<void(size_t)> on_backpressure_{nullptr};
   FramerFactory framer_factory_{nullptr};
-  MessageHandler on_message_{nullptr};
-  BatchMessageHandler message_batch_handler_{nullptr};
+  interface::SharedCallback<MessageHandler> on_message_;
+  interface::SharedCallback<BatchMessageHandler> message_batch_handler_;
 
   // Batching logic
   std::vector<MessageContext> data_batch_queue_;
@@ -421,7 +424,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
                 // #441: snapshot under a shared_lock (pure read), build the
                 // copy before taking the exclusive lock for queue mutation.
                 bool batch_mode;
-                MessageHandler on_message_handler;
+                interface::SharedCallback<MessageHandler> on_message_handler;
                 {
                   std::shared_lock<std::shared_mutex> lock(mutex_);
                   batch_mode = static_cast<bool>(message_batch_handler_);
@@ -430,7 +433,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
 
                 if (batch_mode) {
                   MessageContext ctx(id, memory::SafeDataBuffer(msg));
-                  BatchMessageHandler flush_handler;
+                  interface::SharedCallback<BatchMessageHandler> flush_handler;
                   std::vector<MessageContext> batch;
                   {
                     std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -472,7 +475,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
         // locking level so it no longer blocks concurrent sends even
         // briefly.
         bool batch_mode;
-        MessageHandler handler;
+        interface::SharedCallback<MessageHandler> handler;
         std::shared_ptr<framer::IFramer> framer;
         {
           std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -489,7 +492,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
           // lock is only held for the queue mutation itself, not the
           // allocation.
           MessageContext ctx(id, memory::SafeDataBuffer(data_span));
-          BatchMessageHandler flush_handler;
+          interface::SharedCallback<BatchMessageHandler> flush_handler;
           std::vector<MessageContext> batch;
           {
             std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -624,12 +627,12 @@ TcpServer& TcpServer::on_disconnect(ConnectionHandler h) {
 }
 TcpServer& TcpServer::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->on_data_ = std::move(h);
+  impl_->on_data_ = interface::share_callback(std::move(h));
   return *this;
 }
 TcpServer& TcpServer::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(h);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 TcpServer& TcpServer::on_error(ErrorHandler h) {
@@ -652,13 +655,13 @@ TcpServer& TcpServer::framer(FramerFactory factory) {
 
 TcpServer& TcpServer::on_message(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->on_message_ = std::move(handler);
+  impl_->on_message_ = interface::share_callback(std::move(handler));
   return *this;
 }
 
 TcpServer& TcpServer::on_message_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->message_batch_handler_ = std::move(h);
+  impl_->message_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -447,8 +447,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
                   return;
                 }
 
-                detail::invoke_user_callback("tcp_server", "on_message", on_message_handler,
-                                             MessageContext(id, memory::SafeDataBuffer(msg)));
+                detail::invoke_user_callback("tcp_server", "on_message", on_message_handler, MessageContext(id, msg));
               });
               framers_[id] = std::move(shared_framer);
             }
@@ -505,8 +504,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
           }
           detail::invoke_user_callback("tcp_server", "on_data_batch", flush_handler, batch);
         } else {
-          detail::invoke_user_callback("tcp_server", "on_data", handler,
-                                       MessageContext(id, memory::SafeDataBuffer(data_span)));
+          detail::invoke_user_callback("tcp_server", "on_data", handler, MessageContext(id, data_span));
         }
 
         if (framer) framer->push_bytes(data_span);

--- a/wirestead/wrapper/tcp_server/tcp_server.hpp
+++ b/wirestead/wrapper/tcp_server/tcp_server.hpp
@@ -117,6 +117,18 @@ class WIRESTEAD_API TcpServer : public ServerInterface {
   TcpServer& keep_alive(bool enable = true);
   TcpServer& send_buffer_size(size_t bytes);
   TcpServer& receive_buffer_size(size_t bytes);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Distinct from receive_buffer_size(), which sets the kernel's SO_RCVBUF.
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection - a server
+   * multiplies it by the number of accepted connections. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]; takes effect on the next
+   * start().
+   */
+  TcpServer& read_buffer_size(size_t bytes);
   TcpServer& manage_external_context(bool manage);
   TcpServer& batch_size(size_t size);
   TcpServer& batch_latency(std::chrono::milliseconds latency);

--- a/wirestead/wrapper/udp/udp.cc
+++ b/wirestead/wrapper/udp/udp.cc
@@ -438,7 +438,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
         }
         detail::invoke_user_callback("udp_client", "on_data_batch", flush_handler, batch);
       } else {
-        detail::invoke_user_callback("udp_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("udp_client", "on_data", handler, MessageContext(0, data));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -534,7 +534,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
         return;
       }
 
-      detail::invoke_user_callback("udp_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
+      detail::invoke_user_callback("udp_client", "on_message", handler, MessageContext(0, msg));
     });
   }
 

--- a/wirestead/wrapper/udp/udp.cc
+++ b/wirestead/wrapper/udp/udp.cc
@@ -55,14 +55,17 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
   std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work_guard;
 
   // Event handlers (Context based)
-  MessageHandler data_handler{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the strand copies one out per received datagram, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> data_handler;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ConnectionHandler connect_handler{nullptr};
   ConnectionHandler disconnect_handler{nullptr};
   ErrorHandler error_handler{nullptr};
   std::function<void(size_t)> bp_handler{nullptr};
-  MessageHandler message_handler{nullptr};
-  BatchMessageHandler message_batch_handler_{nullptr};
+  interface::SharedCallback<MessageHandler> message_handler;
+  interface::SharedCallback<BatchMessageHandler> message_batch_handler_;
 
   std::shared_ptr<framer::IFramer> framer{nullptr};
 
@@ -409,7 +412,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       // unique_lock) - this is a pure read, matching try_send's locking
       // level so it no longer blocks concurrent sends even briefly.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -423,7 +426,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
         // lock is only held for the queue mutation itself, not the
         // allocation.
         MessageContext ctx(0, memory::SafeDataBuffer(data));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -508,7 +511,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       // #441: snapshot under a shared_lock (pure read), build the copy
       // before taking the exclusive lock for queue mutation.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         batch_mode = static_cast<bool>(message_batch_handler_);
@@ -517,7 +520,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
 
       if (batch_mode) {
         MessageContext ctx(0, memory::SafeDataBuffer(msg));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -546,13 +549,13 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
 
   void on_message(MessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_handler = std::move(handler);
+    message_handler = interface::share_callback(std::move(handler));
     if (framer) attach_framer_callback();
   }
 
   void on_message_batch(BatchMessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_batch_handler_ = std::move(handler);
+    message_batch_handler_ = interface::share_callback(std::move(handler));
     if (framer) attach_framer_callback();
   }
 };
@@ -593,12 +596,12 @@ void UdpClient::reset_stats() { impl_->reset_stats(); }
 
 UdpClient& UdpClient::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_handler = std::move(h);
+  impl_->data_handler = interface::share_callback(std::move(h));
   return *this;
 }
 UdpClient& UdpClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(h);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 UdpClient& UdpClient::on_connect(ConnectionHandler h) {

--- a/wirestead/wrapper/udp/udp_server.cc
+++ b/wirestead/wrapper/udp/udp_server.cc
@@ -93,13 +93,16 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
 
   ConnectionHandler on_connect{nullptr};
   ConnectionHandler on_disconnect{nullptr};
-  MessageHandler on_data{nullptr};
-  BatchMessageHandler on_data_batch_{nullptr};
+  // Shared snapshots: the strand copies one out per received datagram, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> on_data;
+  interface::SharedCallback<BatchMessageHandler> on_data_batch_;
   ErrorHandler on_error{nullptr};
   std::function<void(size_t)> bp_handler{nullptr};
   FramerFactory framer_factory{nullptr};
-  MessageHandler on_message{nullptr};
-  BatchMessageHandler on_message_batch_{nullptr};
+  interface::SharedCallback<MessageHandler> on_message;
+  interface::SharedCallback<BatchMessageHandler> on_message_batch_;
 
   std::shared_ptr<bool> is_alive{std::make_shared<bool>(true)};
 
@@ -279,7 +282,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
                 // #441: snapshot under a shared_lock (pure read), build the
                 // copy before taking the exclusive lock for queue mutation.
                 bool batch_mode;
-                MessageHandler on_message_handler;
+                interface::SharedCallback<MessageHandler> on_message_handler;
                 {
                   std::shared_lock<std::shared_mutex> lock(mutex);
                   batch_mode = static_cast<bool>(on_message_batch_);
@@ -288,7 +291,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
 
                 if (batch_mode) {
                   MessageContext ctx(client_id, memory::SafeDataBuffer(msg));
-                  BatchMessageHandler flush_handler;
+                  interface::SharedCallback<BatchMessageHandler> flush_handler;
                   std::vector<MessageContext> batch;
                   {
                     std::unique_lock<std::shared_mutex> lock(mutex);
@@ -330,7 +333,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
         // this is a pure read, matching try_send's locking level so it no
         // longer blocks concurrent sends even briefly.
         bool batch_mode;
-        MessageHandler data_handler_copy;
+        interface::SharedCallback<MessageHandler> data_handler_copy;
         {
           std::shared_lock<std::shared_mutex> lock(mutex);
           batch_mode = static_cast<bool>(on_data_batch_);
@@ -342,7 +345,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
           // lock is only held for the queue mutation itself, not the
           // allocation.
           MessageContext ctx(client_id, memory::SafeDataBuffer(data));
-          BatchMessageHandler flush_handler;
+          interface::SharedCallback<BatchMessageHandler> flush_handler;
           std::vector<MessageContext> batch;
           {
             std::unique_lock<std::shared_mutex> lock(mutex);
@@ -652,13 +655,13 @@ UdpServer& UdpServer::on_disconnect(ConnectionHandler h) {
 
 UdpServer& UdpServer::on_data(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
-  impl_->on_data = std::move(h);
+  impl_->on_data = interface::share_callback(std::move(h));
   return *this;
 }
 
 UdpServer& UdpServer::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
-  impl_->on_data_batch_ = std::move(h);
+  impl_->on_data_batch_ = interface::share_callback(std::move(h));
   return *this;
 }
 
@@ -676,13 +679,13 @@ UdpServer& UdpServer::framer(FramerFactory factory) {
 
 UdpServer& UdpServer::on_message(MessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
-  impl_->on_message = std::move(h);
+  impl_->on_message = interface::share_callback(std::move(h));
   return *this;
 }
 
 UdpServer& UdpServer::on_message_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
-  impl_->on_message_batch_ = std::move(h);
+  impl_->on_message_batch_ = interface::share_callback(std::move(h));
   return *this;
 }
 

--- a/wirestead/wrapper/udp/udp_server.cc
+++ b/wirestead/wrapper/udp/udp_server.cc
@@ -306,7 +306,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
                 }
 
                 detail::invoke_user_callback("udp_server", "on_message", on_message_handler,
-                                             MessageContext(client_id, memory::SafeDataBuffer(msg)));
+                                             MessageContext(client_id, msg));
               });
               entry.framer = std::move(framer);
             }
@@ -357,8 +357,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
           }
           detail::invoke_user_callback("udp_server", "on_data_batch", flush_handler, batch);
         } else {
-          detail::invoke_user_callback("udp_server", "on_data", data_handler_copy,
-                                       MessageContext(client_id, memory::SafeDataBuffer(data)));
+          detail::invoke_user_callback("udp_server", "on_data", data_handler_copy, MessageContext(client_id, data));
         }
       }
 

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -485,7 +485,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
         }
         detail::invoke_user_callback("uds_client", "on_data_batch", flush_handler, batch);
       } else {
-        detail::invoke_user_callback("uds_client", "on_data", handler, MessageContext(0, memory::SafeDataBuffer(data)));
+        detail::invoke_user_callback("uds_client", "on_data", handler, MessageContext(0, data));
       }
 
       if (framer_to_push) framer_to_push->push_bytes(data);
@@ -540,7 +540,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
         return;
       }
 
-      detail::invoke_user_callback("uds_client", "on_message", handler, MessageContext(0, memory::SafeDataBuffer(msg)));
+      detail::invoke_user_callback("uds_client", "on_message", handler, MessageContext(0, msg));
     });
   }
 

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -83,6 +83,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
   int max_retries_ = base::constants::DEFAULT_MAX_RETRIES;
   std::chrono::milliseconds connection_timeout_{base::constants::DEFAULT_CONNECTION_TIMEOUT_MS};
   size_t backpressure_threshold_ = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+  size_t read_buffer_size_ = base::constants::DEFAULT_READ_BUFFER_SIZE;
   // Atomic rather than mutex-guarded: read from the send()/send_line() fast
   // path on arbitrary caller threads while the setter can be called
   // concurrently from any other thread (#436).
@@ -189,6 +190,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       cfg.max_retries = max_retries_;
       cfg.connection_timeout_ms = static_cast<unsigned>(connection_timeout_.count());
       cfg.backpressure_threshold = backpressure_threshold_;
+      cfg.read_buffer_size = read_buffer_size_;
       cfg.backpressure_strategy = backpressure_strategy_;
 
       if (use_external_context_) {
@@ -693,6 +695,12 @@ UdsClient& UdsClient::connection_timeout(std::chrono::milliseconds timeout) {
 UdsClient& UdsClient::backpressure_threshold(size_t threshold) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->backpressure_threshold_ = threshold;
+  return *this;
+}
+
+UdsClient& UdsClient::read_buffer_size(size_t bytes) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->read_buffer_size_ = bytes;
   return *this;
 }
 

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -57,14 +57,17 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<bool> started_{false};
   std::shared_ptr<bool> alive_marker_{std::make_shared<bool>(true)};
 
-  MessageHandler data_handler_{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the io thread copies one out per received chunk, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> data_handler_;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ConnectionHandler connect_handler_{nullptr};
   ConnectionHandler disconnect_handler_{nullptr};
   ErrorHandler error_handler_{nullptr};
   std::function<void(size_t)> bp_handler_{nullptr};
-  MessageHandler message_handler_{nullptr};
-  BatchMessageHandler message_batch_handler_{nullptr};
+  interface::SharedCallback<MessageHandler> message_handler_;
+  interface::SharedCallback<BatchMessageHandler> message_batch_handler_;
 
   std::shared_ptr<framer::IFramer> framer_{nullptr};
 
@@ -456,7 +459,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       // unique_lock) - this is a pure read, matching try_send's locking
       // level so it no longer blocks concurrent sends even briefly.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       std::shared_ptr<framer::IFramer> framer_to_push;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -470,7 +473,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
         // lock is only held for the queue mutation itself, not the
         // allocation.
         MessageContext ctx(0, memory::SafeDataBuffer(data));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -514,7 +517,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
       // #441: snapshot under a shared_lock (pure read), build the copy
       // before taking the exclusive lock for queue mutation.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         batch_mode = static_cast<bool>(message_batch_handler_);
@@ -523,7 +526,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
 
       if (batch_mode) {
         MessageContext ctx(0, memory::SafeDataBuffer(msg));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -552,13 +555,13 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
 
   void on_message(MessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_handler_ = std::move(handler);
+    message_handler_ = interface::share_callback(std::move(handler));
     if (framer_) attach_framer_callback();
   }
 
   void on_message_batch(BatchMessageHandler handler) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    message_batch_handler_ = std::move(handler);
+    message_batch_handler_ = interface::share_callback(std::move(handler));
     if (framer_) attach_framer_callback();
   }
 };
@@ -608,13 +611,13 @@ void UdsClient::reset_stats() { impl_->reset_stats(); }
 
 UdsClient& UdsClient::on_data(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_handler_ = std::move(handler);
+  impl_->data_handler_ = interface::share_callback(std::move(handler));
   return *this;
 }
 
 UdsClient& UdsClient::on_data_batch(BatchMessageHandler h) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(h);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(h));
   return *this;
 }
 

--- a/wirestead/wrapper/uds_client/uds_client.hpp
+++ b/wirestead/wrapper/uds_client/uds_client.hpp
@@ -95,6 +95,16 @@ class WIRESTEAD_API UdsClient : public ChannelInterface {
   UdsClient& max_retries(int max_retries);
   UdsClient& connection_timeout(std::chrono::milliseconds timeout);
   UdsClient& backpressure_threshold(size_t threshold);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]; takes effect on the next
+   * start().
+   */
+  UdsClient& read_buffer_size(size_t bytes);
   UdsClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdsClient& manage_external_context(bool manage);
   UdsClient& batch_size(size_t size);

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -45,6 +45,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
   std::atomic<bool> client_limit_enabled_{false};
   std::atomic<int> socket_permissions_{-1};
   std::atomic<size_t> backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
+  std::atomic<size_t> read_buffer_size_{base::constants::DEFAULT_READ_BUFFER_SIZE};
   std::atomic<base::constants::BackpressureStrategy> backpressure_strategy_{
       base::constants::BackpressureStrategy::Reliable};
 
@@ -220,6 +221,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       config.max_connections =
           static_cast<int>(std::min(max_clients_.load(), static_cast<size_t>(base::constants::MAX_MAX_CONNECTIONS)));
       config.backpressure_threshold = backpressure_threshold_.load();
+      config.read_buffer_size = read_buffer_size_.load();
       config.backpressure_strategy = backpressure_strategy_.load();
       config.socket_permissions = socket_permissions_.load();
       server_ = factory::ChannelFactory::create(config, external_ioc_);
@@ -625,6 +627,11 @@ UdsServer& UdsServer::socket_permissions(int mode) {
 
 UdsServer& UdsServer::backpressure_threshold(size_t threshold) {
   impl_->backpressure_threshold_.store(threshold);
+  return *this;
+}
+
+UdsServer& UdsServer::read_buffer_size(size_t bytes) {
+  impl_->read_buffer_size_.store(bytes);
   return *this;
 }
 

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -371,8 +371,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           }
           detail::invoke_user_callback("uds_server", "on_data_batch", flush_handler, batch);
         } else {
-          detail::invoke_user_callback("uds_server", "on_data", handler,
-                                       MessageContext(id, memory::SafeDataBuffer(data_span)));
+          detail::invoke_user_callback("uds_server", "on_data", handler, MessageContext(id, data_span));
         }
 
         if (framer_to_push) framer_to_push->push_bytes(data_span);
@@ -479,8 +478,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
         return;
       }
 
-      detail::invoke_user_callback("uds_server", "on_message", handler,
-                                   MessageContext(id, memory::SafeDataBuffer(msg)));
+      detail::invoke_user_callback("uds_server", "on_message", handler, MessageContext(id, msg));
     });
   }
 };

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -50,13 +50,16 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
 
   ConnectionHandler client_connect_handler_{nullptr};
   ConnectionHandler client_disconnect_handler_{nullptr};
-  MessageHandler data_handler_{nullptr};
-  BatchMessageHandler data_batch_handler_{nullptr};
+  // Shared snapshots: the io thread copies one out per received chunk, and a
+  // std::function copy allocates whenever the user handler outgrows its
+  // small-object buffer. See interface::SharedCallback.
+  interface::SharedCallback<MessageHandler> data_handler_;
+  interface::SharedCallback<BatchMessageHandler> data_batch_handler_;
   ErrorHandler error_handler_{nullptr};
   std::function<void(size_t)> on_backpressure_{nullptr};
   FramerFactory framer_factory_{nullptr};
-  MessageHandler on_message_{nullptr};
-  BatchMessageHandler on_message_batch_{nullptr};
+  interface::SharedCallback<MessageHandler> on_message_;
+  interface::SharedCallback<BatchMessageHandler> on_message_batch_;
 
   std::unordered_map<ClientId, std::shared_ptr<framer::IFramer>> framers_;
 
@@ -339,7 +342,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
         // locking level so it no longer blocks concurrent sends even
         // briefly.
         bool batch_mode;
-        MessageHandler handler;
+        interface::SharedCallback<MessageHandler> handler;
         std::shared_ptr<framer::IFramer> framer_to_push;
         {
           std::shared_lock<std::shared_mutex> lock(mutex_);
@@ -356,7 +359,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
           // lock is only held for the queue mutation itself, not the
           // allocation.
           MessageContext ctx(id, memory::SafeDataBuffer(data_span));
-          BatchMessageHandler flush_handler;
+          interface::SharedCallback<BatchMessageHandler> flush_handler;
           std::vector<MessageContext> batch;
           {
             std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -452,7 +455,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       // #441: snapshot under a shared_lock (pure read), build the copy
       // before taking the exclusive lock for queue mutation.
       bool batch_mode;
-      MessageHandler handler;
+      interface::SharedCallback<MessageHandler> handler;
       {
         std::shared_lock<std::shared_mutex> lock(mutex_);
         batch_mode = static_cast<bool>(on_message_batch_);
@@ -461,7 +464,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
 
       if (batch_mode) {
         MessageContext ctx(id, memory::SafeDataBuffer(msg));
-        BatchMessageHandler flush_handler;
+        interface::SharedCallback<BatchMessageHandler> flush_handler;
         std::vector<MessageContext> batch;
         {
           std::unique_lock<std::shared_mutex> lock(mutex_);
@@ -537,13 +540,13 @@ UdsServer& UdsServer::on_disconnect(ConnectionHandler handler) {
 
 UdsServer& UdsServer::on_data(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_handler_ = std::move(handler);
+  impl_->data_handler_ = interface::share_callback(std::move(handler));
   return *this;
 }
 
 UdsServer& UdsServer::on_data_batch(BatchMessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->data_batch_handler_ = std::move(handler);
+  impl_->data_batch_handler_ = interface::share_callback(std::move(handler));
   return *this;
 }
 
@@ -567,13 +570,13 @@ UdsServer& UdsServer::framer(FramerFactory factory) {
 
 UdsServer& UdsServer::on_message(MessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->on_message_ = std::move(handler);
+  impl_->on_message_ = interface::share_callback(std::move(handler));
   return *this;
 }
 
 UdsServer& UdsServer::on_message_batch(BatchMessageHandler handler) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
-  impl_->on_message_batch_ = std::move(handler);
+  impl_->on_message_batch_ = interface::share_callback(std::move(handler));
   return *this;
 }
 

--- a/wirestead/wrapper/uds_server/uds_server.hpp
+++ b/wirestead/wrapper/uds_server/uds_server.hpp
@@ -106,6 +106,16 @@ class WIRESTEAD_API UdsServer : public ServerInterface {
    */
   UdsServer& socket_permissions(int mode);
   UdsServer& backpressure_threshold(size_t threshold);
+
+  /**
+   * @brief Size of the userspace buffer each read fills, in bytes.
+   *
+   * Raising this reduces read completions and callback dispatches on bulk
+   * transfers, at the cost of that much memory per connection. Clamped to
+   * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]; takes effect on the next
+   * start().
+   */
+  UdsServer& read_buffer_size(size_t bytes);
   UdsServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   UdsServer& manage_external_context(bool manage);
   UdsServer& batch_size(size_t size);


### PR DESCRIPTION
## Description

Cuts per-message cost out of both the receive and send hot paths. Four independent
changes, each measured before and after; the defaults do not change, so nothing
moves for a caller who does not opt in.

| | before | after |
|---|---|---|
| allocations per received callback (TCP client) | 5.06 | **0.06** |
| send syscalls, burst of 16386 small messages | 16386 | **1025** |
| per-connection read buffer | fixed 4 KiB, unreachable | configurable, 512 B – 1 MiB |

Allocation counts and syscall counts are used rather than throughput because they
are deterministic — this repo's throughput harness has a 7–57% run-to-run spread,
so an A/B under that is noise. Allocations were counted by replacing global
`operator new` with a `thread_local` counter read inside `on_data`; syscalls with
`strace -c`. Every number was reproduced with before/after binaries run
interleaved.

## Key Changes

- **Receive path is now allocation-free.** `MessageContext` borrowed its payload
  instead of copying it into an owned `SafeDataBuffer`; only the batch handlers,
  whose contexts outlive the callback, still own. The documented contract does not
  change — `docs/callbacks.md` already scoped the view to the callback. Copying a
  `MessageContext` still takes ownership, so keeping one past the callback stays
  safe.
- **Callbacks are snapshotted through a shared pointer** rather than copied out of
  their guarded member. A `std::function` copy heap-allocates whenever the target
  outgrows its small-object buffer, and the receive path took one such copy per
  chunk at both the transport and wrapper layer. Storage discipline is unchanged:
  same mutex, still invoked outside the lock.
- **Gather writes.** `do_write()` handed one queued buffer to `async_write()`, so
  N ready messages cost N syscalls. It now drains several into one scatter-gather
  write. The socket interfaces gained a buffer-sequence `async_write` overload with
  a working default implementation, so no existing implementation — the test doubles
  in particular — had to change.
- **`read_buffer_size`** on the TCP and UDS configs, wrappers and builders. This
  buffer was a compile-time-fixed 4 KiB `std::array` with no way to reach it;
  `receive_buffer_size` only ever set `SO_RCVBUF`.
- Fixed a real data race: `UdpChannel::on_bytes_from()` assigned without holding
  `callback_mtx_` while the strand-confined read site took it, against the member's
  own documented invariant.

## Related Issues

<!-- none -->

## Type of Change

- [x] **Performance**: Changes that improve system performance.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

### Two bugs I introduced and caught, worth knowing about

Both corrupt the stream **while every byte counter still balances**, so byte
totals alone do not detect them.

1. I first handed asio a non-owning view of the buffer sequence, to avoid asio
   copying the vector into the composed operation. asio's partial-write
   bookkeeping does not survive an aliasing sequence — buffers were duplicated on
   the wire or stalled in the queue. The vector is passed normally now.
2. I capped the gather batch at 64 buffers. asio fills at most 16 per
   `prepared_buffers` (`detail/consuming_buffers.hpp`); above that the stream
   silently **reorders** — messages reach the peer out of order with correct byte
   totals. The cap is 16 now, with the reasoning recorded at the constant.

`test/integration/tcp/test_gather_write.cc` exists for exactly these: it asserts
`bytes_sent == bytes_accepted` and that distinctly-valued messages arrive in order
exactly once. Verified to fail 6/6 runs against the 64-buffer version and pass 8/8
against this one.

### Validation

- 755/755 tests pass in Release and again under Debug + ASan, with no
  AddressSanitizer reports.
- `./scripts/verify.sh` passes end to end.
- New timing-sensitive tests were run repeatedly to check they are not flaky
  (gather 8x, read-buffer 12x).
- Under TSan, one pre-existing failure remains
  (`BackpressureIntegrationTest.TcpServerSessionBackpressureMultithreadedIoContext`);
  it points at asio's own `socket_ops::close`/`reactive_socket_service_base::construct`
  with all gtest assertions passing, and reproduces identically on an untouched
  checkout. System Boost is not TSan-instrumented.

### Not covered here

- **Only verified on Linux.** Gather writes hit platform-specific iovec limits —
  the Windows `WSABUF` path and macOS both need CI to confirm
  `test_gather_write.cc` passes before this merges.
- No Orin benchmark yet; these numbers are syscall and allocation counts on x86,
  not p50 latency on the reference hardware.
- Serial keeps its existing `SerialConfig::read_chunk` rather than gaining
  `read_buffer_size`, so its builder still cannot set it. At the maximum supported
  baud rate a 4 KiB buffer is ~8 ms of data, so the granularity does not matter
  there — but the naming inconsistency is worth resolving before 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8z3Y9SKBUdZDNGhgTeWwv
