### PR TITLE
feat: optional TLS for the TCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,53 @@ jobs:
           retention-days: 7
           overwrite: true
 
+  # ── TLS ───────────────────────────────────────────────────────────────────────
+  # WIRESTEAD_ENABLE_TLS is off by default, so without this job the TLS code is
+  # a configuration nobody compiles and nothing would catch it rotting.
+  tls-tests:
+    name: TLS (ubuntu-24.04, gcc)
+    runs-on: ubuntu-24.04
+    needs: [compile]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache ccache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-tls-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: ccache-${{ runner.os }}-tls-
+
+      - name: Install dependencies
+        uses: ./.github/actions/apt-install
+        with:
+          packages: "build-essential cmake ccache libssl-dev"
+
+      - name: Install dependencies with vcpkg
+        uses: ./.github/actions/setup-vcpkg
+        with:
+          triplet: x64-linux
+
+      - name: Configure CMake with TLS
+        run: |
+          cmake -S . -B build-tls \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_STANDARD=$CXX_STANDARD \
+            -DWIRESTEAD_BUILD_TESTS=ON \
+            -DWIRESTEAD_ENABLE_TLS=ON \
+            -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
+            -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build with TLS
+        run: cmake --build build-tls -j $(nproc)
+
+      - name: Run TLS tests
+        run: ctest --test-dir build-tls --output-on-failure --parallel 2 -R "Tls"
+
   # ── INTEGRATION TESTS ─────────────────────────────────────────────────────────
   integration-tests:
     name: Integration Tests (ubuntu-24.04, gcc)
@@ -498,7 +545,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-24.04
-    needs: [compile, unit-tests, windows, integration-tests, integration-tests-arm64, memory-safety-tests, e2e-tests]
+    needs: [compile, unit-tests, windows, integration-tests, integration-tests-arm64, memory-safety-tests, e2e-tests, tls-tests]
     if: always()
 
     steps:
@@ -511,6 +558,7 @@ jobs:
           echo "| Unit Tests | ${{ needs.unit-tests.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Windows | ${{ needs.windows.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Integration Tests | ${{ needs.integration-tests.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| TLS | ${{ needs.tls-tests.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Integration Tests ARM64 | ${{ needs.integration-tests-arm64.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Memory Safety Tests | ${{ needs.memory-safety-tests.result == 'success' && '✅' || needs.memory-safety-tests.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| E2E Tests | ${{ needs.e2e-tests.result == 'success' && '✅' || needs.e2e-tests.result == 'skipped' && '⏭️' || '❌' }} |" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and ABI policy.
   leaves plain sockets behaving exactly as before. Reads, writes, backpressure
   and stats are the same code either way.
 
+  Closing a TLS connection sends `close_notify` without waiting for the peer's
+  reply: the bidirectional exchange blocks until the peer answers, and a peer
+  that simply stops reading held `stop()` for 8 seconds in testing. `on_connect`
+  fires at accept, before the handshake, so a client that fails it produces a
+  balanced connect/disconnect pair with no data between.
+
   TLS 1.2 is the floor and is not configurable. Setting `tls()` in a build
   without `WIRESTEAD_ENABLE_TLS`, or pointing it at a certificate that cannot be
   loaded, makes `start()` fail - a server asked for encryption it cannot provide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ and ABI policy.
 
 ### Added
 
+- Optional TLS for the TCP server, behind `-DWIRESTEAD_ENABLE_TLS=ON`. A default
+  build is unchanged and has no OpenSSL dependency.
+
+  ```cpp
+  auto server = wirestead::tcp_server(9000).tls("fullchain.pem", "privkey.pem").build();
+  ```
+
+  The session layer was already talking to `TcpSocketInterface` rather than a
+  socket, so this is a second implementation of that interface plus one new
+  method on it - `async_handshake()`, which defaults to immediate success and so
+  leaves plain sockets behaving exactly as before. Reads, writes, backpressure
+  and stats are the same code either way.
+
+  TLS 1.2 is the floor and is not configurable. Setting `tls()` in a build
+  without `WIRESTEAD_ENABLE_TLS`, or pointing it at a certificate that cannot be
+  loaded, makes `start()` fail - a server asked for encryption it cannot provide
+  must not come up in plaintext instead. No client certificates, peer
+  verification, cipher suite selection or certificate reload; the TCP client,
+  UDP, Serial and UDS remain plaintext, and DTLS is not supported. See
+  `docs/security.md`.
+
 - A one-time WARNING log the first time a channel drops queued data, pointing at
   `RuntimeStats::dropped_bytes`. `BestEffort` discards by design and
   `on_backpressure()` is not a reliable signal that it happened, so a caller who

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simple async C++ communication library for Serial, TCP, UDP, and Unix Domain Soc
 
 The project prioritizes **API clarity, predictable runtime behavior, and stability** over rapid feature expansion.
 
-> **Security note**: all transports send data in plaintext - there is no built-in TLS/DTLS support. See [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md) before using `wirestead` over an untrusted network.
+> **Security note**: transports send data in plaintext by default. The TCP server can serve TLS in a build configured with `-DWIRESTEAD_ENABLE_TLS=ON`; the TCP client, UDP, Serial and UDS cannot, and DTLS is not supported. See [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md) before using `wirestead` over an untrusted network.
 
 ## Feature Highlights
 

--- a/cmake/WiresteadDependencies.cmake
+++ b/cmake/WiresteadDependencies.cmake
@@ -284,6 +284,20 @@ if(WIRESTEAD_LINK_BOOST_SYSTEM)
   endif()
 endif()
 
+# Boost.Asio's SSL support is header-only but needs OpenSSL linked. Only looked
+# for when TLS is enabled, so a default build has no new dependency at all.
+if(WIRESTEAD_ENABLE_TLS)
+  find_package(OpenSSL REQUIRED)
+  target_link_libraries(
+    wirestead_dependencies INTERFACE OpenSSL::SSL OpenSSL::Crypto
+  )
+  target_compile_definitions(
+    wirestead_dependencies INTERFACE WIRESTEAD_TLS_ENABLED=1
+  )
+  list(APPEND WIRESTEAD_PKGCONFIG_REQUIRES_PRIVATE "openssl")
+  message(STATUS "TLS enabled, using OpenSSL ${OPENSSL_VERSION}")
+endif()
+
 if(WIRESTEAD_BOOST_INCLUDE_DIR)
   target_include_directories(
     wirestead_dependencies SYSTEM

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -86,6 +86,13 @@ option(WIRESTEAD_ENABLE_ASAN "Enable AddressSanitizer" OFF)
 option(WIRESTEAD_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
 option(WIRESTEAD_ENABLE_TSAN "Enable ThreadSanitizer" OFF)
 
+# Off by default on purpose. Turning it on pulls in OpenSSL, which is a cost the
+# local and embedded deployments this library targets should not pay to get a
+# feature they do not use. See docs/security.md.
+option(WIRESTEAD_ENABLE_TLS "Enable optional TLS support for the TCP server"
+       OFF
+)
+
 option(WIRESTEAD_ENABLE_LTO "Enable Link Time Optimization" OFF)
 
 # Resolved once here so the target helpers can just read it. Asking the

--- a/cmake/WiresteadSources.cmake
+++ b/cmake/WiresteadSources.cmake
@@ -26,6 +26,7 @@ set(WIRESTEAD_SOURCES
     wirestead/memory/safe_data_buffer.cc
     wirestead/transport/tcp_server/boost_tcp_acceptor.cc
     wirestead/transport/tcp_server/boost_tcp_socket.cc
+    wirestead/transport/tcp_server/ssl_tcp_socket.cc
     wirestead/transport/tcp_server/tcp_server_session.cc
     wirestead/transport/udp/udp.cc
     wirestead/transport/uds/boost_uds_acceptor.cc
@@ -100,6 +101,7 @@ set(WIRESTEAD_HEADERS
     wirestead/transport/tcp_client/tcp_client.hpp
     wirestead/transport/tcp_server/boost_tcp_acceptor.hpp
     wirestead/transport/tcp_server/boost_tcp_socket.hpp
+    wirestead/transport/tcp_server/ssl_tcp_socket.hpp
     wirestead/transport/tcp_server/tcp_server_session.hpp
     wirestead/transport/tcp_server/tcp_server.hpp
     wirestead/transport/udp/udp.hpp

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,6 +36,19 @@ What this does not do: no client certificates, no peer verification, no cipher
 suite or ALPN configuration, no certificate reload without a restart. If you need
 any of those, terminate TLS outside the library as described below.
 
+Two behaviours worth knowing:
+
+- **`on_connect` fires at accept, before the handshake.** A client that fails
+  the handshake still produces one `on_connect`, followed by an `on_disconnect`
+  with no `on_data` between them. The pair is always balanced, so bookkeeping
+  keyed on those callbacks does not leak - but treat the first byte of data, not
+  the callback, as proof a peer got through.
+- **Closing sends `close_notify` without waiting for the peer's.** A full
+  bidirectional TLS shutdown blocks until the peer answers, and a peer under no
+  obligation to answer would hold an io thread for as long as it liked -
+  measured at 8 seconds for two silent peers before this was changed. The peer
+  still sees a clean end of stream rather than a truncation.
+
 ### Everything else
 
 The TCP client, UDP, Serial and UDS have no encryption and no hook for adding

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,20 +1,55 @@
 # Security and Threat Model
 
-## No transport encryption
+## Transport encryption
 
-`wirestead` does not implement TLS, DTLS, or any other transport-level
-encryption. Every transport (TCP, UDP, Serial, UDS) sends and receives data
-in plaintext. There is currently no pluggable hook (e.g. an
-`ssl::stream<tcp::socket>`-compatible interface) for adding encryption
-without patching the library.
+Plaintext is the default on every transport. The TCP **server** can serve TLS
+when the library is built with it; nothing else can.
+
+| | TLS |
+|---|---|
+| TCP server | Optional, opt-in at build and at runtime |
+| TCP client | No |
+| UDP, Serial, UDS | No |
+
+### TCP server TLS
+
+Build with `-DWIRESTEAD_ENABLE_TLS=ON`, which requires OpenSSL. A default build
+has no OpenSSL dependency and no TLS code in it.
+
+```cpp
+auto server = wirestead::tcp_server(9000)
+                  .tls("/path/to/fullchain.pem", "/path/to/privkey.pem")
+                  .on_data(handler)
+                  .build();
+```
+
+Both files are PEM. The certificate is a chain file, so intermediates belong in
+it. TLS 1.2 is the floor and is not configurable.
+
+Leaving `tls()` unset serves plaintext, which is the default. Setting it in a
+build without `WIRESTEAD_ENABLE_TLS` makes `start()` **fail** rather than serve
+plaintext: a server asked for encryption that cannot provide it must not come up
+looking healthy. An unreadable or malformed certificate fails `start()` the same
+way, before the listening socket is bound.
+
+What this does not do: no client certificates, no peer verification, no cipher
+suite or ALPN configuration, no certificate reload without a restart. If you need
+any of those, terminate TLS outside the library as described below.
+
+### Everything else
+
+The TCP client, UDP, Serial and UDS have no encryption and no hook for adding
+it. DTLS is not supported at all - Boost.Asio does not provide it, and UDP's
+sessions here are virtual groupings with no place to attach handshake state.
 
 ## Intended trust model
 
 `wirestead` is designed for use over networks and channels you already trust:
 a local machine, a private LAN, a point-to-point serial/UDS link, or inside
 a network perimeter secured by other means (VPN, SSH tunnel, physical
-access control). It is **not** designed to be used directly over the public
-internet or any other untrusted network, since:
+access control). Outside the TCP server TLS described above, it is **not**
+designed to be used directly over the public internet or any other untrusted
+network, since:
 
 - Data (including any application-level credentials or secrets your
   protocol carries) is visible to anyone who can observe the traffic.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -70,6 +70,11 @@ if(WIRESTEAD_ENABLE_TSAN)
   list(REMOVE_ITEM WIRESTEAD_TCP_INTEGRATION_TESTS test_receive_allocations.cc)
 endif()
 
+# Only meaningful in a build that has TLS compiled in.
+if(WIRESTEAD_ENABLE_TLS)
+  list(APPEND WIRESTEAD_TCP_INTEGRATION_TESTS test_tls_loopback.cc)
+endif()
+
 foreach(test_file IN LISTS WIRESTEAD_TCP_INTEGRATION_TESTS)
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/tcp/test_tls_loopback.cc
+++ b/test/integration/tcp/test_tls_loopback.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "test_utils.hpp"
+#include "wirestead/wirestead.hpp"
+
+namespace {
+
+using wirestead::test::TestUtils;
+namespace net = boost::asio;
+namespace ssl = boost::asio::ssl;
+using tcp = net::ip::tcp;
+
+// Generated once per run rather than checked in: a committed key is a key
+// somebody eventually reuses, and an expiry date is a test that breaks on a
+// date nobody picked.
+class SelfSignedCert {
+ public:
+  SelfSignedCert() {
+    dir_ = std::filesystem::temp_directory_path() /
+           ("wirestead-tls-" + std::to_string(::getpid()) + "-" + std::to_string(counter_++));
+    std::filesystem::create_directories(dir_);
+    const auto cmd = "openssl req -x509 -newkey rsa:2048 -keyout " + key().string() + " -out " + cert().string() +
+                     " -days 1 -nodes -subj /CN=localhost >/dev/null 2>&1";
+    ok_ = std::system(cmd.c_str()) == 0 && std::filesystem::exists(cert()) && std::filesystem::exists(key());
+  }
+
+  ~SelfSignedCert() {
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+
+  bool ok() const { return ok_; }
+  std::filesystem::path cert() const { return dir_ / "cert.pem"; }
+  std::filesystem::path key() const { return dir_ / "key.pem"; }
+
+ private:
+  static inline int counter_ = 0;
+  std::filesystem::path dir_;
+  bool ok_{false};
+};
+
+// A plain Asio TLS client. The point of testing against one rather than a
+// second wirestead server is that the handshake has to satisfy something that
+// is not this library.
+std::string tls_round_trip(uint16_t port, const std::filesystem::path& ca, const std::string& payload) {
+  net::io_context ioc;
+  ssl::context ctx(ssl::context::tls_client);
+  ctx.load_verify_file(ca.string());
+  ctx.set_verify_mode(ssl::verify_peer);
+
+  ssl::stream<tcp::socket> stream(ioc, ctx);
+  stream.lowest_layer().connect(tcp::endpoint(net::ip::make_address("127.0.0.1"), port));
+  stream.handshake(ssl::stream_base::client);
+
+  net::write(stream, net::buffer(payload));
+
+  std::string reply(64, '\0');
+  boost::system::error_code ec;
+  const size_t n = stream.read_some(net::buffer(reply.data(), reply.size()), ec);
+  reply.resize(n);
+
+  boost::system::error_code ignored;
+  stream.shutdown(ignored);
+  return reply;
+}
+
+}  // namespace
+
+TEST(TcpTlsLoopbackTest, ServesTlsAndRejectsPlaintextClients) {
+  SelfSignedCert certs;
+  if (!certs.ok()) {
+    GTEST_SKIP() << "openssl CLI unavailable, cannot generate a test certificate";
+  }
+
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = std::make_shared<wirestead::wrapper::TcpServer>(port);
+  server->tls(certs.cert().string(), certs.key().string());
+
+  std::atomic<int> messages{0};
+  server->on_data([&](const wirestead::MessageContext& ctx) {
+    messages.fetch_add(1);
+    server->broadcast("pong");
+  });
+  server->on_error([](const wirestead::ErrorContext&) {});
+
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  EXPECT_EQ(tls_round_trip(port, certs.cert(), "ping"), "pong");
+  EXPECT_EQ(messages.load(), 1);
+
+  // A plaintext client must not get through. Its bytes are not a valid
+  // ClientHello, so the handshake fails and the session closes without ever
+  // reaching on_data - the failure that matters is data being served in the
+  // clear, so assert the callback never fires.
+  {
+    net::io_context ioc;
+    tcp::socket plain(ioc);
+    boost::system::error_code ec;
+    plain.connect(tcp::endpoint(net::ip::make_address("127.0.0.1"), port), ec);
+    if (!ec) {
+      net::write(plain, net::buffer(std::string("plaintext-should-not-work")), ec);
+      std::string buf(16, '\0');
+      plain.read_some(net::buffer(buf.data(), buf.size()), ec);
+    }
+    plain.close(ec);
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  EXPECT_EQ(messages.load(), 1) << "a plaintext client reached the data callback";
+
+  server->stop();
+}
+
+TEST(TcpTlsLoopbackTest, StartFailsWhenTheCertificateCannotBeLoaded) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = std::make_shared<wirestead::wrapper::TcpServer>(port);
+  server->tls("/nonexistent/cert.pem", "/nonexistent/key.pem");
+  server->on_error([](const wirestead::ErrorContext&) {});
+
+  // Coming up in plaintext because the certificate was unreadable is the one
+  // outcome that must never happen.
+  EXPECT_FALSE(server->start().get());
+  EXPECT_FALSE(server->listening());
+
+  server->stop();
+}

--- a/wirestead/builder/tcp_server_builder.cc
+++ b/wirestead/builder/tcp_server_builder.cc
@@ -77,6 +77,8 @@ std::unique_ptr<wrapper::TcpServer> TcpServerBuilder::build() {
   if (idle_timeout_set_) server->idle_timeout(idle_timeout_);
   if (tcp_no_delay_set_) server->tcp_no_delay(tcp_no_delay_);
   if (keep_alive_set_) server->keep_alive(keep_alive_);
+  if (!tls_certificate_file_.empty() || !tls_private_key_file_.empty())
+    server->tls(tls_certificate_file_, tls_private_key_file_);
   if (send_buffer_size_set_) server->send_buffer_size(send_buffer_size_);
   if (receive_buffer_size_set_) server->receive_buffer_size(receive_buffer_size_);
   if (read_buffer_size_set_) server->read_buffer_size(read_buffer_size_);
@@ -155,6 +157,12 @@ TcpServerBuilder& TcpServerBuilder::tcp_no_delay(bool enable) {
 TcpServerBuilder& TcpServerBuilder::keep_alive(bool enable) {
   keep_alive_ = enable;
   keep_alive_set_ = true;
+  return *this;
+}
+
+TcpServerBuilder& TcpServerBuilder::tls(const std::string& certificate_file, const std::string& private_key_file) {
+  tls_certificate_file_ = certificate_file;
+  tls_private_key_file_ = private_key_file;
   return *this;
 }
 

--- a/wirestead/builder/tcp_server_builder.hpp
+++ b/wirestead/builder/tcp_server_builder.hpp
@@ -60,6 +60,9 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
   TcpServerBuilder& port_retry_interval(std::chrono::milliseconds interval);
   TcpServerBuilder& tcp_no_delay(bool enable = true);
   TcpServerBuilder& keep_alive(bool enable = true);
+  /** @brief Serve TLS using this certificate chain and private key (PEM). */
+  TcpServerBuilder& tls(const std::string& certificate_file, const std::string& private_key_file);
+
   TcpServerBuilder& send_buffer_size(size_t bytes);
   TcpServerBuilder& receive_buffer_size(size_t bytes);
 
@@ -109,6 +112,9 @@ class WIRESTEAD_API TcpServerBuilder : public BuilderInterface<wrapper::TcpServe
   bool tcp_no_delay_set_{false};
   bool keep_alive_;
   bool keep_alive_set_{false};
+  std::string tls_certificate_file_;
+  std::string tls_private_key_file_;
+
   size_t send_buffer_size_;
   bool send_buffer_size_set_{false};
   size_t receive_buffer_size_;

--- a/wirestead/config/tcp_server_config.hpp
+++ b/wirestead/config/tcp_server_config.hpp
@@ -41,6 +41,15 @@ struct TcpServerConfig {
   int max_port_retries = 3;           // Maximum number of retry attempts
   int port_retry_interval_ms = 1000;  // Retry interval in milliseconds
 
+  // TLS. Both must be set for the server to serve TLS; leaving them empty keeps
+  // the connection in plaintext, which is the default. Only honoured in a build
+  // configured with WIRESTEAD_ENABLE_TLS - a build without it rejects a
+  // configured certificate at start() rather than silently serving plaintext.
+  std::string tls_certificate_file;
+  std::string tls_private_key_file;
+
+  [[nodiscard]] bool tls_enabled() const { return !tls_certificate_file.empty() && !tls_private_key_file.empty(); }
+
   int idle_timeout_ms = static_cast<int>(base::constants::DEFAULT_IDLE_TIMEOUT_MS);  // 0 = disabled
   bool tcp_no_delay = base::constants::DEFAULT_TCP_NO_DELAY;
   bool keep_alive = base::constants::DEFAULT_KEEP_ALIVE;

--- a/wirestead/interface/itcp_socket.hpp
+++ b/wirestead/interface/itcp_socket.hpp
@@ -56,7 +56,23 @@ class WIRESTEAD_API TcpSocketInterface {
   virtual void shutdown(net::ip::tcp::socket::shutdown_type what, boost::system::error_code& ec) = 0;
   virtual void close(boost::system::error_code& ec) = 0;
   virtual net::ip::tcp::endpoint remote_endpoint(boost::system::error_code& ec) const = 0;
+
+  // Runs whatever has to happen after accept and before the first read. A plain
+  // socket has nothing to do, so the default reports success and the caller
+  // proceeds exactly as it did before this existed; a TLS socket performs the
+  // handshake here. Failure is the session's cue to close rather than read.
+  //
+  // The handler runs on the caller's executor, not necessarily inline - bind it
+  // to the session strand the same way a read completion is bound.
+  virtual void async_handshake(std::function<void(const boost::system::error_code&)> handler);
 };
+
+// Nothing to negotiate on a plain socket. Posting rather than calling inline
+// would need an executor this interface does not carry, and every caller
+// already dispatches onto its own strand before getting here.
+inline void TcpSocketInterface::async_handshake(std::function<void(const boost::system::error_code&)> handler) {
+  if (handler) handler(boost::system::error_code());
+}
 
 // Flattens into one contiguous buffer and delegates. Copies, which is why a
 // socket-backed implementation overrides this; kept here so test doubles and

--- a/wirestead/transport/tcp_server/ssl_tcp_socket.cc
+++ b/wirestead/transport/tcp_server/ssl_tcp_socket.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wirestead/transport/tcp_server/ssl_tcp_socket.hpp"
+
+#ifdef WIRESTEAD_TLS_ENABLED
+
+#include <utility>
+
+namespace wirestead {
+namespace transport {
+
+SslTcpSocket::SslTcpSocket(tcp::socket sock, std::shared_ptr<ssl::context> context)
+    : context_(std::move(context)), stream_(std::move(sock), *context_) {}
+
+void SslTcpSocket::async_read_some(const net::mutable_buffer& buffer,
+                                   std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  stream_.async_read_some(buffer, std::move(handler));
+}
+
+void SslTcpSocket::async_write(const net::const_buffer& buffer,
+                               std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  net::async_write(stream_, buffer, std::move(handler));
+}
+
+void SslTcpSocket::async_write(const std::vector<net::const_buffer>& buffers,
+                               std::function<void(const boost::system::error_code&, std::size_t)> handler) {
+  net::async_write(stream_, buffers, std::move(handler));
+}
+
+void SslTcpSocket::async_handshake(std::function<void(const boost::system::error_code&)> handler) {
+  stream_.async_handshake(ssl::stream_base::server,
+                          [handler = std::move(handler)](const boost::system::error_code& ec) {
+                            if (handler) handler(ec);
+                          });
+}
+
+// TLS wants close_notify sent before the transport goes away, but the caller
+// reaches here through the plain-socket shutdown() contract, which is
+// synchronous and cannot wait for the peer's reply. Send our half and drop the
+// connection: an unclean shutdown is visible to the peer as a truncated stream,
+// which is the same thing a TCP RST would tell it, and waiting here would block
+// the io thread on a peer that may never answer.
+void SslTcpSocket::shutdown(tcp::socket::shutdown_type what, boost::system::error_code& ec) {
+  boost::system::error_code ignored;
+  stream_.shutdown(ignored);
+  stream_.lowest_layer().shutdown(what, ec);
+}
+
+void SslTcpSocket::close(boost::system::error_code& ec) { stream_.lowest_layer().close(ec); }
+
+tcp::endpoint SslTcpSocket::remote_endpoint(boost::system::error_code& ec) const {
+  return stream_.lowest_layer().remote_endpoint(ec);
+}
+
+}  // namespace transport
+}  // namespace wirestead
+
+#endif  // WIRESTEAD_TLS_ENABLED

--- a/wirestead/transport/tcp_server/ssl_tcp_socket.cc
+++ b/wirestead/transport/tcp_server/ssl_tcp_socket.cc
@@ -18,6 +18,8 @@
 
 #ifdef WIRESTEAD_TLS_ENABLED
 
+#include <openssl/ssl.h>
+
 #include <utility>
 
 namespace wirestead {
@@ -48,15 +50,20 @@ void SslTcpSocket::async_handshake(std::function<void(const boost::system::error
                           });
 }
 
-// TLS wants close_notify sent before the transport goes away, but the caller
-// reaches here through the plain-socket shutdown() contract, which is
-// synchronous and cannot wait for the peer's reply. Send our half and drop the
-// connection: an unclean shutdown is visible to the peer as a truncated stream,
-// which is the same thing a TCP RST would tell it, and waiting here would block
-// the io thread on a peer that may never answer.
+// Sends close_notify without waiting for the peer's.
+//
+// ssl::stream::shutdown() is the obvious call here and is wrong: it runs the
+// full bidirectional exchange and blocks until the peer answers. Measured
+// against two peers that completed the handshake and then stopped reading,
+// stop() went from 0 ms to 8035 ms - an io thread parked on a peer under no
+// obligation to reply, for as long as it feels like not replying.
+//
+// SSL_shutdown's first call writes our close_notify and returns 0 rather than
+// waiting for the reply; only a second call would block for it. One call is
+// exactly the half we want. The peer sees a clean end of stream instead of a
+// truncation, and a peer that never answers costs us nothing.
 void SslTcpSocket::shutdown(tcp::socket::shutdown_type what, boost::system::error_code& ec) {
-  boost::system::error_code ignored;
-  stream_.shutdown(ignored);
+  ::SSL_shutdown(stream_.native_handle());
   stream_.lowest_layer().shutdown(what, ec);
 }
 

--- a/wirestead/transport/tcp_server/ssl_tcp_socket.hpp
+++ b/wirestead/transport/tcp_server/ssl_tcp_socket.hpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef WIRESTEAD_TLS_ENABLED
+
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "wirestead/base/visibility.hpp"
+#include "wirestead/interface/itcp_socket.hpp"
+
+namespace wirestead {
+namespace transport {
+
+namespace net = boost::asio;
+namespace ssl = boost::asio::ssl;
+using tcp = net::ip::tcp;
+
+/**
+ * @brief TLS implementation of TcpSocketInterface for accepted server sockets.
+ *
+ * The session above this only ever reads, writes, handshakes, shuts down and
+ * closes, so wrapping ssl::stream is enough to give it TLS without the session
+ * knowing. Only built when WIRESTEAD_ENABLE_TLS is on.
+ */
+class WIRESTEAD_API SslTcpSocket : public interface::TcpSocketInterface {
+ public:
+  // The context is shared across every accepted connection and must outlive
+  // them, which is why it arrives as a shared_ptr rather than a reference.
+  SslTcpSocket(tcp::socket sock, std::shared_ptr<ssl::context> context);
+  ~SslTcpSocket() override = default;
+
+  void async_read_some(const net::mutable_buffer& buffer,
+                       std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
+  void async_write(const net::const_buffer& buffer,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
+
+  // ssl::stream has no scatter-gather write of its own - the record layer has
+  // to see one contiguous plaintext run anyway - so this hands the sequence to
+  // net::async_write, which coalesces it into as few TLS records as it can.
+  // The syscall-per-message saving from #572 survives; the writev does not.
+  void async_write(const std::vector<net::const_buffer>& buffers,
+                   std::function<void(const boost::system::error_code&, std::size_t)> handler) override;
+
+  void shutdown(tcp::socket::shutdown_type what, boost::system::error_code& ec) override;
+  void close(boost::system::error_code& ec) override;
+  tcp::endpoint remote_endpoint(boost::system::error_code& ec) const override;
+  void async_handshake(std::function<void(const boost::system::error_code&)> handler) override;
+
+ private:
+  // Held so the context cannot be destroyed while a connection still uses it.
+  std::shared_ptr<ssl::context> context_;
+  ssl::stream<tcp::socket> stream_;
+};
+
+}  // namespace transport
+}  // namespace wirestead
+
+#endif  // WIRESTEAD_TLS_ENABLED

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -37,6 +37,7 @@
 #include "wirestead/interface/itcp_acceptor.hpp"
 #include "wirestead/transport/base/error_info_holder.hpp"
 #include "wirestead/transport/tcp_server/boost_tcp_acceptor.hpp"
+#include "wirestead/transport/tcp_server/ssl_tcp_socket.hpp"
 #include "wirestead/transport/tcp_server/tcp_server_session.hpp"
 
 namespace wirestead {
@@ -155,6 +156,51 @@ struct TcpServer::Impl {
       }
     } catch (...) {
     }
+  }
+
+  // One context for the whole server, shared by every accepted connection.
+  // Built once in start() so a bad certificate fails there rather than on the
+  // first client.
+#ifdef WIRESTEAD_TLS_ENABLED
+  std::shared_ptr<boost::asio::ssl::context> ssl_context_;
+#endif
+
+  // Builds the ssl::context, or reports why it cannot. Called from start(), so
+  // a certificate problem surfaces as a start failure with a message rather
+  // than as connections that mysteriously drop at handshake.
+  std::string init_tls() {
+    if (!cfg_.tls_enabled()) return {};
+#ifndef WIRESTEAD_TLS_ENABLED
+    return "TLS was configured but this build has WIRESTEAD_ENABLE_TLS=OFF";
+#else
+    namespace ssl = boost::asio::ssl;
+    try {
+      auto ctx = std::make_shared<ssl::context>(ssl::context::tls_server);
+      // Anything below TLS 1.2 is broken in ways nobody should opt into by
+      // accident, so the floor is not configurable.
+      ctx->set_options(ssl::context::default_workarounds | ssl::context::no_sslv2 | ssl::context::no_sslv3 |
+                       ssl::context::no_tlsv1 | ssl::context::no_tlsv1_1 | ssl::context::single_dh_use);
+      ctx->use_certificate_chain_file(cfg_.tls_certificate_file);
+      ctx->use_private_key_file(cfg_.tls_private_key_file, ssl::context::pem);
+      ssl_context_ = std::move(ctx);
+      return {};
+    } catch (const std::exception& e) {
+      return std::string("Failed to load TLS certificate or key: ") + e.what();
+    }
+#endif
+  }
+
+  std::shared_ptr<TcpServerSession> make_session(tcp::socket sock) {
+#ifdef WIRESTEAD_TLS_ENABLED
+    if (ssl_context_) {
+      return std::make_shared<TcpServerSession>(
+          ioc_, std::make_unique<SslTcpSocket>(std::move(sock), ssl_context_), cfg_.backpressure_threshold,
+          cfg_.idle_timeout_ms, cfg_.backpressure_strategy, cfg_.enable_memory_pool, cfg_.read_buffer_size);
+    }
+#endif
+    return std::make_shared<TcpServerSession>(ioc_, std::move(sock), cfg_.backpressure_threshold, cfg_.idle_timeout_ms,
+                                              cfg_.backpressure_strategy, cfg_.enable_memory_pool,
+                                              cfg_.read_buffer_size);
   }
 
   void apply_accepted_socket_options(tcp::socket& sock) {
@@ -322,10 +368,10 @@ struct TcpServer::Impl {
 
       accept_impl->apply_accepted_socket_options(sock);
 
-      auto new_session = std::make_shared<TcpServerSession>(
-          accept_impl->ioc_, std::move(sock), accept_impl->cfg_.backpressure_threshold,
-          accept_impl->cfg_.idle_timeout_ms, accept_impl->cfg_.backpressure_strategy,
-          accept_impl->cfg_.enable_memory_pool, accept_impl->cfg_.read_buffer_size);
+      // The session only talks to TcpSocketInterface, so TLS is a matter of
+      // which implementation it gets wrapped in here. Everything downstream -
+      // reads, writes, backpressure, stats - is identical either way.
+      auto new_session = accept_impl->make_session(std::move(sock));
 
       ClientId client_id = accept_impl->next_client_id_.fetch_add(1);
 
@@ -561,6 +607,18 @@ void TcpServer::start() {
   // what keeps that promise - before absorption they were empty and a restart
   // zeroed the aggregate for free.
   impl->stats_.reset(0);
+
+  // Load the certificate before binding. A server asked for TLS that cannot
+  // provide it must not come up in plaintext instead - that is the failure mode
+  // where everything looks healthy and nothing is encrypted.
+  if (const auto tls_error = impl->init_tls(); !tls_error.empty()) {
+    WIRESTEAD_LOG_ERROR("tcp_server", "start", tls_error);
+    impl->error_info_holder_.record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONFIGURATION,
+                                          "start", {}, tls_error, false, 0);
+    impl->state_.set(base::LinkState::Error);
+    impl->notify_state();
+    return;
+  }
 
   if (impl->uses_shared_context_) {
     auto& manager = concurrency::IoContextManager::instance();

--- a/wirestead/transport/tcp_server/tcp_server_session.cc
+++ b/wirestead/transport/tcp_server/tcp_server_session.cc
@@ -78,7 +78,19 @@ void TcpServerSession::start() {
   auto self = shared_from_this();
   net::dispatch(strand_, [self] {
     self->reset_idle_timer();
-    self->start_read();
+    // No-op on a plain socket, the TLS handshake on an encrypted one. Reading
+    // before it completes would hand the session ciphertext, so the first read
+    // waits on it - and a failed handshake closes rather than reads.
+    self->socket_->async_handshake(net::bind_executor(self->strand_, [self](const boost::system::error_code& ec) {
+      if (self->closing_ || !self->alive_) return;
+      if (ec) {
+        WIRESTEAD_LOG_WARNING("tcp_server_session", "handshake", "Handshake failed: " + ec.message());
+        self->do_close();
+        return;
+      }
+      self->reset_idle_timer();
+      self->start_read();
+    }));
   });
 }
 

--- a/wirestead/wrapper/iserver.hpp
+++ b/wirestead/wrapper/iserver.hpp
@@ -211,6 +211,16 @@ class WIRESTEAD_API ServerInterface {
   virtual bool try_send_to_line(ClientId client_id, std::string_view line) = 0;
 
   // Event handlers
+
+  /**
+   * @brief Fires when a connection is accepted.
+   *
+   * Accepted, not usable. On a TLS server this runs before the handshake, so a
+   * client that fails it still produces one on_connect - followed by an
+   * on_disconnect, with no on_data in between. The two callbacks stay paired
+   * either way, so connection bookkeeping keyed on them does not leak; treat
+   * the first byte of data, not this callback, as proof the peer got through.
+   */
   virtual ServerInterface& on_connect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_disconnect(ConnectionHandler handler) = 0;
   virtual ServerInterface& on_data(MessageHandler handler) = 0;

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -45,6 +45,8 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
   std::condition_variable bp_cv_;
   uint16_t port_;
   std::string bind_address_{"0.0.0.0"};
+  std::string tls_certificate_file_;
+  std::string tls_private_key_file_;
   std::shared_ptr<interface::Channel> channel_;
   std::shared_ptr<boost::asio::io_context> external_ioc_;
   std::atomic<bool> use_external_context_{false};
@@ -238,6 +240,8 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       config.receive_buffer_size = receive_buffer_size_.load();
       config.read_buffer_size = read_buffer_size_.load();
       config.use_shared_context = shared_context_.load();
+      config.tls_certificate_file = tls_certificate_file_;
+      config.tls_private_key_file = tls_private_key_file_;
 
       channel_ = factory::ChannelFactory::create(config, external_ioc_);
       transport_cache_ = std::dynamic_pointer_cast<transport::TcpServer>(channel_);
@@ -743,6 +747,13 @@ TcpServer& TcpServer::tcp_no_delay(bool enable) {
 
 TcpServer& TcpServer::keep_alive(bool enable) {
   impl_->keep_alive_.store(enable);
+  return *this;
+}
+
+TcpServer& TcpServer::tls(const std::string& certificate_file, const std::string& private_key_file) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->tls_certificate_file_ = certificate_file;
+  impl_->tls_private_key_file_ = private_key_file;
   return *this;
 }
 

--- a/wirestead/wrapper/tcp_server/tcp_server.hpp
+++ b/wirestead/wrapper/tcp_server/tcp_server.hpp
@@ -117,6 +117,14 @@ class WIRESTEAD_API TcpServer : public ServerInterface {
   TcpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
   TcpServer& tcp_no_delay(bool enable = true);
   TcpServer& keep_alive(bool enable = true);
+  /**
+   * @brief Serve TLS using this certificate chain and private key (PEM).
+   *
+   * Must be set before start(). Requires a build with WIRESTEAD_ENABLE_TLS;
+   * without it start() fails rather than quietly serving plaintext.
+   */
+  TcpServer& tls(const std::string& certificate_file, const std::string& private_key_file);
+
   TcpServer& send_buffer_size(size_t bytes);
   TcpServer& receive_buffer_size(size_t bytes);
 


### PR DESCRIPTION
## Description

Every transport sent plaintext, and `docs/security.md` said so plainly: no encryption, and no hook for adding it without patching the library. Deployments that needed it put stunnel or a reverse proxy in front.

This adds TLS for the **TCP server**, opt-in at build time and at runtime. Nothing else changes: the TCP client, UDP, Serial and UDS remain plaintext, and DTLS is still unsupported.

The design fell out of what was already there. `TcpServerSession` talks to `TcpSocketInterface`, not to a socket, and it only ever performs four operations on it — `async_read_some`, `async_write`, `shutdown`, `close`. So this is a second implementation of that interface rather than a change to the session. Reads, writes, backpressure and stats are the same code either way; the session gained no knowledge of TLS.

## Key Changes

| | |
|---|---|
| `cmake/WiresteadOptions.cmake`, `WiresteadDependencies.cmake` | `WIRESTEAD_ENABLE_TLS` (default **OFF**); OpenSSL looked for only when on |
| `interface/itcp_socket.hpp` | `async_handshake()`, defaulting to immediate success |
| `transport/tcp_server/ssl_tcp_socket.{hpp,cc}` | new — wraps `ssl::stream<tcp::socket>` |
| `transport/tcp_server/tcp_server.cc` | builds the `ssl::context` in `start()`; accept path picks the implementation |
| `transport/tcp_server/tcp_server_session.cc` | handshake before the first read |
| `config/`, `wrapper/`, `builder/` | `tls(cert, key)` |
| `test/integration/tcp/test_tls_loopback.cc` | new — registered only in a TLS build |
| `docs/security.md`, `README.md`, `CHANGELOG.md` | rewritten around what is now true |

```cpp
auto server = wirestead::tcp_server(9000)
                  .tls("/path/to/fullchain.pem", "/path/to/privkey.pem")
                  .on_data(handler)
                  .build();
```

**A default build is untouched** — no OpenSSL dependency, none of this code compiled in, and `async_handshake()`'s default means a plain socket follows exactly the path it did before. The full suite passes unchanged at 768 with TLS off.

**Failing closed is the point.** A server asked for encryption it cannot provide must not come up in plaintext instead. `start()` fails when the certificate cannot be loaded, and equally when `tls()` is set in a build without `WIRESTEAD_ENABLE_TLS`, rather than binding the port anyway. TLS 1.2 is the floor and is not configurable.

## Related Issues

- Addresses the "optional TLS module" item from the external review that also produced #583 and #584.

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified against an implementation that is not this library.** `openssl s_client`, twice:

- With `-CAfile cert.pem`: handshake completes, `ping-over-tls` in, `pong-over-tls` out, `bytes_received=14`.
- With `-verify_return_error` against a self-signed certificate: the client rejects it, the server logs `tlsv1 alert unknown ca` and closes the session having served nothing.

Both configurations then run the whole suite: **768/768 with TLS off**, **770/770 with TLS on** (the two extra are the new tests).

**The three open questions from the first round were measured, and one was a real defect.** Second commit on this branch.

**`shutdown()` blocked the io thread.** `ssl::stream::shutdown()` runs the full bidirectional exchange and waits for the peer's `close_notify`:

| | `stop()` with two silent peers |
|---|---|
| Plaintext server | 0 ms |
| TLS server, before | **8035 ms** |
| TLS server, after | 0 ms |

The peers had completed the handshake and simply stopped reading — nothing pathological, and nothing obliging them to reply. That is an io thread parked for as long as the peer feels like it, which is the hazard #427, #431 and #449 all exist to avoid. Fixed by calling `SSL_shutdown()` once: the first call writes our `close_notify` and returns instead of waiting, which is exactly the half worth having. The peer still sees a clean end of stream rather than a truncation.

**`on_connect` before the handshake is not a defect.** Three plaintext clients against a TLS server give `connects=3, disconnects=3, datas=0` — the pair is balanced, so bookkeeping keyed on those callbacks does not leak, and no plaintext reaches `on_data`. Moving it would change behaviour for every plaintext user and lose the property that every accepted connection is announced, which is what you want when logging rejected ones. Documented on the callback and in `docs/security.md` instead: accepted is not usable, and the first byte of data is the proof.

**A CI job now builds with TLS on.** `TLS (ubuntu-24.04, gcc)`, wired into the quality summary. Without it, `WIRESTEAD_ENABLE_TLS=ON` is a configuration nobody compiles — the gap that left the TSAN nightly dark for three days in #589.

**Not included:** client TLS (`tcp_client.cc` still owns a `tcp::socket` directly and would need the same extraction the server already had), client certificates, peer verification, cipher suite or ALPN selection, and certificate reload without restart. All are listed as absent in `docs/security.md` rather than left to be discovered.

**No regression test for the shutdown timing.** Asserting on how long `stop()` takes is timing-dependent, and a flaky test in this repo has already cost a round trip (#591). The 8035 ms → 0 ms measurement is reproducible by hand against a peer that stops reading; making it a CI assertion needs a threshold nobody can justify. Say the word if you would rather have one anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep