### PR TITLE
ci: keep the baseline bump PR title in step with its branch

### DIFF
--- a/.github/workflows/vcpkg-baseline-bump.yml
+++ b/.github/workflows/vcpkg-baseline-bump.yml
@@ -14,6 +14,12 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+# Both triggers write the same branch, so a manual run overlapping the schedule
+# would have two jobs force-pushing over each other.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -72,14 +78,36 @@ jobs:
           # A PR opened with GITHUB_TOKEN does not trigger workflow runs, so
           # prefer a PAT when one is configured. Without it the PR still opens,
           # but CI has to be kicked by hand before the bump means anything.
-          GH_TOKEN: ${{ secrets.VCPKG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          BUMP_TOKEN: ${{ secrets.VCPKG_BUMP_TOKEN }}
+          FALLBACK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT: ${{ steps.candidate.outputs.current }}
           CANDIDATE: ${{ steps.candidate.outputs.candidate }}
-          HAS_PAT: ${{ secrets.VCPKG_BUMP_TOKEN != '' }}
         run: |
           set -euo pipefail
           branch="automation/vcpkg-baseline"
           short="${CANDIDATE:0:12}"
+          title="ci: bump the vcpkg baseline to ${short}"
+
+          # `secrets.X != ''` only distinguishes unset from set. An expired PAT
+          # is still a non-empty string, so that test would send us down the PAT
+          # path to a 401 instead of the fallback that exists for exactly this.
+          # Ask GitHub whether the token actually works. The PAT has a one-year
+          # lifetime, so the day this matters is far enough out that nobody will
+          # remember the failure mode.
+          HAS_PAT=false
+          if [ -n "${BUMP_TOKEN}" ]; then
+            if GH_TOKEN="${BUMP_TOKEN}" gh api user --jq '.login' > /dev/null 2>&1; then
+              HAS_PAT=true
+            else
+              echo "::warning::VCPKG_BUMP_TOKEN is set but GitHub rejected it - it has most likely expired. Falling back to GITHUB_TOKEN; CI will not start on the PR by itself."
+            fi
+          fi
+
+          if [ "${HAS_PAT}" = "true" ]; then
+            export GH_TOKEN="${BUMP_TOKEN}"
+          else
+            export GH_TOKEN="${FALLBACK_TOKEN}"
+          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -103,13 +131,17 @@ jobs:
 
           existing="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')"
           if [ -n "${existing}" ]; then
-            gh pr edit "${existing}" --body-file vcpkg-bump-body.md
+            # The title has to move with the branch. This runs weekly against a
+            # long-lived branch, and GitHub composes a squash-merge subject from
+            # the PR title, so leaving it behind writes a baseline sha into main
+            # that was never the one merged. That happened on #558.
+            gh pr edit "${existing}" --title "${title}" --body-file vcpkg-bump-body.md
             echo "updated existing PR #${existing}"
           else
             gh pr create \
               --base main \
               --head "${branch}" \
-              --title "ci: bump the vcpkg baseline to ${short}" \
+              --title "${title}" \
               --body-file vcpkg-bump-body.md
           fi
 


### PR DESCRIPTION
## Description

Three fixes to the weekly vcpkg baseline bump. The first already cost a near miss this month.

### The PR title never moved with the branch

The workflow force-pushes each week's candidate onto one long-lived branch, but the update path called `gh pr edit` with only `--body-file`. The title kept whichever sha the PR was opened with.

On #558 that meant:

```
PR title    : "ci: bump the vcpkg baseline to 8586ecbf125a"   <- stale
branch HEAD :  39344dff01c5                                    <- actual candidate
```

GitHub composes a squash-merge subject from the PR title, so merging would have written a baseline sha into `main` **that was never the one merged** — leaving `VCPKG_BASELINE` and the commit message that changed it disagreeing, for whoever reads that history later. It was caught by hand minutes before merging and fixed with the REST API. Nothing would have caught it automatically.

### An expired PAT skipped its own fallback

```yaml
GH_TOKEN: ${{ secrets.VCPKG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
HAS_PAT:  ${{ secrets.VCPKG_BUMP_TOKEN != '' }}
```

`!= ''` distinguishes *unset* from *set*, not *working* from *expired*. An expired PAT is still a non-empty string, so the run would take the PAT path to a 401 instead of the fallback that exists for exactly this case — and the PR body would claim CI had been triggered when it had not.

Now the token is checked against `gh api user` and the run falls back when it fails, with a `::warning::` annotation explaining why CI will not start on its own. The current PAT expires **2027-07-30**, far enough out that nobody will remember this failure mode when it arrives.

### No concurrency group

A manual dispatch overlapping the 06:00 Monday schedule would put two jobs on the same force-pushed branch. Serialised rather than cancelling: a bump run is short, and finishing one is cheaper than reasoning about a half-pushed branch.

## Related Issues

- No issue. Found reviewing the automation after #558.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] New Feature / Breaking Change / Documentation / Refactor / Performance / Testing

## Checklist

- [ ] I have run `./scripts/verify.sh` locally — **not run**: workflow YAML only, no C++.
- [ ] I have added or updated tests — **not applicable**.
- [x] I have updated the documentation to reflect the changes (if applicable) — the reasoning is in the workflow comments.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Validated locally:

- YAML parses; the `concurrency` block reads `group: ${{ github.workflow }}`, `cancel-in-progress: false`; the step's env is now `BUMP_TOKEN` / `FALLBACK_TOKEN` rather than a pre-resolved `GH_TOKEN`
- The modified step passes `bash -n`; `git diff --check` clean
- **The token-selection logic was executed against a stubbed `gh`**, not just read:

| case | result |
|---|---|
| PAT unset | falls back, no warning |
| PAT valid | uses the PAT |
| PAT set but rejected | **warns and falls back** — the path that was previously unreachable |

Not verified: a real scheduled run. The next one is 06:00 Monday, and the title fix only shows itself on a week where the candidate moves while a PR is already open.
