### PR TITLE
fix: report server max_queued_bytes as a peak, not a sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
+## Unreleased
+
+### Fixed
+
+- `TcpServer::stats()` and `UdsServer::stats()` reported `max_queued_bytes` as
+  the sum of every live session's high-water mark. Peaks that occurred at
+  different times were added together, so the server could report a queue depth
+  that never existed: two sessions that each peaked at 200 KiB an hour apart
+  were reported as 400 KiB. The server-wide value is now the largest depth any
+  one session reached. Servers with a single connected client are unaffected.
+  The remaining fields are genuine totals and keep summing.
+
 ## v0.9.3 - 2026-08-08
 
 ### Breaking

--- a/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
+++ b/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
@@ -152,6 +152,62 @@ TEST(ServerBroadcastSlowConsumerContractTest, TcpBroadcastContinuesDeliveringToH
   server->stop();
 }
 
+// max_queued_bytes is a high-water mark, so the server-wide value is the
+// largest depth any one session reached - not the sum of every session's peak,
+// which would report a depth that never existed because the peaks need not
+// have been simultaneous.
+TEST(ServerBroadcastSlowConsumerContractTest, TcpAggregateMaxQueuedBytesIsPeakNotSum) {
+  uint16_t port = 0;
+  try {
+    port = TestUtils::getAvailableTestPort();
+  } catch (const std::exception& ex) {
+    if (is_port_allocation_failure(ex)) {
+      GTEST_SKIP() << "TCP port allocation unavailable in this environment: " << ex.what();
+    }
+    throw;
+  }
+
+  constexpr size_t kQueueBudget = 64 * 1024;
+  const std::string payload(4096, 'q');
+
+  // BestEffort drops rather than growing past the threshold, which puts a known
+  // ceiling on how deep any single session's queue can get.
+  auto server = std::make_shared<wirestead::wrapper::TcpServer>(port);
+  server->backpressure_strategy(wirestead::base::constants::BackpressureStrategy::BestEffort)
+      .backpressure_threshold(kQueueBudget)
+      .send_buffer_size(kThreshold);
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  // Two consumers that never read, so both sessions back up at once.
+  net::io_context slow_ioc;
+  tcp::socket slow_a(slow_ioc);
+  tcp::socket slow_b(slow_ioc);
+  const auto endpoint = tcp::endpoint(net::ip::make_address("127.0.0.1"), port);
+  slow_a.connect(endpoint);
+  slow_b.connect(endpoint);
+  slow_a.set_option(net::socket_base::receive_buffer_size(static_cast<int>(kThreshold)));
+  slow_b.set_option(net::socket_base::receive_buffer_size(static_cast<int>(kThreshold)));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
+
+  for (int i = 0; i < 4096 && server->stats().dropped_bytes == 0; ++i) {
+    server->broadcast(payload);
+  }
+
+  const auto stats = server->stats();
+  ASSERT_GT(stats.dropped_bytes, 0u) << "session queues never reached the budget";
+  // queued_bytes is a genuine sum across sessions, so exceeding one budget is
+  // what proves both sessions are backed up simultaneously. Without that this
+  // assertion would pass even if only one session had ever queued anything.
+  ASSERT_GT(stats.queued_bytes, kQueueBudget) << "only one session backed up; the peak check cannot discriminate";
+  EXPECT_LE(stats.max_queued_bytes, kQueueBudget + payload.size());
+
+  boost::system::error_code ec;
+  slow_a.close(ec);
+  slow_b.close(ec);
+  server->stop();
+}
+
 TEST(ServerBroadcastSlowConsumerContractTest, UdpBroadcastDoesNotBlockOnSlowVirtualClient) {
   uint16_t port = 0;
   try {

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -18,6 +18,7 @@
 
 #include <spdlog/fmt/fmt.h>
 
+#include <algorithm>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <future>
@@ -640,7 +641,9 @@ wrapper::RuntimeStats TcpServer::stats() const {
     aggregate.backpressure_events += session_stats.backpressure_events;
     aggregate.queued_bytes += session_stats.queued_bytes;
     aggregate.pending_bytes += session_stats.pending_bytes;
-    aggregate.max_queued_bytes += session_stats.max_queued_bytes;
+    // Peak, not a total: summing per-session peaks would report a depth no
+    // session ever reached, because the peaks need not have been simultaneous.
+    aggregate.max_queued_bytes = std::max(aggregate.max_queued_bytes, session_stats.max_queued_bytes);
     aggregate.backpressure_active = aggregate.backpressure_active || session_stats.backpressure_active;
   }
   return aggregate;

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -434,7 +434,9 @@ wrapper::RuntimeStats UdsServer::stats() const {
     aggregate.backpressure_events += session_stats.backpressure_events;
     aggregate.queued_bytes += session_stats.queued_bytes;
     aggregate.pending_bytes += session_stats.pending_bytes;
-    aggregate.max_queued_bytes += session_stats.max_queued_bytes;
+    // Peak, not a total: summing per-session peaks would report a depth no
+    // session ever reached, because the peaks need not have been simultaneous.
+    aggregate.max_queued_bytes = std::max(aggregate.max_queued_bytes, session_stats.max_queued_bytes);
     aggregate.backpressure_active = aggregate.backpressure_active || session_stats.backpressure_active;
   }
   return aggregate;


### PR DESCRIPTION
## Description

`TcpServer::stats()` and `UdsServer::stats()` build their aggregate by walking the live sessions and adding each field. That is right for every field except one: `max_queued_bytes` is a high-water mark, not a total.

Peaks reached by different sessions need not have been simultaneous, so summing them reports a queue depth that never existed. Two sessions that each peaked at 200 KiB an hour apart were reported as a 400 KiB peak. The error scales with connection count, so it is worst exactly where the number matters — a busy server whose queue depth you are trying to size.

Servers with a single connected client are unaffected, which is why this went unnoticed.

## Key Changes

- `wirestead/transport/tcp_server/tcp_server.cc` — take `std::max` across sessions instead of `+=`; add the `<algorithm>` include it now needs.
- `wirestead/transport/uds/uds_server.cc` — same fix; `<algorithm>` was already included.
- `test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc` — regression test, see below.
- `CHANGELOG.md` — new `Unreleased` / `Fixed` entry, since v0.9.3 is already tagged.

The surrounding fields are untouched and keep summing. `queued_bytes` and `pending_bytes` are instantaneous depths, so adding those across sessions is correct; `backpressure_active` stays an OR.

UDP is not affected — `UdpChannel::stats()` reads a single channel-level counter and does no per-session aggregation.

## Related Issues

- N/A — found while writing the framing/backpressure/stats example in `wirestead-examples#14`.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The regression test.** Asserting on a peak is awkward without a per-session accessor, so the test pins the semantic indirectly. It runs a TCP server under `BestEffort` with a 64 KiB budget, which caps how deep any one session's queue can get, and connects two consumers that never read so both sessions back up at once. It then asserts:

- `dropped_bytes > 0` — the queues actually reached the budget, so the run is meaningful rather than trivially passing;
- `queued_bytes > kQueueBudget` — `queued_bytes` is a legitimate sum, so exceeding one budget is what proves *both* sessions are backed up. Without this the peak check would still pass if only one session had ever queued anything;
- `max_queued_bytes <= kQueueBudget + payload` — the peak of any single session.

Reintroducing the `+=` fails the last assertion at `110592 vs 69632`, so the test discriminates rather than merely passing.

**Verification run.** `./scripts/verify.sh` was run under `taskset -c 0-3`. The script derives its job count from `nproc`, which reports 20 here, and this is a WSL host with 15 GB RAM; constraining the CPU set keeps the parallel compile within memory rather than risking an OOM mid-run. That changes only the parallelism, not which checks run.

Before that, the affected suites were built and run individually — `runtime_stats`, `runtime_stats_counter`, `transport_tcp_server_session`, `server_broadcast_contract`, `server_broadcast_slow_consumer_contract`, `tcp_server_wrapper_lifecycle`, `uds_wrapper_lifecycle` — 52 tests, all passing.

**Known gap.** The regression test covers the TCP path only. The UDS fix is the identical one-line change at `uds_server.cc:437`, and `uds_wrapper_lifecycle` passes, but there is no UDS-specific assertion on aggregate `max_queued_bytes`. Worth adding alongside a per-session stats accessor, which would let the invariant be checked directly instead of inferred from a saturated two-client setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
