### PR TITLE
feat: lower the Boost minimum to 1.74

### DIFF
--- a/.github/workflows/boost-floor.yml
+++ b/.github/workflows/boost-floor.yml
@@ -21,9 +21,9 @@ name: Boost floor
 # until a separate pull request lowers the default, and that pull request should
 # cite a run of this workflow rather than an argument.
 #
-# continue-on-error while the answer is unknown: this exists to produce
-# evidence, not to turn main red. Promote it to a required job once the floor
-# is settled.
+# The answer came back on 2026-08-16: both jobs build and pass. So the floor is
+# settled, the declared minimum is 1.74, and these jobs are now the thing that
+# keeps it true - they fail the build rather than reporting.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,6 +31,12 @@ concurrency:
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'cmake/**'
+      - 'wirestead/**'
+      - '.github/workflows/boost-floor.yml'
   pull_request:
     paths:
       - 'cmake/**'
@@ -44,7 +50,6 @@ jobs:
   floor:
     name: ${{ matrix.label }} (Boost ${{ matrix.boost }})
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The project prioritizes **API clarity, predictable runtime behavior, and stabili
 
 * **C++20 compiler and standard library**: GCC 10+, recent Clang/libc++, or MSVC 2022 (required)
 * CMake 3.12 or later for plain builds; CMake 3.21 or later for the repository presets
-* Boost 1.83.0 or later. vcpkg is the recommended dependency supplier; OS package manager Boost versions are supported only when they meet this minimum.
+* Boost 1.74.0 or later, which covers the system packages on Ubuntu 22.04 (1.74), RHEL 9 (1.75) and Ubuntu 24.04 (1.83). vcpkg remains the recommended dependency supplier; CI builds against the 1.74 floor as well as current Boost.
 
 ## 📦 Installation
 
@@ -64,7 +64,7 @@ cmake --build --preset dev-linux-x64
 ```
 
 The setup script installs Boost and spdlog through an untracked, repository-local `vcpkg/` checkout by default. Delete that directory any time to reclaim space; rerun the setup script to recreate it. Set `VCPKG_ROOT` before running the script if you want to reuse an external vcpkg checkout.
-CMake remains the version gate and rejects Boost versions older than 1.83.0.
+CMake remains the version gate and rejects Boost versions older than 1.74.0.
 The preset-based contributor workflow uses `CMakePresets.json` schema version 3, so those `cmake --preset ...` commands require CMake 3.21+.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contributor workflow: running tests, `scripts/verify.sh`, commit conventions, and PR expectations.

--- a/cmake/WiresteadDependencies.cmake
+++ b/cmake/WiresteadDependencies.cmake
@@ -7,8 +7,13 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.31" AND POLICY CMP0167)
   cmake_policy(SET CMP0167 OLD)
 endif()
 
+# 1.74 is where Boost.Asio introduced any_io_executor, the newest Asio API this
+# library uses. The number was 1.83 for years because that is what Ubuntu 24.04
+# ships, which is a packaging convenience rather than a floor;
+# .github/workflows/ boost-floor.yml builds and tests against 1.74 and 1.75 so
+# the claim is measured rather than assumed.
 set(WIRESTEAD_MIN_BOOST_VERSION
-    1.83.0
+    1.74.0
     CACHE STRING "Minimum supported Boost version"
 )
 set(WIRESTEAD_MIN_SPDLOG_VERSION

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ installation notes for Wirestead.
 - C++20 compiler
 - CMake 3.12+ for plain builds
 - CMake 3.21+ for repository presets
-- Boost 1.83.0+
+- Boost 1.74.0+
 - spdlog dependency according to build configuration
 
 vcpkg is the recommended dependency supplier. CMake owns the dependency version
@@ -44,9 +44,10 @@ target_compile_features(my_app PRIVATE cxx_std_20)
 
 ## Source build example
 
-Source builds require Boost 1.83.0+. Ubuntu 22.04 and 24.04 system Boost
-packages may be older than this baseline, so prefer the repository development
-setup or provide Boost through vcpkg/custom CMake prefixes before configuring.
+Source builds require Boost 1.74.0+, which the system packages on Ubuntu 22.04
+(1.74), RHEL 9 (1.75) and Ubuntu 24.04 (1.83) all satisfy. vcpkg or a custom
+CMake prefix is still the way to build against a newer Boost than the
+distribution supplies.
 
 For contributor/source builds with the repository-managed vcpkg checkout:
 

--- a/docs/ros2_support_analysis.md
+++ b/docs/ros2_support_analysis.md
@@ -78,7 +78,10 @@ The following ROS-specific capabilities are not yet complete:
 ## Verified build integration
 
 A local smoke test was performed on Ubuntu 24.04 with ROS 2 Jazzy, GCC 13,
-CMake 3.28, and Boost 1.83.
+CMake 3.28, and Boost 1.83. The Boost minimum has since dropped to 1.74, and
+`.github/workflows/boost-floor.yml` builds and tests the floor on Ubuntu 22.04
+(Boost 1.74) and CentOS Stream 9 (Boost 1.75) - the latter being what the ROS
+build farm compiles against for RHEL 9.
 
 The test performed the following operations:
 
@@ -379,7 +382,7 @@ this part is low risk.
 | Lyrical / Ubuntu 26.04 | Recommended current LTS target after dedicated CI validation |
 | Jazzy / Ubuntu 24.04 | Recommended first implementation target; local CMake/colcon smoke test passed |
 | Kilted / Ubuntu 24.04 | Likely low incremental cost while the distribution remains supported |
-| Humble / Ubuntu 22.04 | Not supported with default system Boost unless Wirestead lowers its Boost minimum or vendors Boost 1.83+ |
+| Humble / Ubuntu 22.04 | Buildable with default system Boost since the minimum dropped to 1.74; needs its own CI validation before it is claimed |
 
 ROS 2 Lyrical is supported until May 2031 and targets Ubuntu 26.04. ROS 2 Jazzy
 targets Ubuntu 24.04 and is supported until May 2029. See the ROS 2
@@ -494,9 +497,10 @@ already known to rosdep.
 
 Only add a `wirestead` rosdep key later if Wirestead itself becomes available
 as an accepted native package. Rosdistro strongly prefers native packages and
-warns against overlaying incompatible versions of system libraries. Therefore,
-do not vendor a private Boost 1.83 into Humble merely to obtain a public Humble
-release.
+warns against overlaying incompatible versions of system libraries. Vendoring a
+private Boost into Humble to obtain a public Humble release was rejected for
+that reason, and it is now moot: the Boost minimum is 1.74, which Ubuntu 22.04
+supplies.
 
 Before release, run:
 


### PR DESCRIPTION
## Description

The minimum was **1.83 because that is what Ubuntu 24.04 ships through apt** — a packaging convenience that had hardened into a requirement. The oldest Boost.Asio API this library actually uses is `any_io_executor`, which is **1.74**.

#616 measured it rather than arguing it. Both floor jobs build and pass:

| job | Boost | result |
|---|---|---|
| Ubuntu 22.04 | 1.74.0 | **pass** — 482 unit tests |
| CentOS Stream 9 | 1.75.0 | **pass** — 482 unit tests |

## The C++20 concern that motivated 1.83 does not apply

- Every C++20 item in Asio's changelog between 1.75 and 1.83 is about **coroutines**, which this library does not use (`co_await`, `co_spawn`, `awaitable`, `experimental::` — none present).
- `std::span` never reaches Asio: every call site converts explicitly, `net::buffer(rx_.data(), rx_.size())`.
- Asio 1.75's *"Fixed compatibility with C++20 concept syntax"* was the one plausible hazard, since `builder/ibuilder.hpp` declares four `concept`s in a public header — **and the 1.74 job compiled them without complaint.**

## What this opens

| platform | Boost | consequence |
|---|---|---|
| Ubuntu 22.04 | 1.74 | **ROS 2 Humble**, the most deployed ROS 2 LTS |
| RHEL 9 | 1.75 | Jazzy **Tier 2** on the ROS build farm, which would otherwise have failed at the CMake gate |

`docs/ros2_support_analysis.md` had already identified the Boost minimum as the single thing blocking Humble, and separately **rejected vendoring a private Boost** to get around it. Both entries are updated: Humble is now buildable with system Boost and needs its own CI validation before it is claimed, rather than a workaround.

## Key Changes

- `cmake/WiresteadDependencies.cmake` — `WIRESTEAD_MIN_BOOST_VERSION` 1.83.0 → 1.74.0, with the reasoning next to it
- `README.md`, `docs/installation.md` — the stated requirement, now naming which distributions satisfy it
- `docs/ros2_support_analysis.md` — the Humble row, the vendoring paragraph, and the verified-build note
- `.github/workflows/boost-floor.yml` — `continue-on-error` removed, `push` trigger added. It existed to answer a question; now that the answer is a declared minimum, it is what keeps the declaration true

## Validation

The number reaches consumers through three generated files. All verified against this tree rather than assumed:

```
wiresteadConfig.cmake:44   Boost 1.74.0 REQUIRED COMPONENTS system
CPACK_DEBIAN_PACKAGE_DEPENDS  "libboost-system-dev (>= 1.74.0), ..."
CPACK_RPM_PACKAGE_REQUIRES    "boost-system >= 1.74.0, ..."
```

`./scripts/verify.sh` passes.

## Type of Change

- [x] **New Feature**: A non-breaking change that adds new functionality. *(widens supported platforms; nothing is removed)*

## Additional Context

This lowers a floor rather than raising one, so no existing consumer can break: anyone who satisfied 1.83 still satisfies 1.74.

Follow-up worth doing separately: ROS 2 Humble is now *buildable*, but `wirestead-ros` CI only covers Jazzy. Claiming Humble should wait for a Humble job there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS