### PR TITLE
fix: keep the TLS stream alive while its operations are pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,20 @@ and ABI policy.
 
 ### Fixed
 
+- The TLS client no longer segfaults when a connection is torn down during a
+  handshake. `close_socket()` destroyed the `ssl::stream` while an
+  `asio::ssl::detail::io_op` continuation was still queued on the strand -
+  `socket_.cancel()`/`close()` do not retract one - so that continuation then
+  called into a freed BIO. Reproducible under parallel load and seen
+  intermittently in CI as `TcpTlsLoopbackTest.ClientRejectsAnUntrustedServerCertificate`
+  crashing inside `BIO_ctrl`.
+
+  The stream now outlives the connection and is destroyed by the next
+  `emplace()` on the strand, or with the transport once the io thread is
+  joined. It cannot simply be moved aside instead: a pending operation holds
+  the stream's original address. Whether IO is routed through TLS is tracked
+  by its own flag rather than by `tls_.has_value()`.
+
 - Every transport instance and every accepted server session eagerly allocated
   roughly 1 MiB of memory-pool buffers at construction. The six call sites
   passed `MemoryPool{50, 200}`, written while `initial_pool_size` was discarded

--- a/wirestead/transport/tcp_client/tcp_client.cc
+++ b/wirestead/transport/tcp_client/tcp_client.cc
@@ -95,12 +95,16 @@ struct TcpClient::Impl {
   // session cannot outlive the socket it negotiated on.
   std::shared_ptr<boost::asio::ssl::context> ssl_context_;
   std::optional<boost::asio::ssl::stream<tcp::socket&>> tls_;
+  // Whether IO should currently be routed through tls_, tracked separately
+  // from tls_.has_value() because the stream now outlives the connection - see
+  // close_socket(). Strand-confined, like the stream itself.
+  bool tls_engaged_ = false;
 #endif
 
   // True when this connection is encrypted. Reads to it happen on the strand.
   bool tls_active() const {
 #ifdef WIRESTEAD_TLS_ENABLED
-    return tls_.has_value();
+    return tls_engaged_;
 #else
     return false;
 #endif
@@ -838,6 +842,7 @@ void TcpClient::Impl::handshake_then(std::shared_ptr<TcpClient> self, uint64_t s
         ssl_context_ = std::move(ctx);
       }
       tls_.emplace(socket_, *ssl_context_);
+      tls_engaged_ = true;
       tls_->set_verify_callback(ssl::host_name_verification(cfg_.host));
       // SNI, and the name the certificate is checked against.
       ::SSL_set_tlsext_host_name(tls_->native_handle(), cfg_.host.c_str());
@@ -847,6 +852,7 @@ void TcpClient::Impl::handshake_then(std::shared_ptr<TcpClient> self, uint64_t s
       record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION, "handshake",
                    boost::asio::error::invalid_argument, msg, false, 0);
       tls_.reset();
+      tls_engaged_ = false;
       handle_close(self, seq, boost::asio::error::invalid_argument);
       return;
     }
@@ -858,7 +864,11 @@ void TcpClient::Impl::handshake_then(std::shared_ptr<TcpClient> self, uint64_t s
                               WIRESTEAD_LOG_ERROR("tcp_client", "handshake", "TLS handshake failed: " + ec.message());
                               record_error(diagnostics::ErrorLevel::ERROR, diagnostics::ErrorCategory::CONNECTION,
                                            "handshake", ec, "TLS handshake failed: " + ec.message(), false, 0);
-                              tls_.reset();
+                              // Not tls_.reset(): this runs from inside the
+                              // stream's own completion handler, and
+                              // close_socket() below explains why the stream
+                              // has to outlive its operations.
+                              tls_engaged_ = false;
                               handle_close(self, seq, ec);
                               return;
                             }
@@ -1009,7 +1019,7 @@ void TcpClient::Impl::start_read(std::shared_ptr<TcpClient> self, uint64_t seq) 
     self->impl_->start_read(self, seq);
   };
 #ifdef WIRESTEAD_TLS_ENABLED
-  if (tls_) {
+  if (tls_active()) {
     tls_->async_read_some(net::buffer(rx_.data(), rx_.size()), std::move(on_read));
     return;
   }
@@ -1081,7 +1091,7 @@ void TcpClient::Impl::do_write(std::shared_ptr<TcpClient> self, uint64_t seq) {
   };
 
 #ifdef WIRESTEAD_TLS_ENABLED
-  if (tls_) {
+  if (tls_active()) {
     net::async_write(*tls_, current_write_views_, on_write);
     return;
   }
@@ -1165,7 +1175,18 @@ void TcpClient::Impl::close_socket() {
   // One SSL_shutdown writes close_notify and returns; a second would wait for
   // the peer's, which is the block measured at 8 s on the server side.
   if (tls_) ::SSL_shutdown(tls_->native_handle());
-  tls_.reset();
+  // Deliberately no tls_.reset() here. socket_.cancel()/close() do not retract
+  // a boost::asio::ssl::detail::io_op continuation that is already queued on
+  // the strand: the strand runs it afterwards, and it calls back into the
+  // engine's BIO. Destroying the stream at this point therefore left that
+  // continuation dereferencing freed memory - a SIGSEGV inside BIO_ctrl,
+  // reproducible under parallel load and seen intermittently in CI.
+  //
+  // The stream is instead destroyed by the next tls_.emplace(), which runs on
+  // the strand after any pending continuation, or by ~Impl once the io thread
+  // has been joined. It cannot be moved out to a holder either - a pending
+  // operation holds the stream's original address.
+  tls_engaged_ = false;
 #endif
   socket_.shutdown(tcp::socket::shutdown_both, ec);
   socket_.close(ec);


### PR DESCRIPTION
## Description

`TcpTlsLoopbackTest.ClientRejectsAnUntrustedServerCertificate` has been
segfaulting intermittently in CI. It is not a flake — it is a real
use-after-free in the TLS client teardown path, and the test happens to be the
one that exercises stop-during-handshake.

`close_socket()` destroyed the `ssl::stream` while an
`asio::ssl::detail::io_op` continuation was still queued on the strand.
`socket_.cancel()` and `close()` do not retract a queued continuation — the
strand simply runs it afterwards — so it called back into a freed BIO.

## Key Changes

- `close_socket()` no longer resets `tls_`. The stream is destroyed by the next
  `tls_.emplace()`, which runs on the strand after any pending continuation,
  or with `Impl` once the io thread has been joined.
- It cannot be moved aside into a holder instead: a pending operation holds the
  stream's **original address**, so relocating it has the same defect.
- The handshake-failure handler no longer resets the stream from inside the
  stream's own completion handler either.
- `tls_active()` now reads a dedicated `tls_engaged_` flag rather than
  `tls_.has_value()`, so "is this connection encrypted" keeps its previous
  meaning while the stream outlives the connection. The two IO call sites that
  tested `if (tls_)` now test `tls_active()`.

## Validation

Reproduced first, then fixed — the reproduction is the part worth trusting:

- **Before:** 1 crash in 96 runs, running the test 8-way parallel (the serial
  loop that CI approximates never reproduced it, and neither did ASAN, which
  perturbs the timing enough to hide it).
- **Backtrace:** io thread in `ssl::detail::engine::handshake` →
  `BIO_ctrl_pending` → SIGSEGV in `BIO_ctrl`, while the main thread sits in
  `TcpClient::stop()` → `join_ioc_thread()`.
- **After:** 240 parallel runs of that test and 200 of the full TLS suite,
  all clean. All 5 TLS tests pass.
- `./scripts/verify.sh` passes.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks pass.
- [ ] I have added or updated tests — see below.
- [x] I have updated the documentation to reflect the changes (CHANGELOG).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**No new test.** The existing test already covers this path; what it lacked was
the concurrency to hit it, and a test that reproduces a ~1% race only under
8-way parallelism would be a flake generator in CI rather than a gate. The
honest gate here is that the previously-crashing test now survives 440 stressed
runs.

## Not included

`UdpServerWrapperLifecycleTest.IPv6EndpointHashCoverage`, the other
intermittent segfault, is **not** fixed here — and it turns out not to be a
crash in that test at all. Running the suite under coverage instrumentation
shows gtest completing all 13 tests and printing its summary, with the process
then segfaulting during exit. CI attributes it to that test only because ctest
runs each test as its own process, and that is the one test which starts a
server and never stops it, so its process carries the most live state into
exit. It needs its own investigation into shutdown ordering at static
destruction time; guessing at a fix for a 0.5%-reproducible exit crash would
not be verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
