### PR TITLE
docs: warn that PacketFramer cannot carry arbitrary binary payloads

### DIFF
--- a/wirestead/builder/ibuilder.hpp
+++ b/wirestead/builder/ibuilder.hpp
@@ -153,7 +153,11 @@ class BuilderInterface {
   // Framing Support
 
   /**
-   * @brief Set a custom framer factory
+   * @brief Set a custom framer factory.
+   *
+   * The escape hatch for any protocol the two built-in framers do not fit -
+   * most often a length-prefixed binary layout, where PacketFramer's
+   * delimiter search is unsafe. See PacketFramer's warning.
    */
   Derived& framer(std::function<std::unique_ptr<framer::IFramer>()> factory) {
     framer_factory_ = std::move(factory);
@@ -173,7 +177,12 @@ class BuilderInterface {
   }
 
   /**
-   * @brief Activate binary packet framing
+   * @brief Activate binary packet framing between a start and end pattern.
+   *
+   * @warning Only safe when the payload cannot contain the end pattern - there
+   * is no escaping, so the first occurrence ends the frame wherever it falls
+   * and a binary payload gets silently truncated. Use framer() with your own
+   * IFramer for length-prefixed protocols. See PacketFramer for the detail.
    */
   Derived& use_packet_framer(const std::vector<uint8_t>& start_pattern, const std::vector<uint8_t>& end_pattern,
                              size_t max_length) {

--- a/wirestead/framer/packet_framer.hpp
+++ b/wirestead/framer/packet_framer.hpp
@@ -25,10 +25,31 @@ namespace wirestead {
 namespace framer {
 
 /**
- * @brief Framer for binary packet protocols.
+ * @brief Framer for binary packet protocols delimited by byte patterns.
  *
- * Handles protocols with start and end patterns.
- * Syncs by searching for start pattern, then collects data until end pattern is found.
+ * Syncs by searching for the start pattern, then collects data until the end
+ * pattern is found.
+ *
+ * @warning **The payload must not be able to contain the end pattern.** There
+ * is no escaping or byte stuffing: the end pattern is located with a plain
+ * search over the collected bytes, so the first occurrence ends the frame
+ * wherever it appears. A binary protocol whose payload spans arbitrary byte
+ * values will therefore be cut short as soon as those bytes happen to match,
+ * and the remainder is resynchronised as if it were a new packet - silently,
+ * since a truncated frame is indistinguishable from a short one.
+ *
+ * That makes this framer a fit for protocols with a reserved delimiter (a
+ * text-ish or escaped wire format), and a poor fit for the common
+ * length-prefixed binary layout. For the latter, implement IFramer and pass it
+ * with `framer()` on the builder - the length field tells you exactly how many
+ * bytes to collect, so no byte value is ever special:
+ *
+ * ```cpp
+ * auto ch = wirestead::serial("/dev/ttyUSB0", 115200)
+ *               .framer([] { return std::make_unique<MyLengthPrefixedFramer>(); })
+ *               .on_message(...)
+ *               .build();
+ * ```
  */
 class WIRESTEAD_API PacketFramer : public IFramer {
  public:


### PR DESCRIPTION
## Description

`PacketFramer` locates the end pattern with a plain `std::search` and has no
escaping or byte stuffing, so the first occurrence ends the frame wherever it
falls. A binary protocol whose payload spans arbitrary byte values is
truncated as soon as those bytes happen to match, and the remainder
resynchronises as a new packet — silently, because a truncated frame is
indistinguishable from a short one.

Nothing said so. The class was documented only as "Framer for binary packet
protocols", which reads as an endorsement of exactly the case it cannot
handle.

## Key Changes

- The class doc now states the constraint, why it bites (no escaping), and how
  it fails (silent truncation plus resync).
- `use_packet_framer()` carries a short version of the warning, since that is
  where the choice is actually made.
- Both point at `framer()` with a custom `IFramer` for length-prefixed binary
  layouts, with a snippet — the length field means no byte value is special.
- `framer()`'s own doc now says what it is for rather than restating its name.

## Related Issues

None.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks pass.
- [ ] I have added or updated tests — not applicable, no behavior change.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Documentation rather than a fix, deliberately. Adding escaping would change the
wire format and break every existing user of this framer, and the escape hatch
already exists — `framer()` takes any `IFramer`. What was missing was any
indication that a caller needed to reach for it.

Verified against the implementation rather than assumed: `packet_framer.cc`
has no escape handling, and the end-pattern lookup is `std::search` over the
collected bytes in both the buffered and zero-copy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
