### PR TITLE
feat: serial low-latency mode and a receive watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ and ABI policy.
   reference, so the client keeps owning its socket and connect, socket options,
   cancel and close are untouched - only reads, writes and shutdown branch.
 
+- Serial `rx_idle_timeout`, off by default, reopening the port after that long
+  with no data received.
+
+  ```cpp
+  auto port = wirestead::serial("/dev/ttyUSB0", 115200)
+                  .rx_idle_timeout(std::chrono::milliseconds(500))
+                  .build();
+  ```
+
+  A device that goes quiet without erroring leaves a healthy open port and a
+  read that never completes, which nothing else in the transport notices.
+  Receives only, unlike the TCP idle timeout that any traffic resets - a driver
+  polling a mute device would otherwise keep a bidirectional timer alive
+  forever. Expiry takes the same path as a read error, so `reopen_on_error`
+  decides between reopening and `Error`.
+
 - Serial `low_latency`, on by default, asking the driver to stop batching
   received bytes behind its own timer (`ASYNC_LOW_LATENCY` on Linux).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ and ABI policy.
   reference, so the client keeps owning its socket and connect, socket options,
   cancel and close are untouched - only reads, writes and shutdown branch.
 
+- Serial `low_latency`, on by default, asking the driver to stop batching
+  received bytes behind its own timer (`ASYNC_LOW_LATENCY` on Linux).
+
+  ```cpp
+  auto port = wirestead::serial("/dev/ttyUSB0", 115200).low_latency(false).build();
+  ```
+
+  USB serial adapters ship this timer at 16 ms on FTDI parts, so a 1 ms packet
+  at 115200 baud could arrive 16 ms late regardless of anything the library
+  did. Best effort: drivers with no such timer refuse the request, which is
+  logged at debug level and does not fail the open. See `docs/tuning.md`.
+
 - Optional TLS for the TCP server, behind `-DWIRESTEAD_ENABLE_TLS=ON`. A default
   build is unchanged and has no OpenSSL dependency.
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -35,6 +35,30 @@ The ceiling is far below `MAX_SOCKET_BUFFER_SIZE` on purpose: this buffer is
 read buffer against the default 1024 connection limit is a gigabyte of
 userspace buffers before any payload.
 
+## Serial low-latency mode
+
+USB serial adapters buffer received bytes behind a driver timer before handing
+them up. An FTDI ships with that timer at **16 ms**, so a 1 ms packet at 115200
+baud can still reach your callback 16 ms late no matter what the rest of the
+stack does. `low_latency` clears it (`ASYNC_LOW_LATENCY` on Linux) and is **on
+by default**.
+
+```cpp
+auto port = wirestead::serial("/dev/ttyUSB0", 115200)
+                .low_latency(false)  // leave the driver's timer alone
+                .on_data([](const wirestead::MessageContext& ctx) { /* ... */ })
+                .build();
+```
+
+Best effort, and deliberately so: drivers with no such timer — native UARTs,
+CDC-ACM — refuse the request, the port opens normally, and the refusal is
+logged at debug level. Linux only; elsewhere the setting is a no-op.
+
+Turn it off to trade latency back for fewer wakeups on a high-rate stream where
+arrival time does not matter. Unlike everything else on this page, this one is
+worth setting without a measurement first: nothing else in the library recovers
+16 ms.
+
 ## Memory pool prefill
 
 `MemoryPool(initial_pool_size, max_pool_size)` pre-allocates

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -59,6 +59,30 @@ arrival time does not matter. Unlike everything else on this page, this one is
 worth setting without a measurement first: nothing else in the library recovers
 16 ms.
 
+## Serial receive watchdog
+
+A device that stops streaming without erroring leaves a healthy open port and a
+read that never completes, so nothing else in the transport notices — the
+classic wedged USB adapter or sensor that just goes quiet.
+`rx_idle_timeout` closes and reopens the port after that long without received
+data. Off by default.
+
+```cpp
+auto port = wirestead::serial("/dev/ttyUSB0", 115200)
+                .rx_idle_timeout(std::chrono::milliseconds(500))
+                .build();
+```
+
+Set it above the device's slowest expected interval, with margin — expiry tears
+the link down, so a value below the real gap between messages produces a reopen
+loop rather than a recovery.
+
+Receives only, deliberately unlike the TCP idle timeout, which any traffic in
+either direction resets: a driver polling a mute device writes on schedule and
+would hold a bidirectional timer open forever. Expiry runs the same path as a
+read error, so `reopen_on_error` decides whether the port is reopened or the
+link goes to `Error`.
+
 ## Memory pool prefill
 
 `MemoryPool(initial_pool_size, max_pool_size)` pre-allocates

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -67,6 +67,11 @@ class FakeSerialPort : public interface::SerialPortInterface {
     ec = flow_control_ec_;
   }
 
+  bool set_low_latency() override {
+    ++low_latency_requests_;
+    return low_latency_supported_;
+  }
+
   void async_read_some(const boost::asio::mutable_buffer&,
                        std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
     read_handler_ = std::move(handler);
@@ -93,6 +98,8 @@ class FakeSerialPort : public interface::SerialPortInterface {
   void set_write_error(boost::system::error_code ec) { write_ec_ = ec; }
   void set_complete_writes(bool complete) { complete_writes_ = complete; }
   int write_count() const { return write_count_; }
+  void set_low_latency_supported(bool supported) { low_latency_supported_ = supported; }
+  int low_latency_requests() const { return low_latency_requests_; }
 
   void complete_pending_write(const boost::system::error_code& ec = {}) {
     if (!pending_write_handler_) return;
@@ -126,6 +133,8 @@ class FakeSerialPort : public interface::SerialPortInterface {
   bool open_{false};
   bool complete_writes_{true};
   int write_count_{0};
+  bool low_latency_supported_{true};
+  int low_latency_requests_{0};
   std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
   std::function<void(const boost::system::error_code&, std::size_t)> pending_write_handler_;
   std::optional<std::size_t> pending_write_size_;
@@ -150,6 +159,68 @@ TEST(TransportSerialTest, CreateProvidesSharedFromThis) {
     auto self = serial->shared_from_this();
     EXPECT_EQ(self.get(), serial.get());
   });
+  serial->stop();
+}
+
+// The whole point of cfg_.low_latency is that it reaches the driver, and that a
+// driver refusing it is not treated as a failure - an FTDI takes it, a native
+// UART does not, and both must end up Connected.
+TEST(TransportSerialTest, LowLatencyIsRequestedByDefault) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  std::atomic<bool> connected{false};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connected = true;
+  });
+
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->low_latency_requests(), 1);
+  EXPECT_TRUE(connected.load());
+  serial->stop();
+}
+
+TEST(TransportSerialTest, LowLatencyDisabledLeavesTheDriverAlone) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.low_latency = false;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->low_latency_requests(), 0);
+  serial->stop();
+}
+
+TEST(TransportSerialTest, UnsupportedLowLatencyStillConnects) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+  port_raw->set_low_latency_supported(false);
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  std::atomic<bool> connected{false};
+  std::atomic<bool> errored{false};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connected = true;
+    if (state == base::LinkState::Error) errored = true;
+  });
+
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->low_latency_requests(), 1);
+  EXPECT_TRUE(connected.load());
+  EXPECT_FALSE(errored.load());
   serial->stop();
 }
 

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -183,6 +183,12 @@ TEST(TransportSerialTest, LowLatencyIsRequestedByDefault) {
   EXPECT_EQ(port_raw->low_latency_requests(), 1);
   EXPECT_TRUE(connected.load());
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 TEST(TransportSerialTest, LowLatencyDisabledLeavesTheDriverAlone) {
@@ -198,6 +204,12 @@ TEST(TransportSerialTest, LowLatencyDisabledLeavesTheDriverAlone) {
 
   EXPECT_EQ(port_raw->low_latency_requests(), 0);
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 TEST(TransportSerialTest, UnsupportedLowLatencyStillConnects) {
@@ -222,6 +234,12 @@ TEST(TransportSerialTest, UnsupportedLowLatencyStillConnects) {
   EXPECT_TRUE(connected.load());
   EXPECT_FALSE(errored.load());
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 // A device that goes quiet without erroring leaves a healthy open port and a
@@ -251,6 +269,12 @@ TEST(TransportSerialTest, RxIdleTimeoutReopensASilentPort) {
 
   EXPECT_GE(connects.load(), 2) << "the silent port was closed but never reopened";
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 TEST(TransportSerialTest, RxIdleTimeoutIsOffByDefault) {
@@ -270,6 +294,12 @@ TEST(TransportSerialTest, RxIdleTimeoutIsOffByDefault) {
 
   EXPECT_EQ(connects.load(), 1) << "a silent port was torn down with the watchdog disabled";
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 // Arriving data has to push the deadline back, otherwise the watchdog tears
@@ -299,6 +329,12 @@ TEST(TransportSerialTest, ReceivedDataRearmsTheRxIdleTimeout) {
 
   EXPECT_EQ(connects.load(), 1) << "a stream arriving every 10ms tripped a 30ms watchdog";
   serial->stop();
+  // stop() only posts its cleanup when the io_context is external, and that
+  // handler owns a shared_ptr to the transport. Leaving it unrun keeps the
+  // transport alive until ~io_context destroys the handler - which runs
+  // perform_cleanup(), and so the state callback, after the locals it
+  // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
 }
 
 // operation_aborted after stop must not trigger reconnect/reopen

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -224,6 +224,83 @@ TEST(TransportSerialTest, UnsupportedLowLatencyStillConnects) {
   serial->stop();
 }
 
+// A device that goes quiet without erroring leaves a healthy open port and a
+// read that never completes, so nothing else in the transport notices. The
+// watchdog has to, and it has to survive its own teardown: closing the port
+// aborts the pending read, and that aborted read must not cancel the reopen it
+// just triggered.
+TEST(TransportSerialTest, RxIdleTimeoutReopensASilentPort) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.rx_idle_timeout_ms = 30;
+  cfg.retry_interval_ms = 20;
+  cfg.reopen_on_error = true;
+
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+
+  // Reaching Connected more than once is the reopen: the port is only opened
+  // by the initial start and by a scheduled retry.
+  std::atomic<int> connects{0};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connects.fetch_add(1);
+  });
+
+  serial->start();
+  ioc.run_for(150ms);
+
+  EXPECT_GE(connects.load(), 2) << "the silent port was closed but never reopened";
+  serial->stop();
+}
+
+TEST(TransportSerialTest, RxIdleTimeoutIsOffByDefault) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.retry_interval_ms = 20;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+
+  std::atomic<int> connects{0};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connects.fetch_add(1);
+  });
+
+  serial->start();
+  ioc.run_for(150ms);
+
+  EXPECT_EQ(connects.load(), 1) << "a silent port was torn down with the watchdog disabled";
+  serial->stop();
+}
+
+// Arriving data has to push the deadline back, otherwise the watchdog tears
+// down a perfectly healthy link on a fixed timer.
+TEST(TransportSerialTest, ReceivedDataRearmsTheRxIdleTimeout) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.rx_idle_timeout_ms = 30;
+  cfg.retry_interval_ms = 20;
+
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+
+  std::atomic<int> connects{0};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connects.fetch_add(1);
+  });
+
+  serial->start();
+  ioc.run_for(5ms);  // open, configure, arm the watchdog
+
+  for (int i = 0; i < 10; ++i) {
+    port_raw->emit_read(1);
+    ioc.run_for(10ms);
+  }
+
+  EXPECT_EQ(connects.load(), 1) << "a stream arriving every 10ms tripped a 30ms watchdog";
+  serial->stop();
+}
+
 // operation_aborted after stop must not trigger reconnect/reopen
 TEST(TransportSerialTest, StopPreventsReopenAfterOperationAborted) {
   boost::asio::io_context ioc;

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -86,6 +86,7 @@ std::unique_ptr<wrapper::Serial> SerialBuilder::build() {
 
   if (reopen_on_error_set_) serial->reopen_on_error(reopen_on_error_);
   if (read_chunk_set_) serial->read_chunk(read_chunk_);
+  if (low_latency_set_) serial->low_latency(low_latency_);
   if (retry_interval_set_) serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
 
   if (this->bp_strategy_set_) serial->backpressure_strategy(this->bp_strategy_);
@@ -172,6 +173,12 @@ SerialBuilder& SerialBuilder::flow_control(const std::string& f) {
 SerialBuilder& SerialBuilder::read_chunk(size_t bytes) {
   read_chunk_ = bytes;
   read_chunk_set_ = true;
+  return *this;
+}
+
+SerialBuilder& SerialBuilder::low_latency(bool enable) {
+  low_latency_ = enable;
+  low_latency_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -87,6 +87,7 @@ std::unique_ptr<wrapper::Serial> SerialBuilder::build() {
   if (reopen_on_error_set_) serial->reopen_on_error(reopen_on_error_);
   if (read_chunk_set_) serial->read_chunk(read_chunk_);
   if (low_latency_set_) serial->low_latency(low_latency_);
+  if (rx_idle_timeout_set_) serial->rx_idle_timeout(rx_idle_timeout_);
   if (retry_interval_set_) serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
 
   if (this->bp_strategy_set_) serial->backpressure_strategy(this->bp_strategy_);
@@ -179,6 +180,12 @@ SerialBuilder& SerialBuilder::read_chunk(size_t bytes) {
 SerialBuilder& SerialBuilder::low_latency(bool enable) {
   low_latency_ = enable;
   low_latency_set_ = true;
+  return *this;
+}
+
+SerialBuilder& SerialBuilder::rx_idle_timeout(std::chrono::milliseconds timeout) {
+  rx_idle_timeout_ = timeout;
+  rx_idle_timeout_set_ = true;
   return *this;
 }
 

--- a/wirestead/builder/serial_builder.hpp
+++ b/wirestead/builder/serial_builder.hpp
@@ -56,6 +56,10 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   // Bytes each read fills. The TCP and UDS builders call the same knob
   // read_buffer_size(); serial named it read_chunk before those existed.
   SerialBuilder& read_chunk(size_t bytes);
+  // Ask the driver to deliver received bytes without waiting out its own
+  // buffering timer (Linux ASYNC_LOW_LATENCY). On by default; see
+  // SerialConfig::low_latency.
+  SerialBuilder& low_latency(bool enable = true);
   SerialBuilder& reopen_on_error(bool enable = true);
   SerialBuilder& retry_interval(std::chrono::milliseconds interval);
   SerialBuilder& independent_context(bool use_independent = true);
@@ -86,6 +90,8 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   bool reopen_on_error_set_{false};
   size_t read_chunk_{base::constants::DEFAULT_READ_BUFFER_SIZE};
   bool read_chunk_set_{false};
+  bool low_latency_{true};
+  bool low_latency_set_{false};
 };
 
 using SerialBuilderDefault = SerialBuilder;

--- a/wirestead/builder/serial_builder.hpp
+++ b/wirestead/builder/serial_builder.hpp
@@ -61,6 +61,9 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   // SerialConfig::low_latency.
   SerialBuilder& low_latency(bool enable = true);
   SerialBuilder& reopen_on_error(bool enable = true);
+  // Reopen the port when no data has been received for this long. Off by
+  // default; see SerialConfig::rx_idle_timeout_ms.
+  SerialBuilder& rx_idle_timeout(std::chrono::milliseconds timeout);
   SerialBuilder& retry_interval(std::chrono::milliseconds interval);
   SerialBuilder& independent_context(bool use_independent = true);
   // Opt into the shared IoContextManager singleton instead of the default
@@ -92,6 +95,8 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   bool read_chunk_set_{false};
   bool low_latency_{true};
   bool low_latency_set_{false};
+  std::chrono::milliseconds rx_idle_timeout_{0};
+  bool rx_idle_timeout_set_{false};
 };
 
 using SerialBuilderDefault = SerialBuilder;

--- a/wirestead/config/serial_config.hpp
+++ b/wirestead/config/serial_config.hpp
@@ -51,6 +51,23 @@ struct SerialConfig {
   bool low_latency = true;
 
   bool reopen_on_error = true;  // Attempt to reopen on device disconnection/error
+
+  // Reopen the port when no data has been *received* for this long. 0 disables
+  // it, which is the default.
+  //
+  // The failure this catches is a device that stops streaming without ever
+  // reporting an error - a wedged USB adapter, a sensor that stopped talking -
+  // where every other mechanism here sees a perfectly healthy open port and
+  // waits forever.
+  //
+  // Receive-only on purpose, unlike the TCP idle timeout, which any traffic in
+  // either direction resets. A driver polling a mute device writes on schedule
+  // and would keep a bidirectional timer alive forever, which is exactly the
+  // case worth catching.
+  //
+  // Expiry runs the same path as a read error, so reopen_on_error decides
+  // whether the port is reopened or the link goes to Error.
+  unsigned rx_idle_timeout_ms = 0;
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_memory_pool = true;
@@ -75,6 +92,8 @@ struct SerialConfig {
            retry_interval_ms <= base::constants::MAX_RETRY_INTERVAL_MS &&
            backpressure_threshold >= base::constants::MIN_BACKPRESSURE_THRESHOLD &&
            backpressure_threshold <= base::constants::MAX_BACKPRESSURE_THRESHOLD &&
+           (rx_idle_timeout_ms == 0 || (rx_idle_timeout_ms >= base::constants::MIN_IDLE_TIMEOUT_MS &&
+                                        rx_idle_timeout_ms <= base::constants::MAX_IDLE_TIMEOUT_MS)) &&
            (max_retries == -1 || (max_retries >= 0 && max_retries <= base::constants::MAX_RETRIES_LIMIT));
   }
 
@@ -112,6 +131,10 @@ struct SerialConfig {
       backpressure_threshold = base::constants::MIN_BACKPRESSURE_THRESHOLD;
     } else if (backpressure_threshold > base::constants::MAX_BACKPRESSURE_THRESHOLD) {
       backpressure_threshold = base::constants::MAX_BACKPRESSURE_THRESHOLD;
+    }
+
+    if (rx_idle_timeout_ms != 0 && rx_idle_timeout_ms > base::constants::MAX_IDLE_TIMEOUT_MS) {
+      rx_idle_timeout_ms = base::constants::MAX_IDLE_TIMEOUT_MS;
     }
 
     if (max_retries != -1 && max_retries > base::constants::MAX_RETRIES_LIMIT) {

--- a/wirestead/config/serial_config.hpp
+++ b/wirestead/config/serial_config.hpp
@@ -37,6 +37,19 @@ struct SerialConfig {
   enum class Flow { None, Software, Hardware } flow = Flow::None;
 
   size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
+
+  // Ask the kernel driver to hand bytes up as soon as they arrive instead of
+  // waiting out its buffering timer. On Linux this is ASYNC_LOW_LATENCY, and
+  // it matters most on USB serial adapters: an FTDI defaults to a 16 ms
+  // latency timer, so a 1 ms packet at 115200 baud can still reach the
+  // callback 16 ms late — enough to break a control loop on its own.
+  //
+  // Best effort by design. Drivers that have no such timer (CDC-ACM, most
+  // native UARTs) reject the request, and that is not an error: the port opens
+  // and runs normally either way. Set false to leave the driver's default
+  // alone, which trades latency for fewer wakeups.
+  bool low_latency = true;
+
   bool reopen_on_error = true;  // Attempt to reopen on device disconnection/error
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;

--- a/wirestead/interface/iserial_port.hpp
+++ b/wirestead/interface/iserial_port.hpp
@@ -48,6 +48,13 @@ class WIRESTEAD_API SerialPortInterface {
   virtual void set_option(const net::serial_port_base::parity& option, boost::system::error_code& ec) = 0;
   virtual void set_option(const net::serial_port_base::flow_control& option, boost::system::error_code& ec) = 0;
 
+  // Ask the driver to stop batching received bytes behind its own timer.
+  // Returns whether the request took effect. Not an error when it does not -
+  // only some drivers (notably USB serial) have such a timer to disable, so
+  // the caller logs the outcome and carries on. Defaults to "unsupported" so
+  // test doubles inherit it for free.
+  virtual bool set_low_latency() { return false; }
+
   virtual void async_read_some(const net::mutable_buffer& buffer,
                                std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;
   virtual void async_write(const net::const_buffer& buffer,

--- a/wirestead/transport/serial/boost_serial_port.hpp
+++ b/wirestead/transport/serial/boost_serial_port.hpp
@@ -19,6 +19,11 @@
 #include "wirestead/base/visibility.hpp"
 #include "wirestead/interface/iserial_port.hpp"
 
+#ifdef __linux__
+#include <linux/serial.h>
+#include <sys/ioctl.h>
+#endif
+
 namespace wirestead {
 namespace transport {
 
@@ -46,6 +51,22 @@ class WIRESTEAD_API BoostSerialPort : public interface::SerialPortInterface {
   }
   void set_option(const net::serial_port_base::flow_control& option, boost::system::error_code& ec) override {
     port_.set_option(option, ec);
+  }
+
+  // Linux only. TIOCGSERIAL fails with ENOTTY on drivers that have no latency
+  // timer to clear, which is the common case for native UARTs and CDC-ACM, so
+  // the caller treats false as "nothing to do" rather than as a failure.
+  bool set_low_latency() override {
+#ifdef __linux__
+    struct serial_struct info;
+    const int fd = port_.native_handle();
+    if (::ioctl(fd, TIOCGSERIAL, &info) != 0) return false;
+    if (info.flags & ASYNC_LOW_LATENCY) return true;
+    info.flags |= ASYNC_LOW_LATENCY;
+    return ::ioctl(fd, TIOCSSERIAL, &info) == 0;
+#else
+    return false;
+#endif
   }
 
   void async_read_some(const net::mutable_buffer& buffer,

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -312,6 +312,13 @@ struct Serial::Impl {
       return;
     }
 
+    // Best effort, after the line settings and before the first read: a driver
+    // without a latency timer just says no, and the port is fine either way.
+    if (cfg_.low_latency && !port_->set_low_latency()) {
+      WIRESTEAD_LOG_DEBUG("serial", "configure",
+                          fmt::format("Low-latency mode unavailable on {}, using the driver default", cfg_.device));
+    }
+
     WIRESTEAD_LOG_INFO("serial", "connect", fmt::format("Device opened: {}", cfg_.device));
     start_read(self);
 

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <boost/asio.hpp>
+#include <chrono>
 #include <cstddef>
 #include <deque>
 #include <memory>
@@ -78,6 +79,9 @@ struct Serial::Impl {
   // The pool fills as buffers are released.
   memory::MemoryPool pool_{0, 200};
   net::steady_timer retry_timer_;
+  // Watchdog for cfg_.rx_idle_timeout_ms: armed on connect, pushed back by
+  // every read that carries bytes, so it only ever fires on silence.
+  net::steady_timer rx_idle_timer_;
 
   std::vector<uint8_t> rx_;
   std::deque<BufferVariant> tx_;
@@ -209,6 +213,7 @@ struct Serial::Impl {
         strand_(ioc_.get_executor()),
         cfg_(cfg),
         retry_timer_(ioc_),
+        rx_idle_timer_(ioc_),
         bp_strategy_(cfg.backpressure_strategy),
         retry_interval_ms_(cfg.retry_interval_ms),
         bp_high_(cfg.backpressure_threshold) {
@@ -223,6 +228,7 @@ struct Serial::Impl {
         port_(std::move(port)),
         cfg_(cfg),
         retry_timer_(ioc),
+        rx_idle_timer_(ioc),
         bp_strategy_(cfg.backpressure_strategy),
         retry_interval_ms_(cfg.retry_interval_ms),
         bp_high_(cfg.backpressure_threshold) {
@@ -321,6 +327,7 @@ struct Serial::Impl {
 
     WIRESTEAD_LOG_INFO("serial", "connect", fmt::format("Device opened: {}", cfg_.device));
     start_read(self);
+    reset_rx_idle_timer(self);
 
     opened_.store(true);
     state_.set(LinkState::Connected);
@@ -336,7 +343,10 @@ struct Serial::Impl {
             impl->handle_error(self, "read", ec);
             return;
           }
-          if (n > 0) impl->stats_.record_received(n);
+          if (n > 0) {
+            impl->stats_.record_received(n);
+            impl->reset_rx_idle_timer(self);
+          }
           interface::SharedCallback<OnBytes> on_bytes;
           {
             std::lock_guard<std::mutex> lock(impl->callback_mtx_);
@@ -448,6 +458,10 @@ struct Serial::Impl {
 
     if (ec == boost::asio::error::operation_aborted) {
       if (state_.is_state(LinkState::Error)) return;
+      // Connecting means a reopen is already scheduled and the port was closed
+      // on purpose - the read this aborts is the one that closure cancelled.
+      // Cleaning up here would cancel that retry and report Closed instead.
+      if (state_.is_state(LinkState::Connecting)) return;
       perform_cleanup();
       return;
     }
@@ -483,7 +497,29 @@ struct Serial::Impl {
     });
   }
 
+  // Rearmed by every read that carried bytes, so the deadline always measures
+  // silence rather than time since connect. Writes deliberately do not rearm
+  // it: a driver polling a mute device would otherwise keep it alive forever.
+  void reset_rx_idle_timer(std::shared_ptr<Serial> self) {
+    const unsigned timeout_ms = cfg_.rx_idle_timeout_ms;
+    if (timeout_ms == 0 || stopping_.load()) return;
+
+    rx_idle_timer_.expires_after(std::chrono::milliseconds(timeout_ms));
+    rx_idle_timer_.async_wait(net::bind_executor(strand_, [self, timeout_ms](const boost::system::error_code& e) {
+      if (e) return;  // rearmed or cancelled
+      auto impl = self->get_impl();
+      if (impl->stopping_.load() || !impl->opened_.load()) return;
+
+      WIRESTEAD_LOG_WARNING("serial", "rx_idle_timeout",
+                            fmt::format("No data received for {}ms on {}", timeout_ms, impl->cfg_.device));
+      // Same path a read error takes, so reopen_on_error decides what happens
+      // next and the reconnect/backoff plumbing is not duplicated here.
+      impl->handle_error(self, "rx_idle_timeout", make_error_code(boost::asio::error::timed_out));
+    }));
+  }
+
   void close_port() {
+    rx_idle_timer_.cancel();
     boost::system::error_code ec;
     if (port_ && port_->is_open()) {
       port_->close(ec);

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -95,6 +95,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   bool reopen_on_error = true;
   size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
   bool low_latency = true;
+  std::chrono::milliseconds rx_idle_timeout{0};
   std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
@@ -601,6 +602,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
     config.reopen_on_error = reopen_on_error;
     config.read_chunk = read_chunk;
     config.low_latency = low_latency;
+    config.rx_idle_timeout_ms = static_cast<unsigned>(rx_idle_timeout.count());
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
     config.use_shared_context = shared_context_.load();
@@ -732,6 +734,12 @@ Serial& Serial::read_chunk(size_t bytes) {
 Serial& Serial::low_latency(bool enable) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->low_latency = enable;
+  return *this;
+}
+
+Serial& Serial::rx_idle_timeout(std::chrono::milliseconds timeout) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->rx_idle_timeout = timeout;
   return *this;
 }
 

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -94,6 +94,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   std::string flow_control = "none";
   bool reopen_on_error = true;
   size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
+  bool low_latency = true;
   std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
@@ -599,6 +600,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
     config.retry_interval_ms = static_cast<unsigned int>(retry_interval.count());
     config.reopen_on_error = reopen_on_error;
     config.read_chunk = read_chunk;
+    config.low_latency = low_latency;
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
     config.use_shared_context = shared_context_.load();
@@ -724,6 +726,12 @@ Serial& Serial::flow_control(const std::string& f) {
 Serial& Serial::read_chunk(size_t bytes) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->read_chunk = bytes;
+  return *this;
+}
+
+Serial& Serial::low_latency(bool enable) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->low_latency = enable;
   return *this;
 }
 

--- a/wirestead/wrapper/serial/serial.hpp
+++ b/wirestead/wrapper/serial/serial.hpp
@@ -114,6 +114,10 @@ class WIRESTEAD_API Serial : public ChannelInterface {
   // SerialConfig::low_latency for what it does and does not cover.
   Serial& low_latency(bool enable = true);
   Serial& reopen_on_error(bool enable);
+  // Reopen the port when no data has been received for this long. Off by
+  // default; see SerialConfig::rx_idle_timeout_ms for why it watches receives
+  // only.
+  Serial& rx_idle_timeout(std::chrono::milliseconds timeout);
   Serial& retry_interval(std::chrono::milliseconds interval);
   Serial& backpressure_threshold(size_t threshold);
   Serial& backpressure_strategy(base::constants::BackpressureStrategy strategy);

--- a/wirestead/wrapper/serial/serial.hpp
+++ b/wirestead/wrapper/serial/serial.hpp
@@ -109,6 +109,10 @@ class WIRESTEAD_API Serial : public ChannelInterface {
   // Bytes each read fills, the serial counterpart of read_buffer_size() on the
   // TCP and UDS wrappers. Clamped to [MIN_READ_BUFFER_SIZE, MAX_READ_BUFFER_SIZE].
   Serial& read_chunk(size_t bytes);
+  // Ask the driver to deliver received bytes without waiting out its own
+  // buffering timer (Linux ASYNC_LOW_LATENCY). On by default; see
+  // SerialConfig::low_latency for what it does and does not cover.
+  Serial& low_latency(bool enable = true);
   Serial& reopen_on_error(bool enable);
   Serial& retry_interval(std::chrono::milliseconds interval);
   Serial& backpressure_threshold(size_t threshold);


### PR DESCRIPTION
## Description

Two serial-side gaps found while reviewing the library from a robotics
deployment angle. Both concern latency and liveness on a real device rather
than throughput, and neither was reachable from the public API before.

**`low_latency`, on by default.** USB serial drivers buffer received bytes
behind their own timer before handing them up, and FTDI parts ship that timer
at 16 ms. A 1 ms packet at 115200 baud therefore reached the callback up to
16 ms late no matter what this library did — larger than every latency cost in
the stack put together. Nothing exposed the port's native handle, so a caller
could not clear it either.

**`rx_idle_timeout`, off by default.** A serial device that stops streaming
without erroring leaves a healthy open port and a read that never completes.
`reopen_on_error` never fires because nothing errored. This is a common way an
embedded deployment loses a sensor, and the transport had no way to notice.

## Key Changes

- `SerialConfig::low_latency` (default `true`) clears the driver's latency
  timer via `ASYNC_LOW_LATENCY`. The request goes through a new
  `SerialPortInterface::set_low_latency()` whose default reports "unsupported",
  so test doubles inherit it for free. Best effort by design: native UARTs and
  CDC-ACM answer `ENOTTY`, which is logged at debug level and must not fail the
  open — `UnsupportedLowLatencyStillConnects` pins that.
- `SerialConfig::rx_idle_timeout_ms` (default `0`, disabled) reopens the port
  after that long without received bytes. Expiry routes through
  `handle_error()`, so `reopen_on_error` keeps deciding between reopen and
  `Error` and no retry plumbing is duplicated.
- Receives only, deliberately unlike the TCP idle timeout that any traffic in
  either direction resets: a driver polling a mute device writes on schedule
  and would hold a bidirectional timer open forever, which is the case worth
  catching. Named `rx_idle_timeout` rather than `idle_timeout` so the
  difference cannot be missed.
- Fixes a latent bug the watchdog exposed. Closing the port aborts the pending
  read, and `handle_error()` treated that abort as a stop: it ran
  `perform_cleanup()`, cancelling the retry that had just been scheduled and
  reporting `Closed`. Aborts arriving in `Connecting` are now ignored, since
  the only way to be `Connecting` with a read outstanding is a closure we
  performed ourselves.
- Both knobs are wired through the wrapper and builder, and documented in
  `docs/tuning.md`.

## Related Issues

None.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality.
- [x] **Bug Fix**: A non-breaking change that resolves an issue.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

`low_latency` defaults to on because the setting it clears is a defect from a
robotics point of view and the cost of clearing it is more frequent wakeups on
a high-rate stream. `rx_idle_timeout` defaults to off because expiry tears the
link down, and a value below the device's real message gap would produce a
reopen loop rather than a recovery — there is no default this library can pick
without knowing the device.

The ioctl is Linux only; elsewhere `set_low_latency()` returns false and the
port opens exactly as before. Verified against the fake serial port only — no
FTDI hardware was in the loop, so the 16 ms figure is the documented driver
default rather than something measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
