### PR TITLE
fix(ci): unbreak the TSAN build by excluding test_receive_allocations

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -42,25 +42,35 @@ function(wirestead_add_integration_gtest target source_path labels timeout)
   )
 endfunction()
 
-foreach(
-  test_file
-  test_integration.cc
-  test_simple_server.cc
-  test_client_limit_integration.cc
-  test_multithread_backpressure.cc
-  test_stop_from_callback.cc
-  test_start_stop_stress.cc
-  test_stop_contract.cc
-  test_dos_protection.cc
-  test_tcp_server_chaos.cc
-  test_tcp_flood.cc
-  test_tcp_abort.cc
-  test_tcp_cancel.cc
-  test_tcp_nodelay_default.cc
-  test_read_buffer_size.cc
-  test_gather_write.cc
-  test_receive_allocations.cc
+set(WIRESTEAD_TCP_INTEGRATION_TESTS
+    test_integration.cc
+    test_simple_server.cc
+    test_client_limit_integration.cc
+    test_multithread_backpressure.cc
+    test_stop_from_callback.cc
+    test_start_stop_stress.cc
+    test_stop_contract.cc
+    test_dos_protection.cc
+    test_tcp_server_chaos.cc
+    test_tcp_flood.cc
+    test_tcp_abort.cc
+    test_tcp_cancel.cc
+    test_tcp_nodelay_default.cc
+    test_read_buffer_size.cc
+    test_gather_write.cc
+    test_receive_allocations.cc
 )
+
+# test_receive_allocations replaces the global operator new/delete to count
+# allocations. ThreadSanitizer defines those itself in libclang_rt.tsan_cxx, so
+# linking the two together fails outright. Excluding the test loses nothing
+# under TSAN: counting allocations while a sanitizer owns allocation measures
+# the sanitizer, not the receive path.
+if(WIRESTEAD_ENABLE_TSAN)
+  list(REMOVE_ITEM WIRESTEAD_TCP_INTEGRATION_TESTS test_receive_allocations.cc)
+endif()
+
+foreach(test_file IN LISTS WIRESTEAD_TCP_INTEGRATION_TESTS)
   get_filename_component(test_name ${test_file} NAME_WE)
 
   set(timeout 300)


### PR DESCRIPTION
## Description

The nightly ThreadSanitizer workflow has failed every run since 2026-08-08. It fails in **Build TSAN targets**, not on a race:

```text
test/integration/tcp/test_receive_allocations.cc:70: multiple definition of `operator new(unsigned long)';
libclang_rt.tsan_cxx-x86_64.a(tsan_new_delete.cpp.o):(.text._Znwm+0x0): first defined here
...same for operator new[], the nothrow overloads, and every operator delete...
clang++: error: linker command failed with exit code 1
```

`test_receive_allocations` replaces the global `operator new`/`delete` so it can count allocations. TSAN defines those itself, so the two cannot be linked together.

The test arrived in #575 (`fbc6e857a`, 2026-08-08 14:00 KST), hours before the first failing nightly at 19:30 UTC the same day. The last green run was 2026-08-07.

| Run | Result |
|---|---|
| 2026-08-07 19:52 | pass |
| 2026-08-08 19:30 | **fail** |
| 2026-08-09 19:34 | **fail** |
| 2026-08-10 19:54 | **fail** |

Nothing has been able to run under TSAN for three days, so the sanitizer has been dark rather than merely red.

## Key Changes

- `test/integration/CMakeLists.txt` — turn the inline `foreach` list into `WIRESTEAD_TCP_INTEGRATION_TESTS`, and drop `test_receive_allocations.cc` from it when `WIRESTEAD_ENABLE_TSAN` is on.

Nothing is lost by excluding it. Counting allocations while a sanitizer owns allocation measures the sanitizer, not the receive path, and the workflow's focused `ctest -R` filter never selected the test to begin with. Every other configuration still builds and runs it — the exclusion is conditional, and the ASAN/UBSAN/LSAN job is unaffected.

## Related Issues

- Regression from #575.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Reproduced and verified locally**, since a scheduled workflow cannot be exercised from a PR. With clang and `-fsanitize=thread`:

- Configuring with `-DWIRESTEAD_ENABLE_TSAN=ON` no longer generates the `run_integration_test_receive_allocations` target; configuring without it still does.
- The full TSAN build completes (it previously stopped at the link).
- The workflow's own focused selection — same `ctest -R` regex, same `TSAN_OPTIONS`, `--parallel 2` — passes **63/63 with zero ThreadSanitizer warnings**.

That last point is the one worth noting: because the build has been broken for three days, no one knew whether races were hiding behind it. There are none in the focused set.

**No tests added and no CHANGELOG entry.** This changes which targets a sanitizer build produces, not library behaviour; the verification is the TSAN build succeeding, which the nightly now exercises. Happy to add a CHANGELOG line if you would rather have build-level changes recorded there.

**One thing this does not address.** The workflow is `workflow_dispatch` + a 19:00 cron, so it is not part of PR checks — which is why a build break sat unnoticed for three days. Moving it into PR checks would add roughly seven minutes to every PR; a lighter option is to have a failing nightly open or update an issue. Out of scope here, but worth deciding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
