### PR TITLE
feat: hook for configuring the library's io threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,28 @@ and ABI policy.
   at the default TTL of 1 - one hop, so the local subnet, which is where a
   robot's sensors are.
 
+- `wirestead::concurrency::set_io_thread_init()`, a callback run on every io
+  thread the library starts, before that thread services any work.
+
+  ```cpp
+  wirestead::concurrency::set_io_thread_init([] {
+    pthread_setname_np(pthread_self(), "wirestead-io");
+    sched_param p{.sched_priority = 20};
+    pthread_setschedparam(pthread_self(), SCHED_FIFO, &p);
+  });
+  ```
+
+  The library creates its own threads, so a deployment needing a real-time
+  policy, a CPU affinity mask, or a readable thread name had nothing to apply
+  it to. The hook runs on the new thread, which is what those APIs require.
+
+  Process-wide rather than per channel: thread policy is a property of the
+  deployment, and a per-config field would have to be threaded through six
+  transports to say the same thing. Install it before starting any channel; it
+  does not reach threads already running. Exceptions escaping the hook are
+  caught, since a thread entry point would otherwise terminate the process.
+  See `docs/tuning.md`.
+
 - Optional TLS for the TCP **client**, behind the same `-DWIRESTEAD_ENABLE_TLS=ON`.
   Two wirestead services can now talk to each other encrypted; before this a
   wirestead client could only reach a wirestead TLS server by not being a

--- a/cmake/WiresteadSources.cmake
+++ b/cmake/WiresteadSources.cmake
@@ -12,6 +12,7 @@ set(WIRESTEAD_SOURCES
     wirestead/builder/udp_builder.cc
     wirestead/builder/unified_builder.cc
     wirestead/concurrency/io_context_manager.cc
+    wirestead/concurrency/io_thread_hook.cc
     wirestead/config/config_factory.cc
     wirestead/config/config_manager.cc
     wirestead/diagnostics/error_handler.cc
@@ -66,6 +67,7 @@ set(WIRESTEAD_HEADERS
     wirestead/builder/uds_builder.hpp
     wirestead/builder/unified_builder.hpp
     wirestead/concurrency/io_context_manager.hpp
+    wirestead/concurrency/io_thread_hook.hpp
     wirestead/concurrency/thread_safe_state.hpp
     wirestead/config/config_factory.hpp
     wirestead/config/config_manager.hpp

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -83,6 +83,39 @@ would hold a bidirectional timer open forever. Expiry runs the same path as a
 read error, so `reopen_on_error` decides whether the port is reopened or the
 link goes to `Error`.
 
+## Io thread policy
+
+The library starts its own threads, so nothing else can reach them: a
+deployment that wants `SCHED_FIFO`, a CPU affinity mask, or just a readable
+name in `top` had no handle to apply it to. `set_io_thread_init()` installs a
+callback that runs on each io thread the library starts, before that thread
+runs any work — which is where `pthread_self()`-based APIs need to be called
+from.
+
+```cpp
+wirestead::concurrency::set_io_thread_init([] {
+  pthread_setname_np(pthread_self(), "wirestead-io");
+  sched_param p{.sched_priority = 20};
+  pthread_setschedparam(pthread_self(), SCHED_FIFO, &p);
+});
+```
+
+Process-wide on purpose. Thread policy belongs to the deployment, not to one
+connection, and a per-channel field would have to be threaded through six
+transports to say the same thing.
+
+Set it before starting any channel — it does not reach threads already
+running. The library never undoes what the hook did, so a raised priority
+outlives the channel that triggered it when the thread is a shared one.
+Blocking in the hook blocks that channel's io; an exception escaping it is
+caught, because the alternative at a thread entry point is process
+termination.
+
+Read the table under [What tuning will not fix](#what-tuning-will-not-fix)
+first if the goal is throughput rather than scheduling determinism. Raising
+priority does not make a channel faster; it makes it preempt other work, which
+is only what you want on a robot with a deadline.
+
 ## Memory pool prefill
 
 `MemoryPool(initial_pool_size, max_pool_size)` pre-allocates

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -73,6 +73,7 @@ foreach(
   test_memory_tracker_and_buffer.cc
   test_pool_stress.cc
   test_io_context_manager_lifecycle.cc
+  test_io_thread_hook.cc
   test_error_mapping.cc
   test_error_mapping_exhaustive.cc
   test_error_codes_to_string.cc

--- a/test/unit/common/test_io_thread_hook.cc
+++ b/test/unit/common/test_io_thread_hook.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include "wirestead/builder/tcp_client_builder.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+// Every test here installs a hook, so none may leave one behind for the next.
+class IoThreadHookTest : public ::testing::Test {
+ protected:
+  void TearDown() override { wirestead::concurrency::set_io_thread_init(nullptr); }
+};
+
+}  // namespace
+
+// The hook exists so a deployment can call pthread_setschedparam(pthread_self())
+// and friends, which only work from the thread being configured. Running on the
+// caller's thread instead would configure the wrong one and look like it
+// worked, so the thread identity is the assertion.
+TEST_F(IoThreadHookTest, RunsOnTheIoThreadNotTheCaller) {
+  std::promise<std::thread::id> ran_on;
+  std::atomic<bool> fired{false};
+  wirestead::concurrency::set_io_thread_init([&] {
+    if (!fired.exchange(true)) ran_on.set_value(std::this_thread::get_id());
+  });
+
+  auto client = wirestead::builder::TcpClientBuilder("127.0.0.1", 59999).build();
+  auto started = client->start();
+
+  auto future = ran_on.get_future();
+  ASSERT_EQ(future.wait_for(2s), std::future_status::ready) << "the hook never ran on any io thread";
+  EXPECT_NE(future.get(), std::this_thread::get_id());
+
+  client->stop();
+  started.wait_for(2s);
+}
+
+TEST_F(IoThreadHookTest, NoHookInstalledIsFine) {
+  wirestead::concurrency::set_io_thread_init(nullptr);
+
+  auto client = wirestead::builder::TcpClientBuilder("127.0.0.1", 59999).build();
+  auto started = client->start();
+  std::this_thread::sleep_for(100ms);
+  EXPECT_NO_THROW(client->stop());
+  started.wait_for(2s);
+}
+
+// A throwing hook reaches the thread entry point, where an escaping exception
+// terminates the process. The io thread has work to do either way.
+TEST_F(IoThreadHookTest, AThrowingHookDoesNotTakeDownTheThread) {
+  std::atomic<int> calls{0};
+  wirestead::concurrency::set_io_thread_init([&] {
+    calls.fetch_add(1);
+    throw std::runtime_error("hook blew up");
+  });
+
+  auto client = wirestead::builder::TcpClientBuilder("127.0.0.1", 59999).build();
+  auto started = client->start();
+  std::this_thread::sleep_for(200ms);
+
+  EXPECT_GE(calls.load(), 1);
+  EXPECT_NO_THROW(client->stop());
+  started.wait_for(2s);
+}

--- a/wirestead/concurrency/io_context_manager.cc
+++ b/wirestead/concurrency/io_context_manager.cc
@@ -24,6 +24,7 @@
 #include <stop_token>
 #include <thread>
 
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/diagnostics/logger.hpp"
 
 namespace wirestead {
@@ -146,6 +147,7 @@ void IoContextManager::start() {
     }
 
     impl_->io_thread_ = std::jthread([this, context](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         // Register stop callback to gracefully stop io_context when jthread is stopped
         std::stop_callback cb(st, [context] { context->stop(); });

--- a/wirestead/concurrency/io_thread_hook.cc
+++ b/wirestead/concurrency/io_thread_hook.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wirestead/concurrency/io_thread_hook.hpp"
+
+#include <memory>
+#include <mutex>
+
+namespace wirestead {
+namespace concurrency {
+
+namespace {
+
+std::mutex& hook_mutex() {
+  static std::mutex m;
+  return m;
+}
+
+// shared_ptr to const, so a thread that has taken a snapshot keeps a valid
+// callable even while another thread installs a replacement - the same
+// discipline interface::SharedCallback uses on the receive path.
+std::shared_ptr<const std::function<void()>>& hook_storage() {
+  static std::shared_ptr<const std::function<void()>> hook;
+  return hook;
+}
+
+}  // namespace
+
+void set_io_thread_init(std::function<void()> fn) {
+  auto installed = fn ? std::make_shared<const std::function<void()>>(std::move(fn))
+                      : std::shared_ptr<const std::function<void()>>{};
+  std::lock_guard<std::mutex> lock(hook_mutex());
+  hook_storage() = std::move(installed);
+}
+
+void run_io_thread_init() noexcept {
+  std::shared_ptr<const std::function<void()>> hook;
+  {
+    std::lock_guard<std::mutex> lock(hook_mutex());
+    hook = hook_storage();
+  }
+  if (!hook) return;
+  // An exception here would cross the thread entry point and terminate the
+  // process. Whatever the hook was setting is not worth that, and the thread
+  // still has io to service.
+  try {
+    (*hook)();
+  } catch (...) {
+  }
+}
+
+}  // namespace concurrency
+}  // namespace wirestead

--- a/wirestead/concurrency/io_thread_hook.hpp
+++ b/wirestead/concurrency/io_thread_hook.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+
+#include "wirestead/base/visibility.hpp"
+
+namespace wirestead {
+namespace concurrency {
+
+/**
+ * @brief Run this on every io thread the library starts, before it runs any
+ *        work.
+ *
+ * The library creates its own threads, so nothing else can reach them: a
+ * deployment that needs `SCHED_FIFO`, a CPU affinity mask, or just a readable
+ * name in `top` had no handle to apply it to. The hook runs on the new thread
+ * itself, which is what those APIs want - `pthread_setschedparam(pthread_self(),
+ * ...)`, `sched_setaffinity(0, ...)`, `pthread_setname_np(pthread_self(), ...)`.
+ *
+ * ```cpp
+ * wirestead::concurrency::set_io_thread_init([] {
+ *   pthread_setname_np(pthread_self(), "wirestead-io");
+ *   sched_param p{.sched_priority = 20};
+ *   pthread_setschedparam(pthread_self(), SCHED_FIFO, &p);
+ * });
+ * ```
+ *
+ * Deliberately process-wide rather than per channel. Thread policy is a
+ * property of the deployment, not of one connection, and a per-config field
+ * would have to be threaded through six transports and their builders to say
+ * the same thing.
+ *
+ * Set it before starting any channel. Installing a hook does not reach threads
+ * that are already running, and the library never removes what the hook did -
+ * a raised priority outlives the channel that triggered it if the thread is a
+ * shared one.
+ *
+ * The hook runs on a thread that is about to service io. Blocking in it blocks
+ * that channel's io, and an exception escaping it would terminate the process,
+ * so exceptions are caught and swallowed. Pass `nullptr` to clear.
+ *
+ * Thread-safe: may be called while other threads are starting, though the
+ * ordering above is what makes it useful.
+ */
+WIRESTEAD_API void set_io_thread_init(std::function<void()> fn);
+
+/**
+ * @brief Invoke the installed hook, if any. Called by the library on each io
+ *        thread it starts; not intended for user code.
+ */
+WIRESTEAD_API void run_io_thread_init() noexcept;
+
+}  // namespace concurrency
+}  // namespace wirestead

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -35,6 +35,7 @@
 #include "wirestead/base/common.hpp"
 #include "wirestead/base/constants.hpp"
 #include "wirestead/concurrency/io_context_manager.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/concurrency/thread_safe_state.hpp"
 #include "wirestead/diagnostics/error_handler.hpp"
 #include "wirestead/diagnostics/logger.hpp"
@@ -622,6 +623,7 @@ void Serial::start() {
       std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(impl->ioc_.get_executor());
   if (impl->owns_ioc_) {
     impl->ioc_thread_ = std::jthread([impl](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [impl] { impl->ioc_.stop(); });
         impl->ioc_.run();

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -16,6 +16,8 @@
 
 #include "wirestead/transport/tcp_client/tcp_client.hpp"
 
+#include "wirestead/concurrency/io_thread_hook.hpp"
+
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
@@ -299,6 +301,7 @@ void TcpClient::start() {
     impl_->work_guard_ =
         std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(impl_->ioc_->get_executor());
     impl_->ioc_thread_ = std::jthread([ioc = impl_->owned_ioc_](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [ioc] { ioc->stop(); });
         ioc->run();

--- a/wirestead/transport/tcp_server/tcp_server.cc
+++ b/wirestead/transport/tcp_server/tcp_server.cc
@@ -30,6 +30,7 @@
 #include <unordered_map>
 
 #include "wirestead/concurrency/io_context_manager.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/concurrency/thread_safe_state.hpp"
 #include "wirestead/diagnostics/exceptions.hpp"
 #include "wirestead/diagnostics/logger.hpp"
@@ -650,6 +651,7 @@ void TcpServer::start() {
     impl->work_guard_ =
         std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(impl->ioc_.get_executor());
     impl->ioc_thread_ = std::jthread([impl](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [impl] { impl->ioc_.stop(); });
         impl->ioc_.run();

--- a/wirestead/transport/udp/udp.cc
+++ b/wirestead/transport/udp/udp.cc
@@ -35,6 +35,7 @@
 
 #include "wirestead/base/common.hpp"
 #include "wirestead/base/constants.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/concurrency/thread_safe_state.hpp"
 #include "wirestead/diagnostics/error_handler.hpp"
 #include "wirestead/diagnostics/logger.hpp"
@@ -775,6 +776,7 @@ void UdpChannel::start() {
 
   if (impl->owns_ioc_) {
     impl->ioc_thread_ = std::jthread([impl](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [impl] { impl->ioc_->stop(); });
         impl->ioc_->run();

--- a/wirestead/transport/uds/uds_client.cc
+++ b/wirestead/transport/uds/uds_client.cc
@@ -16,6 +16,8 @@
 
 #include "wirestead/transport/uds/uds_client.hpp"
 
+#include "wirestead/concurrency/io_thread_hook.hpp"
+
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
@@ -257,6 +259,7 @@ void UdsClient::start() {
     impl_->work_guard_ =
         std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(net::make_work_guard(*impl_->ioc_));
     impl_->ioc_thread_ = std::jthread([ioc = impl_->owned_ioc_](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [ioc] { ioc->stop(); });
         ioc->run();

--- a/wirestead/transport/uds/uds_server.cc
+++ b/wirestead/transport/uds/uds_server.cc
@@ -34,6 +34,7 @@
 #include "wirestead/base/platform.hpp"
 #include "wirestead/builder/auto_initializer.hpp"
 #include "wirestead/concurrency/io_context_manager.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/concurrency/thread_safe_state.hpp"
 #include "wirestead/diagnostics/logger.hpp"
 #include "wirestead/diagnostics/runtime_stats_counter.hpp"
@@ -394,6 +395,7 @@ void UdsServer::start() {
     impl_->work_guard_ =
         std::make_unique<net::executor_work_guard<net::io_context::executor_type>>(net::make_work_guard(*impl_->ioc_));
     impl_->ioc_thread_ = std::jthread([impl = impl_.get()](std::stop_token st) {
+      wirestead::concurrency::run_io_thread_init();
       try {
         std::stop_callback cb(st, [impl] { impl->ioc_->stop(); });
         impl->ioc_->run();

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -31,6 +31,7 @@
 
 #include "wirestead/base/common.hpp"
 #include "wirestead/base/constants.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/factory/channel_factory.hpp"
 #include "wirestead/transport/serial/serial.hpp"
 #include "wirestead/wrapper/callback_guard.hpp"
@@ -208,6 +209,7 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc));
       external_thread = std::thread([ioc = external_ioc]() {
+        wirestead::concurrency::run_io_thread_init();
         try {
           ioc->run();
         } catch (...) {

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -30,6 +30,7 @@
 
 #include "wirestead/base/common.hpp"
 #include "wirestead/base/constants.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/config/tcp_client_config.hpp"
 #include "wirestead/diagnostics/error_mapping.hpp"
 #include "wirestead/factory/channel_factory.hpp"
@@ -226,6 +227,7 @@ struct TcpClient::Impl : public std::enable_shared_from_this<Impl> {
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           external_ioc_->get_executor());
       external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
+        wirestead::concurrency::run_io_thread_init();
         try {
           std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "wirestead/base/common.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/config/tcp_server_config.hpp"
 #include "wirestead/factory/channel_factory.hpp"
 #include "wirestead/transport/tcp_server/tcp_server.hpp"
@@ -270,6 +271,7 @@ struct TcpServer::Impl : public std::enable_shared_from_this<Impl> {
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc_));
       external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
+        wirestead::concurrency::run_io_thread_init();
         try {
           std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();

--- a/wirestead/wrapper/udp/udp.cc
+++ b/wirestead/wrapper/udp/udp.cc
@@ -16,6 +16,8 @@
 
 #include "wirestead/wrapper/udp/udp.hpp"
 
+#include "wirestead/concurrency/io_thread_hook.hpp"
+
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -186,6 +188,7 @@ struct UdpClient::Impl : public std::enable_shared_from_this<Impl> {
       work_guard = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc));
       external_thread = std::thread([this, ioc = external_ioc]() {
+        wirestead::concurrency::run_io_thread_init();
         try {
           ioc->run();
         } catch (...) {

--- a/wirestead/wrapper/udp/udp_server.cc
+++ b/wirestead/wrapper/udp/udp_server.cc
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "wirestead/base/common.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/factory/channel_factory.hpp"
 #include "wirestead/transport/udp/udp.hpp"
 #include "wirestead/wrapper/callback_guard.hpp"
@@ -444,6 +445,7 @@ struct UdpServer::Impl : public std::enable_shared_from_this<Impl> {
       work_guard = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           external_ioc->get_executor());
       external_thread = std::jthread([ioc = external_ioc](std::stop_token st) {
+        wirestead::concurrency::run_io_thread_init();
         try {
           std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -31,6 +31,7 @@
 
 #include "wirestead/base/common.hpp"
 #include "wirestead/base/constants.hpp"
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/config/uds_config.hpp"
 #include "wirestead/diagnostics/error_mapping.hpp"
 #include "wirestead/factory/channel_factory.hpp"
@@ -202,6 +203,7 @@ struct UdsClient::Impl : public std::enable_shared_from_this<Impl> {
           work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
               boost::asio::make_work_guard(*external_ioc_));
           external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
+            wirestead::concurrency::run_io_thread_init();
             try {
               std::stop_callback cb(st, [ioc] { ioc->stop(); });
               ioc->run();

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -9,6 +9,7 @@
 #include <stop_token>
 #include <thread>
 
+#include "wirestead/concurrency/io_thread_hook.hpp"
 #include "wirestead/diagnostics/error_mapping.hpp"
 #include "wirestead/factory/channel_factory.hpp"
 #include "wirestead/framer/line_framer.hpp"
@@ -238,6 +239,7 @@ struct UdsServer::Impl : public std::enable_shared_from_this<Impl> {
       work_guard_ = std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
           boost::asio::make_work_guard(*external_ioc_));
       external_thread_ = std::jthread([ioc = external_ioc_](std::stop_token st) {
+        wirestead::concurrency::run_io_thread_init();
         try {
           std::stop_callback cb(st, [ioc] { ioc->stop(); });
           ioc->run();


### PR DESCRIPTION
## Description

The library creates its own io threads, so nothing outside could reach them. A
deployment that wants `SCHED_FIFO`, a CPU affinity mask, or just a readable
thread name in `top` had no handle to apply it to — and exposing a handle would
not have been enough either, since `pthread_setschedparam`,
`sched_setaffinity` and `pthread_setname_np` all want to run *on* the thread
being configured.

## Key Changes

- `wirestead::concurrency::set_io_thread_init(std::function<void()>)` installs a
  callback that runs on each io thread the library starts, before that thread
  services any work. `nullptr` clears it.
- All 14 thread bodies call it — transports and wrappers, owned and external
  contexts — so no transport is quietly exempt.
- `run_io_thread_init()` is `noexcept` and swallows: the hook runs at a thread
  entry point, where an escaping exception terminates the process, and the
  thread has io to service either way.
- Storage is a `shared_ptr<const std::function>` under a mutex, the same
  discipline `interface::SharedCallback` uses, so a thread that has taken a
  snapshot keeps a valid callable while another installs a replacement.
- Documented in `docs/tuning.md`.

## Related Issues

None.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Process-wide rather than per channel, deliberately. Thread policy is a property
of the deployment, not of one connection, and a per-config field would have to
be threaded through six transports and their builders to express the same
thing. The cost is honest and documented: installing a hook does not reach
threads already running, and the library never undoes what the hook did, so a
raised priority outlives the channel that triggered it when the thread is a
shared one.

`RunsOnTheIoThreadNotTheCaller` asserts the thread *identity*, not merely that
the hook fired. Running it on the caller's thread would configure the wrong
thread and still look like it worked, which is the failure worth catching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
