### PR TITLE
fix: build tests only when asked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" -A "${{ matrix.cmake_arch }}" \
               -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
               -DVCPKG_TARGET_TRIPLET="${{ matrix.triplet }}" \
+              -DWIRESTEAD_BUILD_TESTS=ON \
               -DWIRESTEAD_ENABLE_INSTALL=ON \
               -DWIRESTEAD_ENABLE_PKGCONFIG=ON \
               -DWIRESTEAD_ENABLE_EXPORT_HEADER=ON \
@@ -156,6 +157,7 @@ jobs:
             cmake -S . -B build -G "${{ matrix.cmake_generator }}" \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDK_VER" \
+              -DWIRESTEAD_BUILD_TESTS=ON \
               -DWIRESTEAD_ENABLE_INSTALL=ON \
               -DWIRESTEAD_ENABLE_PKGCONFIG=ON \
               -DWIRESTEAD_ENABLE_EXPORT_HEADER=ON \
@@ -167,6 +169,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER="${CC}" \
               -DCMAKE_CXX_COMPILER="${CXX}" \
+              -DWIRESTEAD_BUILD_TESTS=ON \
               -DWIRESTEAD_ENABLE_INSTALL=ON \
               -DWIRESTEAD_ENABLE_PKGCONFIG=ON \
               -DWIRESTEAD_ENABLE_EXPORT_HEADER=ON \

--- a/cmake/WiresteadOptions.cmake
+++ b/cmake/WiresteadOptions.cmake
@@ -37,7 +37,15 @@ option(WIRESTEAD_LIMIT_EXPORTED_SYMBOLS
        "Restrict shared library exports to wirestead symbols" ON
 )
 option(WIRESTEAD_BUILD_STATIC "Build static library" ON)
-option(WIRESTEAD_BUILD_TESTS "Build tests" ON)
+# OFF by default because a build that does not ask for tests must not need the
+# network: WIRESTEAD_BUILD_TESTS pulls GoogleTest through FetchContent, and the
+# packaging environments that consume this project build offline. vcpkg, the
+# Conan recipe and the ROS integration CI all pass OFF explicitly today, but
+# Bloom generates its debian rules without knowing this option exists, so a
+# default of ON fails the ROS build farm at configure time. Everything that
+# wants tests - CI, the presets, scripts/verify.sh, the release workflow -
+# passes ON explicitly.
+option(WIRESTEAD_BUILD_TESTS "Build tests" OFF)
 option(
   WIRESTEAD_BUILD_DOCS
   "Compatibility option for legacy docs builds. Full docs live in wirestead-docs."


### PR DESCRIPTION
## Description

`WIRESTEAD_BUILD_TESTS` defaulted to **ON**, and turning tests on pulls GoogleTest through `FetchContent`, which clones from github.com at configure time. **A build that did not ask for tests therefore needed the network.**

The comment above that `FetchContent` block already said so — it exists so that "packaging environments (e.g., vcpkg with `FETCHCONTENT_FULLY_DISCONNECTED`) can disable all tests and avoid downloading GoogleTest". The burden was on the consumer to turn it off.

Every packaging consumer does: the vcpkg port, the Conan recipe and the `wirestead-ros` CI all pass `OFF` explicitly. **Bloom does not, and cannot** — it generates its debian rules from `package.xml` without knowing this option exists. So the ROS build farm would have configured with tests on, inside a sandbox with no network, and failed before compiling anything.

## Key Changes

- `cmake/WiresteadOptions.cmake`: `WIRESTEAD_BUILD_TESTS` defaults to `OFF`, with the reasoning recorded next to it
- `.github/workflows/release.yml`: passes `-DWIRESTEAD_BUILD_TESTS=ON` in all three configure branches

`release.yml` was the one place relying on the old default — it configures without the flag and then runs `ctest`. Everything else already asks for tests explicitly: 7 workflows pass the flag, every developer preset in `CMakePresets.json` sets it, and `scripts/verify.sh` passes it twice.

`ci-install-consume.yml` and `vcpkg-package-test.yml` also configure without the flag but never run `ctest` — they were building the whole test suite and downloading GoogleTest for nothing, and now stop.

## Why flip the default rather than special-case Bloom

"A release build does not need the network" is the property worth having everywhere, not just on the ROS build farm. The alternative — carrying a Bloom-specific debian rules override — hides the problem in a place nobody reads.

## Validation

Verified in both directions:

| configure | `_deps/` | test targets |
|---|---|---|
| `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` | **absent** — GoogleTest never fetched | 0 |
| `… -DWIRESTEAD_BUILD_TESTS=ON` | present | **53** unit test targets |

`./scripts/verify.sh` passes.

## Type of Change

- [x] **Bug Fix**: A non-breaking change that resolves an issue.

## Additional Context

Downstream note: anyone who was relying on the default to get tests now has to ask for them. In this repository that is only `release.yml`, fixed here. Outside it, the three packaging consumers already pass `OFF`, so nothing changes for them.

Found while reviewing what the ROS 2 release would hit on the build farm, ahead of ros/rosdistro#53281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS