### PR TITLE
test: cover the UDP options and blocking sends nothing called

### DIFF
--- a/test/integration/transport/transport_udp.cc
+++ b/test/integration/transport/transport_udp.cc
@@ -450,6 +450,149 @@ TEST_F(TransportUdpTest, ExplicitDestinationWriteWithoutRemote) {
   channel->stop();
 }
 
+// async_try_write_to() is the try_ half of the explicit-destination pair and
+// had no caller in the test tree at all. Backpressure is nowhere near active
+// here, so the contract is that it behaves exactly like async_write_to().
+TEST_F(TransportUdpTest, ExplicitDestinationTryWriteWithoutRemote) {
+  net::io_context ioc;
+  udp::socket receiver(ioc, udp::endpoint(udp::v4(), 0));
+  receiver.non_blocking(true);
+
+  config::UdpConfig cfg;
+  cfg.local_port = 0;
+  auto channel = UdpChannel::create(cfg, ioc);
+
+  std::atomic<bool> ready{false};
+  channel->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Listening) ready = true;
+  });
+  channel->start();
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        return ready.load();
+      },
+      1000));
+
+  const std::string payload = "try-explicit";
+  const udp::endpoint destination(net::ip::make_address("127.0.0.1"), receiver.local_endpoint().port());
+  EXPECT_TRUE(channel->async_try_write_to(
+      memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(payload.data()), payload.size()), destination));
+
+  std::array<char, 64> buffer{};
+  udp::endpoint sender;
+  EXPECT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        boost::system::error_code ec;
+        const auto bytes = receiver.receive_from(net::buffer(buffer), sender, 0, ec);
+        return !ec && std::string(buffer.data(), bytes) == payload;
+      },
+      1000));
+
+  channel->stop();
+}
+
+// enable_broadcast sets SO_BROADCAST during open_socket(), a block no test
+// ever entered because nothing set the flag. This does not prove a broadcast
+// datagram is routed - that depends on the network the runner is on - only
+// that asking for the option opens a working socket rather than failing the
+// open, which is the failure mode that would take the whole channel down.
+TEST_F(TransportUdpTest, BroadcastOptionOpensAWorkingSocket) {
+  net::io_context ioc;
+  udp::socket receiver(ioc, udp::endpoint(udp::v4(), 0));
+  receiver.non_blocking(true);
+
+  config::UdpConfig cfg;
+  cfg.local_port = 0;
+  cfg.enable_broadcast = true;
+  auto channel = UdpChannel::create(cfg, ioc);
+
+  std::atomic<bool> ready{false};
+  std::atomic<bool> failed{false};
+  channel->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Listening) ready = true;
+    if (state == base::LinkState::Error) failed = true;
+  });
+  channel->start();
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        return ready.load() || failed.load();
+      },
+      1000));
+  ASSERT_FALSE(failed.load()) << "enable_broadcast failed the socket open";
+
+  const std::string payload = "broadcast-enabled";
+  const udp::endpoint destination(net::ip::make_address("127.0.0.1"), receiver.local_endpoint().port());
+  EXPECT_TRUE(channel->async_write_to(
+      memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(payload.data()), payload.size()), destination));
+
+  std::array<char, 64> buffer{};
+  udp::endpoint sender;
+  EXPECT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        boost::system::error_code ec;
+        const auto bytes = receiver.receive_from(net::buffer(buffer), sender, 0, ec);
+        return !ec && std::string(buffer.data(), bytes) == payload;
+      },
+      1000));
+
+  channel->stop();
+}
+
+// reset_stats() is on the Channel contract - "cleared by reset_stats(), and by
+// a stop()/start() cycle" - and no test called it on this transport.
+TEST_F(TransportUdpTest, ResetStatsClearsCumulativeCounters) {
+  net::io_context ioc;
+  udp::socket receiver(ioc, udp::endpoint(udp::v4(), 0));
+  receiver.non_blocking(true);
+
+  config::UdpConfig cfg;
+  cfg.local_port = 0;
+  auto channel = UdpChannel::create(cfg, ioc);
+
+  std::atomic<bool> ready{false};
+  channel->on_state([&](base::LinkState state) {
+    if (state == base::LinkState::Listening) ready = true;
+  });
+  channel->start();
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        return ready.load();
+      },
+      1000));
+
+  const std::string payload = "counted";
+  const udp::endpoint destination(net::ip::make_address("127.0.0.1"), receiver.local_endpoint().port());
+  ASSERT_TRUE(channel->async_write_to(
+      memory::ConstByteSpan(reinterpret_cast<const uint8_t*>(payload.data()), payload.size()), destination));
+
+  ASSERT_TRUE(TestUtils::waitForCondition(
+      [&] {
+        ioc.poll();
+        ioc.restart();
+        return channel->stats().messages_accepted > 0;
+      },
+      1000));
+  EXPECT_GT(channel->stats().bytes_accepted, 0u);
+
+  channel->reset_stats();
+
+  const auto after = channel->stats();
+  EXPECT_EQ(after.messages_accepted, 0u);
+  EXPECT_EQ(after.bytes_accepted, 0u);
+
+  channel->stop();
+}
+
 TEST_F(TransportUdpTest, MemoryPoolExplicitDestinationWriteWithoutRemote) {
   net::io_context ioc;
   udp::socket receiver(ioc, udp::endpoint(udp::v4(), 0));

--- a/test/unit/wrapper/test_serial_wrapper_options.cc
+++ b/test/unit/wrapper/test_serial_wrapper_options.cc
@@ -75,6 +75,11 @@ TEST(SerialWrapperOptionsTest, SendWithoutConnection) {
   wrapper::Serial s("/dev/null", 9600);
   EXPECT_FALSE(s.send("data"));
   EXPECT_FALSE(s.send_line("line"));
+  // The blocking pair forwards to the same Impl and must refuse the same way
+  // rather than blocking on a link that does not exist. Neither public
+  // forwarder had a caller in the test tree.
+  EXPECT_FALSE(s.send_blocking("data"));
+  EXPECT_FALSE(s.send_line_blocking("line"));
 }
 
 TEST(SerialWrapperOptionsTest, StopWithoutStart) {


### PR DESCRIPTION
## Description

The last two items from the coverage backlog: `udp.cc`'s non-error gaps, and the public API a name scan flagged as having no reference anywhere in the test tree.

The scan turned up more names than turned out to be worth testing, and two of them are dropped here rather than covered — see the end.

## Key Changes

**`test/integration/transport/transport_udp.cc`** — three tests, all following the explicit-destination pattern already in that file:

- **`async_try_write_to()`** — the `try_` half of the explicit-destination pair. `async_write_to()` had four callers and this had none. Backpressure is nowhere near active, so what is under test is that it behaves exactly like its blocking twin and the datagram arrives.
- **`enable_broadcast`** — the `SO_BROADCAST` block in `open_socket()` was never entered, because no test set the flag. The test asserts the channel reaches `Listening` rather than `Error` and still carries a datagram. It deliberately **does not** assert that a broadcast address is routed: that depends on the network the runner sits on, while the failure mode worth catching is the option failing the open and taking the channel down with it.
- **`reset_stats()`** — on the `Channel` contract ("cleared by `reset_stats()`, and by a `stop()`/`start()` cycle") and never called on this transport.

**`test/unit/wrapper/test_serial_wrapper_options.cc`** — `Serial::send_blocking()` / `send_line_blocking()`, the *public forwarders*, as distinct from the Impl methods behind them, which `send_line()` already reaches when the strategy is `Reliable`. Added to the existing `SendWithoutConnection` case, since refusing rather than blocking on a link that does not exist is the same contract.

## Dropped from the scan rather than tested

Both were found by name, and neither earns a test:

- **`local_address()`** on the UDP builders is `[[deprecated]]` and a one-line alias for `bind_address()`. A test asserts nothing new and drags a deprecation warning into the test build.
- **`on_multi_data()` / `on_multi_disconnect()`** have no *direct* test caller, but the server wrappers register them on every start, so every server wrapper test already executes them. The name scan could not see that.

## Related Issues

None.

## Type of Change

- [x] **Testing**: Adding or updating tests.

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [x] I have updated the documentation to reflect the changes (if applicable). *(none needed — no behaviour change)*
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**Verified to discriminate.** Making `UdpChannel::reset_stats()` return early fails its test; the library source was then restored and re-verified clean. The other three assert delivery or a refusal, so they cannot pass against a no-op.

No library code changed; tests only.

This closes the cheap end of the coverage backlog. What remains is the transport error paths (~560 lines, the only item that moves the percentage much) and the teardown/destructor paths (~80 lines, where the last two real bugs actually lived). Neither is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
