### PR TITLE
docs: correct the ROS analysis and surface what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 ## Feature Highlights
 
 * **Unified transport surface**: Consistent builders and wrappers for TCP client/server, UDP, Serial, and UDS.
-* **Callback-scoped data views**: Avoid unnecessary copies during callbacks, with explicit ownership-copy helpers for stored data.
+* **Callback-scoped data views**: Avoid unnecessary copies during callbacks, with explicit ownership-copy helpers for stored data. Each payload carries the time it arrived, so a timestamp does not have to be taken after the fact.
+* **Message framing**: Line-delimited, start/end pattern, and length-prefixed framers, or your own `IFramer`.
+* **Optional TLS**: TCP client and server in a build configured with `-DWIRESTEAD_ENABLE_TLS=ON`, with the client verifying the server.
 * **Fluent API with CRTP Builders**: Type-safe configuration with improved method chaining.
+* **Built for devices**: Serial low-latency mode and RS-485, UDP multicast, a per-channel silence age for spotting a sensor that stopped talking, and a hook for putting the io threads on a real-time policy. See [Tuning](docs/tuning.md).
 * **Tested runtime behavior**: Unit, integration, and end-to-end test suites are part of the repository and documented in `test/`.
 
 ## Requirements

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,12 @@ package consumers, migration users, and release maintainers.
 
 - [Quick Start](quickstart.md)
 - [Installation](installation.md)
+- [Callback Data Lifetime](callbacks.md)
+- [Error Model](error_model.md)
+- [Security and Threat Model](security.md)
 - [API Stability Summary](api_stability.md)
 - [Tuning](tuning.md)
+- [Performance Validation](performance_validation.md)
 - [ROS 2 Support Analysis](ros2_support_analysis.md)
 - [Migrating from Unilink](migration-from-unilink.md)
 - [Release Checklist](release_checklist.md)

--- a/docs/ros2_support_analysis.md
+++ b/docs/ros2_support_analysis.md
@@ -1,7 +1,7 @@
 # ROS 2 Support Analysis
 
 Status: implementation started
-Reviewed: 2026-08-09
+Reviewed: 2026-08-15
 
 > **Implementation decision:** Wirestead core will be registered directly as
 > the plain-CMake ROS package `wirestead`. ROS-specific integration lives in
@@ -48,16 +48,31 @@ a ROS bridge:
 - dedicated or shared Boost.Asio contexts;
 - callback-based receive, connection, disconnection, error, and backpressure
   events;
-- raw, line-delimited, and start/end-pattern framing;
+- raw, line-delimited, start/end-pattern and length-prefixed framing;
 - non-blocking send APIs and ownership-transfer send APIs;
-- reconnect configuration and runtime statistics.
+- reconnect configuration and runtime statistics;
+- an arrival timestamp on every received payload, so a driver can stamp a
+  message from when the bytes landed rather than from when it got round to
+  publishing;
+- a per-channel silence age, which is what tells a driver its device stopped
+  streaming while the link still reports Connected.
+
+Delivered since this analysis was first written (2026-08-13..15):
+
+- `wirestead_ros` diagnostics: `report_channel_stats()` maps `RuntimeStats` onto
+  `diagnostic_updater`, including a STALE level for a silent link;
+- a reference lifecycle driver, `serial_line_driver`, with parameters, ordered
+  shutdown through `CallbackGate`, and semantic `sensor_msgs` output;
+- ROS-level integration tests: the driver's lifecycle and I/O are exercised over
+  a pseudo-terminal.
 
 The following ROS-specific capabilities are not yet complete:
 
 - a released Wirestead tag containing its new plain-CMake `package.xml`;
 - ROS messages defining binary frames and server connection identity;
-- lifecycle nodes, composable nodes, parameters, launch files, and QoS policy;
-- standard ROS diagnostics and ROS-level integration tests;
+- composable nodes, launch files, and a documented QoS policy (the reference
+  driver is a lifecycle node with parameters, but the bridge nodes are not
+  built);
 - bloom and rosdistro release metadata.
 
 ## Verified build integration
@@ -583,13 +598,19 @@ all packages in the repository against that exact version.
 ## Security boundary
 
 ROS security protects the DDS/ROS side of the bridge. It does not secure the
-external Wirestead transport. Wirestead currently sends TCP and UDP data in
-plaintext and does not provide TLS or DTLS.
+external Wirestead transport, and the two are separate contracts: ROS support
+must not imply that the entire end-to-end path is protected by SROS2.
 
-Deployment documentation must therefore require a trusted network, an external
-VPN/tunnel, or application-level authentication and encryption where the
-external link crosses an untrusted network. ROS support must not imply that the
-entire end-to-end path is protected by SROS2.
+TCP can be encrypted. A build configured with `-DWIRESTEAD_ENABLE_TLS=ON`
+offers TLS for both the client and the server, with the client verifying the
+server against the system trust store or a supplied CA. **UDP, Serial and UDS
+send in plaintext and there is no DTLS**, so a bridge on those transports still
+needs a trusted network, an external VPN or tunnel, or application-level
+authentication and encryption wherever the external link crosses an untrusted
+one.
+
+Deployment documentation should say which of the two situations a given bridge
+is in rather than leaving it to be assumed.
 
 ## Superseded recommendation
 


### PR DESCRIPTION
## Description

Documentation drifted behind the last few releases. One item was not merely
incomplete but **wrong in a way that would change a reader's decision**.

## Key Changes

**`docs/ros2_support_analysis.md` said Wirestead "does not provide TLS or
DTLS".** That has been false since the TCP server and client gained TLS. It
tells a ROS integrator to stand up a VPN for a link they could encrypt
directly. The Security boundary section now splits the two cases — TCP can be
encrypted, UDP/Serial/UDS cannot and there is no DTLS — so a deployment
document can state which case a given bridge is in instead of leaving it
assumed.

The same document's readiness lists were stale: ROS diagnostics and ROS-level
integration tests were listed as outstanding when both now exist, and the
framing list predated the length-prefix framer. Delivered work is now recorded
separately from what remains, so the remaining list means something again.

**`docs/README.md` indexed seven of eleven documents.** Callbacks, error model,
security and performance validation were reachable only by already knowing they
were there. All four added.

**`README.md`'s feature list** stopped at the original four bullets, with no
mention of framing, TLS, or any of the device-facing work — arrival timestamps,
serial low-latency and RS-485, UDP multicast, the silence age, the io thread
hook.

## Related Issues

None.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks pass.
- [ ] I have added or updated tests — not applicable, documentation only.
- [x] I have updated the documentation to reflect the changes.
- [x] My changes follow the project's coding style and conventions.

## Additional Context

`docs/quickstart.md` was deliberately left alone. It states its own scope —
"the minimal Wirestead quickstart", with tutorials living in the external
documentation repository — so adding framing examples would work against that.

`docs/api_stability.md` needed no change: framer and config APIs are already
listed as pre-1.0 unstable, which covers everything added recently.

A companion PR updates the `wirestead-ros` README and architecture document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwJVmKRKLwwC4JcFkX4kDG
