### PR TITLE
fix: fail start() when only half the TLS config is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and ABI policy.
   leaves plain sockets behaving exactly as before. Reads, writes, backpressure
   and stats are the same code either way.
 
+  Setting only one of the certificate and key fails `start()` rather than
+  falling back to plaintext.
+
   Closing a TLS connection sends `close_notify` without waiting for the peer's
   reply: the bidirectional exchange blocks until the peer answers, and a peer
   that simply stops reading held `stop()` for 8 seconds in testing. `on_connect`

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,7 +24,9 @@ auto server = wirestead::tcp_server(9000)
 ```
 
 Both files are PEM. The certificate is a chain file, so intermediates belong in
-it. TLS 1.2 is the floor and is not configurable.
+it. TLS 1.2 is the floor and is not configurable. Setting only one of the two
+fails `start()` rather than falling back to plaintext - an empty environment
+variable should not silently turn encryption off.
 
 Leaving `tls()` unset serves plaintext, which is the default. Setting it in a
 build without `WIRESTEAD_ENABLE_TLS` makes `start()` **fail** rather than serve

--- a/test/integration/tcp/test_tls_loopback.cc
+++ b/test/integration/tcp/test_tls_loopback.cc
@@ -25,6 +25,8 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "test_utils.hpp"
 #include "wirestead/wirestead.hpp"
@@ -136,6 +138,27 @@ TEST(TcpTlsLoopbackTest, ServesTlsAndRejectsPlaintextClients) {
   EXPECT_EQ(messages.load(), 1) << "a plaintext client reached the data callback";
 
   server->stop();
+}
+
+// Half a TLS config used to leave tls_enabled() false, which meant the server
+// came up in plaintext without a word - an empty env var or a typo away from
+// serving unencrypted traffic to a caller who asked for TLS.
+TEST(TcpTlsLoopbackTest, StartFailsWhenOnlyHalfTheTlsConfigIsSet) {
+  SelfSignedCert certs;
+  if (!certs.ok()) {
+    GTEST_SKIP() << "openssl CLI unavailable, cannot generate a test certificate";
+  }
+
+  for (const auto& [cert, key] :
+       std::vector<std::pair<std::string, std::string>>{{certs.cert().string(), ""}, {"", certs.key().string()}}) {
+    auto server = std::make_shared<wirestead::wrapper::TcpServer>(TestUtils::getAvailableTestPort());
+    server->tls(cert, key);
+    server->on_error([](const wirestead::ErrorContext&) {});
+
+    EXPECT_FALSE(server->start().get()) << "half a TLS config started anyway";
+    EXPECT_FALSE(server->listening());
+    server->stop();
+  }
 }
 
 TEST(TcpTlsLoopbackTest, StartFailsWhenTheCertificateCannotBeLoaded) {

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -169,6 +169,14 @@ struct TcpServer::Impl {
   // a certificate problem surfaces as a start failure with a message rather
   // than as connections that mysteriously drop at handshake.
   std::string init_tls() {
+    // Half a TLS config is a request for TLS, not a request for plaintext. An
+    // empty environment variable or a typo would otherwise leave tls_enabled()
+    // false and bring the server up unencrypted without saying anything, which
+    // is the one outcome this whole path exists to prevent.
+    if (!cfg_.tls_certificate_file.empty() != !cfg_.tls_private_key_file.empty()) {
+      return cfg_.tls_certificate_file.empty() ? "TLS needs a certificate as well as a private key"
+                                               : "TLS needs a private key as well as a certificate";
+    }
     if (!cfg_.tls_enabled()) return {};
 #ifndef WIRESTEAD_TLS_ENABLED
     return "TLS was configured but this build has WIRESTEAD_ENABLE_TLS=OFF";


### PR DESCRIPTION
## Description

`tls_enabled()` requires both the certificate and the key to be non-empty. Set only one — an empty environment variable, a typo, a config key that did not resolve — and it returns false, so `init_tls()` treats the server as plaintext and **starts it that way without a word**.

```cpp
server->tls(cert_path, "");   // key came from an unset env var
server->start();              // listening. in plaintext. no error.
```

That is the exact outcome #593 was written to prevent — its own commit message says a server asked for encryption it cannot provide must not come up in plaintext instead — and it is reachable from a single missing character.

## Key Changes

- `transport/tcp_server/tcp_server.cc` — half a TLS config fails `start()` instead of falling back:

```cpp
if (!cfg_.tls_certificate_file.empty() != !cfg_.tls_private_key_file.empty()) {
  return cfg_.tls_certificate_file.empty() ? "TLS needs a certificate as well as a private key"
                                           : "TLS needs a private key as well as a certificate";
}
```

- `test/integration/tcp/test_tls_loopback.cc` — regression test covering both halves.
- `docs/security.md`, `CHANGELOG.md` — say so.

Setting neither is still plaintext, which is the documented default and unchanged.

## Related Issues

- Fixes a gap in #593.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**How this surfaced.** The question on the table was whether server TLS should have been a separate `TlsServer` type, or a separate `wirestead_tls` target with a socket factory hook, rather than a build option on the existing server. Working through that comparison meant re-reading the configuration path, and the silent-plaintext case fell out of it.

Neither restructuring would have caught this. Both are about *where TLS lives*; this is about what happens when its configuration is half-supplied, and it would have been reachable in every one of the three designs.

**Both restructurings were rejected, for the record.** A separate target buys a compile-time error and removes three `#ifdef`s, at the cost of a second install/export/pkg-config/vcpkg surface — the core already avoids linking OpenSSL by default, so the dependency argument is already satisfied. Hiding `tls()` behind `#ifdef` in a non-TLS build buys a compile error whose message (`no member named 'tls'`) is *less* useful than the runtime one it replaces, which names `WIRESTEAD_ENABLE_TLS` outright. Happy to revisit either if you disagree, but neither seemed worth the diff.

**Test cost.** The new case takes about 4 s, because it starts two servers and each start failure runs through the normal path. Slower than the assertion deserves, but it exercises the real `start()` rather than poking at `init_tls()` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
