### PR TITLE
docs: how to pick a framer, and how to receive multicast

### DIFF
--- a/docs/callbacks.md
+++ b/docs/callbacks.md
@@ -68,6 +68,36 @@ client->on_message([&](const wirestead::MessageContext& ctx) {
 This is transport arrival, not a kernel or hardware timestamp: it includes
 whatever the kernel spent before the read completed.
 
+## Choosing a framer
+
+`on_message()` needs a framer, and which one is not a style choice:
+
+| framer | splits on | use when |
+| --- | --- | --- |
+| `use_line_framer(delim)` | a delimiter, `\n` by default | text-line protocols |
+| `use_packet_framer(start, end, max)` | a start and end byte pattern | the payload cannot contain the end pattern |
+| `use_length_prefix_framer(bytes, endian, max)` | a length prefix, 2 bytes big-endian by default | binary payloads |
+
+`use_packet_framer()` does no escaping. The **first** occurrence of the end
+pattern ends the frame, wherever it falls, so a binary payload that happens to
+contain those bytes is truncated — and the byte counters still balance, so
+nothing anywhere reports an error. The reader sees a short message and has no
+way to tell it from a real one.
+
+`use_length_prefix_framer()` has no special byte values: the length says how
+many bytes to collect, so the payload may hold anything.
+
+```cpp
+.use_length_prefix_framer(4)   // 4-byte big-endian length, excluding the prefix
+.on_message([](const wirestead::MessageContext& ctx) { /* ... */ })
+```
+
+Its own limit is the mirror image: there is no sync word, so it cannot
+resynchronise and needs a stream that starts on a frame boundary. That is the
+normal case for TCP and UDS, and wrong for a serial line joined mid-stream —
+there, a framer with a sync word is what you want, which
+`builder/ibuilder.hpp`'s `framer(factory)` lets you supply.
+
 ## Do not call a blocking send from within a callback
 
 `on_data`/`on_message` (and every other) callback runs on the channel's own

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -59,6 +59,30 @@ arrival time does not matter. Unlike everything else on this page, this one is
 worth setting without a measurement first: nothing else in the library recovers
 16 ms.
 
+## Receiving a multicast stream
+
+`multicast_group(address)` on the UDP builders joins that group after bind, so
+the socket receives what the group sends. Lidar and camera streams are usually
+published this way, and nothing else in the API substitutes for it:
+`broadcast(true)` sets `SO_BROADCAST` on the **send** side and has no effect on
+what arrives.
+
+```cpp
+auto receiver = wirestead::udp_server(2368)
+                    .multicast_group("239.255.0.1")
+                    .on_data([](auto&& ctx) { /* ... */ })
+                    .build();
+```
+
+A failed join fails `start()` rather than being logged and ignored. That is
+deliberate: a socket that silently did not join is indistinguishable from a
+sensor that stopped sending, and the whole point of the feature is to tell
+those apart.
+
+Sending to a group needs no join — set `remote_address` to the group address.
+The TTL is 1, so it stays on the local subnet, which is where a robot's sensors
+are.
+
 ## Detecting a sensor that went quiet
 
 `RuntimeStats::last_receive_age_ms` is milliseconds since bytes last arrived,


### PR DESCRIPTION
## Description

Two features shipped in v0.9.4 with **no prose anywhere in `docs/`** — only header comments and a changelog entry.

## `use_length_prefix_framer()` → `docs/callbacks.md`

It exists because `use_packet_framer()` cannot carry a binary payload: it does no escaping, so the **first** occurrence of its end pattern ends the frame wherever it falls. The payload is truncated, every byte counter still balances, and the reader sees a short message with nothing anywhere reporting an error.

#602 put that warning on `PacketFramer`'s own doc comment — which is not where someone *choosing* a framer looks first. `callbacks.md` now carries the comparison right next to `on_message()`, which is the call that needs a framer:

| framer | splits on | use when |
| --- | --- | --- |
| `use_line_framer(delim)` | a delimiter | text-line protocols |
| `use_packet_framer(start, end, max)` | a start/end byte pattern | the payload cannot contain the end pattern |
| `use_length_prefix_framer(bytes, endian, max)` | a length prefix | binary payloads |

Including the length-prefix framer's mirror-image limit: no sync word, so it cannot resynchronise and needs a stream that starts on a frame boundary.

## `multicast_group()` → `docs/tuning.md`

Same problem, worse failure mode: **nothing else in the API substitutes for it.** `broadcast(true)` is a send-side socket option, so a reader who never finds `multicast_group()` concludes the library cannot receive a lidar or camera stream at all.

The section says what it does, why a failed join **fails `start()`** rather than being logged and ignored — a socket that silently did not join is indistinguishable from a sensor that stopped sending — and that sending to a group needs no join.

## Validation

Both examples were **compiled against an installed build** rather than written from memory: installed the library to a prefix, built a consumer that calls `udp_server(...).multicast_group(...)` and `tcp_client(...).use_length_prefix_framer(4).on_message(...)`, and linked it.

`./scripts/verify.sh` passes.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Additional Context

Companion to wirestead-docs#20, which fixes the same gap on the user-facing site — where `requirements.md` additionally still claimed Boost 1.83.0+ was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS