### PR TITLE
feat: optional TLS for the TCP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and ABI policy.
 
 ### Added
 
+- Optional TLS for the TCP **client**, behind the same `-DWIRESTEAD_ENABLE_TLS=ON`.
+  Two wirestead services can now talk to each other encrypted; before this a
+  wirestead client could only reach a wirestead TLS server by not being a
+  wirestead client.
+
+  ```cpp
+  auto client = wirestead::tcp_client("example.com", 9000).tls().build();
+  client->tls("/path/to/ca.pem");   // or trust a private CA
+  ```
+
+  Verification is not optional: the chain, the host name and SNI are all checked
+  against the host passed to the constructor. No argument uses the system trust
+  store. `connected()` only becomes true after the handshake, so a peer that
+  fails verification never reports itself connected.
+
+  No extraction refactor was needed. `ssl::stream` can borrow its next layer by
+  reference, so the client keeps owning its socket and connect, socket options,
+  cancel and close are untouched - only reads, writes and shutdown branch.
+
 - Optional TLS for the TCP server, behind `-DWIRESTEAD_ENABLE_TLS=ON`. A default
   build is unchanged and has no OpenSSL dependency.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simple async C++ communication library for Serial, TCP, UDP, and Unix Domain Soc
 
 The project prioritizes **API clarity, predictable runtime behavior, and stability** over rapid feature expansion.
 
-> **Security note**: transports send data in plaintext by default. The TCP server can serve TLS in a build configured with `-DWIRESTEAD_ENABLE_TLS=ON`; the TCP client, UDP, Serial and UDS cannot, and DTLS is not supported. See [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md) before using `wirestead` over an untrusted network.
+> **Security note**: transports send data in plaintext by default. TCP can do TLS in a build configured with `-DWIRESTEAD_ENABLE_TLS=ON` - server and client, with the client verifying the server; UDP, Serial and UDS cannot, and DTLS is not supported. See [Security and Threat Model](https://github.com/wirestead/wirestead/blob/main/docs/security.md) before using `wirestead` over an untrusted network.
 
 ## Feature Highlights
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,19 +2,19 @@
 
 ## Transport encryption
 
-Plaintext is the default on every transport. The TCP **server** can serve TLS
-when the library is built with it; nothing else can.
+Plaintext is the default on every transport. TCP can do TLS when the library is
+built with it; nothing else can.
 
 | | TLS |
 |---|---|
 | TCP server | Optional, opt-in at build and at runtime |
-| TCP client | No |
+| TCP client | Optional, opt-in at build and at runtime |
 | UDP, Serial, UDS | No |
-
-### TCP server TLS
 
 Build with `-DWIRESTEAD_ENABLE_TLS=ON`, which requires OpenSSL. A default build
 has no OpenSSL dependency and no TLS code in it.
+
+### TCP server TLS
 
 ```cpp
 auto server = wirestead::tcp_server(9000)
@@ -23,8 +23,10 @@ auto server = wirestead::tcp_server(9000)
                   .build();
 ```
 
-Both files are PEM. The certificate is a chain file, so intermediates belong in
-it. TLS 1.2 is the floor and is not configurable. Setting only one of the two
+Both files are PEM, and the key must not be passphrase-protected - there is
+nowhere to prompt for one, so `start()` fails with an opaque `UI routines`
+error. Generate with `-nodes`. The certificate is a chain file, so
+intermediates belong in it. TLS 1.2 is the floor and is not configurable. Setting only one of the two
 fails `start()` rather than falling back to plaintext - an empty environment
 variable should not silently turn encryption off.
 
@@ -35,7 +37,8 @@ looking healthy. An unreadable or malformed certificate fails `start()` the same
 way, before the listening socket is bound.
 
 What this does not do: no client certificates, no peer verification, no cipher
-suite or ALPN configuration, no certificate reload without a restart. If you need
+suite or ALPN configuration, and no certificate reload - certificates are read
+once at `start()`, so renewal needs a restart. If you need
 any of those, terminate TLS outside the library as described below.
 
 Two behaviours worth knowing:
@@ -50,6 +53,33 @@ Two behaviours worth knowing:
   obligation to answer would hold an io thread for as long as it liked -
   measured at 8 seconds for two silent peers before this was changed. The peer
   still sees a clean end of stream rather than a truncation.
+
+### TCP client TLS
+
+```cpp
+auto client = wirestead::tcp_client("example.com", 9000)
+                  .tls()                      // system trust store
+                  .on_data(handler)
+                  .build();
+
+client->tls("/path/to/ca.pem");               // or trust a private CA
+```
+
+**Verification is not optional and cannot be turned off.** TLS without it
+encrypts traffic to whoever answered, which is precisely what an attacker in the
+middle wants. The client checks the chain and that the certificate matches the
+host passed to the constructor, and sends that host as SNI. With no argument the
+system trust store is used; pass a PEM to trust a private CA or a self-signed
+certificate instead.
+
+Because the certificate is checked against the connection host, connect by the
+name on the certificate. A certificate issued to `localhost` will not validate
+for `127.0.0.1`.
+
+`connected()` becomes true only after the handshake. A peer that fails
+verification never reports itself connected, and nothing is sent to it.
+
+No client certificates - the server cannot require one from a wirestead client.
 
 ### Everything else
 

--- a/test/integration/tcp/test_tls_loopback.cc
+++ b/test/integration/tcp/test_tls_loopback.cc
@@ -140,6 +140,79 @@ TEST(TcpTlsLoopbackTest, ServesTlsAndRejectsPlaintextClients) {
   server->stop();
 }
 
+// The point of client TLS: both ends are wirestead, and the traffic between
+// them is encrypted. Until this existed a wirestead client could only reach a
+// wirestead TLS server by not being a wirestead client.
+TEST(TcpTlsLoopbackTest, WiresteadClientTalksToWiresteadTlsServer) {
+  SelfSignedCert certs;
+  if (!certs.ok()) {
+    GTEST_SKIP() << "openssl CLI unavailable, cannot generate a test certificate";
+  }
+
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = std::make_shared<wirestead::wrapper::TcpServer>(port);
+  server->tls(certs.cert().string(), certs.key().string());
+  server->on_data([&](const wirestead::MessageContext& ctx) { server->broadcast("pong-tls"); });
+  server->on_error([](const wirestead::ErrorContext&) {});
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  // The certificate is issued to "localhost", so the client has to connect by
+  // that name for host name verification to pass.
+  std::atomic<int> replies{0};
+  std::string received;
+  auto client = std::make_shared<wirestead::wrapper::TcpClient>("localhost", port);
+  client->tls(certs.cert().string());
+  client->on_data([&](const wirestead::MessageContext& ctx) {
+    received.assign(ctx.data());
+    replies.fetch_add(1);
+  });
+  client->on_error([](const wirestead::ErrorContext&) {});
+
+  ASSERT_TRUE(client->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return client->connected(); }, 10000));
+
+  ASSERT_TRUE(client->send("ping-tls"));
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return replies.load() > 0; }, 10000));
+  EXPECT_EQ(received, "pong-tls");
+
+  client->stop();
+  server->stop();
+}
+
+// Verification is the whole point of the client half. Trusting nothing but the
+// system store, a self-signed server must fail rather than connect.
+TEST(TcpTlsLoopbackTest, ClientRejectsAnUntrustedServerCertificate) {
+  SelfSignedCert certs;
+  if (!certs.ok()) {
+    GTEST_SKIP() << "openssl CLI unavailable, cannot generate a test certificate";
+  }
+
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = std::make_shared<wirestead::wrapper::TcpServer>(port);
+  server->tls(certs.cert().string(), certs.key().string());
+  std::atomic<int> served{0};
+  server->on_data([&](const wirestead::MessageContext&) { served.fetch_add(1); });
+  server->on_error([](const wirestead::ErrorContext&) {});
+  ASSERT_TRUE(server->start().get());
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return server->listening(); }, 5000));
+
+  auto client = std::make_shared<wirestead::wrapper::TcpClient>("localhost", port);
+  client->tls();  // system trust store only - our self-signed cert is not in it
+  client->on_data([](const wirestead::MessageContext&) {});
+  client->on_error([](const wirestead::ErrorContext&) {});
+  client->start();
+
+  // Never reports itself connected, and nothing it sends reaches the server.
+  EXPECT_FALSE(TestUtils::waitForCondition([&] { return client->connected(); }, 3000));
+  EXPECT_EQ(served.load(), 0);
+
+  client->stop();
+  server->stop();
+}
+
 // Half a TLS config used to leave tls_enabled() false, which meant the server
 // came up in plaintext without a word - an empty env var or a typo away from
 // serving unencrypted traffic to a caller who asked for TLS.

--- a/wirestead/builder/tcp_client_builder.cc
+++ b/wirestead/builder/tcp_client_builder.cc
@@ -65,6 +65,7 @@ std::unique_ptr<wrapper::TcpClient> TcpClientBuilder::build() {
 
   if (retry_interval_set_) client->retry_interval(retry_interval_);
   if (max_retries_set_) client->max_retries(max_retries_);
+  if (tls_enabled_) client->tls(tls_ca_file_);
   if (connection_timeout_set_) client->connection_timeout(connection_timeout_);
   if (idle_timeout_set_) client->idle_timeout(idle_timeout_);
   if (idle_timeout_action_set_) client->idle_timeout_action(idle_timeout_action_);
@@ -108,6 +109,12 @@ TcpClientBuilder& TcpClientBuilder::retry_interval(std::chrono::milliseconds int
 TcpClientBuilder& TcpClientBuilder::max_retries(int max_retries) {
   max_retries_ = max_retries;
   max_retries_set_ = true;
+  return *this;
+}
+
+TcpClientBuilder& TcpClientBuilder::tls(const std::string& ca_file) {
+  tls_enabled_ = true;
+  tls_ca_file_ = ca_file;
   return *this;
 }
 

--- a/wirestead/builder/tcp_client_builder.hpp
+++ b/wirestead/builder/tcp_client_builder.hpp
@@ -50,6 +50,9 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
 
   TcpClientBuilder& retry_interval(std::chrono::milliseconds interval);
   TcpClientBuilder& max_retries(int max_retries);
+  /** @brief Connect over TLS, verifying the server. Empty ca_file uses the system trust store. */
+  TcpClientBuilder& tls(const std::string& ca_file = "");
+
   TcpClientBuilder& connection_timeout(std::chrono::milliseconds timeout);
   /**
    * @brief Configure application-level idle timeout.
@@ -90,6 +93,9 @@ class WIRESTEAD_API TcpClientBuilder : public BuilderInterface<wrapper::TcpClien
   bool retry_interval_set_{false};
   int max_retries_;
   bool max_retries_set_{false};
+  bool tls_enabled_{false};
+  std::string tls_ca_file_;
+
   std::chrono::milliseconds connection_timeout_;
   bool connection_timeout_set_{false};
   std::chrono::milliseconds idle_timeout_;

--- a/wirestead/config/tcp_client_config.hpp
+++ b/wirestead/config/tcp_client_config.hpp
@@ -47,6 +47,16 @@ struct TcpClientConfig {
   // connection.
   size_t read_buffer_size = base::constants::DEFAULT_READ_BUFFER_SIZE;
 
+  // TLS. Off unless tls_enabled is set, which is the default.
+  //
+  // The server side of TLS proves who it is; the client side is what checks.
+  // Verification is therefore on and not optional: an unverified TLS connection
+  // encrypts traffic to whoever answered, which is exactly what an attacker in
+  // the middle wants. Leave tls_ca_file empty to use the system trust store,
+  // or point it at a PEM to trust a private CA or a self-signed certificate.
+  bool tls_enabled = false;
+  std::string tls_ca_file;
+
   TcpClientConfig() = default;
   TcpClientConfig(const TcpClientConfig&) = default;
   TcpClientConfig& operator=(const TcpClientConfig&) = default;

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -26,6 +26,9 @@
 #include <array>
 #include <atomic>
 #include <boost/asio.hpp>
+#ifdef WIRESTEAD_TLS_ENABLED
+#include <boost/asio/ssl.hpp>
+#endif
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -81,6 +84,25 @@ struct TcpClient::Impl {
   std::atomic<uint64_t> current_seq_{0};
   tcp::resolver resolver_;
   tcp::socket socket_;
+
+#ifdef WIRESTEAD_TLS_ENABLED
+  // The stream borrows socket_ rather than owning it, so connect, socket
+  // options, cancel and close all keep operating on socket_ exactly as they do
+  // without TLS. Only reads, writes and shutdown route through here, and only
+  // while a connection is up - it is rebuilt per connection because a TLS
+  // session cannot outlive the socket it negotiated on.
+  std::shared_ptr<boost::asio::ssl::context> ssl_context_;
+  std::optional<boost::asio::ssl::stream<tcp::socket&>> tls_;
+#endif
+
+  // True when this connection is encrypted. Reads to it happen on the strand.
+  bool tls_active() const {
+#ifdef WIRESTEAD_TLS_ENABLED
+    return tls_.has_value();
+#else
+    return false;
+#endif
+  }
   // Guards the mutable subset of cfg_ (retry_interval_ms, max_retries,
   // connection_timeout_ms, idle_timeout_ms, idle_timeout_action) and
   // reconnect_policy_ below - the fields that have runtime setters
@@ -203,6 +225,8 @@ struct TcpClient::Impl {
   void notify_state();
   void reset_io_objects();
   void apply_socket_options();
+  void handshake_then(std::shared_ptr<TcpClient> self, uint64_t seq, std::function<void()> next);
+  void finish_connect(std::shared_ptr<TcpClient> self, uint64_t seq);
   void reset_idle_timer(std::shared_ptr<TcpClient> self, uint64_t seq);
   void cancel_idle_timer();
   void record_error(diagnostics::ErrorLevel lvl, diagnostics::ErrorCategory cat, std::string_view operation,
@@ -757,7 +781,6 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
           self->impl_->connect_timer_.cancel();
           self->impl_->retry_attempts_ = 0;
           self->impl_->reconnect_attempt_count_ = 0;
-          self->impl_->connected_.store(true);
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
           int yes = 1;
@@ -766,21 +789,102 @@ void TcpClient::Impl::do_resolve_connect(std::shared_ptr<TcpClient> self, uint64
 #endif
 
           self->impl_->apply_socket_options();
-          self->impl_->transition_to(LinkState::Connected);
-          boost::system::error_code ep_ec;
-          auto rep = self->impl_->socket_.remote_endpoint(ep_ec);
-          if (!ep_ec) {
-            WIRESTEAD_LOG_INFO("tcp_client", "connect",
-                               fmt::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
-          }
-          self->impl_->start_read(self, seq);
-          self->impl_->reset_idle_timer(self, seq);
-          net::post(self->impl_->strand_, [self, seq]() {
-            self->impl_->writing_ = false;
-            self->impl_->do_write(self, seq);
-          });
+
+          // TCP is up; TLS still has to prove who answered. Reading before the
+          // handshake completes would hand the session ciphertext, and a failed
+          // handshake must not be reported as a working connection - so the
+          // rest of the connect path waits behind it. Plaintext runs the
+          // continuation immediately, which is what it did before TLS existed.
+          self->impl_->handshake_then(self, seq, [self, seq] { self->impl_->finish_connect(self, seq); });
         });
       });
+}
+
+// Sets up the TLS stream if configured, runs the handshake, then hands control
+// back. Without TLS - or in a build without it - `next` runs straight away and
+// the connect path is byte for byte what it was.
+void TcpClient::Impl::handshake_then(std::shared_ptr<TcpClient> self, uint64_t seq, std::function<void()> next) {
+#ifdef WIRESTEAD_TLS_ENABLED
+  bool want_tls = false;
+  std::string ca_file;
+  {
+    std::lock_guard<std::mutex> lock(cfg_mtx_);
+    want_tls = cfg_.tls_enabled;
+    ca_file = cfg_.tls_ca_file;
+  }
+
+  if (want_tls) {
+    namespace ssl = boost::asio::ssl;
+    try {
+      if (!ssl_context_) {
+        auto ctx = std::make_shared<ssl::context>(ssl::context::tls_client);
+        ctx->set_options(ssl::context::default_workarounds | ssl::context::no_sslv2 | ssl::context::no_sslv3 |
+                         ssl::context::no_tlsv1 | ssl::context::no_tlsv1_1);
+        if (ca_file.empty()) {
+          ctx->set_default_verify_paths();
+        } else {
+          ctx->load_verify_file(ca_file);
+        }
+        // Not optional. An unverified TLS connection encrypts traffic to
+        // whoever answered, which is what an attacker in the middle wants.
+        ctx->set_verify_mode(ssl::verify_peer);
+        ssl_context_ = std::move(ctx);
+      }
+      tls_.emplace(socket_, *ssl_context_);
+      tls_->set_verify_callback(ssl::host_name_verification(cfg_.host));
+      // SNI, and the name the certificate is checked against.
+      ::SSL_set_tlsext_host_name(tls_->native_handle(), cfg_.host.c_str());
+    } catch (const std::exception& e) {
+      const std::string msg = std::string("TLS setup failed: ") + e.what();
+      WIRESTEAD_LOG_ERROR("tcp_client", "handshake", msg);
+      record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "handshake",
+                   boost::asio::error::invalid_argument, msg, false, 0);
+      tls_.reset();
+      handle_close(self, seq, boost::asio::error::invalid_argument);
+      return;
+    }
+
+    tls_->async_handshake(ssl::stream_base::client,
+                          net::bind_executor(strand_, [this, self, seq, next](const boost::system::error_code& ec) {
+                            if (seq != current_seq_.load() || stop_requested_.load() || stopping_.load()) return;
+                            if (ec) {
+                              WIRESTEAD_LOG_ERROR("tcp_client", "handshake", "TLS handshake failed: " + ec.message());
+                              record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
+                                           "handshake", ec, "TLS handshake failed: " + ec.message(), false, 0);
+                              tls_.reset();
+                              handle_close(self, seq, ec);
+                              return;
+                            }
+                            next();
+                          }));
+    return;
+  }
+#else
+  (void)self;
+  (void)seq;
+#endif
+  next();
+}
+
+void TcpClient::Impl::finish_connect(std::shared_ptr<TcpClient> self, uint64_t seq) {
+  // Set here rather than at TCP connect: with TLS, a socket whose handshake
+  // has not finished is not a usable connection, and connected() is what
+  // callers poll before sending. Reporting true for a peer that failed
+  // verification would be worse than useless.
+  connected_.store(true);
+  transition_to(LinkState::Connected);
+  boost::system::error_code ep_ec;
+  auto rep = socket_.remote_endpoint(ep_ec);
+  if (!ep_ec) {
+    WIRESTEAD_LOG_INFO("tcp_client", "connect",
+                       fmt::format("Connected to {}:{}", rep.address().to_string(), rep.port()));
+  }
+  start_read(self, seq);
+  reset_idle_timer(self, seq);
+  net::post(strand_, [self, seq]() {
+    self->impl_->writing_ = false;
+    self->impl_->do_write(self, seq);
+  });
 }
 
 void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t seq) {
@@ -857,7 +961,7 @@ void TcpClient::Impl::schedule_retry(std::shared_ptr<TcpClient> self, uint64_t s
 }
 
 void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) {
-  socket_.async_read_some(net::buffer(rx_.data(), rx_.size()), [self, seq](auto ec, std::size_t n) {
+  auto on_read = [self, seq](auto ec, std::size_t n) {
     if (ec == net::error::operation_aborted || seq != self->impl_->current_seq_.load()) {
       return;
     }
@@ -896,7 +1000,14 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
       }
     }
     self->impl_->start_read(self, seq);
-  });
+  };
+#ifdef WIRESTEAD_TLS_ENABLED
+  if (tls_) {
+    tls_->async_read_some(net::buffer(rx_.data(), rx_.size()), std::move(on_read));
+    return;
+  }
+#endif
+  socket_.async_read_some(net::buffer(rx_.data(), rx_.size()), std::move(on_read));
 }
 
 void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
@@ -962,6 +1073,12 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
     self->impl_->do_write(self, seq);
   };
 
+#ifdef WIRESTEAD_TLS_ENABLED
+  if (tls_) {
+    net::async_write(*tls_, current_write_views_, on_write);
+    return;
+  }
+#endif
   net::async_write(socket_, current_write_views_, on_write);
 }
 
@@ -1037,6 +1154,12 @@ void TcpClient::Impl::handle_idle_timeout(std::shared_ptr<TcpClient> self, uint6
 
 void TcpClient::Impl::close_socket() {
   boost::system::error_code ec;
+#ifdef WIRESTEAD_TLS_ENABLED
+  // One SSL_shutdown writes close_notify and returns; a second would wait for
+  // the peer's, which is the block measured at 8 s on the server side.
+  if (tls_) ::SSL_shutdown(tls_->native_handle());
+  tls_.reset();
+#endif
   socket_.shutdown(tcp::socket::shutdown_both, ec);
   socket_.close(ec);
 }

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -82,6 +82,8 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
   std::chrono::milliseconds retry_interval_{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   int max_retries_ = base::constants::DEFAULT_MAX_RETRIES;
   std::chrono::milliseconds connection_timeout_{base::constants::DEFAULT_CONNECTION_TIMEOUT_MS};
+  bool tls_enabled_{false};
+  std::string tls_ca_file_;
   std::chrono::milliseconds idle_timeout_{base::constants::DEFAULT_IDLE_TIMEOUT_MS};
   IdleTimeoutAction idle_timeout_action_{IdleTimeoutAction::Reconnect};
   size_t backpressure_threshold_{base::constants::DEFAULT_BACKPRESSURE_THRESHOLD};
@@ -200,6 +202,8 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       config.retry_interval_ms = static_cast<unsigned int>(retry_interval_.count());
       config.max_retries = max_retries_;
       config.connection_timeout_ms = static_cast<unsigned>(connection_timeout_.count());
+      config.tls_enabled = tls_enabled_;
+      config.tls_ca_file = tls_ca_file_;
       config.idle_timeout_ms = static_cast<unsigned>(idle_timeout_.count());
       config.idle_timeout_action = idle_timeout_action_;
       config.backpressure_threshold = backpressure_threshold_;
@@ -708,6 +712,13 @@ TcpClient& TcpClient::max_retries(int m) {
   }
   return *this;
 }
+TcpClient& TcpClient::tls(const std::string& ca_file) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->tls_enabled_ = true;
+  impl_->tls_ca_file_ = ca_file;
+  return *this;
+}
+
 TcpClient& TcpClient::connection_timeout(std::chrono::milliseconds t) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->connection_timeout_ = t;

--- a/wirestead/wrapper/tcp_client/tcp_client.hpp
+++ b/wirestead/wrapper/tcp_client/tcp_client.hpp
@@ -95,6 +95,18 @@ class WIRESTEAD_API TcpClient : public ChannelInterface {
   TcpClient& batch_latency(std::chrono::milliseconds latency);
   TcpClient& retry_interval(std::chrono::milliseconds interval);
   TcpClient& max_retries(int max_retries);
+  /**
+   * @brief Connect over TLS, verifying the server's certificate.
+   *
+   * Verification is not optional: an unverified TLS connection encrypts traffic
+   * to whoever answered. With no argument the system trust store is used; pass
+   * a PEM to trust a private CA or a self-signed certificate instead. The host
+   * given to the constructor is the name the certificate must match.
+   *
+   * Must be set before start(). Requires a build with WIRESTEAD_ENABLE_TLS.
+   */
+  TcpClient& tls(const std::string& ca_file = "");
+
   TcpClient& connection_timeout(std::chrono::milliseconds timeout);
   /**
    * @brief Configure application-level idle timeout.


### PR DESCRIPTION
## Description

#593 gave the TCP server TLS, but no wirestead client could speak it. Two wirestead services therefore had no way to encrypt traffic between them — reaching a wirestead TLS server meant not being a wirestead client.

```cpp
auto client = wirestead::tcp_client("example.com", 9000).tls().build();
client->tls("/path/to/ca.pem");   // or trust a private CA
```

## Key Changes

| | |
|---|---|
| `config/tcp_client_config.hpp` | `tls_enabled`, `tls_ca_file` |
| `transport/tcp_client/tcp_client.cc` | handshake between connect and first read; three branch points |
| `wrapper/`, `builder/` | `tls(ca_file = "")` |
| `test/integration/tcp/test_tls_loopback.cc` | wirestead↔wirestead round trip, and rejection of an untrusted certificate |
| `docs/security.md`, `README.md`, `CHANGELOG.md` | updated |

**Verification is not optional and has no off switch.** TLS without it encrypts traffic to whoever answered, which is exactly what an attacker in the middle wants. The chain, the host name and SNI are all checked against the host passed to the constructor; with no argument the system trust store is used.

## Related Issues

- Follows #593 (server TLS) and #594.

## Type of Change

- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [x] **Documentation**: Changes to documentation only.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The extraction refactor turned out to be unnecessary, and the estimate that called for it was wrong.** The plan for this said the client would first need its `tcp::socket` pulled behind an interface — nine operations, "medium to high". `ssl::stream` can take its next layer *by reference*, so the client keeps owning its socket and only three call sites differ:

| | |
|---|---|
| Read, write, shutdown | branch on TLS |
| connect, `set_option` ×4, `native_handle`, `cancel`, `close`, `get_executor`, `remote_endpoint` | untouched — both cases operate on the same `tcp::socket` |

No change to `TcpSocketInterface`, and nothing for the existing test double to implement. That last part mattered: `FakeTcpSocket` holds no real socket, so adding a `lowest_layer()` to the interface — the other design considered — would have broken it.

**`connected()` moved behind the handshake, and a test is why.** `ClientRejectsAnUntrustedServerCertificate` failed on the first run: against a server whose certificate does not verify, the client still reported itself connected, because `connected_` was set at TCP connect. `connected()` is what callers poll before sending, so reporting a peer that failed verification as usable is a worse failure than the equivalent timing on the server's `on_connect`, where the callback is only a notification and stays balanced with `on_disconnect`. The plaintext suite passes unchanged at 768 with the store moved.

**Closing uses a single `SSL_shutdown`**, for the reason measured on the server side in #593: the bidirectional exchange blocks until a peer that need not answer does.

**Verification.** `scripts/verify.sh` with TLS off: 768/768. Full build and `ctest` with TLS on: **773/773**, the five extra being the TLS tests.

One thing worth flagging about that number. An earlier TLS run reported four `SEGFAULT`s, which looked alarming until the stack trace showed `free(0x1388)` — 5000, the default connection timeout, being freed as a pointer. A layout mismatch: the background full build had been launched *before* the builder header was edited, so parts of the tree were compiled against the old class. A clean rebuild passes all four. No code defect, but worth recording so the number in this description is not taken on trust.

**Not included:** client certificates (mTLS) — a server cannot require one from a wirestead client; cipher suite or ALPN selection; certificate reload without restart. UDP, Serial and UDS remain plaintext, and DTLS is still unsupported. `docs/security.md` lists all of these as absent.

**Also documented, from measurement rather than assumption:** a passphrase-protected key fails `start()` with an opaque `UI routines` error because there is nowhere to prompt (generate with `-nodes`), certificates are read once at `start()` so renewal needs a restart, and the client must connect by the name on the certificate — a certificate issued to `localhost` will not validate for `127.0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BTaV7aeq7Nr17nGEHv7Ep
