### PR TITLE
feat: add client_stats() for per-session counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and ABI policy.
 
 ## Unreleased
 
+### Added
+
+- `ServerInterface::client_stats(ClientId)` returns one connected client's
+  `RuntimeStats`, or `std::nullopt` when the id has no session behind it.
+  `stats()` reports the server as a whole and cannot say which client produced
+  the traffic; the per-session counters existed already and were simply summed
+  away at the aggregation boundary.
+
+  Implemented for TCP and UDS. UDP returns `std::nullopt` - its virtual sessions
+  are datagrams grouped by source endpoint and have no queues or counters of
+  their own, so there is nothing per-client to report. A disconnected client also
+  returns `std::nullopt`: its totals live on in `stats()`, but the session does
+  not, so sample while it is connected if you need its numbers in isolation.
+
+  This adds a virtual to `ServerInterface`, which changes the vtable and so
+  breaks ABI. C++ ABI stability is not guaranteed before v1.0; see
+  `docs/api_stability.md`. It has a default returning `std::nullopt`, so any
+  out-of-tree implementer of the interface still compiles.
+
 ### Changed
 
 - A server's cumulative `RuntimeStats` counters now survive the sessions that

--- a/docs/error_model.md
+++ b/docs/error_model.md
@@ -128,6 +128,30 @@ away:
 on `ServerInterface`, `stop()` followed by `start()` begins a fresh lifecycle
 with zeroed counters.
 
+## Per-client stats
+
+`stats()` cannot tell you which client produced the traffic it reports.
+`client_stats(client_id)` returns that one session's `RuntimeStats`, or
+`std::nullopt` when the id has no session behind it:
+
+```cpp
+for (auto id : server.connected_clients()) {
+  if (auto s = server.client_stats(id)) {
+    std::cout << id << ": " << s->bytes_received << " B in, " << s->dropped_bytes << " B dropped\n";
+  }
+}
+```
+
+Two limits are worth knowing before you build on it:
+
+- **It only answers for live sessions.** A disconnected client returns
+  `std::nullopt` - its totals have already been folded into `stats()` and the
+  session is gone. Sample while the client is connected if you need its numbers
+  in isolation.
+- **UDP always returns `std::nullopt`.** A UDP server groups datagrams into
+  virtual sessions keyed by source endpoint, and those have no queues or
+  counters of their own. Their traffic still shows up in the aggregate.
+
 ## Async runtime errors
 
 Use `on_error(...)` for production workflows. `ErrorContext` contains:

--- a/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_tcp_server_wrapper_lifecycle.cc
@@ -603,4 +603,63 @@ TEST_F(TcpServerWrapperLifecycleTest, CumulativeStatsSurviveClientDisconnect) {
   client->stop();
 }
 
+// The aggregate cannot tell you which client is responsible for the traffic it
+// reports. client_stats() answers that for the sessions that have their own
+// counters, and says so honestly when it cannot.
+TEST_F(TcpServerWrapperLifecycleTest, ClientStatsAreReportedPerSession) {
+  server_ = wirestead::tcp_server(test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(server_->start().get());
+
+  const std::string small(64, 's');
+  const std::string large(4096, 'l');
+
+  auto quiet = wirestead::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  auto noisy = wirestead::tcp_client("127.0.0.1", test_port_).on_data([](auto&&) {}).on_error([](auto&&) {}).build();
+  ASSERT_TRUE(quiet->start().get());
+  ASSERT_TRUE(noisy->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_->client_count() >= 2; }, 10000));
+
+  const auto ids = server_->connected_clients();
+  ASSERT_EQ(ids.size(), 2u);
+
+  ASSERT_TRUE(quiet->send(small));
+  ASSERT_TRUE(noisy->send(large));
+
+  // Whichever id each client got, one session must show the small payload and
+  // the other the large one.
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&]() {
+        const auto a = server_->client_stats(ids[0]);
+        const auto b = server_->client_stats(ids[1]);
+        return a && b && a->bytes_received >= small.size() && b->bytes_received >= small.size() &&
+               (a->bytes_received >= large.size() || b->bytes_received >= large.size());
+      },
+      10000));
+
+  const auto a = server_->client_stats(ids[0]);
+  const auto b = server_->client_stats(ids[1]);
+  ASSERT_TRUE(a.has_value());
+  ASSERT_TRUE(b.has_value());
+
+  const auto& heavier = (a->bytes_received >= b->bytes_received) ? *a : *b;
+  const auto& lighter = (a->bytes_received >= b->bytes_received) ? *b : *a;
+  EXPECT_GE(heavier.bytes_received, large.size());
+  EXPECT_LT(lighter.bytes_received, large.size());
+
+  // The aggregate covers both, so it is at least their sum.
+  const auto aggregate = server_->stats();
+  EXPECT_GE(aggregate.bytes_received, a->bytes_received + b->bytes_received);
+
+  // An id that was never handed out has no session behind it.
+  EXPECT_FALSE(server_->client_stats(999999).has_value());
+
+  // After a disconnect the session is gone, so its counters are only reachable
+  // through the aggregate - see CumulativeStatsSurviveClientDisconnect.
+  quiet->stop();
+  noisy->stop();
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&]() { return !server_->client_stats(ids[0]) && !server_->client_stats(ids[1]); }, 10000));
+  EXPECT_GE(server_->stats().bytes_received, large.size());
+}
+
 }  // namespace

--- a/test/integration/wrapper/test_udp_server_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_udp_server_wrapper_lifecycle.cc
@@ -86,6 +86,38 @@ TEST(UdpServerWrapperLifecycleTest, SessionReaping) {
   server.stop();
 }
 
+// UDP groups datagrams into virtual sessions by source endpoint. Those have no
+// queues or counters of their own, so there is nothing per-client to report -
+// client_stats() says so rather than inventing a number, even while a virtual
+// session is live and visible through client_count().
+TEST(UdpServerWrapperLifecycleTest, ClientStatsUnsupportedForVirtualSessions) {
+  auto port = TestUtils::getAvailableTestPort();
+  config::UdpConfig cfg;
+  cfg.bind_address = "127.0.0.1";
+  cfg.local_port = port;
+
+  wrapper::UdpServer server(cfg);
+  auto started = server.start();
+  ASSERT_TRUE(started.get());
+
+  boost::asio::io_context ioc;
+  boost::asio::ip::udp::socket sock(ioc, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0));
+  sock.send_to(boost::asio::buffer("hello", 5),
+               boost::asio::ip::udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), port));
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server.client_count() == 1; }, 5000));
+
+  const auto ids = server.connected_clients();
+  ASSERT_EQ(ids.size(), 1u);
+  EXPECT_FALSE(server.client_stats(ids[0]).has_value());
+  EXPECT_FALSE(server.client_stats(999999).has_value());
+
+  // The traffic is still accounted for, just not per client.
+  EXPECT_GT(server.stats().bytes_received, 0u);
+
+  server.stop();
+}
+
 TEST(UdpServerWrapperLifecycleTest, DefaultIdleTimeoutDisabledKeepsVirtualSession) {
   auto port = TestUtils::getAvailableTestPort();
   config::UdpConfig cfg;

--- a/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
+++ b/test/integration/wrapper/test_uds_wrapper_lifecycle.cc
@@ -344,6 +344,35 @@ TEST(UdsServerWrapperLifecycleTest, CumulativeStatsSurviveClientDisconnect) {
   EXPECT_EQ(after.queued_bytes, 0u);
 }
 
+TEST(UdsServerWrapperLifecycleTest, ClientStatsAreReportedPerSession) {
+  test::wrapper_support::UdsServerLoopbackHarness harness("uws-client-stats");
+  auto server = harness.start_server();
+  auto client = harness.connect_client();
+  ASSERT_TRUE(harness.wait_for_client_count(1));
+
+  const auto ids = server->connected_clients();
+  ASSERT_EQ(ids.size(), 1u);
+
+  const std::string payload(256, 'p');
+  ASSERT_TRUE(client->send(payload));
+  ASSERT_TRUE(wirestead::test::TestUtils::waitForCondition(
+      [&]() {
+        const auto s = server->client_stats(ids[0]);
+        return s && s->bytes_received >= payload.size();
+      },
+      10000));
+
+  const auto session = server->client_stats(ids[0]);
+  ASSERT_TRUE(session.has_value());
+  EXPECT_GE(server->stats().bytes_received, session->bytes_received);
+
+  EXPECT_FALSE(server->client_stats(999999).has_value());
+
+  client->stop();
+  EXPECT_TRUE(
+      wirestead::test::TestUtils::waitForCondition([&]() { return !server->client_stats(ids[0]).has_value(); }, 10000));
+}
+
 TEST(UdsServerWrapperContractTest, InjectedChannelStateAndFallbackOperations) {
   auto fake_channel = std::make_shared<test::wrapper_support::FakeChannel>();
   UdsServer server(std::static_pointer_cast<interface::Channel>(fake_channel));

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -890,6 +890,14 @@ size_t TcpServer::client_count() const {
   return alive;
 }
 
+std::optional<wrapper::RuntimeStats> TcpServer::client_stats(ClientId client_id) const {
+  auto impl = get_impl();
+  std::lock_guard<std::mutex> lock(impl->sessions_mutex_);
+  auto it = impl->sessions_.find(client_id);
+  if (it == impl->sessions_.end() || !it->second) return std::nullopt;
+  return it->second->stats();
+}
+
 std::vector<ClientId> TcpServer::connected_clients() const {
   auto impl = get_impl();
   std::lock_guard<std::mutex> lock(impl->sessions_mutex_);

--- a/wirestead/transport/tcp_server/tcp_server.hpp
+++ b/wirestead/transport/tcp_server/tcp_server.hpp
@@ -94,6 +94,7 @@ class WIRESTEAD_API TcpServer : public interface::Channel, public std::enable_sh
   bool try_send_to_client(ClientId client_id, memory::ConstByteSpan data);
   size_t client_count() const;
   std::vector<ClientId> connected_clients() const;
+  std::optional<wrapper::RuntimeStats> client_stats(ClientId client_id) const;
 
   void request_stop();
 

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -597,6 +597,13 @@ std::vector<ClientId> UdsServer::connected_clients() const {
   return ids;
 }
 
+std::optional<wrapper::RuntimeStats> UdsServer::client_stats(ClientId client_id) const {
+  std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
+  auto it = impl_->sessions_.find(client_id);
+  if (it == impl_->sessions_.end() || !it->second) return std::nullopt;
+  return it->second->stats();
+}
+
 void UdsServer::set_client_limit(size_t max_clients) {
   std::lock_guard<std::mutex> lock(impl_->sessions_mutex_);
   impl_->cfg_.max_connections =

--- a/wirestead/transport/uds/uds_server.hpp
+++ b/wirestead/transport/uds/uds_server.hpp
@@ -89,6 +89,7 @@ class WIRESTEAD_API UdsServer : public interface::Channel, public std::enable_sh
   bool try_send_to_client(ClientId client_id, memory::ConstByteSpan data);
   size_t client_count() const;
   std::vector<ClientId> connected_clients() const;
+  std::optional<wrapper::RuntimeStats> client_stats(ClientId client_id) const;
   void set_client_limit(size_t max_clients);
 
   using MultiClientConnectHandler = std::function<void(ClientId client_id, const std::string& client_info)>;

--- a/wirestead/wrapper/iserver.hpp
+++ b/wirestead/wrapper/iserver.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -92,6 +93,21 @@ class WIRESTEAD_API ServerInterface {
    * contract above. See docs/error_model.md.
    */
   virtual RuntimeStats stats() const = 0;
+
+  /**
+   * @brief Counters for one connected client.
+   *
+   * Returns nullopt when the id is unknown - including for a client that has
+   * already disconnected, since a session's counters are folded into the
+   * server-wide stats() and the session itself is gone. Sample this while the
+   * client is connected if you need its numbers in isolation.
+   *
+   * Not every server can answer. UDP servers group datagrams into virtual
+   * sessions that have no queues or counters of their own, so they always
+   * return nullopt; their traffic is only visible in the aggregate.
+   */
+  virtual std::optional<RuntimeStats> client_stats(ClientId /*client_id*/) const { return std::nullopt; }
+
   virtual void reset_stats() = 0;
 
   // Transmission

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -679,6 +679,12 @@ std::vector<ClientId> TcpServer::connected_clients() const {
   return ts ? ts->connected_clients() : std::vector<ClientId>();
 }
 
+std::optional<RuntimeStats> TcpServer::client_stats(ClientId client_id) const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  const auto& ts = get_impl()->transport_cache_;
+  return ts ? ts->client_stats(client_id) : std::nullopt;
+}
+
 TcpServer& TcpServer::auto_start(bool m) {
   impl_->auto_start_.store(m);
   if (impl_->auto_start_.load() && !impl_->started_.load()) start();

--- a/wirestead/wrapper/tcp_server/tcp_server.hpp
+++ b/wirestead/wrapper/tcp_server/tcp_server.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -92,6 +93,7 @@ class WIRESTEAD_API TcpServer : public ServerInterface {
   // Client count and management
   size_t client_count() const override;
   std::vector<ClientId> connected_clients() const override;
+  std::optional<RuntimeStats> client_stats(ClientId client_id) const override;
 
   // Configuration (Fluent API)
   TcpServer& auto_start(bool manage = true) override;

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -594,6 +594,12 @@ std::vector<ClientId> UdsServer::connected_clients() const {
   return ts ? ts->connected_clients() : std::vector<ClientId>{};
 }
 
+std::optional<RuntimeStats> UdsServer::client_stats(ClientId client_id) const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  auto ts = std::dynamic_pointer_cast<transport::UdsServer>(impl_->server_);
+  return ts ? ts->client_stats(client_id) : std::nullopt;
+}
+
 UdsServer& UdsServer::auto_start(bool manage) {
   impl_->auto_start_.store(manage);
   if (impl_->auto_start_.load() && !impl_->started_.load()) {

--- a/wirestead/wrapper/uds_server/uds_server.hpp
+++ b/wirestead/wrapper/uds_server/uds_server.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <future>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -93,6 +94,7 @@ class WIRESTEAD_API UdsServer : public ServerInterface {
   // Client count and management
   size_t client_count() const override;
   std::vector<ClientId> connected_clients() const override;
+  std::optional<RuntimeStats> client_stats(ClientId client_id) const override;
 
   // Configuration (Fluent API)
   UdsServer& auto_start(bool manage = true) override;


### PR DESCRIPTION
## Description

`stats()` reports a server as a whole, so it cannot say which client is responsible for the traffic, the drops, or the queue depth it shows. On a server with several connected clients that is exactly the question you have when something looks wrong.

The data was already there. Every accepted session has owned a full `RuntimeStatsCounters` all along — the aggregation loop reads each one and sums it away. This exposes it instead of adding new instrumentation.

Follows on from #585, which is the other half of #583.

## Key Changes

- `wrapper/iserver.hpp` — `virtual std::optional<RuntimeStats> client_stats(ClientId) const`, defaulting to `std::nullopt`.
- `transport/tcp_server/`, `transport/uds/` — look the session up in the same `sessions_` map that `client_count()` and `connected_clients()` already walk, under the same mutex.
- `wrapper/tcp_server/`, `wrapper/uds_server/` — delegate through `transport_cache_`, mirroring `connected_clients()`.
- Tests for all three server transports; `docs/error_model.md` gains a "Per-client stats" section; `CHANGELOG.md` entry.

```cpp
for (auto id : server.connected_clients()) {
  if (auto s = server.client_stats(id)) {
    std::cout << id << ": " << s->bytes_received << " B in, " << s->dropped_bytes << " B dropped\n";
  }
}
```

## Related Issues

- Follows #585; completes the per-session half of #583.

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Three decisions worth reviewing, since each could reasonably have gone another way.

**UDP returns `std::nullopt`.** Its virtual sessions are datagrams grouped by source endpoint; they have no queues and no counters of their own. Reporting per-client numbers there would mean restructuring UDP's send path, which is a different change from exposing counters that already exist. A test pins the behaviour so it is documented rather than discovered, and the traffic still shows up in the aggregate.

**Named `client_stats()`, not an overload of `stats()`.** An overload would be hidden in any derived class that declares only one of the two — `udp_server->stats(id)` would fail to compile unless every implementer added `using ServerInterface::stats;`. The chosen name also sits naturally beside `client_count()` and `connected_clients()`.

**The interface method has a default rather than being pure virtual**, so an out-of-tree implementer of `ServerInterface` keeps compiling. Adding the virtual still changes the vtable and so breaks ABI; pre-1.0 policy allows that (`docs/api_stability.md`), and the `CHANGELOG` says so explicitly.

**A disconnected client returns `std::nullopt`.** Its totals live on in `stats()` thanks to #585, but the session does not, so callers who want a client's numbers in isolation have to sample while it is connected. The docs say this plainly because the alternative — returning stale numbers for a client that is gone — seemed worse than an honest empty answer.

**Verification.** `./scripts/verify.sh` — 767/767 tests pass (764 before these three), formatting and build included. Run under `taskset -c 0-3` because the script takes its job count from `nproc`, which reports 20 on this WSL host with 15 GB RAM; that limits parallelism only, not which checks run.

The TCP test is the substantive one: two clients send payloads of different sizes, and it asserts that the two sessions can be told apart by their own counters, that an id never handed out returns `nullopt`, that the aggregate is at least the sum of both, and that both go to `nullopt` after disconnect while the aggregate retains their bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
