### PR TITLE
chore: release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
-## Unreleased
+## v0.10.0 - 2026-08-16
 
 ### Added
 
@@ -304,6 +304,36 @@ and ABI policy.
   were reported as 400 KiB. The server-wide value is now the largest depth any
   one session reached. Servers with a single connected client are unaffected.
   The remaining fields are genuine totals and keep summing.
+
+### Compatibility
+
+- Additive at the symbol level: the shared library exports 1225 symbols against
+  v0.9.3's 1191, with **none removed**. The 34 new ones are the TLS builder and
+  wrapper entry points, `multicast_group()`, the serial `low_latency`/`rs485`/
+  `dtr`/`rts`/`rx_idle_timeout` setters, `client_stats()`, `LengthPrefixFramer`
+  and its vtable, and `concurrency::set_io_thread_init()`. Measured with
+  `nm -D --defined-only` on Release builds of the tag and of v0.9.3.
+
+- **This is a minor release rather than a patch because default behavior
+  changes.** A server's cumulative counters now survive the sessions that
+  produced them, so `TcpServer::stats()` and `UdsServer::stats()` no longer
+  collapse to zero when the last client disconnects, and `max_queued_bytes` is
+  the deepest queue one session reached rather than the sum of every session's
+  peak. Code that sampled `stats()` on an interval sees different numbers
+  without changing a line. `docs/api_stability.md` reserves that kind of change
+  for a minor bump.
+
+- TLS is opt-in and off by default. `WIRESTEAD_ENABLE_TLS=ON` adds OpenSSL as a
+  link dependency; a build that does not ask for it gains no new dependency,
+  and the TLS entry points compile to nothing.
+
+- Serial `low_latency` defaults to **on**, which is a behavior change for USB
+  serial adapters: the driver's receive latency timer is cleared where the
+  platform supports it. Ports that refuse the ioctl are unaffected and the
+  refusal is not an error. `rs485`, `dtr` and `rts` are engaged only when set.
+
+- Consumers must rebuild, as for any pre-1.0 release; see
+  `docs/api_stability.md`.
 
 ## v0.9.3 - 2026-08-08
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   wirestead
-  VERSION 0.9.3
+  VERSION 0.10.0
   DESCRIPTION "Robust, simple, cross-platform async C++ communication library"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"
   LANGUAGES CXX

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>wirestead</name>
-  <version>0.9.3</version>
+  <version>0.10.0</version>
   <description>Cross-platform asynchronous C++ communication library for serial, TCP, UDP, and UDS transports.</description>
 
   <maintainer email="jwsung91@gmail.com">Jinwoo Sung</maintainer>


### PR DESCRIPTION
## Description

Closes the `Unreleased` section and bumps the project version, so the tag can be pushed from a tree that already describes itself correctly. 27 commits since v0.9.3.

**Minor rather than patch.** `docs/api_stability.md` says patch releases should avoid "changing existing default behavior", and this window changes it twice:

- a server's cumulative counters now survive the sessions that produced them, so `stats()` no longer collapses to zero when the last client disconnects, and `max_queued_bytes` is the deepest queue one session reached rather than the sum of every session's peak. Code sampling `stats()` on an interval sees different numbers without changing a line.
- serial `low_latency` defaults **on**.

## Key Changes

- `CMakeLists.txt` `VERSION` 0.9.3 → 0.10.0. Verified it reaches the generated package metadata (`wirestead.pc` reports `Version: 0.10.0`).
- `package.xml` version for the ROS metadata.
- `CHANGELOG.md`: `## Unreleased` → `## v0.10.0 - 2026-08-16`, plus the `### Compatibility` section every previous release carries and this one was missing.

## The Compatibility section is measured, not asserted

`nm -D --defined-only` on Release shared builds of this tree and of the v0.9.3 tag:

| | v0.9.3 | v0.10.0 |
|---|---|---|
| exported symbols | 1191 | **1225** |
| removed | — | **0** |

The 34 additions are exactly the new API: TLS builder/wrapper entry points, `multicast_group()`, the serial `low_latency`/`rs485`/`dtr`/`rts`/`rx_idle_timeout` setters, `client_stats()`, `LengthPrefixFramer` with its vtable, and `concurrency::set_io_thread_init()`. Nothing was dropped, so the break is behavioral rather than link-level.

## Related Issues

None.

## Type of Change

- [x] **Documentation**: Changes to documentation only. *(plus the version strings)*

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes. *(not applicable — version and changelog only, no behavior)*
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

Release-checklist items this covers: project version updated, README version-sensitive examples still valid (README and `docs/installation.md` pin no version, so nothing to change), CHANGELOG current for compatibility changes.

**Still open before the tag is pushed**, from `docs/release_checklist.md`:

- release workflow dry-run and CPack content checks
- Orin benchmark run against the tag with `publish_release: true`, linked from the release notes
- release notes with the pre-1.0 ABI disclaimer and a **known limitations** entry
- after the tag: `wirestead-examples`, `wirestead-container`, `wirestead-python` (`WIRESTEAD_CORE_REF`), then the vcpkg port and the Conan recipe

One thing worth a known-limitations line: an exit-time segfault that appears only under coverage instrumentation, after the suite has finished, and has no issue tracking it. It has never been observed in a normal build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
