### PR TITLE
feat: join a UDP multicast group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ and ABI policy.
 
 ### Added
 
+- UDP multicast receive: `multicast_group(group, interface_address = "")` on
+  both UDP builders joins the group after binding.
+
+  ```cpp
+  auto lidar = wirestead::udp_client()
+                   .local_port(2368)
+                   .reuse_address()
+                   .multicast_group("239.255.42.99", "192.168.1.10")
+                   .on_data(...)
+                   .build();
+  ```
+
+  Sensors that publish to a group could not be received at all before this;
+  `enable_broadcast` covers a different thing. The interface argument names the
+  NIC by its local IPv4 address, which a robot with a sensor network on one
+  interface and everything else on another needs - leave it empty only on a
+  host with one interface. IPv6 groups are supported, always on the kernel's
+  choice of interface.
+
+  A failed join fails `start()` rather than coming up as a socket that receives
+  nothing: silently not joining is indistinguishable from a sensor that stopped
+  sending, which is the confusion the feature exists to remove. A group outside
+  224.0.0.0/4 or ff00::/8 is rejected by config validation instead, where the
+  error can name the setting.
+
+  Receiving only. Sending to a group already worked through `remote_address`,
+  at the default TTL of 1 - one hop, so the local subnet, which is where a
+  robot's sensors are.
+
 - Optional TLS for the TCP **client**, behind the same `-DWIRESTEAD_ENABLE_TLS=ON`.
   Two wirestead services can now talk to each other encrypted; before this a
   wirestead client could only reach a wirestead TLS server by not being a

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -100,6 +100,7 @@ foreach(
   test_tcp_client_wrapper_lifecycle.cc
   test_udp_stop_lifecycle.cc
   test_udp_options.cc
+  test_udp_multicast.cc
   test_udp_failure.cc
   test_udp_state.cc
   test_udp_callback_race_stress.cc

--- a/test/integration/wrapper/test_udp_multicast.cc
+++ b/test/integration/wrapper/test_udp_multicast.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "test_utils.hpp"
+#include "wirestead/config/udp_config.hpp"
+#include "wirestead/wrapper/udp/udp.hpp"
+
+using namespace std::chrono_literals;
+namespace net = boost::asio;
+
+namespace {
+
+constexpr const char* kGroup = "239.255.42.99";
+constexpr const char* kLoopback = "127.0.0.1";
+
+// Multicast needs a route, and a container or a CI runner with no multicast-
+// capable interface has none. That is an environment fact, not a defect, so
+// the setup steps skip while the assertions below still fail loudly.
+class MulticastSender {
+ public:
+  MulticastSender(net::io_context& ioc, uint16_t port) : socket_(ioc), endpoint_(net::ip::make_address(kGroup), port) {
+    boost::system::error_code ec;
+    socket_.open(net::ip::udp::v4(), ec);
+    if (ec) return;
+    // Send out of loopback and let this host see its own traffic - the
+    // receiver under test is in this same process.
+    socket_.set_option(net::ip::multicast::outbound_interface(net::ip::make_address_v4(kLoopback)), ec);
+    if (ec) return;
+    socket_.set_option(net::ip::multicast::enable_loopback(true), ec);
+    if (ec) return;
+    usable_ = true;
+  }
+
+  bool usable() const { return usable_; }
+
+  bool send(const std::string& payload) {
+    boost::system::error_code ec;
+    socket_.send_to(net::buffer(payload), endpoint_, 0, ec);
+    return !ec;
+  }
+
+ private:
+  net::ip::udp::socket socket_;
+  net::ip::udp::endpoint endpoint_;
+  bool usable_{false};
+};
+
+}  // namespace
+
+// The point of joining a group is receiving traffic addressed to it, and
+// nothing short of a real datagram proves the join took effect: a socket that
+// silently failed to join looks exactly like one whose sender went quiet.
+TEST(UdpMulticastTest, JoinedGroupReceivesGroupTraffic) {
+  const uint16_t port = wirestead::test::TestUtils::getAvailableTestPort();
+
+  wirestead::config::UdpConfig cfg;
+  cfg.bind_address = "0.0.0.0";
+  cfg.local_port = port;
+  cfg.reuse_address = true;
+  cfg.multicast_group = kGroup;
+  cfg.multicast_interface = kLoopback;
+
+  wirestead::wrapper::UdpClient receiver(cfg);
+  std::atomic<bool> got_it{false};
+  receiver.on_data([&](const wirestead::wrapper::MessageContext& ctx) {
+    if (ctx.data() == "multicast payload") got_it = true;
+  });
+
+  auto started = receiver.start();
+  ASSERT_EQ(started.wait_for(2s), std::future_status::ready);
+  if (!started.get()) {
+    GTEST_SKIP() << "could not join " << kGroup << " - no multicast route in this environment";
+  }
+
+  net::io_context ioc;
+  MulticastSender sender(ioc, port);
+  if (!sender.usable()) {
+    receiver.stop();
+    GTEST_SKIP() << "loopback multicast is not configurable in this environment";
+  }
+
+  for (int i = 0; i < 20 && !got_it.load(); ++i) {
+    if (!sender.send("multicast payload")) {
+      receiver.stop();
+      GTEST_SKIP() << "sending to " << kGroup << " failed - no multicast route in this environment";
+    }
+    std::this_thread::sleep_for(50ms);
+  }
+
+  EXPECT_TRUE(got_it.load()) << "joined the group but never received a datagram addressed to it";
+  receiver.stop();
+}
+
+// A group that was never joined must not deliver. Without this the test above
+// would still pass on a host that hands every datagram to every socket.
+TEST(UdpMulticastTest, UnjoinedSocketDoesNotReceiveGroupTraffic) {
+  const uint16_t port = wirestead::test::TestUtils::getAvailableTestPort();
+
+  wirestead::config::UdpConfig cfg;
+  cfg.bind_address = "0.0.0.0";
+  cfg.local_port = port;
+  cfg.reuse_address = true;  // no multicast_group: never joined
+
+  wirestead::wrapper::UdpClient receiver(cfg);
+  std::atomic<bool> got_it{false};
+  receiver.on_data([&](const wirestead::wrapper::MessageContext&) { got_it = true; });
+
+  auto started = receiver.start();
+  ASSERT_EQ(started.wait_for(2s), std::future_status::ready);
+  ASSERT_TRUE(started.get());
+
+  net::io_context ioc;
+  MulticastSender sender(ioc, port);
+  if (!sender.usable()) {
+    receiver.stop();
+    GTEST_SKIP() << "loopback multicast is not configurable in this environment";
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    sender.send("multicast payload");
+    std::this_thread::sleep_for(20ms);
+  }
+  std::this_thread::sleep_for(200ms);
+
+  EXPECT_FALSE(got_it.load()) << "received group traffic without joining the group";
+  receiver.stop();
+}

--- a/test/unit/config/test_config.cc
+++ b/test/unit/config/test_config.cc
@@ -390,6 +390,30 @@ TEST_F(ConfigTest, UdpConfigAddressFormatIsValidated) {
   EXPECT_TRUE(cfg.is_valid()) << "IPv6 bind address should be valid";
 }
 
+// A unicast address in multicast_group is rejected here rather than at the
+// setsockopt, where the error names neither the setting nor the address.
+TEST_F(ConfigTest, UdpMulticastGroupMustBeAMulticastAddress) {
+  UdpConfig cfg;
+
+  cfg.multicast_group = "239.255.0.1";
+  EXPECT_TRUE(cfg.is_valid());
+  cfg.multicast_group = "ff02::1";
+  EXPECT_TRUE(cfg.is_valid()) << "IPv6 groups are ff00::/8";
+
+  cfg.multicast_group = "127.0.0.1";
+  EXPECT_FALSE(cfg.is_valid()) << "a unicast address is not a group";
+  cfg.multicast_group = "223.255.255.255";
+  EXPECT_FALSE(cfg.is_valid()) << "just below 224.0.0.0/4";
+  cfg.multicast_group = "multicast.example.com";
+  EXPECT_FALSE(cfg.is_valid()) << "no hostname resolution here";
+
+  cfg.multicast_group = "239.255.0.1";
+  cfg.multicast_interface = "192.168.1.10";
+  EXPECT_TRUE(cfg.is_valid());
+  cfg.multicast_interface = "eth0";
+  EXPECT_FALSE(cfg.is_valid()) << "the interface is named by its IPv4 address";
+}
+
 TEST(SocketTuningConfigTest, SocketBufferConfigValidationAndClamping) {
   TcpClientConfig tcp_client;
   EXPECT_TRUE(tcp_client.tcp_no_delay);

--- a/wirestead/builder/udp_builder.cc
+++ b/wirestead/builder/udp_builder.cc
@@ -53,6 +53,8 @@ std::unique_ptr<wrapper::UdpClient> UdpClientBuilder::build() {
   cfg.remote_port = remote_port_;
   cfg.enable_broadcast = enable_broadcast_;
   cfg.reuse_address = reuse_address_;
+  cfg.multicast_group = multicast_group_;
+  cfg.multicast_interface = multicast_interface_;
   cfg.send_buffer_size = send_buffer_size_;
   cfg.receive_buffer_size = receive_buffer_size_;
 
@@ -121,6 +123,16 @@ UdpClientBuilder& UdpClientBuilder::broadcast(bool enable) {
   return *this;
 }
 
+UdpClientBuilder& UdpClientBuilder::multicast_group(const std::string& group, const std::string& interface_address) {
+  multicast_group_ = group;
+  if (interface_address.empty()) {
+    multicast_interface_.reset();
+  } else {
+    multicast_interface_ = interface_address;
+  }
+  return *this;
+}
+
 UdpClientBuilder& UdpClientBuilder::reuse_address(bool enable) {
   reuse_address_ = enable;
   return *this;
@@ -165,6 +177,8 @@ std::unique_ptr<wrapper::UdpServer> UdpServerBuilder::build() {
   cfg.local_port = local_port_;
   cfg.enable_broadcast = enable_broadcast_;
   cfg.reuse_address = reuse_address_;
+  cfg.multicast_group = multicast_group_;
+  cfg.multicast_interface = multicast_interface_;
   cfg.send_buffer_size = send_buffer_size_;
   cfg.receive_buffer_size = receive_buffer_size_;
 
@@ -232,6 +246,16 @@ UdpServerBuilder& UdpServerBuilder::max_clients(uint32_t max) {
 
 UdpServerBuilder& UdpServerBuilder::broadcast(bool enable) {
   enable_broadcast_ = enable;
+  return *this;
+}
+
+UdpServerBuilder& UdpServerBuilder::multicast_group(const std::string& group, const std::string& interface_address) {
+  multicast_group_ = group;
+  if (interface_address.empty()) {
+    multicast_interface_.reset();
+  } else {
+    multicast_interface_ = interface_address;
+  }
   return *this;
 }
 

--- a/wirestead/builder/udp_builder.hpp
+++ b/wirestead/builder/udp_builder.hpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,15 @@ class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClien
   UdpClientBuilder& remote(const std::string& host, uint16_t port) { return remote_endpoint(host, port); }
   UdpClientBuilder& broadcast(bool enable = true);
   UdpClientBuilder& reuse_address(bool enable = true);
+  // Join a multicast group after binding, so this socket receives datagrams
+  // addressed to it. `interface_address` picks the NIC by its local IPv4
+  // address; leave it empty to let the kernel choose, which is only reliable
+  // on a host with one interface. See UdpConfig::multicast_group.
+  //
+  // Multicast receivers usually want reuse_address(true) as well, so more than
+  // one process on the host can listen to the same group and port.
+  UdpClientBuilder& multicast_group(const std::string& group, const std::string& interface_address = "");
+
   UdpClientBuilder& independent_context(bool use_independent = true);
   UdpClientBuilder& send_buffer_size(size_t bytes);
   UdpClientBuilder& receive_buffer_size(size_t bytes);
@@ -73,6 +83,9 @@ class WIRESTEAD_API UdpClientBuilder : public BuilderInterface<wrapper::UdpClien
   bool independent_context_;
   bool enable_broadcast_;
   bool reuse_address_;
+  std::optional<std::string> multicast_group_;
+  std::optional<std::string> multicast_interface_;
+
   size_t send_buffer_size_;
   size_t receive_buffer_size_;
 };
@@ -103,6 +116,15 @@ class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServe
   UdpServerBuilder& max_clients(uint32_t max);
   UdpServerBuilder& broadcast(bool enable = true);
   UdpServerBuilder& reuse_address(bool enable = true);
+  // Join a multicast group after binding, so this socket receives datagrams
+  // addressed to it. `interface_address` picks the NIC by its local IPv4
+  // address; leave it empty to let the kernel choose, which is only reliable
+  // on a host with one interface. See UdpConfig::multicast_group.
+  //
+  // Multicast receivers usually want reuse_address(true) as well, so more than
+  // one process on the host can listen to the same group and port.
+  UdpServerBuilder& multicast_group(const std::string& group, const std::string& interface_address = "");
+
   UdpServerBuilder& independent_context(bool use_independent = true);
   /**
    * @brief Configure application-level idle timeout for virtual sessions.
@@ -122,6 +144,9 @@ class WIRESTEAD_API UdpServerBuilder : public BuilderInterface<wrapper::UdpServe
   bool independent_context_;
   bool enable_broadcast_;
   bool reuse_address_;
+  std::optional<std::string> multicast_group_;
+  std::optional<std::string> multicast_interface_;
+
   uint32_t max_clients_ = 0;
   bool client_limit_enabled_ = false;
   std::chrono::milliseconds idle_timeout_{0};

--- a/wirestead/config/udp_config.hpp
+++ b/wirestead/config/udp_config.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <boost/asio/ip/address.hpp>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -26,6 +27,17 @@
 namespace wirestead {
 namespace config {
 
+// True for an address literal inside the multicast ranges - 224.0.0.0/4 for
+// IPv4, ff00::/8 for IPv6. Anything else, including a hostname or a unicast
+// address, is rejected: joining a group on a unicast address fails at the
+// setsockopt with an error that says nothing about which setting was wrong.
+inline bool is_multicast_address(const std::string& address) {
+  boost::system::error_code ec;
+  const auto parsed = boost::asio::ip::make_address(address, ec);
+  if (ec) return false;
+  return parsed.is_multicast();
+}
+
 struct UdpConfig {
   std::string bind_address = "0.0.0.0";
   uint16_t local_port = 0;
@@ -35,6 +47,20 @@ struct UdpConfig {
   base::constants::BackpressureStrategy backpressure_strategy = base::constants::BackpressureStrategy::Reliable;
   bool enable_broadcast = false;
   bool reuse_address = false;
+
+  // Join this multicast group after binding, so the socket receives datagrams
+  // addressed to it. IPv4 groups are 224.0.0.0/4, IPv6 groups are ff00::/8.
+  //
+  // `multicast_interface` picks which NIC to join on, by its local IPv4
+  // address. A robot with a sensor on one interface and a network on another
+  // needs it; leave it empty to let the kernel choose, which is only reliable
+  // with a single interface. IPv6 always uses the kernel's choice.
+  //
+  // Receiving is all this covers. Sending to a group already works through
+  // remote_address, at the default TTL of 1 - one hop, so the local subnet
+  // only, which is where a robot's sensors are.
+  std::optional<std::string> multicast_group;
+  std::optional<std::string> multicast_interface;
   bool enable_memory_pool = true;
   bool stop_on_callback_exception = false;
   size_t send_buffer_size = 0;
@@ -57,6 +83,8 @@ struct UdpConfig {
       return false;
     }
     if (remote_port && *remote_port == 0) return false;
+    if (multicast_group && !is_multicast_address(*multicast_group)) return false;
+    if (multicast_interface && !util::InputValidator::is_valid_ipv4(*multicast_interface)) return false;
     if (send_buffer_size != 0 && (send_buffer_size < base::constants::MIN_SOCKET_BUFFER_SIZE ||
                                   send_buffer_size > base::constants::MAX_SOCKET_BUFFER_SIZE)) {
       return false;

--- a/wirestead/transport/udp/udp.cc
+++ b/wirestead/transport/udp/udp.cc
@@ -234,6 +234,29 @@ struct UdpChannel::Impl {
       return;
     }
 
+    // After bind, which is what a group join attaches to. Fatal on failure:
+    // a receiver that silently did not join looks identical to a sensor that
+    // stopped sending, and that is the exact confusion this whole feature is
+    // meant to remove.
+    if (cfg_.multicast_group) {
+      const auto group = net::ip::make_address(*cfg_.multicast_group, ec);
+      if (!ec) {
+        if (group.is_v4() && cfg_.multicast_interface) {
+          const auto iface = net::ip::make_address_v4(*cfg_.multicast_interface, ec);
+          if (!ec) socket_.set_option(net::ip::multicast::join_group(group.to_v4(), iface), ec);
+        } else {
+          socket_.set_option(net::ip::multicast::join_group(group), ec);
+        }
+      }
+      if (ec) {
+        std::string msg = fmt::format("Failed to join multicast group {}: {}", *cfg_.multicast_group, ec.message());
+        WIRESTEAD_LOG_ERROR("udp", "multicast", msg);
+        transition_to(LinkState::Error, ec, "multicast", msg);
+        return;
+      }
+      WIRESTEAD_LOG_INFO("udp", "multicast", fmt::format("Joined multicast group {}", *cfg_.multicast_group));
+    }
+
     // Set large OS buffers for UDP to prevent drops unless explicitly configured.
     const int automatic_buf_size = std::max(static_cast<int>(bp_high_), 4 * 1024 * 1024);
     const int recv_buf_size =


### PR DESCRIPTION
## Description

A sensor that publishes to a multicast group — a common shape for lidar and
camera streams — could not be received at all. `enable_broadcast` is a
different thing and does not cover it, and nothing else exposed the socket, so
there was no workaround at the library level either.

## Key Changes

- `multicast_group(group, interface_address = "")` on `UdpClientBuilder` and
  `UdpServerBuilder`, backed by `UdpConfig::multicast_group` /
  `multicast_interface`. The join happens after bind.
- The interface argument names the NIC by its local IPv4 address. A robot with
  its sensor network on one interface and everything else on another needs it;
  empty lets the kernel choose, which is only reliable on a host with one
  interface. IPv6 groups are supported, always on the kernel's choice.
- A failed join fails `start()`. A socket that silently did not join is
  indistinguishable from a sensor that stopped sending, which is exactly the
  confusion this feature exists to remove.
- A group outside `224.0.0.0/4` or `ff00::/8` is rejected in config validation,
  where the error can name the setting, rather than surfacing later as an
  opaque `setsockopt` failure.

## Related Issues

None.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

The loopback test asserts that a real datagram arrives, because nothing weaker
distinguishes a working join from a quiet sender.
`UnjoinedSocketDoesNotReceiveGroupTraffic` is its control: without it the first
test would pass just as happily on a host that handed group traffic to every
socket regardless of joins.

Both skip rather than fail when the environment has no multicast route or
cannot set the loopback options — a container or a runner without a
multicast-capable interface is an environment fact, not a defect. The
assertions themselves still fail loudly.

Receive side only. Sending to a group already worked through `remote_address`
at the default TTL of 1 — one hop, so the local subnet, which is where a
robot's sensors are. A TTL knob can follow if a routed deployment turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
