### PR TITLE
refactor!: collapse the builder Rebind machinery to Derived&

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,54 @@ and ABI policy.
 
 ## Unreleased
 
+### Breaking
+
+- Builder setters all return `Derived&` and mutate in place. `on_data`,
+  `on_data_batch`, `on_message`, `on_message_batch` and `on_error` used to
+  return a *new* builder of a different type and leave the original
+  moved-from, while `on_connect`, `framer`, `auto_start` and the rest returned
+  a reference — the same builder, two conventions. The `BuilderState` template
+  parameter, the `Rebind` alias and the CRTP machinery behind them are gone.
+
+  **This bought nothing.** Nothing ever read `BuilderState`; `ibuilder.hpp`
+  said so itself, documenting it as "not for mandatory build gating". It only
+  created a trap — take the result of `on_data` and keep using the original and
+  you are working with a moved-from object, which `[[nodiscard]]` cannot catch
+  — and forced 28 explicit template instantiations of otherwise identical code.
+
+  Chained code is unaffected, which is how the quickstart and every example are
+  written:
+
+  ```cpp
+  auto client = wirestead::tcp_client("127.0.0.1", 8080)
+                    .on_data(...)
+                    .on_error(...)
+                    .build();          // unchanged
+  ```
+
+  Two forms need updating. Spelling the type with its state:
+
+  ```cpp
+  builder::TcpClientBuilder<> b{...};                    // before
+  builder::TcpClientBuilder b{...};                      // after
+  ```
+
+  And capturing the result of a handler setter, which used to hand back a new
+  object:
+
+  ```cpp
+  auto b = builder::UdpClientBuilder(0).on_data_batch(h); // before
+  auto udp = std::move(b).auto_start(false).build();
+
+  auto b = builder::UdpClientBuilder(0);                  // after
+  b.on_data_batch(h);
+  auto udp = b.auto_start(false).build();
+  ```
+
+  `TcpClientBuilderDefault` and the other `*Default` aliases still name the
+  builder, so code using those keeps compiling.
+
+
 ### Added
 
 - `read_buffer_size` on the TCP and UDS configs, wrappers, and builders. This

--- a/docs/api_stability.md
+++ b/docs/api_stability.md
@@ -34,6 +34,23 @@ These APIs are available, but may still change before v1.0:
 - config APIs
 - diagnostics APIs
 
+## Builder return convention
+
+Every builder setter returns `Derived&` and mutates the builder in place, so a
+chain and a sequence of separate statements do the same thing:
+
+```cpp
+auto b = wirestead::tcp_client("127.0.0.1", 8080);
+b.on_data(handler);          // b is still usable
+auto client = b.on_error(eh).build();
+```
+
+Before v0.9.3 the handler setters instead returned a new builder of a different
+type and left the original moved-from, while the other setters returned a
+reference. That split is gone, along with the `BuilderState` template parameter
+and the `Rebind` alias. See the CHANGELOG for what to change; chained code,
+which is how every example is written, needs nothing.
+
 ## ABI
 
 C++ ABI stability is not guaranteed before v1.0. The v0.9.0 Wirestead rename

--- a/test/unit/builder/test_builder.cc
+++ b/test/unit/builder/test_builder.cc
@@ -172,7 +172,7 @@ TEST_F(BuilderTest, TcpClientBuilderRejectsInvalidConfiguration) {
 }
 
 TEST_F(BuilderTest, TcpClientBuilderAllowsMissingCallbacks) {
-  auto client = builder::TcpClientBuilder<>("127.0.0.1", test_port_).build();
+  auto client = builder::TcpClientBuilder("127.0.0.1", test_port_).build();
   ASSERT_NE(client, nullptr);
   EXPECT_FALSE(client->connected());
 }
@@ -233,7 +233,7 @@ TEST_F(BuilderTest, SerialBuilderRejectsInvalidConfiguration) {
 }
 
 TEST_F(BuilderTest, SerialBuilderAllowsMissingCallbacks) {
-  auto serial = builder::SerialBuilder<>(nullDevice(), 9600).build();
+  auto serial = builder::SerialBuilder(nullDevice(), 9600).build();
   ASSERT_NE(serial, nullptr);
   EXPECT_FALSE(serial->connected());
 }
@@ -328,7 +328,7 @@ TEST_F(BuilderTest, TcpServerBuilderRejectsInvalidConfiguration) {
 }
 
 TEST_F(BuilderTest, TcpServerBuilderAllowsMissingCallbacks) {
-  auto server = builder::TcpServerBuilder<>(test_port_).build();
+  auto server = builder::TcpServerBuilder(test_port_).build();
   ASSERT_NE(server, nullptr);
   EXPECT_FALSE(server->listening());
 }

--- a/test/unit/builder/test_udp_builder_options.cc
+++ b/test/unit/builder/test_udp_builder_options.cc
@@ -84,10 +84,10 @@ TEST(UdpBuilderOptionsTest, UdpServerBuilderSetters) {
 }
 
 TEST(UdpBuilderOptionsTest, UdpClientBuilderSettersAfterDataHandler) {
-  auto builder = builder::UdpClientBuilder<>(0).on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
+  auto builder = builder::UdpClientBuilder(0);
+  builder.on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
 
-  auto udp = std::move(builder)
-                 .auto_start(false)
+  auto udp = builder.auto_start(false)
                  .local_port(0)
                  .bind_address("127.0.0.1")
                  .remote_endpoint("127.0.0.1", 5678)
@@ -109,10 +109,10 @@ TEST(UdpBuilderOptionsTest, UdpClientBuilderSettersAfterDataHandler) {
 }
 
 TEST(UdpBuilderOptionsTest, UdpClientBuilderSettersAfterErrorHandler) {
-  auto builder = builder::UdpClientBuilder<>(0).on_error([](const wrapper::ErrorContext&) {});
+  auto builder = builder::UdpClientBuilder(0);
+  builder.on_error([](const wrapper::ErrorContext&) {});
 
-  auto udp = std::move(builder)
-                 .auto_start(false)
+  auto udp = builder.auto_start(false)
                  .local_port(0)
                  .bind_address("0.0.0.0")
                  .remote("127.0.0.1", 5678)
@@ -132,10 +132,10 @@ TEST(UdpBuilderOptionsTest, UdpClientBuilderSettersAfterErrorHandler) {
 }
 
 TEST(UdpBuilderOptionsTest, UdpServerBuilderSettersAfterDataHandler) {
-  auto builder = builder::UdpServerBuilder<>(0).on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
+  auto builder = builder::UdpServerBuilder(0);
+  builder.on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
 
-  auto server = std::move(builder)
-                    .auto_start(false)
+  auto server = builder.auto_start(false)
                     .local_port(0)
                     .bind_address("127.0.0.1")
                     .max_clients(2)
@@ -158,10 +158,10 @@ TEST(UdpBuilderOptionsTest, UdpServerBuilderSettersAfterDataHandler) {
 }
 
 TEST(UdpBuilderOptionsTest, UdpServerBuilderSettersAfterErrorHandler) {
-  auto builder = builder::UdpServerBuilder<>(0).on_error([](const wrapper::ErrorContext&) {});
+  auto builder = builder::UdpServerBuilder(0);
+  builder.on_error([](const wrapper::ErrorContext&) {});
 
-  auto server = std::move(builder)
-                    .auto_start(false)
+  auto server = builder.auto_start(false)
                     .local_port(0)
                     .bind_address("0.0.0.0")
                     .max_clients(3)
@@ -182,8 +182,8 @@ TEST(UdpBuilderOptionsTest, UdpServerBuilderSettersAfterErrorHandler) {
 }
 
 TEST(UdpBuilderOptionsTest, MissingCallbacksAreAllowed) {
-  auto client = builder::UdpClientBuilder<>(0).auto_start(false).build();
-  auto server = builder::UdpServerBuilder<>(0).auto_start(false).build();
+  auto client = builder::UdpClientBuilder(0).auto_start(false).build();
+  auto server = builder::UdpServerBuilder(0).auto_start(false).build();
 
   EXPECT_NE(client, nullptr);
   EXPECT_NE(server, nullptr);

--- a/test/unit/builder/test_uds_builder_options.cc
+++ b/test/unit/builder/test_uds_builder_options.cc
@@ -69,11 +69,10 @@ TEST(UdsBuilderOptionsTest, UdsServerBuilderSetters) {
 }
 
 TEST(UdsBuilderOptionsTest, UdsClientBuilderSettersAfterDataHandler) {
-  auto builder = builder::UdsClientBuilder("/tmp/test_uds_client_builder_data.sock")
-                     .on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
+  auto builder = builder::UdsClientBuilder("/tmp/test_uds_client_builder_data.sock");
+  builder.on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
 
-  auto client = std::move(builder)
-                    .auto_start(false)
+  auto client = builder.auto_start(false)
                     .independent_context(false)
                     .retry_interval(200ms)
                     .max_retries(2)
@@ -93,12 +92,10 @@ TEST(UdsBuilderOptionsTest, UdsClientBuilderSettersAfterDataHandler) {
 }
 
 TEST(UdsBuilderOptionsTest, UdsClientBuilderSettersAfterErrorHandler) {
-  auto builder =
-      builder::UdsClientBuilder("/tmp/test_uds_client_builder_error.sock").on_error([](const wrapper::ErrorContext&) {
-      });
+  auto builder = builder::UdsClientBuilder("/tmp/test_uds_client_builder_error.sock");
+  builder.on_error([](const wrapper::ErrorContext&) {});
 
-  auto client = std::move(builder)
-                    .auto_start(false)
+  auto client = builder.auto_start(false)
                     .independent_context(true)
                     .retry_interval(250ms)
                     .max_retries(3)
@@ -116,11 +113,10 @@ TEST(UdsBuilderOptionsTest, UdsClientBuilderSettersAfterErrorHandler) {
 }
 
 TEST(UdsBuilderOptionsTest, UdsServerBuilderSettersAfterDataHandler) {
-  auto builder = builder::UdsServerBuilder("/tmp/test_uds_server_builder_data.sock")
-                     .on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
+  auto builder = builder::UdsServerBuilder("/tmp/test_uds_server_builder_data.sock");
+  builder.on_data_batch([](const std::vector<wrapper::MessageContext>&) {});
 
-  auto server = std::move(builder)
-                    .auto_start(false)
+  auto server = builder.auto_start(false)
                     .independent_context(false)
                     .idle_timeout(250ms)
                     .max_clients(2)
@@ -139,12 +135,10 @@ TEST(UdsBuilderOptionsTest, UdsServerBuilderSettersAfterDataHandler) {
 }
 
 TEST(UdsBuilderOptionsTest, UdsServerBuilderSettersAfterErrorHandler) {
-  auto builder =
-      builder::UdsServerBuilder("/tmp/test_uds_server_builder_error.sock").on_error([](const wrapper::ErrorContext&) {
-      });
+  auto builder = builder::UdsServerBuilder("/tmp/test_uds_server_builder_error.sock");
+  builder.on_error([](const wrapper::ErrorContext&) {});
 
-  auto server = std::move(builder)
-                    .auto_start(false)
+  auto server = builder.auto_start(false)
                     .independent_context(true)
                     .idle_timeout(500ms)
                     .max_clients(3)

--- a/wirestead/builder/ibuilder.hpp
+++ b/wirestead/builder/ibuilder.hpp
@@ -51,17 +51,9 @@ template <typename T>
 concept ConnectionHandler = std::invocable<T, const wrapper::ConnectionContext&>;
 
 /**
- * @brief Builder state bitmask for callback registration tracking.
- *
- * Callback registration is optional. The state is retained for fluent CRTP
- * rebinding and future extension points, not for mandatory build gating.
- */
-enum BuilderState : uint32_t { None = 0, HasData = 1 << 0, HasError = 1 << 1, Ready = HasData | HasError };
-
-/**
  * @brief Generic Builder interface for fluent API pattern
  */
-template <typename T, typename Derived, uint32_t State = BuilderState::None>
+template <typename T, typename Derived>
 class BuilderInterface {
  public:
   virtual ~BuilderInterface() = default;
@@ -84,32 +76,26 @@ class BuilderInterface {
   /**
    * @brief Set data handler callback
    */
-  // Note: this returns a new, moved-to builder value rather than mutating in
-  // place (see BuilderState's doc comment above) - the original object is
-  // left moved-from. [[nodiscard]] turns an accidental
-  // `builder.on_data(...);` statement that ignores the result (which would
-  // silently leave `builder` moved-from) into a compile-time warning instead
-  // of a runtime footgun.
   template <DataHandler F>
-  [[nodiscard]] auto on_data(F&& handler) {
+  Derived& on_data(F&& handler) {
     on_data_ = std::forward<F>(handler);
-    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+    return static_cast<Derived&>(*this);
   }
 
   /**
    * @brief Set batched data handler callback
    */
   template <BatchDataHandler F>
-  [[nodiscard]] auto on_data_batch(F&& handler) {
+  Derived& on_data_batch(F&& handler) {
     on_data_batch_ = std::forward<F>(handler);
-    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+    return static_cast<Derived&>(*this);
   }
 
   /**
    * @brief Set data handler callback using member function pointer
    */
   template <typename U, typename F>
-  [[nodiscard]] auto on_data(U* obj, F method) {
+  Derived& on_data(U* obj, F method) {
     return on_data([obj, method](const wrapper::MessageContext& ctx) { (obj->*method)(ctx); });
   }
 
@@ -151,16 +137,16 @@ class BuilderInterface {
    * @brief Set error handler callback
    */
   template <ErrorHandler F>
-  [[nodiscard]] auto on_error(F&& handler) {
+  Derived& on_error(F&& handler) {
     on_error_ = std::forward<F>(handler);
-    return typename Derived::template Rebind<State | BuilderState::HasError>(std::move(static_cast<Derived&>(*this)));
+    return static_cast<Derived&>(*this);
   }
 
   /**
    * @brief Set error handler callback using member function pointer
    */
   template <typename U, typename F>
-  [[nodiscard]] auto on_error(U* obj, F method) {
+  Derived& on_error(U* obj, F method) {
     return on_error([obj, method](const wrapper::ErrorContext& ctx) { (obj->*method)(ctx); });
   }
 
@@ -201,18 +187,18 @@ class BuilderInterface {
    * @brief Set message handler callback
    */
   template <DataHandler F>
-  [[nodiscard]] auto on_message(F&& handler) {
+  Derived& on_message(F&& handler) {
     on_message_ = std::forward<F>(handler);
-    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+    return static_cast<Derived&>(*this);
   }
 
   /**
    * @brief Set batched framed-message handler callback
    */
   template <BatchDataHandler F>
-  [[nodiscard]] auto on_message_batch(F&& handler) {
+  Derived& on_message_batch(F&& handler) {
     on_message_batch_ = std::forward<F>(handler);
-    return typename Derived::template Rebind<State | BuilderState::HasData>(std::move(static_cast<Derived&>(*this)));
+    return static_cast<Derived&>(*this);
   }
 
   /**
@@ -227,7 +213,7 @@ class BuilderInterface {
    * @brief Set message handler callback using member function pointer
    */
   template <typename U, typename F>
-  [[nodiscard]] auto on_message(U* obj, F method) {
+  Derived& on_message(U* obj, F method) {
     return on_message([obj, method](const wrapper::MessageContext& ctx) { (obj->*method)(ctx); });
   }
 

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -27,8 +27,7 @@
 namespace wirestead {
 namespace builder {
 
-template <uint32_t State>
-SerialBuilder<State>::SerialBuilder(const std::string& device, uint32_t baud_rate)
+SerialBuilder::SerialBuilder(const std::string& device, uint32_t baud_rate)
     : device_(device),
       baud_rate_(baud_rate),
       auto_start_(false),
@@ -46,8 +45,7 @@ SerialBuilder<State>::SerialBuilder(const std::string& device, uint32_t baud_rat
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
+std::unique_ptr<wrapper::Serial> SerialBuilder::build() {
   std::unique_ptr<wrapper::Serial> serial;
   if (independent_context_) {
     serial = std::make_unique<wrapper::Serial>(device_, baud_rate_, std::make_shared<boost::asio::io_context>());
@@ -110,35 +108,30 @@ std::unique_ptr<wrapper::Serial> SerialBuilder<State>::build() {
   return serial;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::auto_start(bool auto_start) {
+SerialBuilder& SerialBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::char_size(unsigned int size) {
+SerialBuilder& SerialBuilder::char_size(unsigned int size) {
   char_size_ = size;
   char_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::stop_bits(unsigned int bits) {
+SerialBuilder& SerialBuilder::stop_bits(unsigned int bits) {
   stop_bits_ = bits;
   stop_bits_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::parity(config::SerialConfig::Parity p) {
+SerialBuilder& SerialBuilder::parity(config::SerialConfig::Parity p) {
   parity_ = p;
   parity_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::parity(const std::string& p) {
+SerialBuilder& SerialBuilder::parity(const std::string& p) {
   std::string value = p;
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -154,15 +147,13 @@ SerialBuilder<State>& SerialBuilder<State>::parity(const std::string& p) {
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::flow_control(config::SerialConfig::Flow f) {
+SerialBuilder& SerialBuilder::flow_control(config::SerialConfig::Flow f) {
   flow_ = f;
   flow_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::flow_control(const std::string& f) {
+SerialBuilder& SerialBuilder::flow_control(const std::string& f) {
   std::string value = f;
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -178,44 +169,35 @@ SerialBuilder<State>& SerialBuilder<State>::flow_control(const std::string& f) {
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::read_chunk(size_t bytes) {
+SerialBuilder& SerialBuilder::read_chunk(size_t bytes) {
   read_chunk_ = bytes;
   read_chunk_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::reopen_on_error(bool enable) {
+SerialBuilder& SerialBuilder::reopen_on_error(bool enable) {
   reopen_on_error_ = enable;
   reopen_on_error_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
+SerialBuilder& SerialBuilder::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ms_ = static_cast<uint32_t>(interval.count());
   retry_interval_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::independent_context(bool use_independent) {
+SerialBuilder& SerialBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-SerialBuilder<State>& SerialBuilder<State>::shared_context(bool use_shared) {
+SerialBuilder& SerialBuilder::shared_context(bool use_shared) {
   shared_context_ = use_shared;
   return *this;
 }
 
 // Explicit template instantiations
-template class SerialBuilder<BuilderState::None>;
-template class SerialBuilder<BuilderState::HasData>;
-template class SerialBuilder<BuilderState::HasError>;
-template class SerialBuilder<BuilderState::Ready>;
 
 }  // namespace builder
 }  // namespace wirestead

--- a/wirestead/builder/serial_builder.hpp
+++ b/wirestead/builder/serial_builder.hpp
@@ -35,50 +35,9 @@ namespace builder {
 /**
  * @brief Modernized Builder for Serial
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, SerialBuilder<State>, State> {
+class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, SerialBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = SerialBuilder<NewState>;
-
   SerialBuilder(const std::string& device, uint32_t baud_rate);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  SerialBuilder(SerialBuilder<OtherState>&& other) noexcept
-      : device_(std::move(other.device_)),
-        baud_rate_(other.baud_rate_),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        shared_context_(other.shared_context_),
-        retry_interval_ms_(other.retry_interval_ms_),
-        retry_interval_set_(other.retry_interval_set_),
-        char_size_(other.char_size_),
-        char_size_set_(other.char_size_set_),
-        stop_bits_(other.stop_bits_),
-        stop_bits_set_(other.stop_bits_set_),
-        parity_(other.parity_),
-        parity_set_(other.parity_set_),
-        flow_(other.flow_),
-        flow_set_(other.flow_set_),
-        reopen_on_error_(other.reopen_on_error_),
-        reopen_on_error_set_(other.reopen_on_error_set_),
-        read_chunk_(other.read_chunk_),
-        read_chunk_set_(other.read_chunk_set_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   SerialBuilder(const SerialBuilder&) = delete;
@@ -86,30 +45,27 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
 
   std::unique_ptr<wrapper::Serial> build() override;
 
-  SerialBuilder<State>& auto_start(bool auto_start = true) override;
-  SerialBuilder<State>& char_size(unsigned int size);
-  SerialBuilder<State>& data_bits(unsigned int size) { return char_size(size); }
-  SerialBuilder<State>& stop_bits(unsigned int bits);
-  SerialBuilder<State>& parity(config::SerialConfig::Parity p);
-  SerialBuilder<State>& parity(const std::string& p);
-  SerialBuilder<State>& flow_control(config::SerialConfig::Flow f);
-  SerialBuilder<State>& flow_control(const std::string& f);
+  SerialBuilder& auto_start(bool auto_start = true) override;
+  SerialBuilder& char_size(unsigned int size);
+  SerialBuilder& data_bits(unsigned int size) { return char_size(size); }
+  SerialBuilder& stop_bits(unsigned int bits);
+  SerialBuilder& parity(config::SerialConfig::Parity p);
+  SerialBuilder& parity(const std::string& p);
+  SerialBuilder& flow_control(config::SerialConfig::Flow f);
+  SerialBuilder& flow_control(const std::string& f);
   // Bytes each read fills. The TCP and UDS builders call the same knob
   // read_buffer_size(); serial named it read_chunk before those existed.
-  SerialBuilder<State>& read_chunk(size_t bytes);
-  SerialBuilder<State>& reopen_on_error(bool enable = true);
-  SerialBuilder<State>& retry_interval(std::chrono::milliseconds interval);
-  SerialBuilder<State>& independent_context(bool use_independent = true);
+  SerialBuilder& read_chunk(size_t bytes);
+  SerialBuilder& reopen_on_error(bool enable = true);
+  SerialBuilder& retry_interval(std::chrono::milliseconds interval);
+  SerialBuilder& independent_context(bool use_independent = true);
   // Opt into the shared IoContextManager singleton instead of the default
   // dedicated io_context + thread (#440). Only meaningful for deliberately
   // trading per-instance parallelism for reduced thread/memory overhead
   // across many instances in one process; most callers should not need this.
-  SerialBuilder<State>& shared_context(bool use_shared = true);
+  SerialBuilder& shared_context(bool use_shared = true);
 
  private:
-  template <uint32_t S>
-  friend class SerialBuilder;
-
   std::string device_;
   uint32_t baud_rate_;
   bool auto_start_;
@@ -132,7 +88,7 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   bool read_chunk_set_{false};
 };
 
-using SerialBuilderDefault = SerialBuilder<BuilderState::None>;
+using SerialBuilderDefault = SerialBuilder;
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/wirestead/builder/tcp_client_builder.cc
+++ b/wirestead/builder/tcp_client_builder.cc
@@ -25,8 +25,7 @@
 namespace wirestead {
 namespace builder {
 
-template <uint32_t State>
-TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port)
+TcpClientBuilder::TcpClientBuilder(const std::string& host, uint16_t port)
     : host_(host),
       port_(port),
       auto_start_(false),
@@ -48,8 +47,7 @@ TcpClientBuilder<State>::TcpClientBuilder(const std::string& host, uint16_t port
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
+std::unique_ptr<wrapper::TcpClient> TcpClientBuilder::build() {
   std::unique_ptr<wrapper::TcpClient> client;
   if (independent_context_) {
     client = std::make_unique<wrapper::TcpClient>(host_, port_, std::make_shared<boost::asio::io_context>());
@@ -96,93 +94,77 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder<State>::build() {
   return client;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::auto_start(bool auto_start) {
+TcpClientBuilder& TcpClientBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
+TcpClientBuilder& TcpClientBuilder::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ = interval;
   retry_interval_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::max_retries(int max_retries) {
+TcpClientBuilder& TcpClientBuilder::max_retries(int max_retries) {
   max_retries_ = max_retries;
   max_retries_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::connection_timeout(std::chrono::milliseconds timeout) {
+TcpClientBuilder& TcpClientBuilder::connection_timeout(std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
   connection_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
+TcpClientBuilder& TcpClientBuilder::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
   idle_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::idle_timeout_action(IdleTimeoutAction action) {
+TcpClientBuilder& TcpClientBuilder::idle_timeout_action(IdleTimeoutAction action) {
   idle_timeout_action_ = action;
   idle_timeout_action_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::independent_context(bool use_independent) {
+TcpClientBuilder& TcpClientBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::tcp_no_delay(bool enable) {
+TcpClientBuilder& TcpClientBuilder::tcp_no_delay(bool enable) {
   tcp_no_delay_ = enable;
   tcp_no_delay_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::keep_alive(bool enable) {
+TcpClientBuilder& TcpClientBuilder::keep_alive(bool enable) {
   keep_alive_ = enable;
   keep_alive_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::send_buffer_size(size_t bytes) {
+TcpClientBuilder& TcpClientBuilder::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
   send_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::receive_buffer_size(size_t bytes) {
+TcpClientBuilder& TcpClientBuilder::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   receive_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpClientBuilder<State>& TcpClientBuilder<State>::read_buffer_size(size_t bytes) {
+TcpClientBuilder& TcpClientBuilder::read_buffer_size(size_t bytes) {
   read_buffer_size_ = bytes;
   read_buffer_size_set_ = true;
   return *this;
 }
 
 // Explicit template instantiations
-template class TcpClientBuilder<BuilderState::None>;
-template class TcpClientBuilder<BuilderState::HasData>;
-template class TcpClientBuilder<BuilderState::HasError>;
-template class TcpClientBuilder<BuilderState::Ready>;
 
 }  // namespace builder
 }  // namespace wirestead

--- a/wirestead/builder/tcp_client_builder.hpp
+++ b/wirestead/builder/tcp_client_builder.hpp
@@ -36,55 +36,9 @@ namespace builder {
 /**
  * @brief Modernized Builder for TcpClient
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient, TcpClientBuilder<State>, State> {
+class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClient, TcpClientBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = TcpClientBuilder<NewState>;
-
   TcpClientBuilder(const std::string& host, uint16_t port);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  TcpClientBuilder(TcpClientBuilder<OtherState>&& other) noexcept
-      : host_(std::move(other.host_)),
-        port_(other.port_),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        retry_interval_(other.retry_interval_),
-        retry_interval_set_(other.retry_interval_set_),
-        max_retries_(other.max_retries_),
-        max_retries_set_(other.max_retries_set_),
-        connection_timeout_(other.connection_timeout_),
-        connection_timeout_set_(other.connection_timeout_set_),
-        idle_timeout_(other.idle_timeout_),
-        idle_timeout_set_(other.idle_timeout_set_),
-        idle_timeout_action_(other.idle_timeout_action_),
-        idle_timeout_action_set_(other.idle_timeout_action_set_),
-        tcp_no_delay_(other.tcp_no_delay_),
-        tcp_no_delay_set_(other.tcp_no_delay_set_),
-        keep_alive_(other.keep_alive_),
-        keep_alive_set_(other.keep_alive_set_),
-        send_buffer_size_(other.send_buffer_size_),
-        send_buffer_size_set_(other.send_buffer_size_set_),
-        receive_buffer_size_(other.receive_buffer_size_),
-        receive_buffer_size_set_(other.receive_buffer_size_set_),
-        read_buffer_size_(other.read_buffer_size_),
-        read_buffer_size_set_(other.read_buffer_size_set_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   TcpClientBuilder(const TcpClientBuilder&) = delete;
@@ -92,30 +46,30 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
 
   std::unique_ptr<wrapper::TcpClient> build() override;
 
-  TcpClientBuilder<State>& auto_start(bool auto_start = true) override;
+  TcpClientBuilder& auto_start(bool auto_start = true) override;
 
-  TcpClientBuilder<State>& retry_interval(std::chrono::milliseconds interval);
-  TcpClientBuilder<State>& max_retries(int max_retries);
-  TcpClientBuilder<State>& connection_timeout(std::chrono::milliseconds timeout);
+  TcpClientBuilder& retry_interval(std::chrono::milliseconds interval);
+  TcpClientBuilder& max_retries(int max_retries);
+  TcpClientBuilder& connection_timeout(std::chrono::milliseconds timeout);
   /**
    * @brief Configure application-level idle timeout.
    *
    * A value of 0ms disables idle timeout. When enabled, inbound or outbound
    * activity resets the timer.
    */
-  TcpClientBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+  TcpClientBuilder& idle_timeout(std::chrono::milliseconds timeout);
   /**
    * @brief Configure what happens when an enabled idle timeout expires.
    *
    * The default is IdleTimeoutAction::Reconnect. This setting has no effect
    * while idle_timeout is 0ms.
    */
-  TcpClientBuilder<State>& idle_timeout_action(IdleTimeoutAction action);
-  TcpClientBuilder<State>& independent_context(bool use_independent = true);
-  TcpClientBuilder<State>& tcp_no_delay(bool enable = true);
-  TcpClientBuilder<State>& keep_alive(bool enable = true);
-  TcpClientBuilder<State>& send_buffer_size(size_t bytes);
-  TcpClientBuilder<State>& receive_buffer_size(size_t bytes);
+  TcpClientBuilder& idle_timeout_action(IdleTimeoutAction action);
+  TcpClientBuilder& independent_context(bool use_independent = true);
+  TcpClientBuilder& tcp_no_delay(bool enable = true);
+  TcpClientBuilder& keep_alive(bool enable = true);
+  TcpClientBuilder& send_buffer_size(size_t bytes);
+  TcpClientBuilder& receive_buffer_size(size_t bytes);
 
   /**
    * @brief Size of the userspace buffer each read fills, in bytes.
@@ -124,12 +78,9 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
    * transfers, at the cost of that much memory per connection. Clamped to
    * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
    */
-  TcpClientBuilder<State>& read_buffer_size(size_t bytes);
+  TcpClientBuilder& read_buffer_size(size_t bytes);
 
  private:
-  template <uint32_t S>
-  friend class TcpClientBuilder;
-
   std::string host_;
   uint16_t port_;
   bool auto_start_;
@@ -157,7 +108,7 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
   bool read_buffer_size_set_{false};
 };
 
-using TcpClientBuilderDefault = TcpClientBuilder<BuilderState::None>;
+using TcpClientBuilderDefault = TcpClientBuilder;
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/wirestead/builder/tcp_server_builder.cc
+++ b/wirestead/builder/tcp_server_builder.cc
@@ -24,8 +24,7 @@
 namespace wirestead {
 namespace builder {
 
-template <uint32_t State>
-TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
+TcpServerBuilder::TcpServerBuilder(uint16_t port)
     : port_(port),
       bind_address_("0.0.0.0"),
       auto_start_(false),
@@ -49,8 +48,7 @@ TcpServerBuilder<State>::TcpServerBuilder(uint16_t port)
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
+std::unique_ptr<wrapper::TcpServer> TcpServerBuilder::build() {
   std::unique_ptr<wrapper::TcpServer> server;
   if (independent_context_) {
     server = std::make_unique<wrapper::TcpServer>(port_, std::make_shared<boost::asio::io_context>());
@@ -103,97 +101,83 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder<State>::build() {
   return server;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::auto_start(bool auto_start) {
+TcpServerBuilder& TcpServerBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::bind_address(const std::string& address) {
+TcpServerBuilder& TcpServerBuilder::bind_address(const std::string& address) {
   bind_address_ = address;
   bind_address_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::independent_context(bool use_independent) {
+TcpServerBuilder& TcpServerBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::shared_context(bool use_shared) {
+TcpServerBuilder& TcpServerBuilder::shared_context(bool use_shared) {
   shared_context_ = use_shared;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::max_clients(uint32_t max_clients) {
+TcpServerBuilder& TcpServerBuilder::max_clients(uint32_t max_clients) {
   max_clients_ = max_clients;
   client_limit_enabled_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::enable_port_retry(bool enable) {
+TcpServerBuilder& TcpServerBuilder::enable_port_retry(bool enable) {
   port_retry_enabled_ = enable;
   port_retry_enabled_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::max_port_retries(uint32_t max_retries) {
+TcpServerBuilder& TcpServerBuilder::max_port_retries(uint32_t max_retries) {
   max_port_retries_ = max_retries;
   max_port_retries_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::port_retry_interval(std::chrono::milliseconds interval) {
+TcpServerBuilder& TcpServerBuilder::port_retry_interval(std::chrono::milliseconds interval) {
   port_retry_interval_ms_ = static_cast<uint32_t>(interval.count());
   port_retry_interval_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::tcp_no_delay(bool enable) {
+TcpServerBuilder& TcpServerBuilder::tcp_no_delay(bool enable) {
   tcp_no_delay_ = enable;
   tcp_no_delay_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::keep_alive(bool enable) {
+TcpServerBuilder& TcpServerBuilder::keep_alive(bool enable) {
   keep_alive_ = enable;
   keep_alive_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::send_buffer_size(size_t bytes) {
+TcpServerBuilder& TcpServerBuilder::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
   send_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::receive_buffer_size(size_t bytes) {
+TcpServerBuilder& TcpServerBuilder::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   receive_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::read_buffer_size(size_t bytes) {
+TcpServerBuilder& TcpServerBuilder::read_buffer_size(size_t bytes) {
   read_buffer_size_ = bytes;
   read_buffer_size_set_ = true;
   return *this;
 }
 
 // Backward compatibility implementations
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::port_retry(bool enable, int max_retries, int retry_interval_ms) {
+TcpServerBuilder& TcpServerBuilder::port_retry(bool enable, int max_retries, int retry_interval_ms) {
   port_retry_enabled_ = enable;
   port_retry_enabled_set_ = true;
   max_port_retries_ = static_cast<uint32_t>(max_retries);
@@ -203,22 +187,19 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::port_retry(bool enable, int ma
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
+TcpServerBuilder& TcpServerBuilder::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
   idle_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::single_client() {
+TcpServerBuilder& TcpServerBuilder::single_client() {
   max_clients_ = 1;
   client_limit_enabled_ = true;
   return *this;
 }
 
-template <uint32_t State>
-TcpServerBuilder<State>& TcpServerBuilder<State>::multi_client(size_t max) {
+TcpServerBuilder& TcpServerBuilder::multi_client(size_t max) {
   if (max == 0) {
     throw diagnostics::BuilderException("multi_client max must be greater than 0");
   }
@@ -228,10 +209,6 @@ TcpServerBuilder<State>& TcpServerBuilder<State>::multi_client(size_t max) {
 }
 
 // Explicit template instantiations
-template class TcpServerBuilder<BuilderState::None>;
-template class TcpServerBuilder<BuilderState::HasData>;
-template class TcpServerBuilder<BuilderState::HasError>;
-template class TcpServerBuilder<BuilderState::Ready>;
 
 }  // namespace builder
 }  // namespace wirestead

--- a/wirestead/builder/tcp_server_builder.hpp
+++ b/wirestead/builder/tcp_server_builder.hpp
@@ -36,57 +36,9 @@ namespace builder {
 /**
  * @brief Modernized Builder for TcpServer with C++20 Concepts
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer, TcpServerBuilder<State>, State> {
+class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServer, TcpServerBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = TcpServerBuilder<NewState>;
-
   explicit TcpServerBuilder(uint16_t port);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  TcpServerBuilder(TcpServerBuilder<OtherState>&& other) noexcept
-      : port_(other.port_),
-        bind_address_(std::move(other.bind_address_)),
-        bind_address_set_(other.bind_address_set_),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        shared_context_(other.shared_context_),
-        max_clients_(other.max_clients_),
-        client_limit_enabled_(other.client_limit_enabled_),
-        port_retry_enabled_(other.port_retry_enabled_),
-        port_retry_enabled_set_(other.port_retry_enabled_set_),
-        max_port_retries_(other.max_port_retries_),
-        max_port_retries_set_(other.max_port_retries_set_),
-        port_retry_interval_ms_(other.port_retry_interval_ms_),
-        port_retry_interval_set_(other.port_retry_interval_set_),
-        idle_timeout_(other.idle_timeout_),
-        idle_timeout_set_(other.idle_timeout_set_),
-        tcp_no_delay_(other.tcp_no_delay_),
-        tcp_no_delay_set_(other.tcp_no_delay_set_),
-        keep_alive_(other.keep_alive_),
-        keep_alive_set_(other.keep_alive_set_),
-        send_buffer_size_(other.send_buffer_size_),
-        send_buffer_size_set_(other.send_buffer_size_set_),
-        receive_buffer_size_(other.receive_buffer_size_),
-        receive_buffer_size_set_(other.receive_buffer_size_set_),
-        read_buffer_size_(other.read_buffer_size_),
-        read_buffer_size_set_(other.read_buffer_size_set_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   TcpServerBuilder(const TcpServerBuilder&) = delete;
@@ -94,22 +46,22 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
 
   std::unique_ptr<wrapper::TcpServer> build() override;
 
-  TcpServerBuilder<State>& auto_start(bool auto_start = true) override;
-  TcpServerBuilder<State>& bind_address(const std::string& address);
-  TcpServerBuilder<State>& independent_context(bool use_independent = true);
+  TcpServerBuilder& auto_start(bool auto_start = true) override;
+  TcpServerBuilder& bind_address(const std::string& address);
+  TcpServerBuilder& independent_context(bool use_independent = true);
   // Opt into the shared IoContextManager singleton instead of the default
   // dedicated io_context + thread (#440). Only meaningful for deliberately
   // trading per-instance parallelism for reduced thread/memory overhead
   // across many servers in one process; most callers should not need this.
-  TcpServerBuilder<State>& shared_context(bool use_shared = true);
-  TcpServerBuilder<State>& max_clients(uint32_t max_clients);
-  TcpServerBuilder<State>& enable_port_retry(bool enable = true);
-  TcpServerBuilder<State>& max_port_retries(uint32_t max_retries);
-  TcpServerBuilder<State>& port_retry_interval(std::chrono::milliseconds interval);
-  TcpServerBuilder<State>& tcp_no_delay(bool enable = true);
-  TcpServerBuilder<State>& keep_alive(bool enable = true);
-  TcpServerBuilder<State>& send_buffer_size(size_t bytes);
-  TcpServerBuilder<State>& receive_buffer_size(size_t bytes);
+  TcpServerBuilder& shared_context(bool use_shared = true);
+  TcpServerBuilder& max_clients(uint32_t max_clients);
+  TcpServerBuilder& enable_port_retry(bool enable = true);
+  TcpServerBuilder& max_port_retries(uint32_t max_retries);
+  TcpServerBuilder& port_retry_interval(std::chrono::milliseconds interval);
+  TcpServerBuilder& tcp_no_delay(bool enable = true);
+  TcpServerBuilder& keep_alive(bool enable = true);
+  TcpServerBuilder& send_buffer_size(size_t bytes);
+  TcpServerBuilder& receive_buffer_size(size_t bytes);
 
   /**
    * @brief Size of the userspace buffer each read fills, in bytes.
@@ -118,26 +70,23 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
    * transfers, at the cost of that much memory per connection. Clamped to
    * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
    */
-  TcpServerBuilder<State>& read_buffer_size(size_t bytes);
+  TcpServerBuilder& read_buffer_size(size_t bytes);
 
   // Backward compatibility methods
-  TcpServerBuilder<State>& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
+  TcpServerBuilder& port_retry(bool enable = true, int max_retries = 3, int retry_interval_ms = 1000);
   /**
    * @brief Configure application-level idle timeout for accepted sessions.
    *
    * A value of 0ms disables idle timeout. When enabled, only the idle client
    * session is closed; the server keeps listening for new connections.
    */
-  TcpServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+  TcpServerBuilder& idle_timeout(std::chrono::milliseconds timeout);
   [[deprecated("Use max_clients(1) instead")]]
-  TcpServerBuilder<State>& single_client();
+  TcpServerBuilder& single_client();
   [[deprecated("Use max_clients(max) instead")]]
-  TcpServerBuilder<State>& multi_client(size_t max);
+  TcpServerBuilder& multi_client(size_t max);
 
  private:
-  template <uint32_t S>
-  friend class TcpServerBuilder;
-
   uint16_t port_;
   std::string bind_address_;
   bool bind_address_set_{false};
@@ -168,7 +117,7 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
   bool read_buffer_size_set_{false};
 };
 
-using TcpServerBuilderDefault = TcpServerBuilder<BuilderState::None>;
+using TcpServerBuilderDefault = TcpServerBuilder;
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/wirestead/builder/udp_builder.cc
+++ b/wirestead/builder/udp_builder.cc
@@ -27,11 +27,9 @@ namespace builder {
 
 // UdpClientBuilder implementation
 
-template <uint32_t State>
-UdpClientBuilder<State>::UdpClientBuilder() : UdpClientBuilder(0) {}
+UdpClientBuilder::UdpClientBuilder() : UdpClientBuilder(0) {}
 
-template <uint32_t State>
-UdpClientBuilder<State>::UdpClientBuilder(uint16_t local_port)
+UdpClientBuilder::UdpClientBuilder(uint16_t local_port)
     : local_port_(local_port),
       bind_address_("0.0.0.0"),
       remote_host_(""),
@@ -46,8 +44,7 @@ UdpClientBuilder<State>::UdpClientBuilder(uint16_t local_port)
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::UdpClient> UdpClientBuilder<State>::build() {
+std::unique_ptr<wrapper::UdpClient> UdpClientBuilder::build() {
   std::unique_ptr<wrapper::UdpClient> client;
   config::UdpConfig cfg;
   cfg.bind_address = bind_address_;
@@ -93,26 +90,22 @@ std::unique_ptr<wrapper::UdpClient> UdpClientBuilder<State>::build() {
   return client;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::auto_start(bool auto_start) {
+UdpClientBuilder& UdpClientBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::local_port(uint16_t port) {
+UdpClientBuilder& UdpClientBuilder::local_port(uint16_t port) {
   local_port_ = port;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::bind_address(const std::string& address) {
+UdpClientBuilder& UdpClientBuilder::bind_address(const std::string& address) {
   bind_address_ = address;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::remote_endpoint(const std::string& host, uint16_t port) {
+UdpClientBuilder& UdpClientBuilder::remote_endpoint(const std::string& host, uint16_t port) {
   boost::system::error_code ec;
   boost::asio::ip::make_address(host, ec);
   if (ec) {
@@ -123,43 +116,36 @@ UdpClientBuilder<State>& UdpClientBuilder<State>::remote_endpoint(const std::str
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::broadcast(bool enable) {
+UdpClientBuilder& UdpClientBuilder::broadcast(bool enable) {
   enable_broadcast_ = enable;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::reuse_address(bool enable) {
+UdpClientBuilder& UdpClientBuilder::reuse_address(bool enable) {
   reuse_address_ = enable;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::independent_context(bool use_independent) {
+UdpClientBuilder& UdpClientBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::send_buffer_size(size_t bytes) {
+UdpClientBuilder& UdpClientBuilder::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
   return *this;
 }
 
-template <uint32_t State>
-UdpClientBuilder<State>& UdpClientBuilder<State>::receive_buffer_size(size_t bytes) {
+UdpClientBuilder& UdpClientBuilder::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   return *this;
 }
 
 // UdpServerBuilder implementation
 
-template <uint32_t State>
-UdpServerBuilder<State>::UdpServerBuilder() : UdpServerBuilder(0) {}
+UdpServerBuilder::UdpServerBuilder() : UdpServerBuilder(0) {}
 
-template <uint32_t State>
-UdpServerBuilder<State>::UdpServerBuilder(uint16_t local_port)
+UdpServerBuilder::UdpServerBuilder(uint16_t local_port)
     : local_port_(local_port),
       bind_address_("0.0.0.0"),
       auto_start_(false),
@@ -172,8 +158,7 @@ UdpServerBuilder<State>::UdpServerBuilder(uint16_t local_port)
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::UdpServer> UdpServerBuilder<State>::build() {
+std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
   std::unique_ptr<wrapper::UdpServer> server;
   config::UdpConfig cfg;
   cfg.bind_address = bind_address_;
@@ -224,77 +209,59 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder<State>::build() {
   return server;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::auto_start(bool auto_start) {
+UdpServerBuilder& UdpServerBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::local_port(uint16_t port) {
+UdpServerBuilder& UdpServerBuilder::local_port(uint16_t port) {
   local_port_ = port;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::bind_address(const std::string& address) {
+UdpServerBuilder& UdpServerBuilder::bind_address(const std::string& address) {
   bind_address_ = address;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::max_clients(uint32_t max) {
+UdpServerBuilder& UdpServerBuilder::max_clients(uint32_t max) {
   max_clients_ = max;
   client_limit_enabled_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::broadcast(bool enable) {
+UdpServerBuilder& UdpServerBuilder::broadcast(bool enable) {
   enable_broadcast_ = enable;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::reuse_address(bool enable) {
+UdpServerBuilder& UdpServerBuilder::reuse_address(bool enable) {
   reuse_address_ = enable;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::independent_context(bool use_independent) {
+UdpServerBuilder& UdpServerBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
+UdpServerBuilder& UdpServerBuilder::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
   idle_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::send_buffer_size(size_t bytes) {
+UdpServerBuilder& UdpServerBuilder::send_buffer_size(size_t bytes) {
   send_buffer_size_ = bytes;
   return *this;
 }
 
-template <uint32_t State>
-UdpServerBuilder<State>& UdpServerBuilder<State>::receive_buffer_size(size_t bytes) {
+UdpServerBuilder& UdpServerBuilder::receive_buffer_size(size_t bytes) {
   receive_buffer_size_ = bytes;
   return *this;
 }
 
 // Explicit template instantiations
-template class UdpClientBuilder<BuilderState::None>;
-template class UdpClientBuilder<BuilderState::HasData>;
-template class UdpClientBuilder<BuilderState::HasError>;
-template class UdpClientBuilder<BuilderState::Ready>;
-template class UdpServerBuilder<BuilderState::None>;
-template class UdpServerBuilder<BuilderState::HasData>;
-template class UdpServerBuilder<BuilderState::HasError>;
-template class UdpServerBuilder<BuilderState::Ready>;
 
 }  // namespace builder
 }  // namespace wirestead

--- a/wirestead/builder/udp_builder.hpp
+++ b/wirestead/builder/udp_builder.hpp
@@ -38,42 +38,10 @@ namespace builder {
 /**
  * @brief Modernized Builder for UdpClient
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClient, UdpClientBuilder<State>, State> {
+class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClient, UdpClientBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = UdpClientBuilder<NewState>;
-
   UdpClientBuilder();
   explicit UdpClientBuilder(uint16_t local_port);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  UdpClientBuilder(UdpClientBuilder<OtherState>&& other) noexcept
-      : local_port_(other.local_port_),
-        bind_address_(std::move(other.bind_address_)),
-        remote_host_(std::move(other.remote_host_)),
-        remote_port_(other.remote_port_),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        enable_broadcast_(other.enable_broadcast_),
-        reuse_address_(other.reuse_address_),
-        send_buffer_size_(other.send_buffer_size_),
-        receive_buffer_size_(other.receive_buffer_size_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   UdpClientBuilder(const UdpClientBuilder&) = delete;
@@ -81,25 +49,22 @@ class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClien
 
   std::unique_ptr<wrapper::UdpClient> build() override;
 
-  UdpClientBuilder<State>& auto_start(bool auto_start = true) override;
-  UdpClientBuilder<State>& local_port(uint16_t port);
-  UdpClientBuilder<State>& bind_address(const std::string& address);
+  UdpClientBuilder& auto_start(bool auto_start = true) override;
+  UdpClientBuilder& local_port(uint16_t port);
+  UdpClientBuilder& bind_address(const std::string& address);
   [[deprecated("Use bind_address instead")]]
-  UdpClientBuilder<State>& local_address(const std::string& address) {
+  UdpClientBuilder& local_address(const std::string& address) {
     return bind_address(address);
   }
-  UdpClientBuilder<State>& remote_endpoint(const std::string& host, uint16_t port);
-  UdpClientBuilder<State>& remote(const std::string& host, uint16_t port) { return remote_endpoint(host, port); }
-  UdpClientBuilder<State>& broadcast(bool enable = true);
-  UdpClientBuilder<State>& reuse_address(bool enable = true);
-  UdpClientBuilder<State>& independent_context(bool use_independent = true);
-  UdpClientBuilder<State>& send_buffer_size(size_t bytes);
-  UdpClientBuilder<State>& receive_buffer_size(size_t bytes);
+  UdpClientBuilder& remote_endpoint(const std::string& host, uint16_t port);
+  UdpClientBuilder& remote(const std::string& host, uint16_t port) { return remote_endpoint(host, port); }
+  UdpClientBuilder& broadcast(bool enable = true);
+  UdpClientBuilder& reuse_address(bool enable = true);
+  UdpClientBuilder& independent_context(bool use_independent = true);
+  UdpClientBuilder& send_buffer_size(size_t bytes);
+  UdpClientBuilder& receive_buffer_size(size_t bytes);
 
  private:
-  template <uint32_t S>
-  friend class UdpClientBuilder;
-
   uint16_t local_port_;
   std::string bind_address_;
   std::string remote_host_;
@@ -112,49 +77,15 @@ class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClien
   size_t receive_buffer_size_;
 };
 
-using UdpClientBuilderDefault = UdpClientBuilder<BuilderState::None>;
+using UdpClientBuilderDefault = UdpClientBuilder;
 
 /**
  * @brief Modernized Builder for UdpServer
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer, UdpServerBuilder<State>, State> {
+class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServer, UdpServerBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = UdpServerBuilder<NewState>;
-
   UdpServerBuilder();
   explicit UdpServerBuilder(uint16_t local_port);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  UdpServerBuilder(UdpServerBuilder<OtherState>&& other) noexcept
-      : local_port_(other.local_port_),
-        bind_address_(std::move(other.bind_address_)),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        enable_broadcast_(other.enable_broadcast_),
-        reuse_address_(other.reuse_address_),
-        max_clients_(other.max_clients_),
-        client_limit_enabled_(other.client_limit_enabled_),
-        idle_timeout_(other.idle_timeout_),
-        idle_timeout_set_(other.idle_timeout_set_),
-        send_buffer_size_(other.send_buffer_size_),
-        receive_buffer_size_(other.receive_buffer_size_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   UdpServerBuilder(const UdpServerBuilder&) = delete;
@@ -162,17 +93,17 @@ class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServe
 
   std::unique_ptr<wrapper::UdpServer> build() override;
 
-  UdpServerBuilder<State>& auto_start(bool auto_start = true) override;
-  UdpServerBuilder<State>& local_port(uint16_t port);
-  UdpServerBuilder<State>& bind_address(const std::string& address);
+  UdpServerBuilder& auto_start(bool auto_start = true) override;
+  UdpServerBuilder& local_port(uint16_t port);
+  UdpServerBuilder& bind_address(const std::string& address);
   [[deprecated("Use bind_address instead")]]
-  UdpServerBuilder<State>& local_address(const std::string& address) {
+  UdpServerBuilder& local_address(const std::string& address) {
     return bind_address(address);
   }
-  UdpServerBuilder<State>& max_clients(uint32_t max);
-  UdpServerBuilder<State>& broadcast(bool enable = true);
-  UdpServerBuilder<State>& reuse_address(bool enable = true);
-  UdpServerBuilder<State>& independent_context(bool use_independent = true);
+  UdpServerBuilder& max_clients(uint32_t max);
+  UdpServerBuilder& broadcast(bool enable = true);
+  UdpServerBuilder& reuse_address(bool enable = true);
+  UdpServerBuilder& independent_context(bool use_independent = true);
   /**
    * @brief Configure application-level idle timeout for virtual sessions.
    *
@@ -180,14 +111,11 @@ class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServe
    * sessions are removed and a later datagram from the same endpoint creates a
    * new virtual session.
    */
-  UdpServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
-  UdpServerBuilder<State>& send_buffer_size(size_t bytes);
-  UdpServerBuilder<State>& receive_buffer_size(size_t bytes);
+  UdpServerBuilder& idle_timeout(std::chrono::milliseconds timeout);
+  UdpServerBuilder& send_buffer_size(size_t bytes);
+  UdpServerBuilder& receive_buffer_size(size_t bytes);
 
  private:
-  template <uint32_t S>
-  friend class UdpServerBuilder;
-
   uint16_t local_port_;
   std::string bind_address_;
   bool auto_start_;
@@ -202,7 +130,7 @@ class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServe
   size_t receive_buffer_size_;
 };
 
-using UdpServerBuilderDefault = UdpServerBuilder<BuilderState::None>;
+using UdpServerBuilderDefault = UdpServerBuilder;
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/wirestead/builder/uds_builder.cc
+++ b/wirestead/builder/uds_builder.cc
@@ -27,8 +27,7 @@ namespace builder {
 
 // UdsClientBuilder implementation
 
-template <uint32_t State>
-UdsClientBuilder<State>::UdsClientBuilder(const std::string& socket_path)
+UdsClientBuilder::UdsClientBuilder(const std::string& socket_path)
     : socket_path_(socket_path),
       auto_start_(false),
       independent_context_(false),
@@ -42,8 +41,7 @@ UdsClientBuilder<State>::UdsClientBuilder(const std::string& socket_path)
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
+std::unique_ptr<wrapper::UdsClient> UdsClientBuilder::build() {
   std::unique_ptr<wrapper::UdsClient> client;
   if (independent_context_) {
     client = std::make_unique<wrapper::UdsClient>(socket_path_, std::make_shared<boost::asio::io_context>());
@@ -84,50 +82,43 @@ std::unique_ptr<wrapper::UdsClient> UdsClientBuilder<State>::build() {
   return client;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::auto_start(bool auto_start) {
+UdsClientBuilder& UdsClientBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::retry_interval(std::chrono::milliseconds interval) {
+UdsClientBuilder& UdsClientBuilder::retry_interval(std::chrono::milliseconds interval) {
   retry_interval_ = interval;
   retry_interval_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::max_retries(int max_retries) {
+UdsClientBuilder& UdsClientBuilder::max_retries(int max_retries) {
   max_retries_ = max_retries;
   max_retries_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::connection_timeout(std::chrono::milliseconds timeout) {
+UdsClientBuilder& UdsClientBuilder::connection_timeout(std::chrono::milliseconds timeout) {
   connection_timeout_ = timeout;
   connection_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::read_buffer_size(size_t bytes) {
+UdsClientBuilder& UdsClientBuilder::read_buffer_size(size_t bytes) {
   read_buffer_size_ = bytes;
   read_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsClientBuilder<State>& UdsClientBuilder<State>::independent_context(bool use_independent) {
+UdsClientBuilder& UdsClientBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
 // UdsServerBuilder implementation
 
-template <uint32_t State>
-UdsServerBuilder<State>::UdsServerBuilder(const std::string& socket_path)
+UdsServerBuilder::UdsServerBuilder(const std::string& socket_path)
     : socket_path_(socket_path),
       auto_start_(false),
       independent_context_(false),
@@ -142,8 +133,7 @@ UdsServerBuilder<State>::UdsServerBuilder(const std::string& socket_path)
   AutoInitializer::ensure_io_context_running();
 }
 
-template <uint32_t State>
-std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
+std::unique_ptr<wrapper::UdsServer> UdsServerBuilder::build() {
   std::unique_ptr<wrapper::UdsServer> server;
   if (independent_context_) {
     server = std::make_unique<wrapper::UdsServer>(socket_path_, std::make_shared<boost::asio::io_context>());
@@ -188,48 +178,41 @@ std::unique_ptr<wrapper::UdsServer> UdsServerBuilder<State>::build() {
   return server;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::auto_start(bool auto_start) {
+UdsServerBuilder& UdsServerBuilder::auto_start(bool auto_start) {
   auto_start_ = auto_start;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::independent_context(bool use_independent) {
+UdsServerBuilder& UdsServerBuilder::independent_context(bool use_independent) {
   independent_context_ = use_independent;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::idle_timeout(std::chrono::milliseconds timeout) {
+UdsServerBuilder& UdsServerBuilder::idle_timeout(std::chrono::milliseconds timeout) {
   idle_timeout_ = timeout;
   idle_timeout_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::read_buffer_size(size_t bytes) {
+UdsServerBuilder& UdsServerBuilder::read_buffer_size(size_t bytes) {
   read_buffer_size_ = bytes;
   read_buffer_size_set_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::max_clients(uint32_t max_clients) {
+UdsServerBuilder& UdsServerBuilder::max_clients(uint32_t max_clients) {
   max_clients_ = max_clients;
   client_limit_enabled_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::single_client() {
+UdsServerBuilder& UdsServerBuilder::single_client() {
   max_clients_ = 1;
   client_limit_enabled_ = true;
   return *this;
 }
 
-template <uint32_t State>
-UdsServerBuilder<State>& UdsServerBuilder<State>::multi_client(size_t max) {
+UdsServerBuilder& UdsServerBuilder::multi_client(size_t max) {
   if (max == 0) {
     throw diagnostics::BuilderException("multi_client max must be greater than 0");
   }
@@ -239,14 +222,6 @@ UdsServerBuilder<State>& UdsServerBuilder<State>::multi_client(size_t max) {
 }
 
 // Explicit template instantiations
-template class UdsClientBuilder<BuilderState::None>;
-template class UdsClientBuilder<BuilderState::HasData>;
-template class UdsClientBuilder<BuilderState::HasError>;
-template class UdsClientBuilder<BuilderState::Ready>;
-template class UdsServerBuilder<BuilderState::None>;
-template class UdsServerBuilder<BuilderState::HasData>;
-template class UdsServerBuilder<BuilderState::HasError>;
-template class UdsServerBuilder<BuilderState::Ready>;
 
 }  // namespace builder
 }  // namespace wirestead

--- a/wirestead/builder/uds_builder.hpp
+++ b/wirestead/builder/uds_builder.hpp
@@ -38,42 +38,9 @@ namespace builder {
 /**
  * @brief Modernized Builder for UdsClient
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient, UdsClientBuilder<State>, State> {
+class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClient, UdsClientBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = UdsClientBuilder<NewState>;
-
   explicit UdsClientBuilder(const std::string& socket_path);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  UdsClientBuilder(UdsClientBuilder<OtherState>&& other) noexcept
-      : socket_path_(std::move(other.socket_path_)),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        retry_interval_(other.retry_interval_),
-        retry_interval_set_(other.retry_interval_set_),
-        max_retries_(other.max_retries_),
-        max_retries_set_(other.max_retries_set_),
-        connection_timeout_(other.connection_timeout_),
-        connection_timeout_set_(other.connection_timeout_set_),
-        read_buffer_size_(other.read_buffer_size_),
-        read_buffer_size_set_(other.read_buffer_size_set_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   UdsClientBuilder(const UdsClientBuilder&) = delete;
@@ -81,10 +48,10 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
 
   std::unique_ptr<wrapper::UdsClient> build() override;
 
-  UdsClientBuilder<State>& auto_start(bool auto_start = true) override;
-  UdsClientBuilder<State>& retry_interval(std::chrono::milliseconds interval);
-  UdsClientBuilder<State>& max_retries(int max_retries);
-  UdsClientBuilder<State>& connection_timeout(std::chrono::milliseconds timeout);
+  UdsClientBuilder& auto_start(bool auto_start = true) override;
+  UdsClientBuilder& retry_interval(std::chrono::milliseconds interval);
+  UdsClientBuilder& max_retries(int max_retries);
+  UdsClientBuilder& connection_timeout(std::chrono::milliseconds timeout);
 
   /**
    * @brief Size of the userspace buffer each read fills, in bytes.
@@ -93,13 +60,10 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
    * transfers, at the cost of that much memory per connection. Clamped to
    * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
    */
-  UdsClientBuilder<State>& read_buffer_size(size_t bytes);
-  UdsClientBuilder<State>& independent_context(bool use_independent = true);
+  UdsClientBuilder& read_buffer_size(size_t bytes);
+  UdsClientBuilder& independent_context(bool use_independent = true);
 
  private:
-  template <uint32_t S>
-  friend class UdsClientBuilder;
-
   std::string socket_path_;
   bool auto_start_;
   bool independent_context_;
@@ -114,45 +78,14 @@ class WIRESTEAD_API UdsClientBuilder : public BuilderInterface<wrapper::UdsClien
   bool read_buffer_size_set_{false};
 };
 
-using UdsClientBuilderDefault = UdsClientBuilder<BuilderState::None>;
+using UdsClientBuilderDefault = UdsClientBuilder;
 
 /**
  * @brief Modernized Builder for UdsServer
  */
-template <uint32_t State = BuilderState::None>
-class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer, UdsServerBuilder<State>, State> {
+class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServer, UdsServerBuilder> {
  public:
-  template <uint32_t NewState>
-  using Rebind = UdsServerBuilder<NewState>;
-
   explicit UdsServerBuilder(const std::string& socket_path);
-
-  // Allow conversion between states
-  template <uint32_t OtherState>
-  UdsServerBuilder(UdsServerBuilder<OtherState>&& other) noexcept
-      : socket_path_(std::move(other.socket_path_)),
-        auto_start_(other.auto_start_),
-        independent_context_(other.independent_context_),
-        max_clients_(other.max_clients_),
-        client_limit_enabled_(other.client_limit_enabled_),
-        idle_timeout_(other.idle_timeout_),
-        idle_timeout_set_(other.idle_timeout_set_),
-        read_buffer_size_(other.read_buffer_size_),
-        read_buffer_size_set_(other.read_buffer_size_set_) {
-    this->on_data_ = std::move(other.on_data_);
-    this->on_error_ = std::move(other.on_error_);
-    this->on_connect_ = std::move(other.on_connect_);
-    this->on_disconnect_ = std::move(other.on_disconnect_);
-    this->on_message_ = std::move(other.on_message_);
-    this->on_data_batch_ = std::move(other.on_data_batch_);
-    this->on_message_batch_ = std::move(other.on_message_batch_);
-    this->on_backpressure_ = std::move(other.on_backpressure_);
-    this->framer_factory_ = std::move(other.framer_factory_);
-    this->bp_strategy_ = other.bp_strategy_;
-    this->bp_threshold_ = other.bp_threshold_;
-    this->bp_strategy_set_ = other.bp_strategy_set_;
-    this->bp_threshold_set_ = other.bp_threshold_set_;
-  }
 
   // Delete copy
   UdsServerBuilder(const UdsServerBuilder&) = delete;
@@ -160,9 +93,9 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
 
   std::unique_ptr<wrapper::UdsServer> build() override;
 
-  UdsServerBuilder<State>& auto_start(bool auto_start = true) override;
-  UdsServerBuilder<State>& independent_context(bool use_independent = true);
-  UdsServerBuilder<State>& idle_timeout(std::chrono::milliseconds timeout);
+  UdsServerBuilder& auto_start(bool auto_start = true) override;
+  UdsServerBuilder& independent_context(bool use_independent = true);
+  UdsServerBuilder& idle_timeout(std::chrono::milliseconds timeout);
 
   /**
    * @brief Size of the userspace buffer each read fills, in bytes.
@@ -171,17 +104,14 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
    * transfers, at the cost of that much memory per connection. Clamped to
    * [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
    */
-  UdsServerBuilder<State>& read_buffer_size(size_t bytes);
-  UdsServerBuilder<State>& max_clients(uint32_t max_clients);
+  UdsServerBuilder& read_buffer_size(size_t bytes);
+  UdsServerBuilder& max_clients(uint32_t max_clients);
   [[deprecated("Use max_clients(1) instead")]]
-  UdsServerBuilder<State>& single_client();
+  UdsServerBuilder& single_client();
   [[deprecated("Use max_clients(max) instead")]]
-  UdsServerBuilder<State>& multi_client(size_t max);
+  UdsServerBuilder& multi_client(size_t max);
 
  private:
-  template <uint32_t S>
-  friend class UdsServerBuilder;
-
   std::string socket_path_;
   bool auto_start_;
   bool independent_context_;
@@ -194,7 +124,7 @@ class WIRESTEAD_API UdsServerBuilder : public BuilderInterface<wrapper::UdsServe
   bool read_buffer_size_set_{false};
 };
 
-using UdsServerBuilderDefault = UdsServerBuilder<BuilderState::None>;
+using UdsServerBuilderDefault = UdsServerBuilder;
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
## Description

**BREAKING CHANGE.** Builder setters now all return `Derived&` and mutate in place.

`on_data`, `on_data_batch`, `on_message`, `on_message_batch` and `on_error` returned a *new* builder of a different type and left the original moved-from. `on_connect`, `on_disconnect`, `framer`, `auto_start`, `backpressure_*` and the rest returned a reference to the same one. One builder, two conventions — and only the first kind carries the trap:

```cpp
auto b  = wirestead::tcp_client("127.0.0.1", 8080);
auto b2 = b.on_data(handler);   // b is now moved-from
b.on_connect(ch);               // compiles; operates on a corpse
```

`[[nodiscard]]` catches `b.on_data(...);` with the result thrown away. It cannot catch the above.

**The machinery bought nothing.** It existed to carry a `BuilderState` bitmask through the type. Nothing ever read it — `ibuilder.hpp` said so itself:

> retained for fluent CRTP rebinding and future extension points, **not for mandatory build gating**

So the `Rebind` alias, the cross-state converting constructors, and **28 explicit template instantiations** of otherwise identical code all existed to propagate a value no code consults.

**−405 lines**, and 28 instantiations become 0.

## Key Changes

- `BuilderState`, `Rebind`, and the `State` template parameter are gone; all seven builders are plain classes
- Five setters change return type; the other ten are untouched
- `*BuilderDefault` aliases still name the builders, so code using those keeps compiling
- CHANGELOG breaking entry with before/after, and a new "Builder return convention" section in `docs/api_stability.md`

## Migration

Chained code — the quickstart and every example — needs **nothing**:

```cpp
auto client = wirestead::tcp_client("127.0.0.1", 8080)
                  .on_data(...).on_error(...).build();     // unchanged
```

Two forms need updating:

```cpp
builder::TcpClientBuilder<> b{...};                     // before
builder::TcpClientBuilder b{...};                       // after

auto b = builder::UdpClientBuilder(0).on_data_batch(h);  // before
auto udp = std::move(b).auto_start(false).build();

auto b = builder::UdpClientBuilder(0);                   // after
b.on_data_batch(h);
auto udp = b.auto_start(false).build();
```

## Type of Change

- [x] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Refactor**: Code changes that neither fix a bug nor add a feature.

## Checklist

- [x] I have run the full suite locally: **761/761 pass**.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Why before 1.0 rather than at it.** The usual argument for deferring is protecting users. The observable C++ user signal is nil: 1 star, 0 watchers, every issue opened by the owner, both forks predate the `unilink` rename, and the single outside contribution is a packaging fix from a vcpkg maintainer. The package *is* published — vcpkg 0.9.2 and PyPI — so silent users cannot be ruled out, but PyPI traffic is the Python binding and does not touch this API. Deferring to 1.0 means carrying the trap permanently, since 1.0 is where breaking stops.

**Three tests were written in the old idiom** and got simpler for the change — a `std::move` of the rebound value became an ordinary second statement on the same builder. That is the usability case in miniature.

**I was wrong about the blast radius partway through.** An early grep suggested no test named the builder types explicitly; several did, via `TcpClientBuilder<>`, and two more captured a rebound value in a form my first pass did not match. Both showed up as compile errors and are fixed; worth stating because it is the reason to trust the build rather than the survey.

Not verified beyond CI: nothing. This is a source-level change with full suite coverage, and the ABI break is already covered by the pre-1.0 policy in `api_stability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CbaG9joaWZMnYNsg4bEue
