### PR TITLE
test: cover four untested public APIs and fix what the coverage job measures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,8 @@ jobs:
             build-essential \
             cmake \
             lcov \
-            ninja-build
+            ninja-build \
+            socat
 
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
@@ -64,6 +65,7 @@ jobs:
             -DCMAKE_C_FLAGS="--coverage -fprofile-arcs -ftest-coverage -fprofile-update=atomic" \
             -DCMAKE_EXE_LINKER_FLAGS="--coverage" \
             -DWIRESTEAD_ENABLE_CONFIG=ON \
+            -DWIRESTEAD_ENABLE_TLS=ON \
             -DWIRESTEAD_BUILD_TESTS=ON \
             -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE \
             -DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET
@@ -74,7 +76,7 @@ jobs:
       - name: Run tests
         run: |
           cd build-coverage
-          ctest --output-on-failure --parallel 2 -LE "performance|benchmark|optional"
+          ctest --output-on-failure --parallel 2
 
       - name: Generate coverage report
         run: |
@@ -99,6 +101,14 @@ jobs:
           lcov --summary coverage_temp.info --rc lcov_branch_coverage=1 2>&1 | grep lines
 
           # Step 2: Remove unwanted files (test, _deps, build)
+          #
+          # --filter branch drops the branches gcc emits for C++ exception
+          # unwinding on lines that contain no conditional at all. They are
+          # never reachable from a test, and they were over half of every
+          # branch counted here: 8596 of 15592 on the 1d367b9fc tree, which
+          # reported 52.2% branch coverage instead of the real 65.7%. The
+          # filter is applied here rather than at summary time so the .info
+          # artifact, the HTML report and the printed number all agree.
           echo "=== Step 2: Remove test and dependency files ==="
           lcov --remove coverage_temp.info \
             "*/test/*" \
@@ -106,6 +116,7 @@ jobs:
             "*/build-coverage/*" \
             --output-file coverage_filtered.info \
             --ignore-errors mismatch,negative,unused \
+            --filter branch \
             --rc lcov_branch_coverage=1
 
           # Debug: Show coverage after filtering
@@ -137,24 +148,6 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           cat coverage_summary.txt | tail -20 >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload HTML Coverage Report
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: build-coverage/coverage_html
-          retention-days: 30
-          overwrite: true
-
-      - name: Upload Coverage Data
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-data
-          path: |
-            build-coverage/coverage_filtered.info
-            build-coverage/coverage_summary.txt
-          retention-days: 30
-          overwrite: true
 
       - name: Save PR Info for Comment
         if: github.event_name == 'pull_request'
@@ -188,8 +181,12 @@ jobs:
           COVERAGE=$(lcov --summary coverage_filtered.info 2>&1 | grep "lines" | awk '{print $2}' | sed 's/%//')
           echo "Coverage: ${COVERAGE}%"
 
-          # Set minimum coverage threshold (adjust as needed)
-          THRESHOLD=65
+          # Measured 85.6% line coverage on 1d367b9fc (801 tests, all passing),
+          # so the old 65 left 20 points of slack: coverage could rot by a
+          # fifth of the library without turning this job red. 80 keeps a real
+          # margin for a skipped test or a platform difference while still
+          # catching an actual regression.
+          THRESHOLD=80
 
           if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
             echo "❌ Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"

--- a/test/integration/transport/transport_tcp_server.cc
+++ b/test/integration/transport/transport_tcp_server.cc
@@ -133,6 +133,13 @@ TEST_F(TransportTcpServerTest, WriteWithoutActiveSessionReturnsFalse) {
   EXPECT_FALSE(server_->async_write_shared(shared_payload));
   EXPECT_FALSE(server_->broadcast("payload"));
   EXPECT_FALSE(server_->broadcast(memory::ConstByteSpan(payload.data(), payload.size())));
+
+  const auto before = server_->stats();
+  EXPECT_FALSE(server_->async_try_write_copy(memory::ConstByteSpan(payload.data(), payload.size())));
+  EXPECT_FALSE(server_->async_try_write_move(std::vector<uint8_t>{1, 2, 3}));
+  EXPECT_FALSE(server_->async_try_write_shared(shared_payload));
+  EXPECT_FALSE(server_->try_send_to_client(1, "no such client"));
+  EXPECT_EQ(server_->stats().failed_sends, before.failed_sends + 4);
 }
 
 TEST_F(TransportTcpServerTest, BindFailureTriggerError) {
@@ -539,6 +546,22 @@ TEST_F(TransportTcpServerTest, ConnectedClientWriteAndQueryApis) {
       server_->send_to_client(client_id.load(), memory::ConstByteSpan(span_payload.data(), span_payload.size())));
   EXPECT_FALSE(server_->send_to_client(client_id.load() + 1000, "missing"));
 
+  // The try_* family forwards to the same session and only refuses under
+  // backpressure, which is not active here. TryWriteTransportContractTest
+  // covers the refusal side for every other transport but cannot reach
+  // TcpServer, whose sessions are owned by the acceptor.
+  std::vector<uint8_t> try_copy_payload = {'t', 'r', 'y', 'c', 'o', 'p', 'y'};
+  auto try_shared_payload =
+      std::make_shared<const std::vector<uint8_t>>(std::vector<uint8_t>{'t', 'r', 'y', 's', 'h', 'a', 'r', 'e', 'd'});
+
+  EXPECT_TRUE(server_->async_try_write_copy(memory::ConstByteSpan(try_copy_payload.data(), try_copy_payload.size())));
+  EXPECT_TRUE(server_->async_try_write_move(std::vector<uint8_t>{'t', 'r', 'y', 'm', 'o', 'v', 'e'}));
+  EXPECT_TRUE(server_->async_try_write_shared(try_shared_payload));
+  EXPECT_TRUE(server_->try_send_to_client(client_id.load(), "trydirect"));
+  EXPECT_TRUE(
+      server_->try_send_to_client(client_id.load(), memory::ConstByteSpan(span_payload.data(), span_payload.size())));
+  EXPECT_FALSE(server_->try_send_to_client(client_id.load() + 1000, "missing"));
+
   client.non_blocking(true);
   std::string received;
   std::array<char, 256> buffer{};
@@ -551,7 +574,9 @@ TEST_F(TransportTcpServerTest, ConnectedClientWriteAndQueryApis) {
         }
         return received.find("copy") != std::string::npos && received.find("move") != std::string::npos &&
                received.find("shared") != std::string::npos && received.find("broadcast") != std::string::npos &&
-               received.find("span") != std::string::npos && received.find("direct") != std::string::npos;
+               received.find("span") != std::string::npos && received.find("direct") != std::string::npos &&
+               received.find("trycopy") != std::string::npos && received.find("trymove") != std::string::npos &&
+               received.find("tryshared") != std::string::npos && received.find("trydirect") != std::string::npos;
       },
       1000));
 

--- a/test/integration/uds/test_uds_integration.cc
+++ b/test/integration/uds/test_uds_integration.cc
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "test_utils.hpp"
 #include "wirestead/builder/auto_initializer.hpp"
@@ -103,6 +104,63 @@ TEST_F(UdsIntegrationTest, BasicCommunication) {
 
   EXPECT_TRUE(success) << "Data was not received by server";
   EXPECT_EQ(received_data, test_msg);
+
+  client->stop();
+  server->stop();
+}
+
+// use_length_prefix_framer() exists because the pattern-based framers cannot
+// carry a binary payload: PacketFramer ends the frame at the first occurrence
+// of its end pattern wherever it falls, and LineFramer at the first newline.
+// The payload here contains 0x02, 0x03 and '\n' for exactly that reason, so
+// this fails if build() ever stops installing the framer the builder was
+// asked for and falls back to a delimiter-based one.
+TEST_F(UdsIntegrationTest, LengthPrefixFramerCarriesAnArbitraryBinaryPayload) {
+  const std::vector<uint8_t> payload = {0x02, 0x00, 0x03, '\n', 0xFF, 'a', 0x00, 0x03};
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  std::vector<uint8_t> received;
+  std::atomic<bool> message_received{false};
+  std::atomic<bool> server_connected{false};
+
+  auto server = wirestead::uds_server(socket_path_)
+                    .independent_context(true)
+                    .use_length_prefix_framer(2)
+                    .on_connect([&server_connected](const wrapper::ConnectionContext&) { server_connected = true; })
+                    .on_message([&](const wrapper::MessageContext& ctx) {
+                      std::lock_guard<std::mutex> lock(mtx);
+                      received = ctx.data_as_vector();
+                      message_received = true;
+                      cv.notify_one();
+                    })
+                    .on_error([](auto&&) {})
+                    .build();
+
+  server->start();
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server->listening(); }, 2000))
+      << "Server failed to start listening";
+
+  auto client = wirestead::uds_client(socket_path_)
+                    .independent_context(true)
+                    .on_data([](auto&&) {})
+                    .on_error([](auto&&) {})
+                    .build();
+
+  client->start();
+  ASSERT_TRUE(TestUtils::waitForCondition([&]() { return server_connected.load(); }, 5000))
+      << "Failed to establish connection";
+
+  // 2-byte big-endian length, excluding the prefix itself.
+  std::vector<uint8_t> frame = {static_cast<uint8_t>((payload.size() >> 8) & 0xFF),
+                                static_cast<uint8_t>(payload.size() & 0xFF)};
+  frame.insert(frame.end(), payload.begin(), payload.end());
+  ASSERT_TRUE(client->send_move(std::move(frame)));
+
+  std::unique_lock<std::mutex> lock(mtx);
+  EXPECT_TRUE(cv.wait_for(lock, 5s, [&]() { return message_received.load(); })) << "Framed message never arrived";
+  EXPECT_EQ(received, payload);
+  lock.unlock();
 
   client->stop();
   server->stop();

--- a/test/unit/builder/test_builder_option_wiring.cc
+++ b/test/unit/builder/test_builder_option_wiring.cc
@@ -46,6 +46,7 @@ TEST_F(SerialBuilderConfigTest, ExplicitOptionsArePropagatedToTheWrapper) {
                     .stop_bits(2)
                     .reopen_on_error(false)
                     .retry_interval(500ms)
+                    .rx_idle_timeout(250ms)
                     .on_data([](auto&&) {})
                     .on_error([](auto&&) {})
                     .build();
@@ -56,6 +57,7 @@ TEST_F(SerialBuilderConfigTest, ExplicitOptionsArePropagatedToTheWrapper) {
   EXPECT_EQ(cfg.stop_bits, 2u);
   EXPECT_FALSE(cfg.reopen_on_error);
   EXPECT_EQ(cfg.retry_interval_ms, 500u);
+  EXPECT_EQ(cfg.rx_idle_timeout_ms, 250u);
 }
 
 TEST_F(SerialBuilderConfigTest, UnsetOptionsFallBackToConfigDefaultsNotBuilderDefaults) {
@@ -71,4 +73,8 @@ TEST_F(SerialBuilderConfigTest, UnsetOptionsFallBackToConfigDefaultsNotBuilderDe
   EXPECT_EQ(cfg.stop_bits, expected.stop_bits);
   EXPECT_EQ(cfg.reopen_on_error, expected.reopen_on_error);
   EXPECT_EQ(cfg.retry_interval_ms, expected.retry_interval_ms);
+  // Off unless asked for: an rx watchdog shorter than the device's real
+  // message gap tears the link down and reopens in a loop.
+  EXPECT_EQ(cfg.rx_idle_timeout_ms, expected.rx_idle_timeout_ms);
+  EXPECT_EQ(cfg.rx_idle_timeout_ms, 0u);
 }


### PR DESCRIPTION
## Description

The coverage job was reporting numbers that did not describe this library, and a scan for public API with no test references found four entry points nothing ever called. This fixes the measurement and covers the four.

Measured before and after, same pipeline both times:

| | before | after |
|---|---|---|
| lines | 85.6% (9717/11349) | **86.2%** (9861/11440) |
| branches | 52.2% reported / 65.7% real | **66.3%** |
| functions | 90.9% | **91.2%** |
| `tcp_server.cc` lines | 82.5% | **90.2%** |
| `ssl_tcp_socket.cc` lines | not measured (0 lines compiled) | **79.2%** |

The line denominator grows by 91 because TLS code is compiled into the coverage build for the first time.

## Key Changes

**`.github/workflows/coverage.yml`**

- `--filter branch`: gcc emits branches for C++ exception unwinding on lines with no conditional, and no test can reach them. 8596 of 15592 counted branches were that, which is why the job reported 52.2% instead of 65.7%. Applied at the `--remove` step so the `.info` artifact, the HTML report and the printed number agree.
- `-DWIRESTEAD_ENABLE_TLS=ON`: `ssl_tcp_socket.cc` is behind `#ifdef WIRESTEAD_TLS_ENABLED`, so it contributed zero lines while a five-test TLS suite went unrun.
- `socat`: without it the serial integration tests `GTEST_SKIP` themselves and take the serial paths with them. `ci.yml` already installs it for its own job.
- Removed `-LE "performance|benchmark|optional"` — no label in this repo contains any of those three tokens, so it excluded nothing.
- `THRESHOLD` 65 → 80. Against a measured 86.2%, the old value let coverage rot by a fifth of the library without turning the job red.
- Dropped a duplicated pair of artifact upload steps.

**Tests for four public APIs with zero references in the test tree**

- `TcpServer::async_try_write_{copy,move,shared}` and `try_send_to_client` — 42 uncovered lines. `TryWriteTransportContractTest` covers this contract for TcpClient, Udp, UdsClient, UdsServerSession and Serial but cannot reach TcpServer, whose sessions belong to the acceptor. Added to the two existing tests that already exercise the `async_write_*` twins on both sides of "is there a session".
- `use_length_prefix_framer()` (#605) — the framer had unit tests; the builder method that installs it had none. The payload contains `0x02`, `0x03` and `\n`, which is the entire reason the framer exists.
- `rx_idle_timeout()` (#597) — `SerialBuilder` captures it and `build()` forwards it, exactly the shape of the bug `test_builder_option_wiring.cc` was written for in #432. Explicit value and default-off both asserted.

## Related Issues

None.

## Type of Change

- [x] **Testing**: Adding or updating tests.
- [x] **Bug Fix**: A non-breaking change that resolves an issue. *(the coverage job's measurement)*

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable). *(none needed — the README coverage badge reports line %, which the branch filter does not touch)*
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**The length-prefix test was verified to discriminate.** Swapping `use_length_prefix_framer(2)` for `use_line_framer()` in the builder chain makes it fail — the framed message never arrives. It is not a test that passes regardless.

**Enabling TLS in the coverage job was checked, not assumed.** A separate TLS build (OpenSSL 3.0.13) runs `TcpTlsLoopbackTest` 5/5 green, including `ClientRejectsAnUntrustedServerCertificate`, the one fixed in #601.

Full suite: **802 tests, 0 failures**, 30s. The 12 skips are the pre-existing UDP large-payload cases, unrelated.

Worth watching on the first few runs: a coverage build with TLS enabled is a new combination, and there is a known intermittent segfault *during process exit* under coverage instrumentation that ctest attributes to `UdpServerWrapperLifecycleTest.IPv6EndpointHashCoverage`. It is an exit crash rather than a test crash, and every attempt to observe it so far has suppressed it.

Not included, and the next thing worth doing: six public APIs still have no test references (`on_multi_data`, `on_multi_disconnect`, `async_try_write_to`, `local_address`, `send_line_blocking`, `set_idle_timeout`/`set_idle_timeout_action`), and `udp.cc` remains the largest gap at 197 uncovered lines, concentrated in `open_socket()`'s option-failure paths and `enable_broadcast`, which no test sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
