### PR TITLE
docs: add the ROS changelog the release tooling reads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,25 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package wirestead
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Wirestead is not a ROS package by origin; ``package.xml`` was added in v0.9.4
+so the library can be released into a ROS distribution. This file exists for
+the ROS release tooling, which reads reStructuredText. ``CHANGELOG.md`` remains
+the full changelog and covers every release, including the ones before this
+file existed.
+
+0.9.4 (2026-08-16)
+------------------
+* Add optional TLS for the TCP client and server, off by default.
+* Add UDP multicast group membership.
+* Add a process-wide io thread init hook for scheduling policy and affinity.
+* Add serial RS-485 mode, modem control lines, low-latency mode and a receive
+  watchdog.
+* Add a length-prefixed framer, which unlike the pattern framer can carry an
+  arbitrary binary payload.
+* Add arrival timestamps and a silence signal to the message and stats API.
+* Add per-client stats on the servers.
+* Fix server counters being destroyed with the session that produced them, and
+  a peak queue depth reported as a sum.
+* First release carrying ``package.xml``; the ROS build type is plain CMake.
+* Contributors: Jinwoo Sung


### PR DESCRIPTION
## Description

The ROS release plan in `wirestead-ros/docs/releasing.md` lists a `CHANGELOG.rst` per released package as a prerequisite. `wirestead_ros` has one; the core did not.

Bloom does not fail without it — it generates a generic `debian/changelog` entry instead — but then the Debian package carries no description of what the release contains.

## Key Changes

- `CHANGELOG.rst`, starting at v0.9.4

reStructuredText rather than a second Markdown file because that is what `catkin_pkg` parses.

**Deliberately not a copy of `CHANGELOG.md`.** That file stays the full changelog and covers the releases that predate `package.xml`. This one starts at v0.9.4, the first release a ROS distribution can build, and says so at the top so the gap does not read as an omission.

## Validation

Verified with catkin_pkg's own parser rather than by eye:

```python
>>> populate_changelog_from_rst(Changelog('wirestead'), open('CHANGELOG.rst').read())
version= 0.9.4 date= 2026-08-16 00:00:00
```

The version matches `package.xml`, which is what the ROS tooling cross-checks.

## Related Issues

Follows `wirestead-ros` PR #8, which corrects the release path to request the release repositories from `ros2-gbp`.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Additional Context

**Timing note for whoever runs bloom:** this lands *after* the `v0.9.4` tag, so a bloom release of that exact tag will not see it — bloom reads the tag, not `main`. It takes effect from the next tag. Given the rosdistro and `ros2-gbp` queues ahead of the first ROS release, that may well be a later version anyway, but it is worth knowing rather than discovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS