### PR TITLE
test: cover the setters that only do their real work while live

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -113,6 +113,7 @@ foreach(
   test_server_broadcast_contract.cc
   test_server_broadcast_slow_consumer_contract.cc
   test_server_batch_latency_flush.cc
+  test_live_setter_forwarding.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/integration/wrapper/test_live_setter_forwarding.cc
+++ b/test/integration/wrapper/test_live_setter_forwarding.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "test_utils.hpp"
+#include "wirestead/base/constants.hpp"
+#include "wrapper_contract_test_utils.hpp"
+
+using namespace wirestead;
+using namespace wirestead::test;
+using namespace wirestead::test::wrapper_support;
+using namespace std::chrono_literals;
+
+// wrapper::TcpClient's tuning setters have two halves: they store the value
+// for the next channel build, and - when a channel already exists - they push
+// it into the live transport. Every test so far called them before start(),
+// so impl_->channel_ was null and the second half never ran. That is the half
+// that matters and the half that has broken before: #432 was a live setter
+// whose value reached the config but not the running client.
+
+TEST(LiveSetterForwardingTest, IdleTimeoutSetOnALiveClientClosesTheStaleLink) {
+  TcpServerLoopbackHarness harness;
+  auto server = harness.start_server();
+  auto client = harness.connect_client();
+  ASSERT_TRUE(client->connected());
+
+  // Neither was configured before start(), so the transport opened with the
+  // idle watchdog off. Turning it on now only works if the wrapper forwards
+  // to the transport rather than only recording it for a future build.
+  client->idle_timeout_action(IdleTimeoutAction::Close);
+  client->idle_timeout(200ms);
+
+  // The transport arms the idle timer from the activity path, so one write is
+  // what starts the clock. The harness server does not echo, so the link then
+  // goes quiet and stays quiet.
+  ASSERT_TRUE(client->send("wake"));
+
+  ASSERT_TRUE(TestUtils::waitForCondition([&] { return !client->connected(); }, 5000))
+      << "the live idle timeout never fired, so the setter did not reach the transport";
+
+  // Close, not Reconnect: it must stay down rather than come back.
+  std::this_thread::sleep_for(500ms);
+  EXPECT_FALSE(client->connected());
+}
+
+TEST(LiveSetterForwardingTest, TuningSettersAreAcceptedWhileConnected) {
+  TcpServerLoopbackHarness harness;
+  auto server = harness.start_server();
+  auto client = harness.connect_client();
+  ASSERT_TRUE(client->connected());
+
+  // Each of these takes the wrapper's unique_lock and then calls into the
+  // transport while its io thread is live, so a lock-order mistake here shows
+  // up as this test hanging rather than failing.
+  client->retry_interval(300ms);
+  client->max_retries(7);
+  client->connection_timeout(2500ms);
+  client->read_buffer_size(8192);
+
+  EXPECT_TRUE(client->connected());
+  ASSERT_TRUE(client->send("still here"));
+  EXPECT_TRUE(TestUtils::waitForCondition([&] { return client->stats().messages_accepted > 0; }, 2000));
+}

--- a/test/unit/wrapper/test_serial_config_mapping.cc
+++ b/test/unit/wrapper/test_serial_config_mapping.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <string>
 
 #include "wirestead/config/serial_config.hpp"
@@ -89,4 +90,50 @@ TEST_F(SerialConfigMappingTest, InvalidStringsFallbackToNoneAndClampBits) {
 
   EXPECT_EQ(cfg.char_size, 5u);
   EXPECT_EQ(cfg.stop_bits, 2u);
+}
+
+// The RS-485 and modem-line options from #603. Nothing called these setters,
+// so the wrapper half of that feature was unverified end to end: the builder
+// forwards to them and build_config() is what the transport finally opens the
+// port with, which is the same silently-dropped-option shape as #432.
+TEST_F(SerialConfigMappingTest, MapsRs485AndModemLineOptions) {
+  auto wrapper = std::make_shared<TestableSerial>("/dev/ttyUSB0", 115200);
+
+  wrapper->low_latency(false);
+  wrapper->rs485(/*rts_on_send=*/false, /*rx_during_tx=*/true, /*delay_before_ms=*/2, /*delay_after_ms=*/3);
+  wrapper->dtr(false);
+  wrapper->rts(true);
+  wrapper->rx_idle_timeout(std::chrono::milliseconds(750));
+
+  auto cfg = wrapper->build_config();
+
+  EXPECT_FALSE(cfg.low_latency);
+  // rs485() enables the mode by being called at all - there is no separate
+  // enable flag on the wrapper.
+  EXPECT_TRUE(cfg.rs485.enabled);
+  EXPECT_FALSE(cfg.rs485.rts_on_send);
+  EXPECT_TRUE(cfg.rs485.rx_during_tx);
+  EXPECT_EQ(cfg.rs485.delay_rts_before_send_ms, 2u);
+  EXPECT_EQ(cfg.rs485.delay_rts_after_send_ms, 3u);
+  ASSERT_TRUE(cfg.dtr.has_value());
+  EXPECT_FALSE(*cfg.dtr);
+  ASSERT_TRUE(cfg.rts.has_value());
+  EXPECT_TRUE(*cfg.rts);
+  EXPECT_EQ(cfg.rx_idle_timeout_ms, 750u);
+}
+
+// The defaults are load-bearing and differ from "unset": low_latency is on
+// because the FTDI 16 ms latency timer is larger than every other cost in the
+// stack, while dtr/rts stay nullopt because driving DTR at open reboots an
+// Arduino - "leave the driver alone" is a different request from "drive low".
+TEST_F(SerialConfigMappingTest, UntouchedRs485AndModemLinesKeepConfigDefaults) {
+  auto wrapper = std::make_shared<TestableSerial>("/dev/ttyUSB0", 115200);
+
+  auto cfg = wrapper->build_config();
+
+  EXPECT_TRUE(cfg.low_latency);
+  EXPECT_FALSE(cfg.rs485.enabled);
+  EXPECT_FALSE(cfg.dtr.has_value());
+  EXPECT_FALSE(cfg.rts.has_value());
+  EXPECT_EQ(cfg.rx_idle_timeout_ms, 0u);
 }


### PR DESCRIPTION
## Description

Two clusters of wrapper setters had never been called in a state where they do anything.

**`wrapper::TcpClient`'s tuning setters have two halves**: they store the value for the next channel build, and — when a channel already exists — push it into the live transport. Every test so far called them before `start()`, so `impl_->channel_` was null and the second half never ran. That is the half that has broken before: **#432 was a live setter whose value reached the config but not the running client.**

**`wrapper::Serial`'s RS-485 and modem-line setters from #603 had no caller at all** — `low_latency()`, `rs485()`, `dtr()`, `rts()`. The builder forwards to them and `build_config()` is what the transport finally opens the port with, so this is the silently-dropped-option shape of #432 again, on the feature where getting it wrong means a shared bus driven in UART mode that collides on every write.

## Key Changes

**`test/integration/wrapper/test_live_setter_forwarding.cc`** (new)

- `IdleTimeoutSetOnALiveClientClosesTheStaleLink` — **observable, not merely executed.** Neither `idle_timeout` nor its action is set before `start()`, so the transport opens with the watchdog off. Setting them on the connected client only takes effect if the wrapper forwards to the transport; one write then arms the timer from the activity path, and with `IdleTimeoutAction::Close` the link must drop and stay down.
- `TuningSettersAreAcceptedWhileConnected` — `retry_interval`, `max_retries`, `connection_timeout`, `read_buffer_size` on a connected client. Each takes the wrapper's `unique_lock` and then calls into the transport while its io thread is live, so a lock-order mistake surfaces here as a hang rather than a failure.

**`test/unit/wrapper/test_serial_config_mapping.cc`** — two tests through the `build_config()` subclass already in that file, so no hardware and no socat. One asserts the RS-485/DTR/RTS/`low_latency`/`rx_idle_timeout` values reach `SerialConfig`; the other asserts the defaults, which are load-bearing and differ from "unset": `low_latency` defaults **on** because the FTDI 16 ms latency timer dominates everything else in the stack, and `dtr`/`rts` stay `nullopt` because driving DTR at open reboots an Arduino.

Line coverage of the two files, measured on a tree that also carried the batch-latency work in #608:

| file | before | after |
|---|---|---|
| `wrapper/tcp_client` | 92.8% | **96.6%** |
| `wrapper/serial` | 90.1% | **94.6%** |

## Related Issues

None.

## Type of Change

- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable). *(none needed — no behaviour change)*
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified to discriminate.** Dropping the forward inside `TcpClient::idle_timeout()` — keeping the `dynamic_pointer_cast` and throwing the result away — fails the idle-timeout test at its 5 s bound. The library source was then restored and re-verified clean.

No library code changed; this PR is tests only.

Independent of #608 — the two touch different files apart from one line each in `test/integration/CMakeLists.txt`, and either can merge first. The coverage figures above were measured with both applied, which is why they are quoted as a pair rather than as this PR's own delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
