### PR TITLE
feat: report how long a channel has been silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and ABI policy.
 
 ### Added
 
+- `RuntimeStats::last_receive_age_ms`, milliseconds since bytes last arrived,
+  on every transport.
+
+  ```cpp
+  auto s = channel->stats();
+  if (s.last_receive_age_ms && *s.last_receive_age_ms > 500) { /* sensor is quiet */ }
+  ```
+
+  The signal for "has this sensor gone quiet". A device that stops streaming
+  without erroring leaves every other counter healthy and the link reporting
+  Connected, because nothing went wrong - the data simply stopped. Only the age
+  says so. `nullopt` until something arrives, and cleared by `reset_stats()`, so
+  a restarted channel cannot report an age carried over from its previous life.
+
+  Passive by design: what to do about silence differs per device, so this
+  reports rather than acts. Serial additionally has `rx_idle_timeout`, which
+  does act, because there a concrete recovery exists - reopening the port. UDP
+  and the socket transports have no such recovery, which is why they get the
+  signal rather than a policy.
+
 - UDP multicast receive: `multicast_group(group, interface_address = "")` on
   both UDP builders joins the group after binding.
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -59,6 +59,27 @@ arrival time does not matter. Unlike everything else on this page, this one is
 worth setting without a measurement first: nothing else in the library recovers
 16 ms.
 
+## Detecting a sensor that went quiet
+
+`RuntimeStats::last_receive_age_ms` is milliseconds since bytes last arrived,
+on every transport, and `nullopt` until something has. It exists because a
+device that stops streaming without erroring leaves every other counter looking
+healthy and the link reporting `Connected` — nothing failed, the data just
+stopped.
+
+```cpp
+const auto s = channel->stats();
+const bool quiet = s.last_receive_age_ms && *s.last_receive_age_ms > 500;
+```
+
+Compare it against the slowest interval that device is expected to hit, with
+margin. It reports rather than acts, because what to do about silence differs
+per device — and `reset_stats()` clears it, so a restarted channel does not
+report an age from its previous life.
+
+Serial additionally offers an active version below, because there a concrete
+recovery exists.
+
 ## Serial receive watchdog
 
 A device that stops streaming without erroring leaves a healthy open port and a

--- a/test/unit/diagnostics/test_runtime_stats_counter.cc
+++ b/test/unit/diagnostics/test_runtime_stats_counter.cc
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include "wirestead/diagnostics/runtime_stats_counter.hpp"
 
 namespace {
@@ -128,6 +131,47 @@ TEST(RuntimeStatsCounterTest, DropWarningIsLatchedButCountersKeepAdding) {
   counters.reset(0);
   EXPECT_TRUE(counters.drop_warned.load());
   EXPECT_EQ(counters.snapshot(0, 0, false).dropped_bytes, 0u);
+}
+
+// A sensor going quiet leaves every other counter healthy and the link
+// reporting Connected, because nothing failed - the data just stopped. The age
+// is the only field that says so.
+TEST(RuntimeStatsCounterTest, LastReceiveAgeIsUnsetUntilSomethingArrives) {
+  RuntimeStatsCounters counters;
+
+  EXPECT_FALSE(counters.snapshot(0, 0, false).last_receive_age_ms.has_value())
+      << "reported an age before anything had ever been received";
+
+  counters.record_received(16);
+  const auto stats = counters.snapshot(0, 0, false);
+  ASSERT_TRUE(stats.last_receive_age_ms.has_value());
+  EXPECT_LT(*stats.last_receive_age_ms, 1000u);
+}
+
+TEST(RuntimeStatsCounterTest, LastReceiveAgeGrowsWithSilenceAndResetsOnData) {
+  RuntimeStatsCounters counters;
+  counters.record_received(1);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(60));
+  const auto stale = counters.snapshot(0, 0, false);
+  ASSERT_TRUE(stale.last_receive_age_ms.has_value());
+  EXPECT_GE(*stale.last_receive_age_ms, 40u) << "the age did not grow while nothing arrived";
+
+  counters.record_received(1);
+  const auto fresh = counters.snapshot(0, 0, false);
+  ASSERT_TRUE(fresh.last_receive_age_ms.has_value());
+  EXPECT_LT(*fresh.last_receive_age_ms, 40u) << "arriving data did not refresh the age";
+}
+
+// A restarted channel must not report an age carried over from its previous
+// life, which would read as "fresh data" when none has arrived yet.
+TEST(RuntimeStatsCounterTest, ResetClearsTheLastReceiveAge) {
+  RuntimeStatsCounters counters;
+  counters.record_received(1);
+  ASSERT_TRUE(counters.snapshot(0, 0, false).last_receive_age_ms.has_value());
+
+  counters.reset(0);
+  EXPECT_FALSE(counters.snapshot(0, 0, false).last_receive_age_ms.has_value());
 }
 
 }  // namespace

--- a/wirestead/diagnostics/runtime_stats_counter.hpp
+++ b/wirestead/diagnostics/runtime_stats_counter.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 
@@ -35,6 +36,8 @@ struct RuntimeStatsCounters {
 
   std::atomic<uint64_t> bytes_received{0};
   std::atomic<uint64_t> messages_received{0};
+  // Steady-clock nanoseconds at the last receive; 0 means nothing has arrived.
+  std::atomic<int64_t> last_receive_ns{0};
 
   std::atomic<uint64_t> failed_sends{0};
 
@@ -62,9 +65,17 @@ struct RuntimeStatsCounters {
   void record_received(size_t bytes) {
     messages_received.fetch_add(1, std::memory_order_relaxed);
     bytes_received.fetch_add(bytes, std::memory_order_relaxed);
+    // Steady rather than system clock: this is only ever read as an age, and
+    // an age computed across a clock step is worse than no age at all.
+    last_receive_ns.store(steady_now_ns(), std::memory_order_relaxed);
   }
 
   void record_failed_send() { failed_sends.fetch_add(1, std::memory_order_relaxed); }
+
+  static int64_t steady_now_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+  }
 
   // Every drop in the library routes through here. BestEffort discards by
   // design and can do it hundreds of thousands of times a second, so the
@@ -128,6 +139,11 @@ struct RuntimeStatsCounters {
     stats.pending_bytes = pending_bytes;
     stats.max_queued_bytes = max_queued_bytes.load(std::memory_order_relaxed);
     stats.backpressure_active = backpressure_active;
+    const int64_t last = last_receive_ns.load(std::memory_order_relaxed);
+    if (last != 0) {
+      const int64_t age = steady_now_ns() - last;
+      stats.last_receive_age_ms = static_cast<uint64_t>(age > 0 ? age / 1'000'000 : 0);
+    }
     return stats;
   }
 
@@ -138,6 +154,7 @@ struct RuntimeStatsCounters {
     messages_sent.store(0, std::memory_order_relaxed);
     bytes_received.store(0, std::memory_order_relaxed);
     messages_received.store(0, std::memory_order_relaxed);
+    last_receive_ns.store(0, std::memory_order_relaxed);
     failed_sends.store(0, std::memory_order_relaxed);
     dropped_messages.store(0, std::memory_order_relaxed);
     dropped_bytes.store(0, std::memory_order_relaxed);

--- a/wirestead/wrapper/runtime_stats.hpp
+++ b/wirestead/wrapper/runtime_stats.hpp
@@ -18,6 +18,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace wirestead {
 namespace wrapper {
@@ -44,6 +45,20 @@ struct RuntimeStats {
   size_t max_queued_bytes = 0;
 
   bool backpressure_active = false;
+
+  // Milliseconds since bytes last arrived, or nullopt if none ever have.
+  //
+  // The signal a robot needs for "has this sensor gone quiet". A device that
+  // stops streaming without erroring leaves every other counter looking
+  // healthy and every state machine reporting Connected, because nothing has
+  // gone wrong - the data simply stopped. Only the age says so.
+  //
+  // Passive on purpose: what to do about silence is the caller's decision and
+  // differs per device, so this reports rather than acts. Compare it against
+  // the slowest interval that device is expected to hit, with margin. Serial
+  // additionally offers rx_idle_timeout, which does act, because there a
+  // concrete recovery exists - reopening the port.
+  std::optional<uint64_t> last_receive_age_ms;
 };
 
 }  // namespace wrapper


### PR DESCRIPTION
## Description

A device that stops streaming without erroring leaves every counter healthy and
the link reporting `Connected` — because nothing failed, the data simply
stopped. Serial got an active watchdog for this in #597; UDP and the socket
transports had nothing, which is the half of that review item left undone.

> **I did not build a UDP watchdog, and the difference is deliberate** — see
> below. If an active, callback-driven UDP watchdog is what you want instead,
> say so and I'll build that; it's a different design decision, not an
> oversight.

## Key Changes

- `RuntimeStats::last_receive_age_ms` — milliseconds since bytes last arrived,
  `nullopt` until some have.
- Recording lives in `RuntimeStatsCounters::record_received()`, which **every
  transport already routes receives through**, so one file covers all six
  rather than each growing its own timer. That is why this ended up broader
  than the UDP-only item it started as.
- `reset_stats()` clears it, so a restarted channel cannot report an age from
  its previous life and read as fresh.
- Steady clock: the value is only ever read as an age, and an age computed
  across a clock step is worse than no age at all.

## Why passive rather than an active watchdog

Serial can act because a concrete recovery exists — close and reopen the port.
UDP has none: the socket is fine, the *peer* went quiet. The available
in-band signal would be `LinkState::Error`, which is terminal-ish and would
kill a link that a 200 ms gap should not kill; a lidar that pauses and resumes
must not need a restart.

What to do about silence also differs per device — mark stale in diagnostics,
fail over, restart, or ignore — so the library reports and the caller decides.

## Related Issues

None.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Three tests: the age is unset until something arrives (reporting an age for a
channel that has never received anything is the failure that would make this
field lie), it grows during silence and refreshes on data, and `reset()` clears
it.

Follow-on, not in this PR: `wirestead_ros`'s `report_channel_stats()` should
publish this as a staleness check, which is the shape a ROS driver actually
consumes it in. That lives in the other repo and needs this released first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
