### PR TITLE
fix: keep server stats when a client disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and ABI policy.
 
 ## Unreleased
 
+### Changed
+
+- A server's cumulative `RuntimeStats` counters now survive the sessions that
+  produced them. `TcpServer::stats()` and `UdsServer::stats()` aggregate live
+  sessions, and a session's counters used to be destroyed along with the session
+  on disconnect - so a server that had moved 795 MB reported zero the moment its
+  last client went away, and anything sampling `stats()` on an interval watched
+  throughput collapse on every disconnect. A closing session's totals are now
+  folded into the server before it is erased.
+
+  This applies to `bytes_*`, `messages_*`, `failed_sends`, `dropped_*` and
+  `backpressure_events`; `max_queued_bytes` keeps the deepest queue any session
+  reached. `queued_bytes`, `pending_bytes` and `backpressure_active` are
+  unchanged - they describe live queues, and a closed session has none. The
+  restart contract is unchanged too: `stop()` followed by `start()` still begins
+  with zeroed counters.
+
 ### Fixed
 
 - `TcpServer::stats()` and `UdsServer::stats()` reported `max_queued_bytes` as

--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -109,6 +109,25 @@ corresponding per-transport `RuntimeStats` counters: Reliable fanout rejects
 increase `failed_sends`, while BestEffort fanout drops increase
 `dropped_messages` and `dropped_bytes`.
 
+## Server stats across disconnects
+
+A server accumulates its counters per accepted session, and its `stats()` adds
+them up. The two halves of the snapshot behave differently when a client goes
+away:
+
+- **Cumulative fields survive.** `bytes_*`, `messages_*`, `failed_sends`,
+  `dropped_*` and `backpressure_events` carry over to the server when a session
+  closes, so sampling `stats()` on an interval sees monotonic totals rather than
+  a collapse to zero on every disconnect. `max_queued_bytes` likewise keeps the
+  deepest queue any session reached, live or closed.
+- **Instantaneous fields describe live sessions only.** `queued_bytes`,
+  `pending_bytes` and `backpressure_active` refer to queues that exist right
+  now, so a disconnected session contributes nothing to them.
+
+`reset_stats()` clears both halves. So does a restart: per the restart contract
+on `ServerInterface`, `stop()` followed by `start()` begins a fresh lifecycle
+with zeroed counters.
+
 ## Async runtime errors
 
 Use `on_error(...)` for production workflows. `ErrorContext` contains:

--- a/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
@@ -544,4 +544,63 @@ TEST_F(TcpServerWrapperLifecycleTest, LineSendingVariantsReachConnectedClients) 
   EXPECT_NE(received_data.find("try-send-to\n"), std::string::npos);
 }
 
+// A session's counters used to vanish with the session, so anything sampling
+// stats() on an interval watched server throughput collapse to zero on every
+// disconnect. The cumulative fields now survive the connection that produced
+// them; the instantaneous ones still describe live sessions only.
+TEST_F(TcpServerWrapperLifecycleTest, CumulativeStatsSurviveClientDisconnect) {
+  server_ = wirestead::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(server_->start().get());
+
+  const std::string payload = "stats-survive-probe\n";
+
+  auto client = wirestead::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(client->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 1; }, 10000));
+
+  ASSERT_TRUE(client->send(payload));
+  ASSERT_TRUE(server_->broadcast(payload));
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&]() {
+        const auto s = server_->stats();
+        return s.bytes_received >= payload.size() && s.bytes_accepted >= payload.size();
+      },
+      10000));
+
+  const auto connected = server_->stats();
+  ASSERT_GT(connected.bytes_received, 0u);
+  ASSERT_GT(connected.bytes_accepted, 0u);
+
+  client->stop();
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() == 0; }, 10000));
+
+  // client_count() stops counting a session as soon as it is no longer alive,
+  // which is before the server erases it, so there is no observable moment to
+  // sample "just after the erase". Assert the negative instead: give the
+  // teardown room to run and require that the counters never collapse. Without
+  // the session's totals being carried over they drop to zero almost at once,
+  // so this is what discriminates.
+  const bool collapsed = TestUtils::waitForCondition([&]() { return server_->stats().bytes_received == 0; }, 2000);
+  EXPECT_FALSE(collapsed) << "cumulative counters vanished along with the disconnected session";
+
+  const auto after = server_->stats();
+  EXPECT_GE(after.bytes_received, connected.bytes_received);
+  EXPECT_GE(after.messages_received, connected.messages_received);
+  EXPECT_GE(after.bytes_accepted, connected.bytes_accepted);
+  EXPECT_GE(after.messages_accepted, connected.messages_accepted);
+
+  // The queue is gone with the session, so the instantaneous fields do drop.
+  EXPECT_EQ(after.queued_bytes, 0u);
+  EXPECT_FALSE(after.backpressure_active);
+
+  // A restart is a fresh lifecycle - see the restart contract on IServer.
+  server_->stop();
+  ASSERT_TRUE(server_->start().get());
+  const auto restarted = server_->stats();
+  EXPECT_EQ(restarted.bytes_received, 0u);
+  EXPECT_EQ(restarted.bytes_accepted, 0u);
+
+  client->stop();
+}
+
 }  // namespace

--- a/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
@@ -305,6 +305,45 @@ TEST(UdsServerWrapperLifecycleTest, FramedMessageDoesNotDeadlock) {
   EXPECT_TRUE(wirestead::test::TestUtils::waitForCondition([&]() { return messages.load() == 1; }, 5000));
 }
 
+// Mirrors CumulativeStatsSurviveClientDisconnect in the TCP lifecycle suite.
+// UdsServer aggregates its sessions the same way and lost their counters the
+// same way when a client went. See docs/error_model.md.
+TEST(UdsServerWrapperLifecycleTest, CumulativeStatsSurviveClientDisconnect) {
+  test::wrapper_support::UdsServerLoopbackHarness harness("uws-stats");
+  auto server = harness.start_server();
+  auto client = harness.connect_client();
+  ASSERT_TRUE(harness.wait_for_client_count(1));
+
+  const std::string payload = "stats-survive-probe\n";
+  ASSERT_TRUE(client->send(payload));
+  ASSERT_TRUE(server->broadcast(payload));
+  ASSERT_TRUE(wirestead::test::TestUtils::waitForCondition(
+      [&]() {
+        const auto s = server->stats();
+        return s.bytes_received >= payload.size() && s.bytes_accepted >= payload.size();
+      },
+      10000));
+
+  const auto connected = server->stats();
+  ASSERT_GT(connected.bytes_received, 0u);
+  ASSERT_GT(connected.bytes_accepted, 0u);
+
+  client->stop();
+  ASSERT_TRUE(wirestead::test::TestUtils::waitForCondition([&]() { return server->client_count() == 0; }, 10000));
+
+  // client_count() drops a session as soon as it stops being alive, which is
+  // before the server erases it, so assert the negative: give the teardown room
+  // to run and require that the counters never collapse.
+  const bool collapsed =
+      wirestead::test::TestUtils::waitForCondition([&]() { return server->stats().bytes_received == 0; }, 2000);
+  EXPECT_FALSE(collapsed) << "cumulative counters vanished along with the disconnected session";
+
+  const auto after = server->stats();
+  EXPECT_GE(after.bytes_received, connected.bytes_received);
+  EXPECT_GE(after.bytes_accepted, connected.bytes_accepted);
+  EXPECT_EQ(after.queued_bytes, 0u);
+}
+
 TEST(UdsServerWrapperContractTest, InjectedChannelStateAndFallbackOperations) {
   auto fake_channel = std::make_shared<test::wrapper_support::FakeChannel>();
   UdsServer server(std::static_pointer_cast<interface::Channel>(fake_channel));

--- a/wirestead/diagnostics/runtime_stats_counter.hpp
+++ b/wirestead/diagnostics/runtime_stats_counter.hpp
@@ -75,6 +75,28 @@ struct RuntimeStatsCounters {
     }
   }
 
+  // Folds a finished contributor's totals in, so a server's counters outlive
+  // the session that produced them. The cumulative fields add; max_queued_bytes
+  // takes the deeper of the two peaks, matching how a server aggregates it
+  // across live sessions.
+  //
+  // queued_bytes, pending_bytes and backpressure_active are deliberately left
+  // out: they describe a live queue, and a contributor being absorbed no longer
+  // has one.
+  void absorb(const wrapper::RuntimeStats& other) {
+    bytes_accepted.fetch_add(other.bytes_accepted, std::memory_order_relaxed);
+    messages_accepted.fetch_add(other.messages_accepted, std::memory_order_relaxed);
+    bytes_sent.fetch_add(other.bytes_sent, std::memory_order_relaxed);
+    messages_sent.fetch_add(other.messages_sent, std::memory_order_relaxed);
+    bytes_received.fetch_add(other.bytes_received, std::memory_order_relaxed);
+    messages_received.fetch_add(other.messages_received, std::memory_order_relaxed);
+    failed_sends.fetch_add(other.failed_sends, std::memory_order_relaxed);
+    dropped_messages.fetch_add(other.dropped_messages, std::memory_order_relaxed);
+    dropped_bytes.fetch_add(other.dropped_bytes, std::memory_order_relaxed);
+    backpressure_events.fetch_add(other.backpressure_events, std::memory_order_relaxed);
+    observe_queue(other.max_queued_bytes);
+  }
+
   wrapper::RuntimeStats snapshot(size_t queued_bytes, size_t pending_bytes, bool backpressure_active) const {
     wrapper::RuntimeStats stats;
     stats.bytes_accepted = bytes_accepted.load(std::memory_order_relaxed);

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -372,6 +372,13 @@ struct TcpServer::Impl {
         bool was_current = false;
         {
           std::lock_guard<std::mutex> lock(close_impl->sessions_mutex_);
+          // Carry the session's totals over to the server before it goes away,
+          // so stats() keeps reporting what this connection did. Tied to the
+          // erase below, which makes it exactly once even if on_close re-fires.
+          auto it = close_impl->sessions_.find(client_id);
+          if (it != close_impl->sessions_.end() && it->second) {
+            close_impl->stats_.absorb(it->second->stats());
+          }
           close_impl->sessions_.erase(client_id);
           was_current = (close_impl->current_session_ == new_session);
           if (was_current) {
@@ -549,6 +556,11 @@ void TcpServer::start() {
   }
   impl->stopping_.store(false);
   impl->cleanup_started_.store(false);
+  // Restart contract (#444): stats() resets on restart. The server-level
+  // counters now outlive the sessions that fed them, so clearing them here is
+  // what keeps that promise - before absorption they were empty and a restart
+  // zeroed the aggregate for free.
+  impl->stats_.reset(0);
 
   if (impl->uses_shared_context_) {
     auto& manager = concurrency::IoContextManager::instance();

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -289,6 +289,11 @@ void UdsServer::start() {
   if (impl_->state_.get() == base::LinkState::Listening) return;
 
   impl_->stopping_ = false;
+  // Restart contract (#444): stats() resets on restart. The server-level
+  // counters now outlive the sessions that fed them, so clearing them here is
+  // what keeps that promise - before absorption they were empty and a restart
+  // zeroed the aggregate for free.
+  impl_->stats_.reset(0);
 
   if (!impl_->cfg_.is_valid()) {
     WIRESTEAD_LOG_ERROR("uds_server", "start", "Invalid UDS server configuration or socket path");
@@ -663,6 +668,13 @@ void UdsServer::Impl::do_accept(std::shared_ptr<UdsServer> self) {
         {
           std::lock_guard<std::mutex> lock(s->impl_->sessions_mutex_);
           if (s->impl_->stopping_) return;  // Double check inside lock
+          // Carry the session's totals over to the server before it goes away,
+          // so stats() keeps reporting what this connection did. Tied to the
+          // erase below, which makes it exactly once even if on_close re-fires.
+          auto it = s->impl_->sessions_.find(client_id);
+          if (it != s->impl_->sessions_.end() && it->second) {
+            s->impl_->stats_.absorb(it->second->stats());
+          }
           s->impl_->sessions_.erase(client_id);
           disconnect_handler = s->impl_->on_multi_disconnect_;
         }

--- a/wirestead/wrapper/iserver.hpp
+++ b/wirestead/wrapper/iserver.hpp
@@ -78,6 +78,19 @@ class WIRESTEAD_API ServerInterface {
    */
   virtual void stop() = 0;
   virtual bool listening() const = 0;
+
+  /**
+   * @brief Snapshot of this server's runtime counters.
+   *
+   * The cumulative fields (`bytes_*`, `messages_*`, `failed_sends`, `dropped_*`,
+   * `backpressure_events`, `max_queued_bytes`) cover every session this server
+   * has accepted, including ones that have since disconnected. The
+   * instantaneous fields (`queued_bytes`, `pending_bytes`,
+   * `backpressure_active`) describe only the sessions that are live right now.
+   *
+   * Cleared by reset_stats(), and by a stop()/start() cycle per the restart
+   * contract above. See docs/error_model.md.
+   */
   virtual RuntimeStats stats() const = 0;
   virtual void reset_stats() = 0;
 


### PR DESCRIPTION
## Description

Fixes #583.

`TcpServer::stats()` and `UdsServer::stats()` build their aggregate from the **live** sessions. A session's counters live on the session object, which is erased on disconnect, so everything it accumulated went with it.

The server-wide numbers therefore went backwards on every disconnect and hit zero once the last client left. Measured on the telemetry example — 1.5 M framed records over one connection, sampling `stats()` every two seconds:

```text
[stats] clients=1 decoded=1500000 malformed=0
        in  : 795000000 B over 219452 socket reads
        drop: 404703760 B / 763592 msgs

[server] client disconnected: id=0

[stats] clients=0 decoded=1500000 malformed=0
        in  : 0 B over 0 socket reads
        drop: 0 B / 0 msgs
```

795 MB of ingest and 404 MB of drops vanish at the disconnect. Anything scraping `stats()` on an interval cannot tell "idle" from "served a million messages and the client went away", and on a server with normal connection churn the totals never accumulate at all.

## Key Changes

- `diagnostics/runtime_stats_counter.hpp` — new `absorb(const RuntimeStats&)`, folding a finished contributor's totals in.
- `transport/tcp_server/tcp_server.cc`, `transport/uds/uds_server.cc` — absorb a closing session before erasing it; clear the server counters in `start()`.
- `wrapper/iserver.hpp` — document what `stats()` covers.
- `docs/error_model.md` — new "Server stats across disconnects" section.
- Regression tests for both transports, plus a `CHANGELOG.md` entry.

Only the cumulative fields carry over. `queued_bytes`, `pending_bytes` and `backpressure_active` describe live queues and a closed session has none; `max_queued_bytes` takes the deeper peak, matching how it has been aggregated across live sessions since #582.

Nothing new is allocated or locked: the server already owns a `RuntimeStatsCounters` that the aggregate reads (it was simply always empty), the absorption happens inside the `sessions_mutex_` block that already existed around the erase, and `reset_stats()` already walked the same two levels. Tying absorption to the erase makes it exactly once even if `on_close` re-fires.

UDP is unaffected — `UdpServer::stats()` reads a single channel-level counter and does no per-session aggregation.

## Related Issues

- Fixes #583

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The restart contract needed protecting.** `ServerInterface` documents that "Connected-client state and stats() reset on restart". That used to hold for free — the server-level counters were empty and `stop()` dropped every session, so a restart zeroed the aggregate either way. Now that the counters outlive their sessions, `start()` clears them explicitly. A regression test covers it.

**The tests assert a negative, deliberately.** The first version passed even with the fix disabled. `client_count()` stops counting a session as soon as it is no longer `alive()`, which happens *before* the server erases it, so waiting on `client_count() == 0` and then sampling still sees the session in the map. There is no public way to observe the erase itself. So both tests give the teardown 2 s and require that the counters never collapse. With the absorption removed they drop to zero almost immediately:

```text
test_tcp_server_wrapper_lifecycle.cc:585: Failure
Value of: collapsed
cumulative counters vanished along with the disconnected session
```

Both tests were confirmed to fail with the change reverted and pass with it, on TCP and UDS independently.

**Verification.** `./scripts/verify.sh` — 764/764 tests pass, formatting and build included. It was run under `taskset -c 0-3` because the script derives its job count from `nproc`, which reports 20 on this WSL host with 15 GB RAM; that constrains parallelism only, not which checks run.

**Follow-up left open.** #583 also raised per-session stats (`stats(ClientId)`). That is a separate API addition and is not here — this change makes the aggregate correct, which is the part that needed no new public surface. Once per-session stats exist, the two tests here could assert on the counters directly instead of inferring from a bounded wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
