### PR TITLE
feat: serial RS-485 and modem control lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,30 @@ and ABI policy.
   line you attach to mid-stream, or a protocol carrying a sync word, still
   needs a custom `IFramer`.
 
+- Serial RS-485 and modem control lines: `rs485()`, `dtr()`, `rts()`.
+
+  ```cpp
+  auto bus = wirestead::serial("/dev/ttyUSB0", 1000000).rs485().build();
+  ```
+
+  Half-duplex RS-485 is what Dynamixel servos, Modbus RTU and much industrial
+  sensing run on, and the transceiver's direction pin has to be driven around
+  each write at an instant userspace cannot hit - so the kernel driver does it
+  (`TIOCSRS485`). Nothing previously exposed this, or the port's native handle,
+  so those devices could not be driven at all.
+
+  RTS polarity, full-duplex mode and the pre/post delays are all settable; the
+  delays default to 0, which suits most transceivers, and exist because slow
+  ones need a millisecond or two that no default can guess.
+
+  A refusal is logged at warning level rather than debug: an adapter that
+  switches direction in hardware refuses legitimately, but so does a plain
+  UART, and a shared bus running in plain UART mode collides on every write.
+
+  `dtr()`/`rts()` are engaged only when called - leaving one unset keeps the
+  driver's default, which differs from passing `false`, since an Arduino
+  reboots on an asserted DTR at open.
+
 - UDP multicast receive: `multicast_group(group, interface_address = "")` on
   both UDP builders joins the group after binding.
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -80,6 +80,38 @@ report an age from its previous life.
 Serial additionally offers an active version below, because there a concrete
 recovery exists.
 
+## RS-485 and modem control lines
+
+Half-duplex RS-485 is the wiring behind Dynamixel servos, Modbus RTU and much
+industrial sensing. The transceiver's direction pin has to be driven around
+each write, at an instant userspace cannot hit, so the kernel driver does it
+and `rs485()` turns that on.
+
+```cpp
+auto bus = wirestead::serial("/dev/ttyUSB0", 1000000)
+               .rs485()          // rts_on_send=true, rx_during_tx=false
+               .low_latency()
+               .build();
+```
+
+The delays are milliseconds and default to 0, which suits most transceivers.
+A slow one needs a millisecond or two either side, and nothing but the hardware
+in front of you can say which — that is what the arguments are for.
+
+Unlike the other settings here, a refusal is logged as a **warning**: adapters
+that switch direction in hardware refuse it legitimately, but so does a plain
+UART, and running a shared bus in plain UART mode makes every write collide.
+That presents as garbage from the device rather than as a configuration
+problem, which is why it is worth a line in the log.
+
+`dtr()` and `rts()` drive the modem control lines at open. Not calling them
+leaves the driver's default alone, which is **not** the same as passing
+`false`: an Arduino reboots when DTR is asserted at open, so a driver that must
+not reset the board calls `dtr(false)` explicitly.
+
+Linux only (`TIOCSRS485`); DTR/RTS also work on macOS. Elsewhere both are
+no-ops.
+
 ## Serial receive watchdog
 
 A device that stops streaming without erroring leaves a healthy open port and a

--- a/test/unit/transport/transport_serial.cc
+++ b/test/unit/transport/transport_serial.cc
@@ -72,6 +72,22 @@ class FakeSerialPort : public interface::SerialPortInterface {
     return low_latency_supported_;
   }
 
+  bool set_rs485(bool rts_on_send, bool rx_during_tx, unsigned delay_before_ms, unsigned delay_after_ms) override {
+    ++rs485_requests_;
+    rs485_rts_on_send_ = rts_on_send;
+    rs485_rx_during_tx_ = rx_during_tx;
+    rs485_delay_before_ = delay_before_ms;
+    rs485_delay_after_ = delay_after_ms;
+    return rs485_supported_;
+  }
+
+  bool set_modem_lines(std::optional<bool> dtr, std::optional<bool> rts) override {
+    ++modem_requests_;
+    modem_dtr_ = dtr;
+    modem_rts_ = rts;
+    return true;
+  }
+
   void async_read_some(const boost::asio::mutable_buffer&,
                        std::function<void(const boost::system::error_code&, std::size_t)> handler) override {
     read_handler_ = std::move(handler);
@@ -100,6 +116,15 @@ class FakeSerialPort : public interface::SerialPortInterface {
   int write_count() const { return write_count_; }
   void set_low_latency_supported(bool supported) { low_latency_supported_ = supported; }
   int low_latency_requests() const { return low_latency_requests_; }
+  void set_rs485_supported(bool supported) { rs485_supported_ = supported; }
+  int rs485_requests() const { return rs485_requests_; }
+  bool rs485_rts_on_send() const { return rs485_rts_on_send_; }
+  bool rs485_rx_during_tx() const { return rs485_rx_during_tx_; }
+  unsigned rs485_delay_before() const { return rs485_delay_before_; }
+  unsigned rs485_delay_after() const { return rs485_delay_after_; }
+  int modem_requests() const { return modem_requests_; }
+  std::optional<bool> modem_dtr() const { return modem_dtr_; }
+  std::optional<bool> modem_rts() const { return modem_rts_; }
 
   void complete_pending_write(const boost::system::error_code& ec = {}) {
     if (!pending_write_handler_) return;
@@ -135,6 +160,15 @@ class FakeSerialPort : public interface::SerialPortInterface {
   int write_count_{0};
   bool low_latency_supported_{true};
   int low_latency_requests_{0};
+  bool rs485_supported_{true};
+  int rs485_requests_{0};
+  bool rs485_rts_on_send_{false};
+  bool rs485_rx_during_tx_{false};
+  unsigned rs485_delay_before_{0};
+  unsigned rs485_delay_after_{0};
+  int modem_requests_{0};
+  std::optional<bool> modem_dtr_;
+  std::optional<bool> modem_rts_;
   std::function<void(const boost::system::error_code&, std::size_t)> read_handler_;
   std::function<void(const boost::system::error_code&, std::size_t)> pending_write_handler_;
   std::optional<std::size_t> pending_write_size_;
@@ -334,6 +368,112 @@ TEST(TransportSerialTest, ReceivedDataRearmsTheRxIdleTimeout) {
   // transport alive until ~io_context destroys the handler - which runs
   // perform_cleanup(), and so the state callback, after the locals it
   // captures are gone. Drain here instead.
+  ioc.run_for(50ms);
+}
+
+// RS-485 is off unless asked for, and when asked for the settings must reach
+// the driver verbatim - a wrong RTS polarity produces a link that looks dead
+// in one direction only, which is near-impossible to diagnose from the outside.
+TEST(TransportSerialTest, Rs485SettingsReachTheDriver) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.rs485.enabled = true;
+  cfg.rs485.rts_on_send = false;
+  cfg.rs485.rx_during_tx = true;
+  cfg.rs485.delay_rts_before_send_ms = 2;
+  cfg.rs485.delay_rts_after_send_ms = 3;
+
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->rs485_requests(), 1);
+  EXPECT_FALSE(port_raw->rs485_rts_on_send());
+  EXPECT_TRUE(port_raw->rs485_rx_during_tx());
+  EXPECT_EQ(port_raw->rs485_delay_before(), 2u);
+  EXPECT_EQ(port_raw->rs485_delay_after(), 3u);
+  serial->stop();
+  ioc.run_for(50ms);
+}
+
+TEST(TransportSerialTest, Rs485IsNotRequestedUnlessEnabled) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->rs485_requests(), 0);
+  serial->stop();
+  ioc.run_for(50ms);
+}
+
+// An adapter that switches direction in hardware refuses the ioctl. The port
+// must still come up - refusing is the normal answer on such hardware.
+TEST(TransportSerialTest, UnsupportedRs485StillConnects) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.rs485.enabled = true;
+
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+  port_raw->set_rs485_supported(false);
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  std::atomic<bool> connected{false};
+  serial->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Connected) connected = true;
+  });
+
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->rs485_requests(), 1);
+  EXPECT_TRUE(connected.load());
+  serial->stop();
+  ioc.run_for(50ms);
+}
+
+// Leaving a line unset must not touch it: an Arduino reboots when DTR is
+// asserted at open, so "no opinion" and "drive it low" are different requests.
+TEST(TransportSerialTest, ModemLinesAreOnlyTouchedWhenSet) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->modem_requests(), 0) << "an unset line was still written";
+  serial->stop();
+  ioc.run_for(50ms);
+}
+
+TEST(TransportSerialTest, ModemLinesAreAppliedWhenSet) {
+  boost::asio::io_context ioc;
+  config::SerialConfig cfg;
+  cfg.dtr = false;  // the Arduino case: explicitly do not assert
+
+  auto port = std::make_unique<FakeSerialPort>(ioc);
+  auto* port_raw = port.get();
+  auto serial = Serial::create(cfg, std::move(port), ioc);
+
+  serial->start();
+  ioc.run_for(20ms);
+
+  EXPECT_EQ(port_raw->modem_requests(), 1);
+  ASSERT_TRUE(port_raw->modem_dtr().has_value());
+  EXPECT_FALSE(*port_raw->modem_dtr());
+  EXPECT_FALSE(port_raw->modem_rts().has_value()) << "RTS was written despite being unset";
+  serial->stop();
   ioc.run_for(50ms);
 }
 

--- a/wirestead/builder/serial_builder.cc
+++ b/wirestead/builder/serial_builder.cc
@@ -87,6 +87,12 @@ std::unique_ptr<wrapper::Serial> SerialBuilder::build() {
   if (reopen_on_error_set_) serial->reopen_on_error(reopen_on_error_);
   if (read_chunk_set_) serial->read_chunk(read_chunk_);
   if (low_latency_set_) serial->low_latency(low_latency_);
+  if (rs485_.enabled) {
+    serial->rs485(rs485_.rts_on_send, rs485_.rx_during_tx, rs485_.delay_rts_before_send_ms,
+                  rs485_.delay_rts_after_send_ms);
+  }
+  if (dtr_) serial->dtr(*dtr_);
+  if (rts_) serial->rts(*rts_);
   if (rx_idle_timeout_set_) serial->rx_idle_timeout(rx_idle_timeout_);
   if (retry_interval_set_) serial->retry_interval(std::chrono::milliseconds(retry_interval_ms_));
 
@@ -180,6 +186,26 @@ SerialBuilder& SerialBuilder::read_chunk(size_t bytes) {
 SerialBuilder& SerialBuilder::low_latency(bool enable) {
   low_latency_ = enable;
   low_latency_set_ = true;
+  return *this;
+}
+
+SerialBuilder& SerialBuilder::rs485(bool rts_on_send, bool rx_during_tx, unsigned delay_before_ms,
+                                    unsigned delay_after_ms) {
+  rs485_.enabled = true;
+  rs485_.rts_on_send = rts_on_send;
+  rs485_.rx_during_tx = rx_during_tx;
+  rs485_.delay_rts_before_send_ms = delay_before_ms;
+  rs485_.delay_rts_after_send_ms = delay_after_ms;
+  return *this;
+}
+
+SerialBuilder& SerialBuilder::dtr(bool assert_line) {
+  dtr_ = assert_line;
+  return *this;
+}
+
+SerialBuilder& SerialBuilder::rts(bool assert_line) {
+  rts_ = assert_line;
   return *this;
 }
 

--- a/wirestead/builder/serial_builder.hpp
+++ b/wirestead/builder/serial_builder.hpp
@@ -60,6 +60,13 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   // buffering timer (Linux ASYNC_LOW_LATENCY). On by default; see
   // SerialConfig::low_latency.
   SerialBuilder& low_latency(bool enable = true);
+  // Half-duplex RS-485. Delays are milliseconds; see SerialConfig::Rs485.
+  SerialBuilder& rs485(bool rts_on_send = true, bool rx_during_tx = false, unsigned delay_before_ms = 0,
+                       unsigned delay_after_ms = 0);
+  // Assert or clear DTR / RTS at open. Not calling these leaves the driver's
+  // default alone, which differs from passing false.
+  SerialBuilder& dtr(bool assert_line);
+  SerialBuilder& rts(bool assert_line);
   SerialBuilder& reopen_on_error(bool enable = true);
   // Reopen the port when no data has been received for this long. Off by
   // default; see SerialConfig::rx_idle_timeout_ms.
@@ -95,6 +102,9 @@ class WIRESTEAD_API SerialBuilder : public BuilderInterface<wrapper::Serial, Ser
   bool read_chunk_set_{false};
   bool low_latency_{true};
   bool low_latency_set_{false};
+  config::SerialConfig::Rs485 rs485_{};
+  std::optional<bool> dtr_;
+  std::optional<bool> rts_;
   std::chrono::milliseconds rx_idle_timeout_{0};
   bool rx_idle_timeout_set_{false};
 };

--- a/wirestead/config/serial_config.hpp
+++ b/wirestead/config/serial_config.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "wirestead/base/constants.hpp"
@@ -49,6 +50,38 @@ struct SerialConfig {
   // and runs normally either way. Set false to leave the driver's default
   // alone, which trades latency for fewer wakeups.
   bool low_latency = true;
+
+  // Half-duplex RS-485, the wiring behind Dynamixel servos, Modbus RTU and a
+  // good deal of industrial sensing. The driver has to drive the transceiver's
+  // direction pin around each write, which is not something a caller can do
+  // from userspace at the right instant - hence a setting rather than advice.
+  //
+  // Linux only (TIOCSRS485). Adapters that switch direction in hardware need
+  // none of this and will refuse it; that refusal is not an error.
+  struct Rs485 {
+    bool enabled = false;
+    // Logical level RTS takes while transmitting. The usual wiring wants it
+    // high to send, but the opposite exists and produces a link that looks
+    // dead in one direction only.
+    bool rts_on_send = true;
+    // Whether the receiver stays on during transmit. Off for true half duplex,
+    // which is what stops a device hearing its own echo.
+    bool rx_during_tx = false;
+    // Milliseconds the driver holds the direction pin either side of the
+    // frame. Both default to 0 because most transceivers need nothing; slow
+    // ones need a millisecond or two, and no model can guess which - this is
+    // the knob for the hardware in front of you.
+    unsigned delay_rts_before_send_ms = 0;
+    unsigned delay_rts_after_send_ms = 0;
+  } rs485;
+
+  // Modem control lines, engaged only when set. std::nullopt means "leave the
+  // driver's default alone", which is a different request from "drive it low":
+  // an Arduino resets when DTR is asserted at open, so a driver that must not
+  // reboot the board sets dtr=false explicitly, while one that has no opinion
+  // leaves it unset.
+  std::optional<bool> dtr;
+  std::optional<bool> rts;
 
   bool reopen_on_error = true;  // Attempt to reopen on device disconnection/error
 

--- a/wirestead/interface/iserial_port.hpp
+++ b/wirestead/interface/iserial_port.hpp
@@ -19,6 +19,7 @@
 #include <boost/asio.hpp>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -54,6 +55,29 @@ class WIRESTEAD_API SerialPortInterface {
   // the caller logs the outcome and carries on. Defaults to "unsupported" so
   // test doubles inherit it for free.
   virtual bool set_low_latency() { return false; }
+
+  // Put the port into half-duplex RS-485, letting the driver drive the
+  // transceiver's direction pin around each write. Delays are milliseconds.
+  // Returns whether the request took effect; adapters that switch direction in
+  // hardware refuse it, and that is not an error. Primitives rather than a
+  // struct so this interface stays independent of the config layer - there is
+  // exactly one caller.
+  virtual bool set_rs485(bool rts_on_send, bool rx_during_tx, unsigned delay_before_ms, unsigned delay_after_ms) {
+    (void)rts_on_send;
+    (void)rx_during_tx;
+    (void)delay_before_ms;
+    (void)delay_after_ms;
+    return false;
+  }
+
+  // Assert or clear DTR/RTS. std::nullopt leaves a line untouched, which is
+  // distinct from driving it low. Returns whether every requested change was
+  // applied.
+  virtual bool set_modem_lines(std::optional<bool> dtr, std::optional<bool> rts) {
+    (void)dtr;
+    (void)rts;
+    return false;
+  }
 
   virtual void async_read_some(const net::mutable_buffer& buffer,
                                std::function<void(const boost::system::error_code&, std::size_t)> handler) = 0;

--- a/wirestead/transport/serial/boost_serial_port.hpp
+++ b/wirestead/transport/serial/boost_serial_port.hpp
@@ -23,6 +23,11 @@
 #include <linux/serial.h>
 #include <sys/ioctl.h>
 #endif
+#if defined(__APPLE__)
+#include <sys/ioctl.h>
+#endif
+
+#include <optional>
 
 namespace wirestead {
 namespace transport {
@@ -65,6 +70,59 @@ class WIRESTEAD_API BoostSerialPort : public interface::SerialPortInterface {
     info.flags |= ASYNC_LOW_LATENCY;
     return ::ioctl(fd, TIOCSSERIAL, &info) == 0;
 #else
+    return false;
+#endif
+  }
+
+  // Linux only. A driver with no RS-485 support answers ENOTTY, which the
+  // caller treats as "this adapter does the switching itself".
+  bool set_rs485(bool rts_on_send, bool rx_during_tx, unsigned delay_before_ms, unsigned delay_after_ms) override {
+#ifdef __linux__
+    struct serial_rs485 rs485 {};
+    const int fd = port_.native_handle();
+    // Read first: some drivers carry board-specific bits in flags that a
+    // blind write would clear.
+    if (::ioctl(fd, TIOCGRS485, &rs485) != 0) return false;
+    rs485.flags |= SER_RS485_ENABLED;
+    if (rts_on_send) {
+      rs485.flags |= SER_RS485_RTS_ON_SEND;
+      rs485.flags &= ~static_cast<decltype(rs485.flags)>(SER_RS485_RTS_AFTER_SEND);
+    } else {
+      rs485.flags &= ~static_cast<decltype(rs485.flags)>(SER_RS485_RTS_ON_SEND);
+      rs485.flags |= SER_RS485_RTS_AFTER_SEND;
+    }
+    if (rx_during_tx) {
+      rs485.flags |= SER_RS485_RX_DURING_TX;
+    } else {
+      rs485.flags &= ~static_cast<decltype(rs485.flags)>(SER_RS485_RX_DURING_TX);
+    }
+    rs485.delay_rts_before_send = delay_before_ms;
+    rs485.delay_rts_after_send = delay_after_ms;
+    return ::ioctl(fd, TIOCSRS485, &rs485) == 0;
+#else
+    (void)rts_on_send;
+    (void)rx_during_tx;
+    (void)delay_before_ms;
+    (void)delay_after_ms;
+    return false;
+#endif
+  }
+
+  bool set_modem_lines(std::optional<bool> dtr, std::optional<bool> rts) override {
+#if defined(__linux__) || defined(__APPLE__)
+    const int fd = port_.native_handle();
+    bool ok = true;
+    auto apply = [&](std::optional<bool> want, int bit) {
+      if (!want) return;
+      int lines = bit;
+      if (::ioctl(fd, *want ? TIOCMBIS : TIOCMBIC, &lines) != 0) ok = false;
+    };
+    apply(dtr, TIOCM_DTR);
+    apply(rts, TIOCM_RTS);
+    return ok;
+#else
+    (void)dtr;
+    (void)rts;
     return false;
 #endif
   }

--- a/wirestead/transport/serial/serial.cc
+++ b/wirestead/transport/serial/serial.cc
@@ -319,6 +319,27 @@ struct Serial::Impl {
       return;
     }
 
+    // RS-485 before the first read and before anything is written: the very
+    // first frame out has to be sent with the direction pin already under the
+    // driver's control, or it goes out with the transceiver still in receive.
+    //
+    // Unlike low_latency, a refusal here is worth a warning rather than a
+    // debug line. Asking for RS-485 and silently running in plain UART mode
+    // means every write collides on a shared bus, which presents as garbage
+    // from the device rather than as a configuration problem.
+    if (cfg_.rs485.enabled &&
+        !port_->set_rs485(cfg_.rs485.rts_on_send, cfg_.rs485.rx_during_tx, cfg_.rs485.delay_rts_before_send_ms,
+                          cfg_.rs485.delay_rts_after_send_ms)) {
+      WIRESTEAD_LOG_WARNING("serial", "configure",
+                            fmt::format("RS-485 mode was requested but {} does not support it; the adapter must switch "
+                                        "direction in hardware or the bus will collide",
+                                        cfg_.device));
+    }
+
+    if ((cfg_.dtr || cfg_.rts) && !port_->set_modem_lines(cfg_.dtr, cfg_.rts)) {
+      WIRESTEAD_LOG_WARNING("serial", "configure", fmt::format("Could not set DTR/RTS on {}", cfg_.device));
+    }
+
     // Best effort, after the line settings and before the first read: a driver
     // without a latency timer just says no, and the port is fine either way.
     if (cfg_.low_latency && !port_->set_low_latency()) {

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -24,6 +24,7 @@
 #include <cctype>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <stdexcept>
 #include <thread>
@@ -96,6 +97,9 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
   bool reopen_on_error = true;
   size_t read_chunk = base::constants::DEFAULT_READ_BUFFER_SIZE;
   bool low_latency = true;
+  config::SerialConfig::Rs485 rs485{};
+  std::optional<bool> dtr;
+  std::optional<bool> rts;
   std::chrono::milliseconds rx_idle_timeout{0};
   std::chrono::milliseconds retry_interval{base::constants::DEFAULT_RETRY_INTERVAL_MS};
   size_t backpressure_threshold = base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
@@ -604,6 +608,9 @@ struct Serial::Impl : public std::enable_shared_from_this<Impl> {
     config.reopen_on_error = reopen_on_error;
     config.read_chunk = read_chunk;
     config.low_latency = low_latency;
+    config.rs485 = rs485;
+    config.dtr = dtr;
+    config.rts = rts;
     config.rx_idle_timeout_ms = static_cast<unsigned>(rx_idle_timeout.count());
     config.backpressure_threshold = backpressure_threshold;
     config.backpressure_strategy = backpressure_strategy;
@@ -736,6 +743,28 @@ Serial& Serial::read_chunk(size_t bytes) {
 Serial& Serial::low_latency(bool enable) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->low_latency = enable;
+  return *this;
+}
+
+Serial& Serial::rs485(bool rts_on_send, bool rx_during_tx, unsigned delay_before_ms, unsigned delay_after_ms) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->rs485.enabled = true;
+  impl_->rs485.rts_on_send = rts_on_send;
+  impl_->rs485.rx_during_tx = rx_during_tx;
+  impl_->rs485.delay_rts_before_send_ms = delay_before_ms;
+  impl_->rs485.delay_rts_after_send_ms = delay_after_ms;
+  return *this;
+}
+
+Serial& Serial::dtr(bool assert_line) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->dtr = assert_line;
+  return *this;
+}
+
+Serial& Serial::rts(bool assert_line) {
+  std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
+  impl_->rts = assert_line;
   return *this;
 }
 

--- a/wirestead/wrapper/serial/serial.hpp
+++ b/wirestead/wrapper/serial/serial.hpp
@@ -113,6 +113,17 @@ class WIRESTEAD_API Serial : public ChannelInterface {
   // buffering timer (Linux ASYNC_LOW_LATENCY). On by default; see
   // SerialConfig::low_latency for what it does and does not cover.
   Serial& low_latency(bool enable = true);
+  // Half-duplex RS-485: the driver drives the transceiver's direction pin
+  // around each write. Delays are milliseconds and default to 0, which suits
+  // most transceivers; slow ones need a millisecond or two. See
+  // SerialConfig::Rs485.
+  Serial& rs485(bool rts_on_send = true, bool rx_during_tx = false, unsigned delay_before_ms = 0,
+                unsigned delay_after_ms = 0);
+  // Assert or clear DTR / RTS at open. Unset means the driver's default is
+  // left alone, which is not the same as driving the line low - an Arduino
+  // reboots on an asserted DTR.
+  Serial& dtr(bool assert_line);
+  Serial& rts(bool assert_line);
   Serial& reopen_on_error(bool enable);
   // Reopen the port when no data has been received for this long. Off by
   // default; see SerialConfig::rx_idle_timeout_ms for why it watches receives


### PR DESCRIPTION
## Description

Half-duplex RS-485 is the wiring behind Dynamixel servos, Modbus RTU and much
industrial sensing. The transceiver's direction pin has to be driven around
each write at an instant userspace cannot hit, so the kernel driver has to do
it — and nothing exposed `TIOCSRS485`, nor the port's native handle, so those
devices could not be driven at all.

That also left the recent `low_latency` work half-useful: it helps precisely
the USB serial adapters these buses run on, which were then unusable for the
protocol they exist to carry.

## Key Changes

- `rs485(rts_on_send, rx_during_tx, delay_before_ms, delay_after_ms)` on the
  wrapper and builder, backed by `SerialConfig::Rs485`. Applied before the
  first read and before anything is written, so the first frame does not go out
  with the transceiver still in receive.
- The ioctl **reads before writing**, since some drivers carry board-specific
  bits in `flags` that a blind write would clear.
- `dtr()` / `rts()` drive the modem control lines at open, held as
  `std::optional<bool>`: "leave the driver's default" and "drive the line low"
  are different requests, and an Arduino reboots when DTR is asserted at open.
- Two new methods on `SerialPortInterface`, both defaulting to "unsupported" so
  test doubles inherit them for free — the same shape `set_low_latency()`
  established.

## Related Issues

None.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**A refusal is logged at warning level, not debug** — deliberately unlike
`low_latency`. An adapter that switches direction in hardware refuses
legitimately, but so does a plain UART, and a shared bus running in plain UART
mode collides on every write. That presents as garbage arriving from the
device rather than as a configuration problem, so it is worth a line in the
log.

The delays default to 0, which suits most transceivers. They are exposed rather
than assumed away because slow ones need a millisecond or two either side and
nothing but the hardware in front of you can say which.

Five tests cover the settings reaching the driver verbatim (a wrong RTS
polarity yields a link that looks dead in one direction only), RS-485 not being
requested unless asked for, a refusing adapter still connecting, and modem
lines being touched only when set.

**Not verified against hardware** — there is no RS-485 adapter in the loop
here, so the tests exercise the plumbing through a fake port, not the
electrical behaviour. Linux only for RS-485; DTR/RTS also work on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
