### PR TITLE
test: make the max_queued_bytes peak test deterministic

### DIFF
--- a/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
+++ b/test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <boost/asio.hpp>
 #include <chrono>
@@ -190,17 +191,32 @@ TEST(ServerBroadcastSlowConsumerContractTest, TcpAggregateMaxQueuedBytesIsPeakNo
   slow_b.set_option(net::socket_base::receive_buffer_size(static_cast<int>(kThreshold)));
   ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->client_count() >= 2; }, 5000));
 
-  for (int i = 0; i < 4096 && server->stats().dropped_bytes == 0; ++i) {
+  const auto ids = server->connected_clients();
+  ASSERT_EQ(ids.size(), 2u);
+
+  // Both sessions only need a queue depth on record - not one at the same
+  // instant. Requiring them to be backed up simultaneously made this flaky on
+  // Windows, where one session could drop before the other had queued much.
+  const auto peaks_recorded = [&] {
+    const auto a = server->client_stats(ids[0]);
+    const auto b = server->client_stats(ids[1]);
+    return a && b && a->max_queued_bytes > 0 && b->max_queued_bytes > 0;
+  };
+  for (int i = 0; i < 4096 && !peaks_recorded(); ++i) {
     server->broadcast(payload);
   }
+  ASSERT_TRUE(peaks_recorded()) << "neither session ever queued anything";
 
-  const auto stats = server->stats();
-  ASSERT_GT(stats.dropped_bytes, 0u) << "session queues never reached the budget";
-  // queued_bytes is a genuine sum across sessions, so exceeding one budget is
-  // what proves both sessions are backed up simultaneously. Without that this
-  // assertion would pass even if only one session had ever queued anything.
-  ASSERT_GT(stats.queued_bytes, kQueueBudget) << "only one session backed up; the peak check cannot discriminate";
-  EXPECT_LE(stats.max_queued_bytes, kQueueBudget + payload.size());
+  const auto a = server->client_stats(ids[0]);
+  const auto b = server->client_stats(ids[1]);
+  ASSERT_TRUE(a.has_value());
+  ASSERT_TRUE(b.has_value());
+
+  // The point of the fix: a server-wide peak is the deepest any one session
+  // reached, not the sum of both. Comparing against the sessions directly beats
+  // inferring it from the aggregate, which is what the earlier version did.
+  EXPECT_EQ(server->stats().max_queued_bytes, std::max(a->max_queued_bytes, b->max_queued_bytes));
+  EXPECT_LT(server->stats().max_queued_bytes, a->max_queued_bytes + b->max_queued_bytes);
 
   boost::system::error_code ec;
   slow_a.close(ec);


### PR DESCRIPTION
## Description

`TcpAggregateMaxQueuedBytesIsPeakNotSum` (added in #582) failed the Windows MSVC job on #590 while passing on #585, #587 and #589. Flaky, not broken:

```text
test_server_broadcast_slow_consumer_contract.cc(202): error:
Expected: (stats.queued_bytes) > (kQueueBudget), actual: 4096 vs 65536
```

The test drove two non-reading consumers until the first drop, then asserted that the summed `queued_bytes` exceeded one session's budget — a proxy for "both sessions are backed up **at the same instant**", which is what made a summed aggregate distinguishable from a peak. On Windows one session can drop before the other has queued much, and the proxy fails.

## Key Changes

- `test/integration/wrapper/test_server_broadcast_slow_consumer_contract.cc` — compare against the sessions directly instead of inferring from the aggregate.

```cpp
EXPECT_EQ(server->stats().max_queued_bytes, std::max(a->max_queued_bytes, b->max_queued_bytes));
EXPECT_LT(server->stats().max_queued_bytes, a->max_queued_bytes + b->max_queued_bytes);
```

Simultaneity was never what the property needed — only that each session has a peak on record. `client_stats()` landed in #587, so the peaks are now readable per session and the aggregate can be checked against `max()` of them. This is what #582's own description anticipated: *"Once per-session stats exist, the two tests here could assert on the counters directly instead of inferring from a bounded wait."*

The loop now runs until both sessions have a non-zero peak rather than until the first drop, which is a far weaker and platform-independent precondition.

## Related Issues

- Fixes flakiness introduced by #582. Unblocks #590, which is red only because of this test.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Still discriminates.** Reintroducing the summing bug that #582 fixed fails both assertions — `32768` (sum) against `24576` (max). A test that stops catching its own bug is worse than a flaky one, so this was checked before and after.

**Why not fold this into #590.** The failure has nothing to do with that PR's change; the two land better separately, and a squash merge would file this test fix under `feat: warn once when a channel starts dropping queued data`.

**Verification.** `./scripts/verify.sh` — 767/767 pass, run under `taskset -c 0-3` because the script derives its job count from `nproc` (20 on this WSL host, 15 GB RAM). Parallelism only, not which checks run. The Windows path cannot be reproduced locally, so this PR's own CI is the real check on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
