### PR TITLE
chore: release 0.9.4 instead of 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
-## v0.10.0 - 2026-08-16
+## v0.9.4 - 2026-08-16
 
 ### Added
 
@@ -314,14 +314,21 @@ and ABI policy.
   and its vtable, and `concurrency::set_io_thread_init()`. Measured with
   `nm -D --defined-only` on Release builds of the tag and of v0.9.3.
 
-- **This is a minor release rather than a patch because default behavior
-  changes.** A server's cumulative counters now survive the sessions that
-  produced them, so `TcpServer::stats()` and `UdsServer::stats()` no longer
-  collapse to zero when the last client disconnects, and `max_queued_bytes` is
-  the deepest queue one session reached rather than the sum of every session's
-  peak. Code that sampled `stats()` on an interval sees different numbers
-  without changing a line. `docs/api_stability.md` reserves that kind of change
-  for a minor bump.
+- **Read this before upgrading: a patch release that does change two default
+  behaviors.** `docs/api_stability.md` says patch releases *should* avoid
+  changing existing default behavior, and this one does it twice, so the
+  exceptions are named here rather than left to be discovered.
+
+  A server's cumulative counters now survive the sessions that produced them,
+  so `TcpServer::stats()` and `UdsServer::stats()` no longer collapse to zero
+  when the last client disconnects, and `max_queued_bytes` is the deepest queue
+  one session reached rather than the sum of every session's peak. Code that
+  samples `stats()` on an interval sees different numbers without changing a
+  line. Both were previously wrong rather than merely different - a server that
+  had moved 795 MB reported zero the moment its last client went away - which
+  is why the fix landed in the 0.9 line instead of waiting.
+
+  The other is serial `low_latency`, below.
 
 - TLS is opt-in and off by default. `WIRESTEAD_ENABLE_TLS=ON` adds OpenSSL as a
   link dependency; a build that does not ask for it gains no new dependency,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   wirestead
-  VERSION 0.10.0
+  VERSION 0.9.4
   DESCRIPTION "Robust, simple, cross-platform async C++ communication library"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"
   LANGUAGES CXX

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>wirestead</name>
-  <version>0.10.0</version>
+  <version>0.9.4</version>
   <description>Cross-platform asynchronous C++ communication library for serial, TCP, UDP, and UDS transports.</description>
 
   <maintainer email="jwsung91@gmail.com">Jinwoo Sung</maintainer>


### PR DESCRIPTION
## Description

Keeps the release on the 0.9 line. #611 had set 0.10.0 on the grounds that `docs/api_stability.md` reserves default-behavior changes for a minor bump; the call is to stay on 0.9. Nothing was tagged, so this is only the version strings and the changelog heading.

## Key Changes

- `CMakeLists.txt` and `package.xml`: 0.10.0 → 0.9.4. Verified it reaches the generated metadata (`build/wirestead.pc` reports `Version: 0.9.4`).
- `CHANGELOG.md`: heading → `## v0.9.4 - 2026-08-16`.
- **The Compatibility section changed its argument, not just its numbers.** It previously justified a minor bump. It now names the two default-behavior changes as explicit exceptions, because the policy language is *should*, not *must*, and a reader upgrading inside the 0.9 line has to be told in the release itself rather than discover it:

  - a server's cumulative counters survive their sessions, so `stats()` no longer collapses to zero when the last client disconnects, and `max_queued_bytes` is a peak rather than a sum;
  - serial `low_latency` defaults on.

  Both fix numbers that were previously *wrong* rather than merely different — a server that had moved 795 MB reported zero the moment its last client went away — which is the reason they belong in a patch on this line instead of waiting.

The measured symbol comparison is unaffected: 1191 exported symbols in v0.9.3 to 1225 here, **none removed**.

## Related Issues

None.

## Type of Change

- [x] **Documentation**: Changes to documentation only. *(plus the version strings)*

## Checklist

- [x] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes. *(not applicable — version and changelog only, no behavior)*
- [x] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

The release-workflow dry-run, CPack content check and release-candidate consumer smoke were all run against the 0.10.0 tree. None of them depends on the version number beyond the filename and the two metadata fields verified above, so they were not repeated; say the word if you would rather see them re-run at 0.9.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS
