### PR TITLE
ci: file an issue when the TSAN nightly fails

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 19 * * *"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   tsan:
     name: TSAN focused contract tests
@@ -60,3 +64,24 @@ jobs:
           path: build-tsan/Testing/
           retention-days: 14
           overwrite: true
+
+      # Nothing watches a scheduled run. This one broke on 2026-08-08 and stayed
+      # broken for three nights before anyone noticed, so a failed nightly files
+      # an issue. Comment on the existing one rather than opening a new issue
+      # every 24 hours - one issue per outage, not per night.
+      - name: Report a failing nightly
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "ThreadSanitizer nightly is failing"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Exact title match: `in:title` is a full-text search, so a loose
+          # match could comment on somebody else's issue instead of filing one.
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            | jq -r --arg t "$TITLE" '[.[] | select(.title == $t)] | .[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: $RUN_URL"
+          else
+            gh issue create --title "$TITLE" --label bug --body "The nightly ThreadSanitizer run failed: $RUN_URL"
+          fi


### PR DESCRIPTION
## Description

The ThreadSanitizer workflow is `workflow_dispatch` plus a nightly cron, so it never runs on a PR and nothing surfaces a failure. It broke on 2026-08-08 (#589) and stayed broken for three nights before anyone looked — not red, dark.

This adds a step that files an issue when a scheduled run fails.

## Key Changes

- `.github/workflows/tsan.yml` — `permissions: issues: write`, and a `Report a failing nightly` step.

```yaml
- name: Report a failing nightly
  if: failure() && github.event_name == 'schedule'
  run: |
    existing=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
      | jq -r --arg t "$TITLE" '[.[] | select(.title == $t)] | .[0].number // empty')
    if [ -n "$existing" ]; then
      gh issue comment "$existing" --body "Still failing: $RUN_URL"
    else
      gh issue create --title "$TITLE" --label bug --body "The nightly ThreadSanitizer run failed: $RUN_URL"
    fi
```

Three details that are deliberate:

- **Comments on the existing issue instead of opening a new one.** The 2026-08-08 outage would otherwise have produced three issues in three nights. One issue per outage.
- **Exact title match.** GitHub's `in:title` is a full-text search, so a loose match could put "Still failing" on somebody else's issue. The `jq` filter compares the title exactly.
- **Scheduled runs only.** Someone who triggers the workflow by hand is already watching the result.

## Related Issues

- Follow-up to #589, which fixed the outage this would have surfaced.

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [ ] **Testing**: Adding or updating tests.

Build/CI only — the list above has no category for it.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [ ] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

`verify.sh` is not checked because this touches no source: it builds nothing, and the workflow file is outside what the script formats or compiles. What was checked instead is below.

## Additional Context

**What was verified**, since a failure path in a scheduled workflow cannot be exercised from a PR:

- The YAML parses, and the new step lands with the intended `if:` condition.
- The `jq` filter was run against all three shapes it will meet: an exact match returns the number, an empty list returns empty, and a *similar but different* title (`"...is failing on arm"`) also returns empty — the case that would otherwise comment on the wrong issue.
- `gh issue list --search "... in:title"` was run against this repository and returns well-formed JSON.

The one thing that cannot be tested short of an actual failing nightly is the `gh issue create` call itself. If it misbehaves, the blast radius is one spurious issue.

**Not addressed: the other four scheduled workflows.** `benchmark.yml`, `codeql.yml`, `security.yml` and `vcpkg-baseline-bump.yml` are equally unwatched. Extracting a shared reusable workflow for what is six lines of shell would cost more than copying it, so this stays in `tsan.yml`; if you want the same on the others, say so and it is a copy-paste per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
