### PR TITLE
fix: stop memory pools from prefilling at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,25 @@ and ABI policy.
 
 ### Fixed
 
+- Every transport instance and every accepted server session eagerly allocated
+  roughly 1 MiB of memory-pool buffers at construction. The six call sites
+  passed `MemoryPool{50, 200}`, written while `initial_pool_size` was discarded
+  and so allocated nothing; v0.9.3 made that parameter real without revisiting
+  them, which turned it into 48 `new[]` calls per object. For a server the cost
+  landed on the accept handler itself, before the next connection could be
+  accepted - measured at 128.7 µs per session against 1.4 µs without the
+  prefill - and scaled with connected clients, reaching about 1 GiB at the
+  default 1024 connection limit. `enable_memory_pool(false)` did not avoid it.
+  The pools now start empty, as `docs/tuning.md` already documented, and fill
+  themselves as buffers are released. Callers constructing a `MemoryPool`
+  directly are unaffected; prefill remains available and still defaults to 0.
+
+  `GlobalMemoryPool::create_optimized()` and `create_size_optimized()` carried
+  the same stale prefill arguments and so allocated roughly 17 MB and 26 MB up
+  front since v0.9.3. Both now start empty. Their `max_pool_size` is unchanged,
+  which is what those factories were for: they raise how many released buffers
+  stay resident, not how many exist before the first `acquire()`.
+
 - `TcpServer::stats()` and `UdsServer::stats()` reported `max_queued_bytes` as
   the sum of every live session's high-water mark. Peaks that occurred at
   different times were added together, so the server could report a queue depth

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -42,34 +42,36 @@ function(wirestead_add_integration_gtest target source_path labels timeout)
   )
 endfunction()
 
-foreach(
-  test_file
-  test_integration.cc
-  test_simple_server.cc
-  test_client_limit_integration.cc
-  test_multithread_backpressure.cc
-  test_stop_from_callback.cc
-  test_start_stop_stress.cc
-  test_stop_contract.cc
-  test_dos_protection.cc
-  test_tcp_server_chaos.cc
-  test_tcp_flood.cc
-  test_tcp_abort.cc
-  test_tcp_cancel.cc
-  test_tcp_nodelay_default.cc
-  test_read_buffer_size.cc
-  test_gather_write.cc
-  test_receive_allocations.cc
-  test_accept_allocations.cc
+set(WIRESTEAD_TCP_INTEGRATION_TESTS
+    test_integration.cc
+    test_simple_server.cc
+    test_client_limit_integration.cc
+    test_multithread_backpressure.cc
+    test_stop_from_callback.cc
+    test_start_stop_stress.cc
+    test_stop_contract.cc
+    test_dos_protection.cc
+    test_tcp_server_chaos.cc
+    test_tcp_flood.cc
+    test_tcp_abort.cc
+    test_tcp_cancel.cc
+    test_tcp_nodelay_default.cc
+    test_read_buffer_size.cc
+    test_gather_write.cc
+    test_receive_allocations.cc
+    test_accept_allocations.cc
 )
 
-# test_receive_allocations replaces the global operator new/delete to count
-# allocations. ThreadSanitizer defines those itself in libclang_rt.tsan_cxx, so
-# linking the two together fails outright. Excluding the test loses nothing
-# under TSAN: counting allocations while a sanitizer owns allocation measures
-# the sanitizer, not the receive path.
+# These tests replace the global operator new/delete to count allocations.
+# ThreadSanitizer defines those itself in libclang_rt.tsan_cxx, so linking the
+# two together fails outright. Excluding them loses nothing under TSAN: counting
+# allocations while a sanitizer owns allocation measures the sanitizer, not the
+# path under test. Any future test that replaces global operator new belongs in
+# this list too.
 if(WIRESTEAD_ENABLE_TSAN)
-  list(REMOVE_ITEM WIRESTEAD_TCP_INTEGRATION_TESTS test_receive_allocations.cc)
+  list(REMOVE_ITEM WIRESTEAD_TCP_INTEGRATION_TESTS test_receive_allocations.cc
+       test_accept_allocations.cc
+  )
 endif()
 
 # Only meaningful in a build that has TLS compiled in.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -60,6 +60,7 @@ foreach(
   test_read_buffer_size.cc
   test_gather_write.cc
   test_receive_allocations.cc
+  test_accept_allocations.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/tcp/test_accept_allocations.cc
+++ b/test/integration/tcp/test_accept_allocations.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "wirestead/wirestead.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace std::chrono_literals;
+
+// Accepting a connection must not eagerly allocate a megabyte.
+//
+// TcpServerSession holds a per-session memory::MemoryPool. Its
+// initial_pool_size argument was written while MemoryPool discarded that
+// parameter, so the 50 it passed allocated nothing. #575 made the parameter
+// real without revisiting the call sites, which turned every accept into
+// ~1 MiB of prefill across 48 new[] calls - charged synchronously on the
+// accept handler, before the next async_accept is issued, and paid again for
+// every connected client (1 GiB at the default 1024 connection limit).
+//
+// Like test_receive_allocations.cc this must stay its own executable: the
+// counter below replaces global operator new for the whole binary, and the
+// integration CMakeLists builds one executable per test file.
+
+namespace {
+
+// thread_local so the server's io thread is measured in isolation. The server
+// transport runs its io_context on a single jthread, so every accept lands on
+// the same thread and the counter is comparable across connections. gtest, the
+// main thread and each client's own io thread allocate freely and are never
+// read.
+thread_local size_t t_bytes = 0;
+
+struct AcceptProbe {
+  std::atomic<size_t> connects{0};
+  size_t bytes_at_first_connect = 0;
+  size_t bytes_at_second_connect = 0;
+};
+
+AcceptProbe g_probe;
+
+}  // namespace
+
+void* operator new(std::size_t n) {
+  t_bytes += n;
+  void* p = std::malloc(n ? n : 1);
+  if (!p) throw std::bad_alloc();
+  return p;
+}
+void* operator new[](std::size_t n) { return ::operator new(n); }
+void* operator new(std::size_t n, const std::nothrow_t&) noexcept {
+  t_bytes += n;
+  return std::malloc(n ? n : 1);
+}
+void* operator new[](std::size_t n, const std::nothrow_t&) noexcept { return ::operator new(n, std::nothrow); }
+
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+void operator delete(void* p, const std::nothrow_t&) noexcept { std::free(p); }
+void operator delete[](void* p, const std::nothrow_t&) noexcept { std::free(p); }
+
+TEST(AcceptAllocationsTest, DoesNotEagerlyAllocatePerAcceptedSession) {
+  const uint16_t port = TestUtils::getAvailableTestPort();
+
+  auto server = wirestead::tcp_server(port).build();
+  server->on_connect([](const wirestead::ConnectionContext&) {
+    // Runs on the server's io thread, from the accept handler that just
+    // constructed the session - so t_bytes here already includes that
+    // session's construction.
+    //
+    // Snapshot first, then publish the count with release against the waiter's
+    // acquire below. The main thread reads these plain members as soon as it
+    // observes the count, so incrementing first would let it read a slot this
+    // thread has not written yet - which underflows the subtraction below into
+    // a spurious multi-megabyte failure. The relaxed load is safe because the
+    // server runs its io_context on one thread, so nothing else writes here.
+    const size_t seen = g_probe.connects.load(std::memory_order_relaxed);
+    if (seen == 0) {
+      g_probe.bytes_at_first_connect = t_bytes;
+    } else if (seen == 1) {
+      g_probe.bytes_at_second_connect = t_bytes;
+    }
+    g_probe.connects.fetch_add(1, std::memory_order_release);
+  });
+  ASSERT_TRUE(server->start_sync());
+
+  // Two connections, measured between them: the delta covers exactly one
+  // accept-and-construct cycle with io_context and acceptor startup - which
+  // legitimately allocates - already excluded by the first connection.
+  std::vector<std::shared_ptr<wirestead::TcpClient>> clients;
+  for (int i = 0; i < 2; ++i) {
+    auto client = wirestead::tcp_client("127.0.0.1", port).max_retries(50).build();
+    ASSERT_TRUE(client->start_sync()) << "client " << i << " never connected";
+    clients.push_back(std::move(client));
+
+    // start_sync() only promises the client's half of the handshake; the
+    // server registers the session on its own io thread. Wait for the accept
+    // to land so the two measurements bracket one connection, not two. Acquire
+    // pairs with the release in the callback: observing the count here also
+    // makes that connection's byte snapshot visible.
+    ASSERT_TRUE(TestUtils::waitForCondition(
+        [&] { return g_probe.connects.load(std::memory_order_acquire) > static_cast<size_t>(i); }, 5000))
+        << "server never accepted connection " << i;
+  }
+
+  const size_t per_accept = g_probe.bytes_at_second_connect - g_probe.bytes_at_first_connect;
+
+  // The prefill this gates against is 1,044,480 bytes on its own
+  // (12 buffers each of 1 KiB, 4 KiB, 16 KiB and 64 KiB). What a session
+  // legitimately costs is dominated by the 4 KiB default read buffer plus the
+  // session object, its deques and asio's per-connection state - tens of KiB,
+  // not hundreds.
+  //
+  // 256 KiB sits an order of magnitude below the regression and an order of
+  // magnitude above the real cost, so it neither flakes on allocator or
+  // platform differences nor goes blind. If a legitimate change pushes a
+  // session past this, re-measure rather than raising the bound: a session
+  // that grew to a quarter megabyte is itself the finding.
+  constexpr size_t kMaxBytesPerAccept = 256 * 1024;
+
+  // An upper bound alone would still pass if the counter never saw the io
+  // thread's allocations at all - the bound would read zero and hold. A session
+  // always costs something (the 4 KiB read buffer alone), so zero means the
+  // operator new replacement above is not interposing on the library: that
+  // happens when the tests link wirestead_shared instead of wirestead_static
+  // (-DWIRESTEAD_BUILD_STATIC=OFF), because a Windows DLL keeps its own
+  // operator new. Fail there rather than pass while measuring nothing.
+  EXPECT_GT(per_accept, 0U) << "no allocation was counted for an accepted session - the global operator new "
+                               "replacement is not interposing on the library, so this test is measuring nothing";
+
+  EXPECT_LT(per_accept, kMaxBytesPerAccept)
+      << "accepting a connection allocated " << per_accept
+      << " bytes on the server io thread - something on the accept path is eagerly allocating per session again";
+
+  for (auto& client : clients) client->stop();
+  server->stop();
+}

--- a/wirestead/memory/memory_pool.hpp
+++ b/wirestead/memory/memory_pool.hpp
@@ -134,14 +134,21 @@ class WIRESTEAD_API GlobalMemoryPool {
  public:
   static MemoryPool& instance();
 
+  // Both factories tune capacity, not prefill: they raise max_pool_size so more
+  // released buffers stay resident under concurrency. Their prefill arguments
+  // (800 and 1200) were written while initial_pool_size was discarded and so
+  // allocated nothing; #575 made the parameter real, which would have turned
+  // them into roughly 17 MB and 26 MB allocated up front. Both start empty and
+  // fill as buffers are released, matching the constructor's default.
+
   // Factory method to create optimized memory pool
   static std::unique_ptr<MemoryPool> create_optimized() {
-    return std::make_unique<MemoryPool>(800, 4000);  // Optimized default sizes
+    return std::make_unique<MemoryPool>(0, 4000);  // Optimized default sizes
   }
 
   // Factory method to create size-optimized memory pool
   static std::unique_ptr<MemoryPool> create_size_optimized() {
-    return std::make_unique<MemoryPool>(1200, 6000);  // Even larger for better concurrency
+    return std::make_unique<MemoryPool>(0, 6000);  // Even larger for better concurrency
   }
 
   // Non-copyable, non-movable

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -72,7 +72,11 @@ struct Serial::Impl {
   // singleton - avoids cross-channel contention on the singleton's bucket
   // mutexes. Capacity is much smaller than the old shared default since
   // it's no longer amortized across every channel in the process.
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per channel at construction.
+  // The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   net::steady_timer retry_timer_;
 
   std::vector<uint8_t> rx_;

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -95,7 +95,11 @@ struct TcpClient::Impl {
   // singleton - avoids cross-channel contention on the singleton's bucket
   // mutexes. Capacity is much smaller than the old shared default (400/2000)
   // since it's no longer amortized across every channel in the process.
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per channel at construction.
+  // The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   net::steady_timer retry_timer_;
   net::steady_timer connect_timer_;
   net::steady_timer idle_timer_;

--- a/wirestead/transport/tcp_server/tcp_server_session.hpp
+++ b/wirestead/transport/tcp_server/tcp_server_session.hpp
@@ -106,7 +106,11 @@ class WIRESTEAD_API TcpServerSession : public std::enable_shared_from_this<TcpSe
   // singleton - avoids cross-channel contention on the singleton's bucket
   // mutexes. Capacity is much smaller than the old shared default since
   // it's no longer amortized across every connected client in the process.
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per accepted session, on the
+  // accept handler itself. The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   bool enable_memory_pool_ = true;
   // Sized from the server's read_buffer_size rather than being a fixed
   // std::array: this buffer exists per connection, so a server trades memory

--- a/wirestead/transport/udp/udp.cc
+++ b/wirestead/transport/udp/udp.cc
@@ -90,7 +90,11 @@ struct UdpChannel::Impl {
   // singleton - avoids cross-channel contention on the singleton's bucket
   // mutexes. Capacity is much smaller than the old shared default since
   // it's no longer amortized across every channel in the process.
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per channel at construction.
+  // The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   // Atomic rather than mutex-guarded: read both from the strand (report_backpressure,
   // do_write) and from arbitrary caller threads (the async_try_write_* fast-fail
   // prechecks) - a strand-post here would only protect the former, not the latter (#436).

--- a/wirestead/transport/uds/uds_client.cc
+++ b/wirestead/transport/uds/uds_client.cc
@@ -73,7 +73,11 @@ struct UdsClient::Impl {
   // a fresh std::vector, despite a dead PooledBuffer std::visit branch
   // suggesting otherwise. Give it a real per-channel pool like every other
   // transport, instead of the process-wide GlobalMemoryPool singleton.
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per channel at construction.
+  // The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   net::steady_timer retry_timer_;
   net::steady_timer connect_timer_;
   bool owns_ioc_ = true;

--- a/wirestead/transport/uds/uds_server_session.hpp
+++ b/wirestead/transport/uds/uds_server_session.hpp
@@ -105,7 +105,11 @@ class WIRESTEAD_API UdsServerSession : public std::enable_shared_from_this<UdsSe
   // singleton - avoids cross-channel contention on the singleton's bucket
   // mutexes. Also fixes UDS never actually pooling at all (async_write_copy
   // used to always heap-allocate a fresh std::vector).
-  memory::MemoryPool pool_{50, 200};
+  // Prefill stays 0. This literal was written while MemoryPool discarded
+  // initial_pool_size, so 50 allocated nothing; #575 made the parameter real
+  // and turned it into ~1 MiB eagerly allocated per accepted session, on the
+  // accept handler itself. The pool fills as buffers are released.
+  memory::MemoryPool pool_{0, 200};
   bool enable_memory_pool_ = true;
   // Sized from the server's read_buffer_size rather than being a fixed
   // std::array: this buffer exists per connection, so a server trades memory


### PR DESCRIPTION
## Description

Every transport instance and every accepted server session eagerly allocated roughly 1 MiB of memory-pool buffers at construction.

The six call sites passed `MemoryPool{50, 200}`. That literal was written while `MemoryPool` discarded `initial_pool_size`, so the `50` allocated nothing. #575 made the parameter real without revisiting the call sites, which turned it into 48 `new[]` calls per object (12 buffers each of 1 KiB, 4 KiB, 16 KiB and 64 KiB = 1,044,480 bytes).

For a server the cost lands on the accept handler itself, synchronously between `make_shared<TcpServerSession>` and the `do_accept()` that issues the next `async_accept` — so it delays the next connection, and it is paid again for every connected client: about 1 GiB at the default 1024 connection limit. `enable_memory_pool(false)` did not avoid it, because the pool is a member and is constructed either way.

The pools now start empty, as `docs/tuning.md` already documented, and fill themselves as buffers are released.

## Key Changes

- Six transport call sites go from `MemoryPool{50, 200}` to `{0, 200}`: `serial.cc`, `tcp_client.cc`, `udp.cc`, `uds_client.cc`, `tcp_server_session.hpp`, `uds_server_session.hpp`. `max_pool_size` is untouched.
- `GlobalMemoryPool::create_optimized()` and `create_size_optimized()` carried the same stale prefill arguments and so allocated roughly 17 MB and 26 MB up front since v0.9.3. Both now start empty. Their `max_pool_size` is unchanged, which is what those factories were for: they raise how many released buffers stay resident under concurrency, not how many exist before the first `acquire()`.
- New `test/integration/tcp/test_accept_allocations.cc` gates the accept path. It replaces global `operator new` for that one executable, measures bytes allocated on the server io thread across exactly one accept-and-construct cycle, and bounds it at 256 KiB — an order of magnitude below the regression and an order of magnitude above what a session legitimately costs. A lower bound of `> 0` is asserted too, so a build where the replacement does not interpose fails instead of passing while measuring nothing.
- CHANGELOG entry under Unreleased / Fixed.

## Related Issues

Regression introduced by #575 (`feat: expose serial read_chunk and make initial_pool_size mean something`), released in v0.9.3. No tracking issue was filed.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.
- [ ] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [x] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist

- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

`verify.sh` was run twice and did not come back green on this machine, so the first box is left unchecked. Each run failed exactly one test, a **different** one each time and both with a timeout signature:

| Run | Failure |
| --- | --- |
| 1 | `GatherWriteTest.SendMovePreservesByteCountAndOrder` |
| 2 | `TcpServerWrapperLifecycleTest.ConcurrentStartStop` (Timeout) |

Both pass in isolation, and a full `ctest -j4` over the same build tree has zero real failures. `verify.sh` fixes parallelism at `nproc`, which is 22 on this WSL box — far above the `-j2` the repository's own guidance recommends for WSL. Reading these as load-induced flakes rather than fallout from this change: the failures are on unrelated paths (`send_move` queues plain vectors, not pooled buffers, per that test's own comment), and this change only ever removes allocations from construction.

Worth a second opinion in CI, which runs at saner parallelism.

## Additional Context

**Behavior change for out-of-tree callers of the two factories.** `create_optimized()` and `create_size_optimized()` stop pre-allocating. This restores what they did before v0.9.3 — the prefill was never intended, it was a dormant argument that #575 woke up — but it is a change relative to the released v0.9.3, so it is called out here rather than buried. Callers who want the old behavior can construct `MemoryPool{800, 4000}` directly; prefill remains supported and still defaults to 0.

**Measurements.** 128.7 µs per accepted session with the prefill against 1.4 µs without it.

**Residual risk, not addressed here.** This removes the eager allocation but does not cap retention. With `max_pool_size = 200` a bucket holds up to 50 buffers, so a session that exercises all four buckets can still accumulate about 4.15 MiB of resident pool. In practice a session touches the buckets its traffic needs, and buffers only enter the pool after a real `acquire()`/`release()` — but the ceiling is worth knowing.

**Not covered.** The UDS accept path gets the same fix but no equivalent regression test; only TCP is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNqxhSwboZhtqh1Se3731U
