### PR TITLE
docs: write down which repository answers which question

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,29 @@
 # Wirestead Core Documentation
 
-This core repository keeps minimal documentation entrypoints for source users,
-package consumers, migration users, and release maintainers.
+## What lives here, and what lives on the site
+
+Wirestead's documentation is split across two repositories, and the split is by
+**question**, not by topic:
+
+| | this directory | [wirestead-docs](https://github.com/wirestead/wirestead-docs) |
+| --- | --- | --- |
+| answers | *how does this behave, and why* | *how do I use this* |
+| examples | the callback data lifetime, the error model, the threat model, what a tuning knob costs | quick start, installation, the API guide, the transport matrix, troubleshooting |
+| reader | someone who has to reason about behaviour, and contributors | someone building an application |
+
+Three documents deliberately exist in both: `quickstart.md`,
+`installation.md` and `api_stability.md`. The release checklist requires this
+repository to carry them, so a reader who arrives at the source has something
+to stand on. The versions here are **minimal on purpose**; the site's are the
+extended ones, and neither should grow into the other.
+
+API signatures are in neither. Doxygen generates those from these headers, so
+they cannot go stale, and prose that repeats a signature only creates something
+to keep in sync.
+
+When a public API changes, `scripts/check_docs_coverage.sh` lists what has no
+mention on either side. It exists because two releases shipped eight APIs that
+neither had.
 
 ## Core entrypoints
 
@@ -16,3 +38,9 @@ package consumers, migration users, and release maintainers.
 - [ROS 2 Support Analysis](ros2_support_analysis.md)
 - [Migrating from Unilink](migration-from-unilink.md)
 - [Release Checklist](release_checklist.md)
+
+## Extended user documentation
+
+Quick start tutorials, the full API guide, the transport feature matrix,
+troubleshooting and platform requirements live on the site:
+<https://wirestead.github.io/wirestead-docs/>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,9 @@
 # Quick Start
 
-This repository contains the minimal Wirestead quickstart. Extended tutorials
-remain in the external documentation repository until that repository is moved.
+This is the minimal quickstart, kept here so the source repository stands on its
+own. The extended tutorial lives on the [documentation
+site](https://wirestead.github.io/wirestead-docs/). That split is deliberate
+rather than temporary - see `docs/README.md`.
 
 ## Minimal CMake
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -43,7 +43,12 @@ CI, CPack, and consumer smoke workflows live here.
   - [ ] `docs/quickstart.md`
   - [ ] `docs/api_stability.md`
   - [ ] `docs/release_checklist.md`
-- [ ] `wirestead-docs` is updated when public API or behavior changes.
+- [ ] `wirestead-docs` is updated when public API or behavior changes. Verified
+      with `scripts/check_docs_coverage.sh <previous-tag>`, which lists public
+      API added since that tag with no mention in either this repository's
+      `docs/` or the documentation site. This box was tickable without checking
+      before, and was ticked for two releases that added eight undocumented
+      APIs.
 - [ ] Doxygen workflow in `wirestead-docs` passes.
 
 ## Benchmark / validation

--- a/scripts/check_docs_coverage.sh
+++ b/scripts/check_docs_coverage.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Lists public API added since a tag that no user-facing documentation mentions.
+#
+# The release checklist asks whether wirestead-docs was updated when the public
+# API changed. That box was tickable without checking, and it was ticked while
+# v0.9.4 and v0.9.5 added eight APIs the documentation site never mentioned. So
+# this answers the question mechanically instead of asking a human to remember.
+#
+#   scripts/check_docs_coverage.sh [since-tag] [path-to-wirestead-docs]
+#
+# With no docs path it does a shallow clone into a temporary directory. Both
+# this repository's docs/ and the site are searched: an API documented in either
+# is reported as covered, since the two split the work between them.
+#
+# The extraction is deliberately crude - it reports identifiers, not semantics -
+# so expect entries that need no prose. Read the list, do not obey it.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+SINCE="${1:-$(git describe --tags --abbrev=0 2>/dev/null || echo "")}"
+DOCS_PATH="${2:-}"
+
+if [ -z "$SINCE" ]; then
+  echo "No tag to compare against. Pass one explicitly." >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify "$SINCE" >/dev/null 2>&1; then
+  echo "Not a valid ref: $SINCE" >&2
+  exit 2
+fi
+
+CLEANUP_DIR=""
+if [ -z "$DOCS_PATH" ]; then
+  CLEANUP_DIR="$(mktemp -d)"
+  trap 'rm -rf "$CLEANUP_DIR"' EXIT
+  echo "Cloning wirestead-docs..." >&2
+  git clone --depth 1 --quiet https://github.com/wirestead/wirestead-docs.git \
+    "$CLEANUP_DIR/docs" 2>/dev/null || {
+      echo "Could not clone wirestead-docs; pass a local checkout as the second argument." >&2
+      exit 2
+    }
+  DOCS_PATH="$CLEANUP_DIR/docs"
+fi
+
+if [ ! -d "$DOCS_PATH" ]; then
+  echo "Not a directory: $DOCS_PATH" >&2
+  exit 2
+fi
+
+# Identifiers introduced on added lines of the headers a user actually calls -
+# builders, wrappers, framers, the concurrency hook, shared base types. Transport
+# and interface headers are excluded on purpose: they are full of internals whose
+# names would drown the signal, and nothing there is API a reader looks up.
+#
+# Names ending in an underscore are dropped as member variables by convention.
+# The file list is built first and filtered to headers, rather than passed to
+# git diff as a glob: 'dir/**/*.hpp' does not match 'dir/x.hpp' in a git
+# pathspec, which silently skipped every builder header on the first attempt.
+mapfile -t HEADERS < <(
+  git diff --name-only "$SINCE"..HEAD -- \
+      wirestead/builder wirestead/wrapper wirestead/framer \
+      wirestead/concurrency wirestead/base |
+    grep '\.hpp$'
+)
+
+if [ ${#HEADERS[@]} -eq 0 ]; then
+  echo "No user-facing headers changed since $SINCE."
+  exit 0
+fi
+
+mapfile -t NAMES < <(
+  git diff "$SINCE"..HEAD -- "${HEADERS[@]}" |
+    grep '^+' | grep -v '^+++' |
+    grep -oE '\b[a-z_][a-z0-9_]{3,}\s*\(' |
+    tr -d ' (' |
+    grep -vE '_$' |
+    grep -vE '^(if|for|while|switch|return|sizeof|catch|and|or|not|else|case|throw|delete|decltype|static_cast|reinterpret_cast|const_cast|dynamic_cast|make_shared|make_unique|move|forward|size|data|empty|begin|end|value|count|find|push_back|emplace_back|lock|unlock|load|store|get|set)$' |
+    sort -u
+)
+
+if [ ${#NAMES[@]} -eq 0 ]; then
+  echo "No new public API identifiers since $SINCE."
+  exit 0
+fi
+
+missing=()
+for name in "${NAMES[@]}"; do
+  if grep -rqw "$name" docs/ README.md 2>/dev/null; then continue; fi
+  if grep -rqw "$name" "$DOCS_PATH" --include='*.md' 2>/dev/null; then continue; fi
+  missing+=("$name")
+done
+
+echo "Public API identifiers added since $SINCE: ${#NAMES[@]}"
+echo "Documented in this repository's docs/ or in wirestead-docs: $(( ${#NAMES[@]} - ${#missing[@]} ))"
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo
+  echo "Nothing undocumented."
+  exit 0
+fi
+
+echo
+echo "No mention anywhere:"
+printf '  %s\n' "${missing[@]}"
+echo
+echo "Each of these is either an API that needs prose or a false positive from"
+echo "the crude extraction. Decide per entry; do not bulk-document them."
+exit 1


### PR DESCRIPTION
## Description

The split between `docs/` here and `wirestead-docs` was **real but unwritten**, which is how three documents came to exist in both, and how the site ended up carrying a stale fork of a checklist this repository declares itself to own.

## Key Changes

**`docs/README.md`** — the rule, stated once:

| | this directory | wirestead-docs |
|---|---|---|
| answers | *how does this behave, and why* | *how do I use this* |
| examples | callback data lifetime, error model, threat model, what a tuning knob costs | quick start, installation, API guide, transport matrix, troubleshooting |
| reader | someone reasoning about behaviour, and contributors | someone building an application |

API signatures belong to **neither**: Doxygen generates them from these headers, and prose that repeats a signature only creates something to keep in sync.

The three documents that exist in both — `quickstart.md`, `installation.md`, `api_stability.md` — stay, and **the reason is written down rather than left looking like an accident**: the release checklist requires this repository to carry them, so a reader arriving at the source has something to stand on. The versions here are minimal on purpose; neither side should grow into the other.

**`docs/quickstart.md`** — it said extended tutorials live on the site *"until that repository is moved"*. No such move is planned, and a temporary-sounding note is exactly what lets a reader assume the split will resolve itself and write in whichever place is nearest. It now says the split is deliberate and points at the rule.

## Validation

`./scripts/verify.sh` passes.

## Type of Change

- [x] **Documentation**: Changes to documentation only.

## Additional Context

Written from both sides: wirestead-docs#21 states the same boundary there and removes the forked checklist — 72 lines against the 103 here, missing the verification step #624 adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU3HbkfikSqr2CGDocJ3tS