### PR TITLE
docs: record the #575 changes and document the tuning knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,25 @@ and ABI policy.
   `[MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]` (512 B to 1 MiB). The ceiling
   is far below `MAX_SOCKET_BUFFER_SIZE` because this buffer is per connection
   and a server multiplies it by `max_connections`.
+- `read_chunk` on the serial wrapper and builder. Serial already had the knob
+  on its config and the transport already honoured it, but with no wrapper or
+  builder surface it was reachable only by constructing a `SerialConfig` by
+  hand — serial was the one transport whose read buffer could not be set the
+  way TCP and UDS set `read_buffer_size`. It is the same setting under the
+  older name, and is now clamped to the same
+  `[MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]` bounds, which also closes a
+  hole where `read_chunk = 0` reached the transport as `rx_.resize(0)`.
 
 ### Changed
 
+- `MemoryPool`'s `initial_pool_size` now prefills the buckets instead of being
+  discarded, and its default moves from 400 to 0. **If you pass this argument
+  explicitly, the pool now really does pre-allocate**; previously the value was
+  ignored and every pool started empty. The default changes to 0 so that
+  behaviour is preserved for callers who never set it: the buckets run 1 KiB to
+  64 KiB, so honouring the old nominal 400 would have reserved roughly 8.3 MiB
+  before the first `acquire()` — a cost the old signature implied and never
+  charged, and one that matters on the embedded targets this library targets.
 - Stream transports now drain several queued buffers into one scatter-gather
   write instead of one send syscall per queued message. Measured on a TCP
   loopback burst of 16386 small messages, send syscalls drop from 16386 to

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,6 @@ package consumers, migration users, and release maintainers.
 - [Quick Start](quickstart.md)
 - [Installation](installation.md)
 - [API Stability Summary](api_stability.md)
+- [Tuning](tuning.md)
 - [Migrating from Unilink](migration-from-unilink.md)
 - [Release Checklist](release_checklist.md)

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,74 @@
+# Tuning
+
+Every setting here has a default that is meant to be right for most callers.
+Change one when a measurement says to, not on principle — and see
+[Performance Validation](performance_validation.md) for what counts as a
+measurement.
+
+## Read buffer
+
+The buffer each read fills, in userspace. Not the kernel's socket buffer:
+`receive_buffer_size` sets `SO_RCVBUF`, this sets how much of a filled socket
+buffer one read completion can take.
+
+| transport | setting | default |
+|---|---|---|
+| TCP client / server | `read_buffer_size(bytes)` | 4 KiB |
+| UDS client / server | `read_buffer_size(bytes)` | 4 KiB |
+| Serial | `read_chunk(bytes)` | 4 KiB |
+
+Serial's name is older; the setting is the same one. All three clamp to
+`[MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE]` — 512 B to 1 MiB.
+
+```cpp
+auto client = wirestead::tcp_client("127.0.0.1", 9000)
+                  .read_buffer_size(64 * 1024)
+                  .on_data([](const wirestead::MessageContext& ctx) { /* ... */ })
+                  .build();
+```
+
+Raising it cuts read completions, and so callback dispatches, on bulk
+transfers. It buys nothing for small messages that already arrive one per read.
+
+The ceiling is far below `MAX_SOCKET_BUFFER_SIZE` on purpose: this buffer is
+**per connection**, so a server multiplies it by `max_connections`. A 1 MiB
+read buffer against the default 1024 connection limit is a gigabyte of
+userspace buffers before any payload.
+
+## Memory pool prefill
+
+`MemoryPool(initial_pool_size, max_pool_size)` pre-allocates
+`initial_pool_size` buffers, split evenly across four size buckets (1 KiB,
+4 KiB, 16 KiB, 64 KiB).
+
+It defaults to **0**. Prefilling trades startup memory for a first-acquire that
+does not allocate, and because the buckets reach 64 KiB the trade is steeper
+than the number suggests: a nominal 400 reserves roughly 8.3 MiB.
+
+Prefill only if a measurement shows first-acquire allocation on a latency-
+sensitive path. Steady-state traffic recycles buffers through the pool anyway,
+so the prefill stops mattering once the pool is warm.
+
+## What tuning will not fix
+
+Two things worth knowing before reaching for a knob, both measured rather than
+assumed:
+
+**Per-message costs do not move tail latency.** Removing three allocations per
+received message and collapsing up to 16 send syscalls into one — both real,
+both merged — produced no p99 change at 8, 32 or 64 connections under sustained
+load, with the mechanism confirmed live in the same runs. Hundreds of
+nanoseconds do not show inside a p99 of hundreds of microseconds. Those changes
+are worth having for CPU and allocator pressure; they are not latency work.
+
+**Connection count costs threads, and threads cost more on small machines.**
+Each TCP/UDP/UDS client owns an `io_context` and a thread, so connections and
+threads scale together — measured at 3.0 threads and roughly 0.4–0.6 MiB per
+connection. On a 20-core x86_64 host, p99 is flat from 8 to 1024 connections.
+On a 6-core Jetson Orin Nano the same sweep rises about 2.6x from 8 to 512.
+If you are fanning out many connections from one embedded process, that is the
+cost to plan around; no buffer setting changes it.
+
+`benchmarks/tcp/tcp_load_latency.cpp` in
+[wirestead-benchmarks](https://github.com/wirestead/wirestead-benchmarks) is
+the harness those numbers come from, if you want them for your own hardware.


### PR DESCRIPTION
## Description

#575 shipped without touching `CHANGELOG.md` or `docs/`. Two gaps, both mine.

**The behaviour change was unrecorded.** `MemoryPool`'s `initial_pool_size` used to be discarded and now prefills, so anyone passing it explicitly gets pre-allocation they were not getting before. The default moving 400 → 0 preserves what callers actually *observed*, but the argument now doing something has to be written down or nobody finds out.

**The read buffer had no user-facing documentation at all.** #572 added `read_buffer_size` across TCP and UDS, #575 finished the set with serial's `read_chunk` — neither touched `docs/`. The only way to discover any of it was to read a header.

## Key Changes

- CHANGELOG: the missing `read_chunk` entry under Added, and the `MemoryPool` behaviour change under Changed
- `docs/tuning.md`: the three read-buffer knobs, the memory pool prefill trade, and a section on what tuning will **not** fix
- Linked from the docs index

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Checklist

- [ ] `./scripts/verify.sh` — **not run**: documentation only, no code.
- [ ] Tests — **not applicable**.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

The "what tuning will not fix" section exists because both claims in it were measured this week, and both are the opposite of what a reader would guess:

- **Per-message costs do not move tail latency.** Removing three allocations per received message and collapsing up to 16 send syscalls into one produced no p99 change at 8, 32 or 64 connections under sustained load — with the gather path confirmed live in the same runs (`sendto` 15344 → `sendmsg` 2056). Worth having for CPU and allocator pressure; not latency work.
- **Connection count costs threads, and threads cost more on small machines.** 3.0 threads and ~0.4–0.6 MiB per connection. p99 flat from 8 to 1024 connections on a 20-core x86_64 host; the same sweep rises ~2.6× from 8 to 512 on the 6-core Orin.

Documenting the ceiling on the read buffer matters for the same reason: it is **per connection**, so 1 MiB against the default 1024 connection limit is a gigabyte of userspace buffers before any payload arrives.

Verified: `git diff --check` clean, and every relative link in the new file and the index resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue