### PR TITLE
chore: release 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
-## Unreleased
+## v0.9.5 - 2026-08-16
 
 ### Changed
 
@@ -39,6 +39,30 @@ and ABI policy.
 
   If you build from source and want the tests, pass `-DWIRESTEAD_BUILD_TESTS=ON`.
   Every preset in `CMakePresets.json` and `scripts/verify.sh` already does.
+
+### Compatibility
+
+- **Release this rather than v0.9.4 if you are packaging Wirestead for a
+  distribution.** v0.9.4 shipped before both changes above, so a build from that
+  tag still requires Boost 1.83 and still fetches GoogleTest at configure time.
+  A ROS build farm, which builds offline against Ubuntu 22.04's Boost 1.74,
+  fails on both counts. vcpkg, Conan and PyPI are unaffected, since each of them
+  supplies a recent Boost and passes `WIRESTEAD_BUILD_TESTS=OFF` explicitly.
+
+- **A patch release that changes one default.** `docs/api_stability.md` says
+  patch releases *should* avoid that, and `WIRESTEAD_BUILD_TESTS` moving from ON
+  to OFF is the exception, named here rather than left to be discovered. It
+  changes what a plain `cmake` build produces, not what the library does at
+  runtime.
+
+- Lowering the Boost minimum cannot break an existing consumer: anyone who
+  satisfied 1.83 satisfies 1.74. The generated `wiresteadConfig.cmake`, the
+  Debian dependency string and the RPM one all now read 1.74.0.
+
+- No public API changed and no symbol was removed.
+
+- Consumers must rebuild, as for any pre-1.0 release; see
+  `docs/api_stability.md`.
 
 ## v0.9.4 - 2026-08-16
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ the ROS release tooling, which reads reStructuredText. ``CHANGELOG.md`` remains
 the full changelog and covers every release, including the ones before this
 file existed.
 
+0.9.5 (2026-08-16)
+------------------
+* Lower the minimum Boost version to 1.74, which is what Ubuntu 22.04 supplies,
+  so the library builds on ROS 2 Humble and on RHEL 9.
+* Build tests only when asked. ``WIRESTEAD_BUILD_TESTS`` now defaults to OFF, so
+  a package build no longer downloads GoogleTest at configure time.
+* First release a ROS build farm can build; v0.9.4 predates both changes.
+* Contributors: Jinwoo Sung
+
 0.9.4 (2026-08-16)
 ------------------
 * Add optional TLS for the TCP client and server, off by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(
   wirestead
-  VERSION 0.9.4
+  VERSION 0.9.5
   DESCRIPTION "Robust, simple, cross-platform async C++ communication library"
   HOMEPAGE_URL "https://github.com/wirestead/wirestead"
   LANGUAGES CXX

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>wirestead</name>
-  <version>0.9.4</version>
+  <version>0.9.5</version>
   <description>Cross-platform asynchronous C++ communication library for serial, TCP, UDP, and UDS transports.</description>
 
   <maintainer email="jwsung91@gmail.com">Jinwoo Sung</maintainer>


### PR DESCRIPTION
## Description

**v0.9.4 cannot be packaged for a distribution**, and that is the reason for this release rather than any new feature.

It shipped before both changes below, so a build from that tag still requires Boost 1.83 and still fetches GoogleTest at configure time:

```
v0.9.4:cmake/WiresteadDependencies.cmake  →  WIRESTEAD_MIN_BOOST_VERSION 1.83.0
v0.9.4:cmake/WiresteadOptions.cmake       →  WIRESTEAD_BUILD_TESTS "Build tests" ON
v0.9.4:CHANGELOG.rst                      →  absent
```

A ROS build farm builds **offline** against Ubuntu 22.04's Boost 1.74 and fails on both counts — Jazzy as well as Humble, since the GoogleTest fetch is distribution-independent. Bloom releases a *tag*, not `main`, so this had to be a new version.

## Key Changes

- `CMakeLists.txt`, `package.xml` — 0.9.4 → 0.9.5
- `CHANGELOG.md` — `## Unreleased` closed as `## v0.9.5 - 2026-08-16`, plus a Compatibility section
- `CHANGELOG.rst` — the 0.9.5 entry, verified with `catkin_pkg`'s parser rather than by eye

Contents are the two changes already recorded under Unreleased: the Boost minimum dropping to **1.74**, and `WIRESTEAD_BUILD_TESTS` defaulting to **OFF**.

## Who needs this release

| channel | affected by v0.9.4's gaps |
|---|---|
| ROS build farm (bloom) | **yes** — would fail before compiling |
| Source build on Ubuntu 22.04 / RHEL 9 | **yes** — Boost gate |
| vcpkg, Conan, PyPI | no — each supplies a recent Boost and passes `WIRESTEAD_BUILD_TESTS=OFF` |

## Patch rather than minor

Same reasoning as v0.9.4: the one default that changes is a **build option** rather than library behaviour, and it is named as an exception in Compatibility instead of being left to be discovered. Lowering the Boost floor cannot break an existing consumer — anyone who satisfied 1.83 satisfies 1.74.

## Validation

`./scripts/verify.sh` passes. The version reaches the generated metadata: `build/wirestead.pc` reports `Version: 0.9.5`.

## Type of Change

- [x] **Documentation**: version metadata and changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS