### PR TITLE
test: cover the batch latency flush on all seven wrappers

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -112,6 +112,7 @@ foreach(
   test_send_contract.cc
   test_server_broadcast_contract.cc
   test_server_broadcast_slow_consumer_contract.cc
+  test_server_batch_latency_flush.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/wrapper/test_server_batch_latency_flush.cc
+++ b/test/integration/wrapper/test_server_batch_latency_flush.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "wirestead/framer/line_framer.hpp"
+#include "wrapper_contract_test_utils.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace wirestead::test::wrapper_support;
+using namespace std::chrono_literals;
+
+namespace {
+
+// The client-side half of this behaviour lives in
+// test/unit/wrapper/test_batch_latency_flush.cc, which can drive a wrapper
+// through an injected interface::Channel. The server wrappers cannot be
+// reached that way: their receive path hangs off
+// transport_server->on_multi_data(), obtained by dynamic_pointer_cast to the
+// concrete transport, so a fake channel delivers nothing to them and only a
+// real loopback exercises the queue.
+//
+// What is under test is the same either way - one message, a batch size it
+// cannot reach, and a latency it must wait out, so the only thing that can
+// deliver the partial batch is the timer that calls flush_batches().
+template <typename Harness>
+void expect_server_partial_batch_flushes_after_latency() {
+  Harness harness;
+  auto server = harness.start_server();
+
+  std::mutex mutex;
+  std::vector<std::string> data_payloads;
+  std::vector<std::string> message_payloads;
+  std::atomic<int> data_batches{0};
+  std::atomic<int> message_batches{0};
+
+  server->batch_size(10).batch_latency(50ms);
+  // Set before the client connects: the per-client framer is built from this
+  // factory when the connection arrives.
+  server->framer([]() { return std::make_unique<framer::LineFramer>(); });
+  server->on_data_batch([&](const std::vector<wrapper::MessageContext>& batch) {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& ctx : batch) data_payloads.push_back(ctx.data_as_string());
+    data_batches++;
+  });
+  server->on_message_batch([&](const std::vector<wrapper::MessageContext>& batch) {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& ctx : batch) message_payloads.push_back(ctx.data_as_string());
+    message_batches++;
+  });
+
+  std::shared_ptr<void> keep_client_alive;
+  if constexpr (requires { harness.connect_client(); }) {
+    auto client = harness.connect_client();
+    ASSERT_TRUE(harness.wait_for_client_count(1));
+    ASSERT_TRUE(client->send("only\n"));
+    keep_client_alive = client;
+  } else {
+    auto sender = harness.start_sender();
+    ASSERT_TRUE(sender->send("only\n"));
+    keep_client_alive = sender;
+  }
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return data_batches.load() > 0 && message_batches.load() > 0; }, 5000))
+      << "partial batch was never flushed: data_batches=" << data_batches.load()
+      << " message_batches=" << message_batches.load();
+
+  std::lock_guard<std::mutex> lock(mutex);
+  ASSERT_EQ(data_payloads.size(), 1U);
+  ASSERT_EQ(message_payloads.size(), 1U);
+  EXPECT_EQ(data_payloads[0], "only\n");
+  EXPECT_EQ(message_payloads[0], "only");
+}
+
+}  // namespace
+
+TEST(ServerBatchLatencyFlushTest, TcpServerFlushesAPartialBatch) {
+  expect_server_partial_batch_flushes_after_latency<TcpServerLoopbackHarness>();
+}
+
+TEST(ServerBatchLatencyFlushTest, UdsServerFlushesAPartialBatch) {
+  expect_server_partial_batch_flushes_after_latency<UdsServerLoopbackHarness>();
+}
+
+TEST(ServerBatchLatencyFlushTest, UdpServerFlushesAPartialBatch) {
+  expect_server_partial_batch_flushes_after_latency<UdpServerLoopbackHarness>();
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -139,9 +139,13 @@ wirestead_add_unit_gtest(
 # Wrapper tests (separate executables across TCP/UDP/UDS/Serial)
 foreach(
   test_file
-  test_serial_wrapper_lifecycle.cc test_serial_wrapper_options.cc
-  test_runtime_stats.cc test_send_buffer_apis.cc test_error_context_builder.cc
+  test_serial_wrapper_lifecycle.cc
+  test_serial_wrapper_options.cc
+  test_runtime_stats.cc
+  test_send_buffer_apis.cc
+  test_error_context_builder.cc
   test_message_context.cc
+  test_batch_latency_flush.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/wrapper/test_batch_latency_flush.cc
+++ b/test/unit/wrapper/test_batch_latency_flush.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <boost/asio.hpp>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "test_utils.hpp"
+#include "wirestead/framer/line_framer.hpp"
+#include "wirestead/interface/channel.hpp"
+#include "wirestead/wrapper/serial/serial.hpp"
+#include "wirestead/wrapper/tcp_client/tcp_client.hpp"
+#include "wirestead/wrapper/udp/udp.hpp"
+#include "wirestead/wrapper/uds_client/uds_client.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace std::chrono_literals;
+namespace net = boost::asio;
+
+namespace {
+
+// Batch delivery has two triggers and only one of them was ever tested. The
+// size trigger fires inline from the receive path, so a test that emits
+// batch_size() messages exercises it without an io_context going anywhere.
+// The latency trigger is different: the first message into an empty queue arms
+// a steady_timer on the channel's executor, and flush_batches() runs only from
+// that timer's completion handler. The shared FakeChannel hands out an executor
+// for an io_context nobody runs, so the timer never fires there and
+// flush_batches() went uncovered in all seven wrappers.
+//
+// This channel therefore owns a real io_context and runs it, which is the
+// whole point of the fixture - a partial batch has to reach the user when the
+// device goes quiet, and that is the only path that delivers it.
+class RunningFakeChannel : public interface::Channel {
+ public:
+  RunningFakeChannel() : work_(net::make_work_guard(ioc_)), thread_([this] { ioc_.run(); }) {}
+
+  ~RunningFakeChannel() override {
+    work_.reset();
+    ioc_.stop();
+    if (thread_.joinable()) thread_.join();
+  }
+
+  void start() override { connected_ = true; }
+  void stop() override { connected_ = false; }
+  bool is_connected() const override { return connected_; }
+  bool is_backpressure_active() const override { return false; }
+
+  net::any_io_executor get_executor() override { return ioc_.get_executor(); }
+
+  bool async_write_copy(memory::ConstByteSpan) override { return true; }
+  bool async_write_move(std::vector<uint8_t>&&) override { return true; }
+  bool async_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return true; }
+  bool async_try_write_copy(memory::ConstByteSpan) override { return true; }
+  bool async_try_write_move(std::vector<uint8_t>&&) override { return true; }
+  bool async_try_write_shared(std::shared_ptr<const std::vector<uint8_t>>) override { return true; }
+
+  void on_bytes(OnBytes cb) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_bytes_ = std::move(cb);
+  }
+  void on_state(OnState cb) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    on_state_ = std::move(cb);
+  }
+  void on_backpressure(OnBackpressure) override {}
+
+  // Delivered on the io thread, the way a real transport delivers it, so the
+  // queue mutation and the timer that flushes it share a thread here too.
+  void emit_bytes(std::string_view text) {
+    std::vector<uint8_t> bytes(text.begin(), text.end());
+    net::post(ioc_, [this, bytes = std::move(bytes)]() {
+      OnBytes handler;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handler = on_bytes_;
+      }
+      if (handler) handler(memory::ConstByteSpan(bytes.data(), bytes.size()));
+    });
+  }
+
+  void emit_state(base::LinkState state) {
+    if (state == base::LinkState::Connected) connected_ = true;
+    OnState handler;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      handler = on_state_;
+    }
+    if (handler) handler(state);
+  }
+
+ private:
+  net::io_context ioc_;
+  net::executor_work_guard<net::io_context::executor_type> work_;
+  std::thread thread_;
+  bool connected_{false};
+  std::mutex mutex_;
+  OnBytes on_bytes_;
+  OnState on_state_;
+};
+
+// One message, a batch size it cannot reach, and a latency it must wait out.
+// Both queues inside flush_batches() are loaded: the raw bytes land in the data
+// batch queue and the framer turns the same bytes into one framed message.
+template <typename Wrapper>
+void expect_partial_batch_flushes_after_latency() {
+  auto channel = std::make_shared<RunningFakeChannel>();
+  Wrapper wrapper(std::static_pointer_cast<interface::Channel>(channel));
+
+  std::mutex mutex;
+  std::vector<std::string> data_payloads;
+  std::vector<std::string> message_payloads;
+  std::atomic<int> data_batches{0};
+  std::atomic<int> message_batches{0};
+
+  wrapper.batch_size(10).batch_latency(50ms);
+  wrapper.framer(std::make_unique<framer::LineFramer>());
+  wrapper.on_data_batch([&](const std::vector<wrapper::MessageContext>& batch) {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& ctx : batch) data_payloads.push_back(ctx.data_as_string());
+    data_batches++;
+  });
+  wrapper.on_message_batch([&](const std::vector<wrapper::MessageContext>& batch) {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& ctx : batch) message_payloads.push_back(ctx.data_as_string());
+    message_batches++;
+  });
+
+  auto started = wrapper.start();
+  channel->emit_state(base::LinkState::Connected);
+  ASSERT_TRUE(started.get());
+
+  channel->emit_bytes("only\n");
+
+  // Nothing else arrives, so the queues stay at one entry each - far below the
+  // batch size of 10. Only the latency timer can deliver them.
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return data_batches.load() > 0 && message_batches.load() > 0; }, 2000))
+      << "partial batch was never flushed: data_batches=" << data_batches.load()
+      << " message_batches=" << message_batches.load();
+
+  std::lock_guard<std::mutex> lock(mutex);
+  EXPECT_EQ(data_batches.load(), 1);
+  EXPECT_EQ(message_batches.load(), 1);
+  ASSERT_EQ(data_payloads.size(), 1U);
+  ASSERT_EQ(message_payloads.size(), 1U);
+  EXPECT_EQ(data_payloads[0], "only\n");
+  EXPECT_EQ(message_payloads[0], "only");
+
+  wrapper.stop();
+}
+
+}  // namespace
+
+// The server wrappers are covered in
+// test/integration/wrapper/test_server_batch_latency_flush.cc instead: their
+// receive path hangs off transport_server->on_multi_data(), reached through a
+// dynamic_pointer_cast to the concrete transport, so an interface::Channel
+// fake never delivers a byte to them and they need a real loopback.
+
+TEST(BatchLatencyFlushTest, TcpClientFlushesAPartialBatch) {
+  expect_partial_batch_flushes_after_latency<wrapper::TcpClient>();
+}
+
+TEST(BatchLatencyFlushTest, UdpClientFlushesAPartialBatch) {
+  expect_partial_batch_flushes_after_latency<wrapper::UdpClient>();
+}
+
+TEST(BatchLatencyFlushTest, UdsClientFlushesAPartialBatch) {
+  expect_partial_batch_flushes_after_latency<wrapper::UdsClient>();
+}
+
+TEST(BatchLatencyFlushTest, SerialFlushesAPartialBatch) {
+  expect_partial_batch_flushes_after_latency<wrapper::Serial>();
+}


### PR DESCRIPTION
## Description

Batch delivery has two triggers and only one of them was ever tested.

The **size trigger** fires inline from the receive path, so a test that feeds it `batch_size()` messages exercises it without an `io_context` going anywhere — that is what the existing wrapper tests do. The **latency trigger** is different: the first message into an empty queue arms a `steady_timer` on the channel's executor, and `flush_batches()` runs only from that timer's completion handler.

Nothing reached it. The shared `FakeChannel` hands out an executor for a static `io_context` nobody runs, so in every wrapper test the timer was armed and never fired. `flush_batches()` sat uncovered in **all seven wrappers** — roughly 23 lines each — along with the #450 keepalive guard on the timer handler, which had no test either.

This is the path that delivers a partial batch when the peer goes quiet, which is the case that matters. A full batch arrives on its own.

## Key Changes

Two files, because the wrappers split into two shapes:

- **`test/unit/wrapper/test_batch_latency_flush.cc`** — drives `TcpClient`, `UdpClient`, `UdsClient` and `Serial` through an injected `interface::Channel` that owns a *running* `io_context`. No sockets, ~50 ms per test.
- **`test/integration/wrapper/test_server_batch_latency_flush.cc`** — covers `TcpServer`, `UdsServer` and `UdpServer` over a real loopback, reusing the three harnesses already in `wrapper_contract_test_utils.hpp`. A fake channel cannot reach these: their receive path hangs off `transport_server->on_multi_data()`, obtained by `dynamic_pointer_cast` to the concrete transport, so an `interface::Channel` fake delivers nothing to them.

Both load **both** queues inside `flush_batches()` — the raw bytes go to the data batch queue and a `LineFramer` turns the same bytes into one framed message — against a batch size of 10 that a single message cannot reach.

Line coverage per wrapper, measured on the coverage build:

| wrapper | before | after |
|---|---|---|
| `wrapper/tcp_client` | 86.0% | **92.8%** |
| `wrapper/udp` | 85.4% | **92.3%** |
| `wrapper/uds_client` | 86.9% | **93.3%** |
| `wrapper/serial` | 83.6% | **90.1%** |
| `wrapper/tcp_server` | 93.6% | **96.3%** |
| `wrapper/uds_server` | 89.3% | **91.2%** |
| `wrapper/udp_server` | 88.6% | **90.2%** |

Overall **86.2% → 87.5%** lines, **66.3% → 66.9%** branches.

## Related Issues

None.

## Type of Change

- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable). *(none needed — no behaviour change)*
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified to discriminate.** Changing `schedule_batch_timer()` to return without arming the timer fails the client test at its 2 s bound and the server test at its 5 s bound. Both were run against that broken build and both failed; the library sources were then restored and re-verified clean.

No library code changed — this PR is tests only. 809 tests in the plain build, 814 in the coverage build (TLS on), all passing.

Why the shared `FakeChannel` was left alone: six existing test files use it, and one of them documents its non-running executor as the reason a blocking wait behaves the way it does. Giving it a real io thread would change behaviour under those tests for the benefit of this one, so the running channel is local to the new file instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
