### PR TITLE
feat: read back the configured backpressure settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ This project follows the Keep a Changelog section names where practical. The
 core C++ API is still pre-1.0; see `docs/api_stability.md` for compatibility
 and ABI policy.
 
+## Unreleased
+
+### Added
+
+- `backpressure_threshold()` and `backpressure_strategy()` on `Serial`,
+  `TcpClient`, `TcpServer`, `UdpClient`, `UdpServer`, `UdsClient`, and
+  `UdsServer`.
+
+  ```cpp
+  server.backpressure_threshold(8192);
+  const size_t configured = server.backpressure_threshold();  // 8192
+  ```
+
+  Both settings were write-only. The setters have been there all along, but
+  nothing read them back, so a caller could not log the configuration it was
+  running under, round-trip it, or assert on it from a test without tracking
+  the value separately alongside the transport.
+
+  v0.9.4 added `RuntimeStats` because backpressure could be configured with no
+  way to observe what it produced. That covered the runtime half; the setting
+  itself stayed unreadable. This covers the other half.
+
+  The Python bindings raised `AttributeError: backpressure_threshold is
+  write-only` on read for the same reason, and can now expose real properties.
+
 ## v0.9.5 - 2026-08-16
 
 ### Changed

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -146,6 +146,7 @@ foreach(
   test_error_context_builder.cc
   test_message_context.cc
   test_batch_latency_flush.cc
+  test_backpressure_getters.cc
 )
   get_filename_component(test_name ${test_file} NAME_WE)
 

--- a/test/unit/wrapper/test_backpressure_getters.cc
+++ b/test/unit/wrapper/test_backpressure_getters.cc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Jinwoo Sung
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The backpressure setters are spread across five different storage shapes:
+// a plain member, a std::atomic member, and a field on an embedded config
+// struct, guarded by either the impl mutex or by the atomic itself. Each getter
+// has to match the shape its own class uses, so every transport is covered
+// here rather than one representative.
+
+#include <gtest/gtest.h>
+
+#include "wirestead/base/constants.hpp"
+#include "wirestead/config/udp_config.hpp"
+#include "wirestead/wrapper/serial/serial.hpp"
+#include "wirestead/wrapper/tcp_client/tcp_client.hpp"
+#include "wirestead/wrapper/tcp_server/tcp_server.hpp"
+#include "wirestead/wrapper/udp/udp.hpp"
+#include "wirestead/wrapper/udp/udp_server.hpp"
+#include "wirestead/wrapper/uds_client/uds_client.hpp"
+#include "wirestead/wrapper/uds_server/uds_server.hpp"
+
+using namespace wirestead;
+using base::constants::BackpressureStrategy;
+using base::constants::DEFAULT_BACKPRESSURE_THRESHOLD;
+
+namespace wirestead {
+namespace test {
+namespace {
+
+// Reads back what was set, and reports the documented default before any set.
+template <typename T>
+void CheckRoundTrip(T& transport) {
+  EXPECT_EQ(transport.backpressure_threshold(), DEFAULT_BACKPRESSURE_THRESHOLD);
+  EXPECT_EQ(transport.backpressure_strategy(), BackpressureStrategy::Reliable);
+
+  transport.backpressure_threshold(4096);
+  EXPECT_EQ(transport.backpressure_threshold(), 4096u);
+
+  transport.backpressure_strategy(BackpressureStrategy::BestEffort);
+  EXPECT_EQ(transport.backpressure_strategy(), BackpressureStrategy::BestEffort);
+
+  // Setters chain, so the getter must survive a chained call.
+  transport.backpressure_threshold(8192).backpressure_strategy(BackpressureStrategy::Reliable);
+  EXPECT_EQ(transport.backpressure_threshold(), 8192u);
+  EXPECT_EQ(transport.backpressure_strategy(), BackpressureStrategy::Reliable);
+}
+
+}  // namespace
+
+TEST(BackpressureGettersTest, Serial) {
+  wrapper::Serial s("/dev/null", 9600);
+  CheckRoundTrip(s);
+}
+
+TEST(BackpressureGettersTest, TcpClient) {
+  wrapper::TcpClient c("127.0.0.1", 9000);
+  CheckRoundTrip(c);
+}
+
+TEST(BackpressureGettersTest, TcpServer) {
+  wrapper::TcpServer s(0);
+  CheckRoundTrip(s);
+}
+
+TEST(BackpressureGettersTest, UdpClient) {
+  config::UdpConfig cfg;
+  cfg.remote_address = "127.0.0.1";
+  cfg.remote_port = 9000;
+  wrapper::UdpClient c(cfg);
+  CheckRoundTrip(c);
+}
+
+TEST(BackpressureGettersTest, UdpServer) {
+  wrapper::UdpServer s(0);
+  CheckRoundTrip(s);
+}
+
+TEST(BackpressureGettersTest, UdsClient) {
+  wrapper::UdsClient c("/tmp/wirestead-backpressure-getters.sock");
+  CheckRoundTrip(c);
+}
+
+TEST(BackpressureGettersTest, UdsServer) {
+  wrapper::UdsServer s("/tmp/wirestead-backpressure-getters.sock");
+  CheckRoundTrip(s);
+}
+
+}  // namespace test
+}  // namespace wirestead

--- a/wirestead/wrapper/serial/serial.cc
+++ b/wirestead/wrapper/serial/serial.cc
@@ -805,6 +805,16 @@ Serial& Serial::backpressure_strategy(base::constants::BackpressureStrategy stra
   return *this;
 }
 
+size_t Serial::backpressure_threshold() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_threshold;
+}
+
+base::constants::BackpressureStrategy Serial::backpressure_strategy() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_strategy;
+}
+
 config::SerialConfig Serial::build_config() const {
   std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
   return impl_->build_config_locked();

--- a/wirestead/wrapper/serial/serial.hpp
+++ b/wirestead/wrapper/serial/serial.hpp
@@ -132,6 +132,11 @@ class WIRESTEAD_API Serial : public ChannelInterface {
   Serial& retry_interval(std::chrono::milliseconds interval);
   Serial& backpressure_threshold(size_t threshold);
   Serial& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   Serial& manage_external_context(bool manage);
   Serial& batch_size(size_t size);
   Serial& batch_latency(std::chrono::milliseconds latency);

--- a/wirestead/wrapper/tcp_client/tcp_client.cc
+++ b/wirestead/wrapper/tcp_client/tcp_client.cc
@@ -770,6 +770,16 @@ TcpClient& TcpClient::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t TcpClient::backpressure_threshold() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_threshold_;
+}
+
+base::constants::BackpressureStrategy TcpClient::backpressure_strategy() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_strategy_;
+}
+
 TcpClient& TcpClient::tcp_no_delay(bool enable) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->tcp_no_delay_ = enable;

--- a/wirestead/wrapper/tcp_client/tcp_client.hpp
+++ b/wirestead/wrapper/tcp_client/tcp_client.hpp
@@ -124,6 +124,11 @@ class WIRESTEAD_API TcpClient : public ChannelInterface {
   TcpClient& idle_timeout_action(IdleTimeoutAction action);
   TcpClient& backpressure_threshold(size_t threshold);
   TcpClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   // Socket-option setters below have no live/runtime effect on an already-open
   // socket: they stage a value that is only applied the next time start()
   // builds a fresh connection (e.g. after stop() + start() again). Calling

--- a/wirestead/wrapper/tcp_server/tcp_server.cc
+++ b/wirestead/wrapper/tcp_server/tcp_server.cc
@@ -742,6 +742,12 @@ TcpServer& TcpServer::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t TcpServer::backpressure_threshold() const { return impl_->backpressure_threshold_.load(); }
+
+base::constants::BackpressureStrategy TcpServer::backpressure_strategy() const {
+  return impl_->backpressure_strategy_.load();
+}
+
 TcpServer& TcpServer::tcp_no_delay(bool enable) {
   impl_->tcp_no_delay_.store(enable);
   return *this;

--- a/wirestead/wrapper/tcp_server/tcp_server.hpp
+++ b/wirestead/wrapper/tcp_server/tcp_server.hpp
@@ -115,6 +115,11 @@ class WIRESTEAD_API TcpServer : public ServerInterface {
   TcpServer& max_clients(size_t max);
   TcpServer& backpressure_threshold(size_t threshold);
   TcpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   TcpServer& tcp_no_delay(bool enable = true);
   TcpServer& keep_alive(bool enable = true);
   /**

--- a/wirestead/wrapper/udp/udp.cc
+++ b/wirestead/wrapper/udp/udp.cc
@@ -665,6 +665,16 @@ UdpClient& UdpClient::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t UdpClient::backpressure_threshold() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->cfg.backpressure_threshold;
+}
+
+base::constants::BackpressureStrategy UdpClient::backpressure_strategy() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->cfg.backpressure_strategy;
+}
+
 UdpClient& UdpClient::send_buffer_size(size_t bytes) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex_);
   impl_->cfg.send_buffer_size = bytes;

--- a/wirestead/wrapper/udp/udp.hpp
+++ b/wirestead/wrapper/udp/udp.hpp
@@ -92,6 +92,11 @@ class WIRESTEAD_API UdpClient : public ChannelInterface {
 
   UdpClient& backpressure_threshold(size_t threshold);
   UdpClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   UdpClient& send_buffer_size(size_t bytes);
   UdpClient& receive_buffer_size(size_t bytes);
   UdpClient& manage_external_context(bool manage);

--- a/wirestead/wrapper/udp/udp_server.cc
+++ b/wirestead/wrapper/udp/udp_server.cc
@@ -769,6 +769,16 @@ UdpServer& UdpServer::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t UdpServer::backpressure_threshold() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex);
+  return impl_->cfg.backpressure_threshold;
+}
+
+base::constants::BackpressureStrategy UdpServer::backpressure_strategy() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex);
+  return impl_->cfg.backpressure_strategy;
+}
+
 UdpServer& UdpServer::send_buffer_size(size_t bytes) {
   std::unique_lock<std::shared_mutex> lock(impl_->mutex);
   impl_->cfg.send_buffer_size = bytes;

--- a/wirestead/wrapper/udp/udp_server.hpp
+++ b/wirestead/wrapper/udp/udp_server.hpp
@@ -99,6 +99,11 @@ class WIRESTEAD_API UdpServer : public ServerInterface {
   UdpServer& max_clients(size_t max);
   UdpServer& backpressure_threshold(size_t threshold);
   UdpServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   UdpServer& send_buffer_size(size_t bytes);
   UdpServer& receive_buffer_size(size_t bytes);
   UdpServer& manage_external_context(bool manage);

--- a/wirestead/wrapper/uds_client/uds_client.cc
+++ b/wirestead/wrapper/uds_client/uds_client.cc
@@ -716,6 +716,16 @@ UdsClient& UdsClient::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t UdsClient::backpressure_threshold() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_threshold_;
+}
+
+base::constants::BackpressureStrategy UdsClient::backpressure_strategy() const {
+  std::shared_lock<std::shared_mutex> lock(impl_->mutex_);
+  return impl_->backpressure_strategy_;
+}
+
 UdsClient& UdsClient::manage_external_context(bool manage) {
   impl_->manage_external_context_.store(manage);
   return *this;

--- a/wirestead/wrapper/uds_client/uds_client.hpp
+++ b/wirestead/wrapper/uds_client/uds_client.hpp
@@ -106,6 +106,11 @@ class WIRESTEAD_API UdsClient : public ChannelInterface {
    */
   UdsClient& read_buffer_size(size_t bytes);
   UdsClient& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   UdsClient& manage_external_context(bool manage);
   UdsClient& batch_size(size_t size);
   UdsClient& batch_latency(std::chrono::milliseconds latency);

--- a/wirestead/wrapper/uds_server/uds_server.cc
+++ b/wirestead/wrapper/uds_server/uds_server.cc
@@ -648,6 +648,12 @@ UdsServer& UdsServer::backpressure_strategy(base::constants::BackpressureStrateg
   return *this;
 }
 
+size_t UdsServer::backpressure_threshold() const { return impl_->backpressure_threshold_.load(); }
+
+base::constants::BackpressureStrategy UdsServer::backpressure_strategy() const {
+  return impl_->backpressure_strategy_.load();
+}
+
 UdsServer& UdsServer::manage_external_context(bool manage) {
   impl_->manage_external_context_.store(manage);
   return *this;

--- a/wirestead/wrapper/uds_server/uds_server.hpp
+++ b/wirestead/wrapper/uds_server/uds_server.hpp
@@ -119,6 +119,11 @@ class WIRESTEAD_API UdsServer : public ServerInterface {
    */
   UdsServer& read_buffer_size(size_t bytes);
   UdsServer& backpressure_strategy(base::constants::BackpressureStrategy strategy);
+
+  /// Returns the configured backpressure threshold in bytes.
+  size_t backpressure_threshold() const;
+  /// Returns the configured backpressure strategy.
+  base::constants::BackpressureStrategy backpressure_strategy() const;
   UdsServer& manage_external_context(bool manage);
   UdsServer& batch_size(size_t size);
   UdsServer& batch_latency(std::chrono::milliseconds latency);


### PR DESCRIPTION
## Description

`backpressure_threshold()` and `backpressure_strategy()` were write-only on
every transport. The setters have been there all along, but nothing read them
back, so a caller could not log the configuration it was running under,
round-trip it, or assert on it from a test without tracking the value
separately alongside the transport.

v0.9.4 added `RuntimeStats` because backpressure could be configured with no
way to observe what it produced. That covered the runtime half; the setting
itself stayed unreadable. This covers the other half.

```cpp
server.backpressure_threshold(8192);
const size_t configured = server.backpressure_threshold();  // 8192
```

The Python bindings raised `AttributeError: backpressure_threshold is
write-only` on read for the same reason, and can now expose real properties.

## Key Changes

- Add `backpressure_threshold() const` and `backpressure_strategy() const` to
  `Serial`, `TcpClient`, `TcpServer`, `UdpClient`, `UdpServer`, `UdsClient`,
  and `UdsServer` — 14 getters.
- Add `test/unit/wrapper/test_backpressure_getters.cc`, covering all seven.

The value was already stored, so each getter reads what its own setter writes
and no new state is introduced. That storage is not uniform, which is the one
thing worth reviewing closely here:

| transport | storage | read under |
| --- | --- | --- |
| `Serial` | `impl_->backpressure_threshold` | `shared_lock` on `impl_->mutex_` |
| `TcpClient` | `impl_->backpressure_threshold_` | `shared_lock` on `impl_->mutex_` |
| `TcpServer` | `std::atomic` member | `.load()` |
| `UdpClient` | `impl_->cfg.backpressure_threshold` | `shared_lock` on `impl_->mutex_` |
| `UdpServer` | `impl_->cfg.backpressure_threshold` | `shared_lock` on `impl_->mutex` |
| `UdsClient` | `impl_->backpressure_threshold_` | `shared_lock` on `impl_->mutex_` |
| `UdsServer` | `std::atomic` member | `.load()` |

Note `UdpServer`'s mutex is `impl_->mutex`, without the trailing underscore the
others use.

No interface changed. These go on the concrete wrapper classes only, so
`interface/*` and its out-of-tree implementors are untouched.

## Related Issues
- N/A

## Type of Change
- [ ] **Bug Fix**: A non-breaking change that resolves an issue.
- [x] **New Feature**: A non-breaking change that adds new functionality.
- [ ] **Breaking Change**: A fix or feature that would cause existing functionality to change.
- [ ] **Documentation**: Changes to documentation only.
- [ ] **Refactor**: Code changes that neither fix a bug nor add a feature.
- [ ] **Performance**: Changes that improve system performance.
- [x] **Testing**: Adding or updating tests.

## Checklist
- [ ] I have run `./scripts/verify.sh` locally and confirmed that all checks (formatting, build, and unit tests) pass.
- [x] I have added or updated tests to verify my changes.
- [ ] I have updated the documentation to reflect the changes (if applicable).
- [x] My changes follow the project's coding style and conventions.

## Additional Context

**`./scripts/verify.sh` was run and did not fully pass**, so that box is left
unchecked. 2 of 823 tests failed. Both were checked against `main` and neither
is caused by this change:

- `GatherWriteTest.SendMovePreservesByteCountAndOrder` — flaky on `main` too.
  Six isolated runs of the same binary on each side:

  | | pass | fail |
  | --- | --- | --- |
  | `main` (dea503a8) | 2 | 4 |
  | this branch | 2 | 4 |

  Same rate, and the same failure: `test_gather_write.cc:119`, with `assembled`
  still all `'\0'` at the assert. Reads like the assertion racing the receive
  rather than anything about backpressure — `test_gather_write.cc` does not
  contain the string `backpressure`. Worth its own issue; not addressed here.

- `TcpServerWrapperLifecycleTest.ConcurrentStartStop` — timed out in the full
  parallel run, passed 3/3 in isolation. Load, not a defect in this change.

Formatting, build, and the unit suite (489 tests) all pass; the two failures
are integration tests.

**The new test was verified to fail, not only to pass.** The risk in this
change is a getter reading a member its own setter does not write, which a
test that only ever passes would not catch. Making `UdpServer`'s getter ignore
its setter and return the default makes `BackpressureGettersTest.UdpServer`
fail on the 8192 assertion; restoring it passes again.

The test also exercises the chained form
`t.backpressure_threshold(8192).backpressure_strategy(...)`, since the setters
return `T&` and that is how they are used in practice.

Documentation is left unchecked because no file under `docs/` or `README.md`
mentions `backpressure_threshold` or `backpressure_strategy` at all — there is
no existing surface describing these APIs to extend. `CHANGELOG.md` is updated.
