### PR TITLE
feat: warn once when a channel starts dropping queued data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and ABI policy.
 
 ### Added
 
+- A one-time WARNING log the first time a channel drops queued data, pointing at
+  `RuntimeStats::dropped_bytes`. `BestEffort` discards by design and
+  `on_backpressure()` is not a reliable signal that it happened, so a caller who
+  never polls the counters could lose data in silence. Latched per channel, not
+  per drop - BestEffort can drop hundreds of thousands of times a second.
+
 - `ServerInterface::client_stats(ClientId)` returns one connected client's
   `RuntimeStats`, or `std::nullopt` when the id has no session behind it.
   `stats()` reports the server as a whole and cannot say which client produced

--- a/test/unit/diagnostics/test_runtime_stats_counter.cc
+++ b/test/unit/diagnostics/test_runtime_stats_counter.cc
@@ -105,4 +105,29 @@ TEST(RuntimeStatsCounterTest, ResetClearsCumulativeCountersAndSetsMaxQueueBaseli
   EXPECT_TRUE(stats.backpressure_active);
 }
 
+// BestEffort can drop hundreds of thousands of times a second, so the warning
+// has to be latched - it says "you are losing data" once, and dropped_bytes
+// carries the running total from there.
+TEST(RuntimeStatsCounterTest, DropWarningIsLatchedButCountersKeepAdding) {
+  RuntimeStatsCounters counters;
+
+  EXPECT_FALSE(counters.drop_warned.load());
+
+  counters.record_dropped(1, 10);
+  EXPECT_TRUE(counters.drop_warned.load());
+
+  counters.record_dropped(2, 20);
+  counters.record_dropped(3, 30);
+
+  const auto stats = counters.snapshot(0, 0, false);
+  EXPECT_EQ(stats.dropped_messages, 6u);
+  EXPECT_EQ(stats.dropped_bytes, 60u);
+
+  // reset() deliberately leaves the latch alone: the point is once per process,
+  // not once per measurement window.
+  counters.reset(0);
+  EXPECT_TRUE(counters.drop_warned.load());
+  EXPECT_EQ(counters.snapshot(0, 0, false).dropped_bytes, 0u);
+}
+
 }  // namespace

--- a/wirestead/diagnostics/runtime_stats_counter.hpp
+++ b/wirestead/diagnostics/runtime_stats_counter.hpp
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "wirestead/diagnostics/logger.hpp"
 #include "wirestead/wrapper/runtime_stats.hpp"
 
 namespace wirestead {
@@ -44,6 +45,10 @@ struct RuntimeStatsCounters {
 
   std::atomic<size_t> max_queued_bytes{0};
 
+  // Latched, deliberately not cleared by reset() - the warning below is meant
+  // to fire once in a process's life, not once per measurement window.
+  std::atomic<bool> drop_warned{false};
+
   void record_accepted(size_t bytes) {
     messages_accepted.fetch_add(1, std::memory_order_relaxed);
     bytes_accepted.fetch_add(bytes, std::memory_order_relaxed);
@@ -61,9 +66,19 @@ struct RuntimeStatsCounters {
 
   void record_failed_send() { failed_sends.fetch_add(1, std::memory_order_relaxed); }
 
+  // Every drop in the library routes through here. BestEffort discards by
+  // design and can do it hundreds of thousands of times a second, so the
+  // running total is the counter to watch - but a caller who never looks at it
+  // would otherwise lose data in complete silence, which is what makes the
+  // first one worth saying out loud exactly once.
   void record_dropped(size_t messages, size_t bytes) {
     dropped_messages.fetch_add(static_cast<uint64_t>(messages), std::memory_order_relaxed);
     dropped_bytes.fetch_add(static_cast<uint64_t>(bytes), std::memory_order_relaxed);
+    if (!drop_warned.exchange(true, std::memory_order_relaxed)) {
+      WIRESTEAD_LOG_WARNING("runtime_stats", "record_dropped",
+                            "Dropping queued data (BestEffort). Watch RuntimeStats::dropped_bytes - "
+                            "on_backpressure() is not a reliable loss signal under this strategy.");
+    }
   }
 
   void record_backpressure_event() { backpressure_events.fetch_add(1, std::memory_order_relaxed); }


### PR DESCRIPTION
## Description

Addresses #584.

`BestEffort` discards queued data by design, and `on_backpressure()` is not a reliable signal that it happened — dropping is what holds the queue below the threshold that would fire the callback. A measured run shed **404 MB with `backpressure_events` still at 0**. `RuntimeStats::dropped_bytes` has always carried the truth, but a caller who never polls it loses data in complete silence.

This logs a warning the first time a channel drops, naming the counter to watch.

## Key Changes

- `diagnostics/runtime_stats_counter.hpp` — latched `drop_warned` flag and a one-time `WARNING` in `record_dropped()`.
- `test/unit/diagnostics/test_runtime_stats_counter.cc` — one test for the latch.
- `CHANGELOG.md` — entry.

```cpp
void record_dropped(size_t messages, size_t bytes) {
  dropped_messages.fetch_add(messages, std::memory_order_relaxed);
  dropped_bytes.fetch_add(bytes, std::memory_order_relaxed);
  if (!drop_warned.exchange(true, std::memory_order_relaxed)) {
    WIRESTEAD_LOG_WARNING("runtime_stats", "record_dropped",
                          "Dropping queued data (BestEffort). Watch RuntimeStats::dropped_bytes - "
                          "on_backpressure() is not a reliable loss signal under this strategy.");
  }
}
```

## Related Issues

- Addresses #584. Left open rather than auto-closed — see the note below on whether a callback is still wanted.

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**No `on_drop()` callback, deliberately.** #584 floated one, wired through six transports. Two things argued against it:

All 25 drop sites already route through `record_dropped()`, so the six-transport wiring was never necessary — the choke point is one function. And more importantly, a per-drop callback is the wrong shape here: BestEffort dropped **763,592 messages in two seconds** in the run that motivated the issue. A callback firing at that rate is a footgun, not a feature. The right interface for expected, high-frequency, aggregate information is a counter, and `dropped_bytes` already is one, exposed on every transport in C++ and (since wirestead-python#57) in Python.

That leaves exactly one real gap — the caller who never looks — which one latched log line closes. No new API, no ABI change, nothing to bind.

**Also considered and rejected:** bumping `backpressure_events` on the drop path. That counter means ON/OFF transitions of `backpressure_active`; folding drop counts into it would corrupt an existing metric to avoid adding a new signal.

**Latched per channel, not per process-wide singleton.** Each `RuntimeStatsCounters` warns once, so a server warns once per session that drops. `reset()` deliberately does not clear the latch. Verified against the existing slow-consumer suite: 5 tests, hundreds of thousands of drops, **2 warnings**.

**Verification.** `./scripts/verify.sh` — 768/768 pass. Run under `taskset -c 0-3`; the script takes its job count from `nproc`, which reports 20 on this WSL host with 15 GB RAM, so constraining the CPU set keeps the parallel compile within memory. Parallelism only, not which checks run.

**Two things worth a reviewer's opinion:**

1. **Is this enough to close #584?** If a push callback is still wanted for a real use case, the issue should stay open and this is a partial mitigation. If the counter plus one warning covers it, close it on merge.
2. **New log output.** Existing `BestEffort` users will see one WARNING per dropping channel that was not there before. That seems right for silent data loss, but it is a visible behaviour change.

**No doc update.** `docs/error_model.md` and the Python `docs/api.md` already tell callers to watch `dropped_bytes`; the warning says the same thing at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
