### PR TITLE
docs: record the two changes that landed after v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
+## Unreleased
+
+### Changed
+
+- The minimum supported Boost version is now **1.74**, down from 1.83.
+
+  1.83 was never an API floor - it is what Ubuntu 24.04 ships through apt, and
+  the number had hardened into a requirement. The oldest Boost.Asio API this
+  library uses is `any_io_executor`, which is 1.74. The C++20 concern behind the
+  higher number does not apply either: every C++20 entry in Asio's changelog
+  between 1.75 and 1.83 is about coroutines, which Wirestead does not use, and
+  `std::span` never reaches Asio because every call site converts to pointer and
+  size explicitly.
+
+  This is measured rather than argued. `.github/workflows/boost-floor.yml`
+  builds and runs the unit suite against Boost 1.74 on Ubuntu 22.04 and Boost
+  1.75 on CentOS Stream 9, and is a required job so the floor stays true.
+
+  Nothing breaks by lowering a floor - anyone who satisfied 1.83 satisfies 1.74.
+  What it opens is two platforms that were shut out: Ubuntu 22.04, and so ROS 2
+  Humble, and RHEL 9, which the ROS build farm compiles for.
+
+- `WIRESTEAD_BUILD_TESTS` now defaults to **OFF**.
+
+  Building tests pulls GoogleTest through `FetchContent`, which clones at
+  configure time, so the old default meant a build that never asked for tests
+  still needed the network. Packaging environments all passed `OFF` explicitly
+  already - vcpkg, the Conan recipe, the ROS integration CI - but Bloom
+  generates its Debian rules from `package.xml` without knowing the option
+  exists, and would have failed offline on the ROS build farm.
+
+  If you build from source and want the tests, pass `-DWIRESTEAD_BUILD_TESTS=ON`.
+  Every preset in `CMakePresets.json` and `scripts/verify.sh` already does.
+
 ## v0.9.4 - 2026-08-16
 
 ### Added

--- a/docs/ros2_support_analysis.md
+++ b/docs/ros2_support_analysis.md
@@ -21,8 +21,9 @@ The implementation assessment is:
 - **Prototype and client-only MVP: relatively straightforward**
 - **Lifecycle-aware bridge for every transport: moderate effort**
 - **Release-quality ROS distribution support: moderate to high effort**
-- **ROS 2 Humble support with system dependencies: difficult with the current
-  Boost requirement**
+- **ROS 2 Humble support with system dependencies: available since the Boost
+  minimum dropped to 1.74; CI builds it, and claiming support is now a
+  validation question rather than a dependency one**
 
 The communication engine does not need to be rewritten. Production drivers
 should link Wirestead directly and publish semantic ROS messages. A generic raw
@@ -382,7 +383,7 @@ this part is low risk.
 | Lyrical / Ubuntu 26.04 | Recommended current LTS target after dedicated CI validation |
 | Jazzy / Ubuntu 24.04 | Recommended first implementation target; local CMake/colcon smoke test passed |
 | Kilted / Ubuntu 24.04 | Likely low incremental cost while the distribution remains supported |
-| Humble / Ubuntu 22.04 | Buildable with default system Boost since the minimum dropped to 1.74; needs its own CI validation before it is claimed |
+| Humble / Ubuntu 22.04 | Builds and tests green in `wirestead-ros` CI since the Boost minimum dropped to 1.74; the row is still marked experimental there until it has been stable for a while |
 
 ROS 2 Lyrical is supported until May 2031 and targets Ubuntu 26.04. ROS 2 Jazzy
 targets Ubuntu 24.04 and is supported until May 2029. See the ROS 2
@@ -405,7 +406,7 @@ on Ubuntu 26.04. The successful local result applies only to Jazzy on Ubuntu
 | Framing parameters | Medium | Existing framers help, but parameter validation and protocol contracts are required |
 | Diagnostics | Low to medium | Runtime counters already exist; ROS mapping and update scheduling remain |
 | ROS build-farm release | Medium to high | Vendor packaging, rosdep, bloom, and per-distribution CI are new |
-| Humble compatibility | High | Ubuntu 22.04 system Boost is below Wirestead's current minimum |
+| Humble compatibility | Low | Resolved: the Boost minimum is 1.74, which Ubuntu 22.04 supplies, and `wirestead-ros` CI builds and tests Humble |
 
 Overall, the adapter is technically feasible and does not reveal a core API
 blocker. A client-only MVP is straightforward. Production support becomes more


### PR DESCRIPTION
## Description

The tag closed the `Unreleased` section, and **two user-visible changes have merged since with nothing in the changelog to show for them**. Both change what a source build does, so neither is an internal detail.

## Key Changes

`CHANGELOG.md` gains an `## Unreleased` section with:

**Boost minimum 1.83 → 1.74** (#617). A floor that moves down cannot break an existing consumer, but it is the reason Ubuntu 22.04 and RHEL 9 became buildable. The entry records that the number was *packaging inertia rather than an API requirement*, so it does not drift back up unexamined, and points at the CI that keeps it honest.

**`WIRESTEAD_BUILD_TESTS` defaults to OFF** (#615). Smaller and easier to trip over: anyone building from source who expected `ctest` to find tests now has to ask for them. The entry says how.

`docs/ros2_support_analysis.md` — two claims the same work made false:

- the executive summary calling Humble *"difficult with the current Boost requirement"*
- a risk-table row rating **Humble compatibility: High** for the same reason

Humble now builds and tests green in `wirestead-ros` CI (wirestead-ros#9), so both are corrected rather than left to mislead the next reader of that document.

## Validation

`./scripts/verify.sh` passes.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Additional Context

Found by asking what the release left behind rather than by a failure. The changelog gap is the kind that only shows up at the *next* release, when someone writes release notes from a section that was never filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS