### PR TITLE
docs: add conan-center-index to the release checklist

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -65,6 +65,31 @@ CI, CPack, and consumer smoke workflows live here.
 - [ ] `wirestead-examples` compatibility impact checked, if examples depend on changed API.
 - [ ] `wirestead-benchmarks` compatibility impact checked, if benchmark APIs changed.
 
+## Package registries
+
+These are downstream of the tag: they reference `vX.Y.Z`, so they can only be
+updated once it is pushed. Both take the source tarball's SHA-256, which is the
+GitHub archive (`/archive/refs/tags/vX.Y.Z.tar.gz`), not a release asset.
+
+- [ ] `microsoft/vcpkg` port updated: `ports/wirestead/vcpkg.json` version and
+      `portfile.cmake` `SHA512`. `REF` is `v${VERSION}`, so nothing else moves.
+      Regenerate the version database with `./vcpkg x-add-version wirestead` —
+      never edit `versions/` by hand.
+- [ ] `conan-center-index` recipe updated: `recipes/wirestead/config.yml` and
+      `recipes/wirestead/all/conandata.yml`. Conan Center wants a new recipe to
+      carry **only** the latest version, so replace the version rather than
+      appending to it.
+- [ ] Conan recipe still matches the build system: every `WIRESTEAD_*` cache
+      variable `conanfile.py` sets still exists, new options default to values
+      the recipe can live with, and `test_package` compiles against the release
+      API. The test package links the shared library, so a change to
+      `cmake/wirestead.map` that narrows exports would break it.
+- [ ] Conan recipe is not published yet — until conan-io/conan-center-index#30653
+      is merged, updating it is a push to the `wirestead-recipe` fork branch and
+      does not ship anything. CI there needs a maintainer to approve each run, so
+      `Job scheduler: action_required` is the expected state, not a failure.
+      Leave `docs/installation.md` free of Conan instructions until it merges.
+
 ## Release notes
 
 - [ ] Release notes summarize user-facing changes.


### PR DESCRIPTION
## Summary

Adds a **Package registries** section to `docs/release_checklist.md`. The
checklist covered the tag, the satellite repos and `VCPKG_BASELINE`, but not the
two registries a release is published through. `VCPKG_BASELINE` is the CI
dependency pin, not the port, so neither the vcpkg port nor the Conan recipe had
a step — both were done from memory at v0.9.3.

## Changes

`docs/release_checklist.md` — new section after **External repositories**:

- vcpkg port: version + `SHA512`, `REF` is `v${VERSION}`, regenerate `versions/`
  with `x-add-version` rather than by hand.
- Conan recipe: `config.yml` + `all/conandata.yml`, **replace** the version
  instead of appending — Conan Center asks a new recipe to carry only the latest
  one (`docs/adding_packages/README.md`).
- A recipe-vs-build-system check: the `WIRESTEAD_*` cache variables
  `conanfile.py` sets, defaults of new options, and `test_package` still
  compiling. It links the shared library, so narrowing `cmake/wirestead.map`
  would break it — v0.9.3 added that script and it was verified by hand.
- A note that Conan is not a shipping channel yet: conan-io/conan-center-index#30653
  has never had CI run, `Job scheduler: action_required` is the expected state
  rather than a failure, and `docs/installation.md` should stay free of Conan
  instructions until it merges.

Both registries state that they are downstream of the tag and both take the
SHA-256/512 of the GitHub archive tarball, not a release asset.

## Validation

- [x] Ran: `git diff --check` — clean
- [ ] Not run: build/test — documentation only, no code or build files touched
- Tests: not needed
- Documentation: this is the documentation change

## Not Included

- `docs/installation.md` gains no Conan section; the package is not published.
- No change to the vcpkg or Conan recipes themselves.

## Follow-up

- When #30653 merges, add Conan to `docs/installation.md` and drop the
  not-published caveat from this checklist.
