### PR TITLE
docs: Humble is a required CI row, not an experimental one

### DIFF
--- a/docs/ros2_support_analysis.md
+++ b/docs/ros2_support_analysis.md
@@ -383,7 +383,7 @@ this part is low risk.
 | Lyrical / Ubuntu 26.04 | Recommended current LTS target after dedicated CI validation |
 | Jazzy / Ubuntu 24.04 | Recommended first implementation target; local CMake/colcon smoke test passed |
 | Kilted / Ubuntu 24.04 | Likely low incremental cost while the distribution remains supported |
-| Humble / Ubuntu 22.04 | Builds and tests green in `wirestead-ros` CI since the Boost minimum dropped to 1.74; the row is still marked experimental there until it has been stable for a while |
+| Humble / Ubuntu 22.04 | Supported: a required `wirestead-ros` CI row since the Boost minimum dropped to 1.74, and a source entry in ros/rosdistro |
 
 ROS 2 Lyrical is supported until May 2031 and targets Ubuntu 26.04. ROS 2 Jazzy
 targets Ubuntu 24.04 and is supported until May 2029. See the ROS 2


### PR DESCRIPTION
## Description

The platform table in `docs/ros2_support_analysis.md` still said the Humble row was experimental *"until it has been stable for a while"*. It has been — four consecutive green runs, two on `main` — and [wirestead-ros#11](https://github.com/wirestead/wirestead-ros/pull/11) made it required, because [ros/rosdistro#53281](https://github.com/ros/rosdistro/pull/53281) now carries a Humble source entry that the job is what defends.

## Key Changes

- `docs/ros2_support_analysis.md` — the Humble platform row

## Type of Change

- [x] **Documentation**: Changes to documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS