### PR TITLE
feat: expose serial read_chunk and make initial_pool_size mean something

### DIFF
--- a/test/integration/serial/test_serial_builder_validation.cc
+++ b/test/integration/serial/test_serial_builder_validation.cc
@@ -65,3 +65,22 @@ TEST_F(SerialBuilderValidationTest, InvalidParityFallsBackDuringBuild) {
     ASSERT_NE(serial_ptr, nullptr);
   });
 }
+
+// read_chunk reached the config layer but had no builder or wrapper surface,
+// so serial was the one transport whose read buffer could not be set the way
+// TCP and UDS set read_buffer_size(). These pin the surface down; the value
+// itself is exercised at the config layer, which is where the clamp lives.
+TEST_F(SerialBuilderValidationTest, AcceptsReadChunkOption) {
+  auto serial_ptr = serial(device_, 115200).read_chunk(16384).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_NE(serial_ptr, nullptr);
+}
+
+TEST_F(SerialBuilderValidationTest, OutOfRangeReadChunkIsClampedNotRejected) {
+  EXPECT_NO_THROW({
+    auto too_small = serial(device_, 9600).read_chunk(1).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+    ASSERT_NE(too_small, nullptr);
+    auto too_large =
+        serial(device_, 9600).read_chunk(64 * 1024 * 1024).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+    ASSERT_NE(too_large, nullptr);
+  });
+}

--- a/test/integration/tcp/test_receive_allocations.cc
+++ b/test/integration/tcp/test_receive_allocations.cc
@@ -117,6 +117,13 @@ TEST(ReceiveAllocationsTest, DoesNotAllocatePerDeliveredMessage) {
   });
   ASSERT_TRUE(client->start_sync());
 
+  // start_sync() only promises the client's side of the handshake. The server
+  // registers the session on its own io thread, and broadcast() with no
+  // sessions accepts nothing - which fails this test for a reason that has
+  // nothing to do with allocations.
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() > 0; }, 5000))
+      << "server never registered the connection";
+
   const std::string payload(kPayload, 'a');
   // broadcast() is a non-blocking fan-out, so a tight loop legitimately drops
   // once the queue fills. Count what it accepted rather than what was offered -

--- a/test/unit/common/test_pool_stress.cc
+++ b/test/unit/common/test_pool_stress.cc
@@ -40,7 +40,10 @@ class MemoryPoolStressTest : public ::testing::Test {
 TEST_F(MemoryPoolStressTest, ExhaustionAndRecovery) {
   // Create a pool with small capacity
   // 4 buckets, if max_pool_size is 20, capacity per bucket is 5.
-  MemoryPool pool(5, 20);
+  // Prefill is 0 on purpose: this test counts hits against an empty start, so
+  // a prefilled bucket would satisfy the first acquires and shift every number
+  // below. MemoryPoolPrefillTest covers the prefill path itself.
+  MemoryPool pool(0, 20);
 
   std::vector<std::unique_ptr<uint8_t[]>> allocations;
   size_t alloc_size = 1024;  // Should fall into SMALL bucket (size 1024)
@@ -54,11 +57,8 @@ TEST_F(MemoryPoolStressTest, ExhaustionAndRecovery) {
 
   auto stats = pool.stats();
   EXPECT_EQ(stats.total_allocations, 6);
-  // Hits might be 0 because pool starts empty and fills on release?
-  // No, pool starts with empty vector (reserve only).
-  // So all 6 are new allocations (misses in terms of "getting from pool", but counted as total_allocations).
-  // Implementation: acquire -> if !empty pop (hit) else create (total++).
-  // So all 6 are created. pool_hits should be 0.
+  // Nothing to hit yet: the pool was constructed unprefilled and buckets only
+  // fill on release. total_allocations counts every acquire, hits included.
   EXPECT_EQ(stats.pool_hits, 0);
 
   // Release all
@@ -77,19 +77,14 @@ TEST_F(MemoryPoolStressTest, ExhaustionAndRecovery) {
   }
 
   stats = pool.stats();
-  // Total allocations: 6 (initial) + 6 (second round) = 12?
-  // Wait, acquire_from_bucket:
-  // if from stack: hits++, total++
-  // if create: total++
-  // So total should be 12.
-  // First 5 should be hits.
-  // 6th should be create (miss).
+  // 12 acquires in total. Of the second six, the five the bucket could hold are
+  // hits and the sixth has to be created.
   EXPECT_EQ(stats.total_allocations, 12);
   EXPECT_EQ(stats.pool_hits, 5);
 }
 
 TEST_F(MemoryPoolStressTest, ReuseAddress) {
-  MemoryPool pool(5, 20);
+  MemoryPool pool(0, 20);  // unprefilled: this test tracks a specific buffer's address
   size_t size = 1024;
 
   auto ptr1 = pool.acquire(size);

--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -1147,3 +1147,26 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+// read_chunk is the serial counterpart of read_buffer_size and shares its
+// bounds. Left unclamped, a 0 reaches the transport as rx_.resize(0).
+TEST(SerialConfigReadChunkTest, ClampsToTheSharedReadBufferBounds) {
+  config::SerialConfig low;
+  low.read_chunk = 1;
+  low.validate_and_clamp();
+  EXPECT_EQ(low.read_chunk, base::constants::MIN_READ_BUFFER_SIZE);
+
+  config::SerialConfig high;
+  high.read_chunk = base::constants::MAX_READ_BUFFER_SIZE * 4;
+  high.validate_and_clamp();
+  EXPECT_EQ(high.read_chunk, base::constants::MAX_READ_BUFFER_SIZE);
+
+  config::SerialConfig ok;
+  ok.read_chunk = 16384;
+  ok.validate_and_clamp();
+  EXPECT_EQ(ok.read_chunk, 16384U) << "a value inside the bounds must be left alone";
+
+  config::SerialConfig zero;
+  zero.read_chunk = 0;
+  EXPECT_FALSE(zero.is_valid()) << "is_valid must reject what validate_and_clamp would have to fix";
+}

--- a/test/unit/memory/test_pool_limits.cc
+++ b/test/unit/memory/test_pool_limits.cc
@@ -119,8 +119,11 @@ TEST_F(MemoryPoolLimitsTest, LargeAllocation) {
 // this is what makes per-channel pools (one MemoryPool member per
 // transport instance) actually isolated from each other.
 TEST(PooledBufferPerPoolTest, DrawsFromAndReleasesToTheGivenPoolNotGlobal) {
-  MemoryPool pool_a(4, 16);
-  MemoryPool pool_b(4, 16);
+  // Prefill is deliberately 0: this test is about which pool a PooledBuffer
+  // draws from, and the hit counts below only mean that if the first acquire
+  // has to allocate rather than take a prefilled buffer.
+  MemoryPool pool_a(0, 16);
+  MemoryPool pool_b(0, 16);
 
   {
     PooledBuffer buf(MemoryPool::BufferSize::SMALL, pool_a);
@@ -142,3 +145,34 @@ TEST(PooledBufferPerPoolTest, DrawsFromAndReleasesToTheGivenPoolNotGlobal) {
 }
 
 }  // namespace
+
+// initial_pool_size used to be (void)-discarded, so the pool always started
+// empty however much the caller asked for. Now it prefills, split evenly
+// across the four buckets - which means the first acquire is a hit rather
+// than an allocation.
+TEST(MemoryPoolPrefillTest, InitialPoolSizePrefillsTheBuckets) {
+  MemoryPool prefilled(4, 16);  // 4 buckets, so one buffer each
+
+  {
+    PooledBuffer buf(MemoryPool::BufferSize::SMALL, prefilled);
+    ASSERT_TRUE(buf.valid());
+  }
+  // pool_hits is the assertion that matters: a hit on the very first acquire is
+  // only possible if the bucket was prefilled. total_allocations counts every
+  // acquire, hits included, so it is 1 either way and proves nothing here.
+  EXPECT_EQ(prefilled.stats().pool_hits, 1U) << "the prefilled buffer should have satisfied the first acquire";
+}
+
+// The default has to stay 0. The buckets run 1 KiB to 64 KiB, so a nominal
+// 400 would reserve 8.3 MiB before the first acquire - a cost the old
+// discarded parameter never actually charged.
+TEST(MemoryPoolPrefillTest, DefaultConstructionPrefillsNothing) {
+  MemoryPool pool;
+
+  {
+    PooledBuffer buf(MemoryPool::BufferSize::SMALL, pool);
+    ASSERT_TRUE(buf.valid());
+  }
+  EXPECT_EQ(pool.stats().pool_hits, 0U) << "an unprefilled pool has nothing to hit on the first acquire";
+  EXPECT_EQ(pool.stats().total_allocations, 1U);
+}

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -87,6 +87,7 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   }
 
   if (reopen_on_error_set_) serial->reopen_on_error(reopen_on_error_);
+  if (read_chunk_set_) serial->read_chunk(read_chunk_);
   if (retry_interval_set_) serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
 
   if (this->bp_strategy_set_) serial->backpressure_strategy(this->bp_strategy_);
@@ -174,6 +175,13 @@ SerialBuilder<State>& SerialBuilder<State>::flow_control(const std::string& f) {
     flow_ = config::SerialConfig::Flow::None;
   }
   flow_set_ = true;
+  return *this;
+}
+
+template <uint32_t State>
+SerialBuilder<State>& SerialBuilder<State>::read_chunk(size_t bytes) {
+  read_chunk_ = bytes;
+  read_chunk_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/serial_builder.hpp
+++ b/wirestead/builder/serial_builder.hpp
@@ -62,7 +62,9 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
         flow_(other.flow_),
         flow_set_(other.flow_set_),
         reopen_on_error_(other.reopen_on_error_),
-        reopen_on_error_set_(other.reopen_on_error_set_) {
+        reopen_on_error_set_(other.reopen_on_error_set_),
+        read_chunk_(other.read_chunk_),
+        read_chunk_set_(other.read_chunk_set_) {
     this->on_data_ = std::move(other.on_data_);
     this->on_error_ = std::move(other.on_error_);
     this->on_connect_ = std::move(other.on_connect_);
@@ -92,6 +94,9 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   SerialBuilder<State>& parity(const std::string& p);
   SerialBuilder<State>& flow_control(config::SerialConfig::Flow f);
   SerialBuilder<State>& flow_control(const std::string& f);
+  // Bytes each read fills. The TCP and UDS builders call the same knob
+  // read_buffer_size(); serial named it read_chunk before those existed.
+  SerialBuilder<State>& read_chunk(size_t bytes);
   SerialBuilder<State>& reopen_on_error(bool enable = true);
   SerialBuilder<State>& retry_interval(std::chrono::milliseconds interval);
   SerialBuilder<State>& independent_context(bool use_independent = true);
@@ -123,6 +128,8 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   bool flow_set_{false};
   bool reopen_on_error_;
   bool reopen_on_error_set_{false};
+  size_t read_chunk_{base::constants::DEFAULT_READ_BUFFER_SIZE};
+  bool read_chunk_set_{false};
 };
 
 using SerialBuilderDefault = SerialBuilder<BuilderState::None>;

--- a/wirestead/config/serial_config.hpp
+++ b/wirestead/config/serial_config.hpp
@@ -55,7 +55,8 @@ struct SerialConfig {
 
   // Validation methods
   bool is_valid() const {
-    return util::InputValidator::is_valid_device_path(device) && baud_rate >= base::constants::MIN_BAUD_RATE &&
+    return read_chunk >= base::constants::MIN_READ_BUFFER_SIZE && read_chunk <= base::constants::MAX_READ_BUFFER_SIZE &&
+           util::InputValidator::is_valid_device_path(device) && baud_rate >= base::constants::MIN_BAUD_RATE &&
            baud_rate <= base::constants::MAX_BAUD_RATE && char_size >= 5 && char_size <= 8 &&
            (stop_bits == 1 || stop_bits == 2) && retry_interval_ms >= base::constants::MIN_RETRY_INTERVAL_MS &&
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
@@ -66,6 +67,15 @@ struct SerialConfig {
 
   // Apply validation and clamp values to valid ranges
   void validate_and_clamp() {
+    // Same bounds the TCP and UDS configs apply to read_buffer_size: this is
+    // the per-connection userspace read buffer under a different name, and an
+    // unclamped 0 reaches the transport as rx_.resize(0).
+    if (read_chunk < base::constants::MIN_READ_BUFFER_SIZE) {
+      read_chunk = base::constants::MIN_READ_BUFFER_SIZE;
+    } else if (read_chunk > base::constants::MAX_READ_BUFFER_SIZE) {
+      read_chunk = base::constants::MAX_READ_BUFFER_SIZE;
+    }
+
     if (baud_rate < base::constants::MIN_BAUD_RATE) {
       baud_rate = base::constants::MIN_BAUD_RATE;
     } else if (baud_rate > base::constants::MAX_BAUD_RATE) {

--- a/wirestead/memory/memory_pool.cc
+++ b/wirestead/memory/memory_pool.cc
@@ -36,9 +36,6 @@ MemoryPool& GlobalMemoryPool::instance() {
 // ============================================================================
 
 MemoryPool::MemoryPool(size_t initial_pool_size, size_t max_pool_size) {
-  // Suppress unused parameter warning since we reserve based on max_pool_size
-  (void)initial_pool_size;
-
   // Initialize 4 fixed-size pools
   static constexpr std::array<size_t, 4> BUCKET_SIZES = {
       static_cast<size_t>(BufferSize::SMALL),   // 1KB
@@ -51,6 +48,20 @@ MemoryPool::MemoryPool(size_t initial_pool_size, size_t max_pool_size) {
     buckets_[i].size_ = BUCKET_SIZES[i];
     buckets_[i].capacity_ = max_pool_size / buckets_.size();
     buckets_[i].buffers_.reserve(buckets_[i].capacity_);
+  }
+
+  // Prefill, split evenly across the buckets. This used to be discarded, so
+  // the pool always started empty whatever the caller asked for. It defaults
+  // to 0 rather than to the old nominal 400: the buckets run 1 KiB to 64 KiB,
+  // so honouring 400 would have meant 8.3 MiB reserved before the first
+  // acquire() - a cost the previous behaviour never actually charged, and one
+  // that matters on the embedded targets this library is aimed at.
+  const size_t per_bucket = initial_pool_size / buckets_.size();
+  for (auto& bucket : buckets_) {
+    const size_t count = std::min(per_bucket, bucket.capacity_);
+    for (size_t n = 0; n < count; ++n) {
+      bucket.buffers_.push_back(create_buffer(bucket.size_));
+    }
   }
 }
 

--- a/wirestead/memory/memory_pool.hpp
+++ b/wirestead/memory/memory_pool.hpp
@@ -60,7 +60,10 @@ class WIRESTEAD_API MemoryPool {
     XLARGE = 65536  // 64KB - bulk operations
   };
 
-  explicit MemoryPool(size_t initial_pool_size = 400, size_t max_pool_size = 2000);
+  // initial_pool_size buffers are created up front, split evenly across the
+  // four size buckets. It defaults to 0 because the buckets run 1 KiB to
+  // 64 KiB: prefilling 400 would reserve 8.3 MiB before the first acquire().
+  explicit MemoryPool(size_t initial_pool_size = 0, size_t max_pool_size = 2000);
   ~MemoryPool() = default;
 
   // Non-copyable, non-movable

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -93,6 +93,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   std::string parity = "none";
   std::string flow_control = "none";
   bool reopen_on_error = true;
+  size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
   std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
@@ -597,6 +598,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
 
     config.retry_interval_ms = static_cast<unsigned int>(retry_interval.count());
     config.reopen_on_error = reopen_on_error;
+    config.read_chunk = read_chunk;
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
     config.use_shared_context = shared_context_.load();
@@ -719,6 +721,12 @@ Serial& Serial::flow_control(const std::string& f) {
   impl_->flow_control = f;
   return *this;
 }
+Serial& Serial::read_chunk(size_t bytes) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->read_chunk = bytes;
+  return *this;
+}
+
 Serial& Serial::reopen_on_error(bool enable) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->reopen_on_error = enable;

--- a/wirestead/wrapper/serial/serial.hpp
+++ b/wirestead/wrapper/serial/serial.hpp
@@ -106,6 +106,9 @@ class WIRESTEAD_API Serial : public ChannelInterface {
   Serial& stop_bits(int stop_bits);
   Serial& parity(const std::string& parity);
   Serial& flow_control(const std::string& flow_control);
+  // Bytes each read fills, the serial counterpart of read_buffer_size() on the
+  // TCP and UDS wrappers. Clamped to [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
+  Serial& read_chunk(size_t bytes);
   Serial& reopen_on_error(bool enable);
   Serial& retry_interval(std::chrono::milliseconds interval);
   Serial& backpressure_threshold(size_t threshold);


### PR DESCRIPTION
## Description

Two small holes, both cases of a knob that exists but cannot be reached or does not do what it says.

### Serial could not set its read buffer

#572 gave TCP and UDS a `read_buffer_size()` across config, wrapper and builder. Serial has the same knob under an older name, `read_chunk`, and **the transport already honours it** — `serial.cc` resizes `rx_` to it — but there was no wrapper or builder surface. It was reachable only by hand-constructing a `SerialConfig`, so serial ended up the one transport whose read buffer could not be set the way the others can.

Wired through both layers, and clamped in `validate_and_clamp()` to the bounds TCP and UDS already use. That also closes a hole: `read_chunk = 0` previously reached the transport as `rx_.resize(0)`.

### `MemoryPool`'s `initial_pool_size` was discarded

```cpp
MemoryPool::MemoryPool(size_t initial_pool_size, size_t max_pool_size) {
  (void)initial_pool_size;   // default was 400
```

The pool always started empty however much the caller asked for. It now prefills for real, split evenly across the four buckets.

**The default moves 400 → 0, which sounds like a behaviour change and is the opposite.** 400 never did anything; honouring it would reserve **8.3 MiB** before the first `acquire()`, since the buckets run 1 KiB to 64 KiB. That is a cost the old signature implied and never charged, and it matters on the embedded targets this library aims at. Callers who want prefill now get it; callers who never asked keep exactly what they had.

## Key Changes

- `SerialConfig`: clamp `read_chunk`, and reject out-of-range in `is_valid()`
- `wrapper::Serial::read_chunk(size_t)`, `SerialBuilder::read_chunk(size_t)` — carried across the builder's `Rebind` copy like every other setting
- `MemoryPool`: prefill honoured, default 0, both documented in the header

## Related Issues

- No issue. From a performance/usability review of the remaining backlog.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] Breaking Change / Documentation / Refactor / Performance / Testing

## Checklist

- [x] I have run the full suite locally: **761/761 pass**.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable) — header comments carry the reasoning.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Three existing tests failed, and they were right to.** They passed a non-zero `initial_pool_size` while assuming the pool started empty — one said so in a comment reasoning about why hits had to be zero:

```cpp
MemoryPool pool(5, 20);
// Hits might be 0 because pool starts empty and fills on release?
// No, pool starts with empty vector (reserve only).
EXPECT_EQ(stats.pool_hits, 0);
```

That was a correct description of the old behaviour. Once prefill works, the first acquires become hits and every count downstream shifts. They are now constructed with `0`, which is what they actually meant, with the reasoning updated rather than the numbers fudged.

New coverage: prefill satisfies the first acquire; default construction prefills nothing; `read_chunk` clamps low, clamps high, leaves in-range values alone, and `is_valid()` rejects what the clamp would have to fix.

One thing worth knowing for anyone reading `PoolStats`: `total_allocations` counts **every acquire, hits included**, not heap allocations. It is not a prefill signal — `pool_hits` is. My first draft of the prefill test asserted against the wrong one and failed until I read the counter.

Not covered: serial `read_chunk` end to end against real hardware. The builder tests assert the surface accepts and clamps; the value's effect lives at the config layer, which is tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue
